### PR TITLE
Proxy translation support

### DIFF
--- a/src/mainwindow.cpp
+++ b/src/mainwindow.cpp
@@ -3726,6 +3726,9 @@ void MainWindow::languageChange(const QString &newLanguage)
 
   installTranslator("qt");
   installTranslator(ToQString(AppConfig::translationPrefix()));
+  for (const QString &fileName : m_PluginContainer.pluginFileNames()) {
+    installTranslator(QFileInfo(fileName).baseName());
+  }
   ui->retranslateUi(this);
   qDebug("loaded language %s", qPrintable(newLanguage));
 

--- a/src/plugincontainer.cpp
+++ b/src/plugincontainer.cpp
@@ -53,6 +53,12 @@ QStringList PluginContainer::pluginFileNames() const
   for (QPluginLoader *loader : m_PluginLoaders) {
     result.append(loader->fileName());
   }
+  std::vector<IPluginProxy *> proxyList = bf::at_key<IPluginProxy>(m_Plugins);
+  for (IPluginProxy *proxy : proxyList) {
+    QStringList proxiedPlugins = proxy->pluginList(
+            QCoreApplication::applicationDirPath() + "/" + ToQString(AppConfig::pluginPath()));
+    result.append(proxiedPlugins);
+  }
   return result;
 }
 


### PR DESCRIPTION
This is necessary if translations for Python-based plugins, such as the Configurator and https://github.com/AnyOldName3/ModOrganizer-to-OpenMW are to be loaded.

It also ensures plugin translations are reloaded when the language is changed as we didn't seem to be doing that.

The implementation could have been done in several different ways, so I'd like to discuss that before this gets merged. When generating the list of pluginFileNames, we could:
* Query the available plugins for each loaded proxy. This has the advantage that once a proxy gets unloaded, its plugins don't show up in the last. It has the disadvantage that if a proxied plugin failed to load, it will still be included in the list. This is the implementation here.
* When a proxy loads a plugin successfully, push this into a vector somewhere. Get values from this vector.
  * We could store just one big vector for all proxies. This is easy to do, but a nuisance if we're going to remove plugins from the list when the proxy responsible for them is unloaded.
  * We could store a map from proxies to plugins they have loaded. This is barely any harder but means removing items when a proxy is unloaded is much easier.
  * We could make the existing plugin list contain pairs of proxies and vectors of plugin files they've loaded. This has basically the same advantages of the above option but means we have one fewer place where plugins are listed at the expense of meaning more things need changing.

Which of these is best depends on how frequently we unload plugins and how much we care about loading translation databases for plugins that are inactive. If we literally never reload plugins (which is how it works now), then this isn't something to care about, but as we seem to have the ability to easily add a 'Refresh Plugins' button, it seems like a bad idea to have a function that looks like it would do that, but would lead to things giving wonky results.