### PR TITLE
Load qtbase qm

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -12,6 +12,7 @@ stderr.log
 stdout.log
 vs_stderr.log
 vs_stdout.log
+msbuild.log
 build
 /vsbuild
 /CMakeFiles

--- a/src/mainwindow.cpp
+++ b/src/mainwindow.cpp
@@ -3725,6 +3725,7 @@ void MainWindow::languageChange(const QString &newLanguage)
   m_CurrentLanguage = newLanguage;
 
   installTranslator("qt");
+  installTranslator("qtbase");
   installTranslator(ToQString(AppConfig::translationPrefix()));
   for (const QString &fileName : m_PluginContainer.pluginFileNames()) {
     installTranslator(QFileInfo(fileName).baseName());


### PR DESCRIPTION
When combined with https://github.com/Modorganizer2/modorganizer-umbrella/pull/22, this will ensure that all built-in Qt strings get translated.

Also updates `.gitignore` with msbuild stuff.