### PR TITLE
Deploy the qtdds.dll as part of the MO install

### DIFF
--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -368,6 +368,9 @@ INSTALL(
     file(REMOVE_RECURSE ${CMAKE_INSTALL_PREFIX}/bin/qtplugins)"
 )
 
+# qdds.dll needs installing manually as Qt no longer ships with it by default.
+INSTALL(FILES ${CMAKE_CURRENT_SOURCE_DIR}/../qdds.dll DESTINATION bin/dlls/imageformats)
+
 INSTALL(DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR}/stylesheets
                   ${CMAKE_CURRENT_SOURCE_DIR}/tutorials
         DESTINATION bin)


### PR DESCRIPTION
This fixes an issue where running the install build project would delete the `qtdds.dll` and not replace it. Ideally should be merged with the umbrella pull request I'm about to make.