### PR TITLE
Improve Qt deployment so all DLLs are staged properly

### DIFF
--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -347,13 +347,16 @@ INSTALL(FILES ${CMAKE_CURRENT_SOURCE_DIR}/dlls.manifest.qt5
 SET(windeploy_parameters "--no-translations --plugindir qtplugins --libdir dlls --release-with-debug-info --no-compiler-runtime")
 INSTALL(
     CODE
-    "EXECUTE_PROCESS(
-        COMMAND
+    "EXECUTE_PROCESS(COMMAND
         ${qt5bin}/windeployqt.exe ModOrganizer.exe --webenginewidgets ${windeploy_parameters}
-	# run it a second time because on the first run it misses some files
-	COMMAND
+        WORKING_DIRECTORY ${CMAKE_INSTALL_PREFIX}/bin
+    )
+    # run it a second time because on the first run it misses some files
+    EXECUTE_PROCESS(COMMAND
         ${qt5bin}/windeployqt.exe ModOrganizer.exe --webenginewidgets ${windeploy_parameters}
-        COMMAND
+        WORKING_DIRECTORY ${CMAKE_INSTALL_PREFIX}/bin
+    )
+    EXECUTE_PROCESS(COMMAND
         ${qt5bin}/windeployqt.exe uibase.dll ${windeploy_parameters}
         WORKING_DIRECTORY ${CMAKE_INSTALL_PREFIX}/bin
     )


### PR DESCRIPTION
`EXECUTE_PROCESS` runs all commands it is given in parallel piping output from each process to its successor and printing the output of the final command. This was breaking the multiple calls to `windeployqt` as they needed to run sequentially in order to put all the DLLs where they need to be.

@SuperSandro2000 had already tried to resolve this by inserting an extra `windeployqt` call, but as it was run at the same time as the existing one, it made no difference.

Before this PR:
After unimake had finished, the produced MO build would complain about missing DLLs and refuse to start. This could be resolved by manually copying them, building the INSTALL project of `organizer.sln`, running `nmake install` to build the equivalent Makefile, or deleting the relevant progress file from unimake and running it again.

After this PR:
After unimake has finished, the produced MO build works as expected with no additional setup.