### PR TITLE
Better version parsing

### DIFF
--- a/src/selfupdater.cpp
+++ b/src/selfupdater.cpp
@@ -133,7 +133,6 @@ SelfUpdater::SelfUpdater(NexusInterface *nexusInterface)
     {
       // Trust the string to make sense
       m_MOVersion = VersionInfo(versionString);
-      qDebug() << "<: " << (m_MOVersion < VersionInfo(2, 1, 4)) << ", >: " << (m_MOVersion > VersionInfo(2, 1, 4));
     }
   }
   else

--- a/src/selfupdater.cpp
+++ b/src/selfupdater.cpp
@@ -104,10 +104,46 @@ SelfUpdater::SelfUpdater(NexusInterface *nexusInterface)
 
   VS_FIXEDFILEINFO version = GetFileVersion(ToWString(QApplication::applicationFilePath()));
 
-  m_MOVersion = VersionInfo(version.dwFileVersionMS >> 16,
-                            version.dwFileVersionMS & 0xFFFF,
-                            version.dwFileVersionLS >> 16,
-                            version.dwFileVersionLS & 0xFFFF);
+  if (version.dwFileFlags | VS_FF_PRERELEASE)
+  {
+    // Pre-release builds need annotating
+    QString versionString = QString::fromStdWString(GetFileVersionString(ToWString(QApplication::applicationFilePath())));
+
+    // The pre-release flag can be set without the string specifying what type of pre-release
+    bool noLetters = true;
+    for (QChar character : versionString)
+    {
+      if (character.isLetter())
+      {
+        noLetters = false;
+        break;
+      }
+    }
+
+    if (noLetters)
+    {
+      // Default to pre-alpha when release type is unspecified
+      m_MOVersion = VersionInfo(version.dwFileVersionMS >> 16,
+                                version.dwFileVersionMS & 0xFFFF,
+                                version.dwFileVersionLS >> 16,
+                                version.dwFileVersionLS & 0xFFFF,
+                                VersionInfo::RELEASE_PREALPHA);
+    }
+    else
+    {
+      // Trust the string to make sense
+      m_MOVersion = VersionInfo(versionString);
+      qDebug() << "<: " << (m_MOVersion < VersionInfo(2, 1, 4)) << ", >: " << (m_MOVersion > VersionInfo(2, 1, 4));
+    }
+  }
+  else
+  {
+    // Non-pre-release builds just need their version numbers reading
+    m_MOVersion = VersionInfo(version.dwFileVersionMS >> 16,
+                              version.dwFileVersionMS & 0xFFFF,
+                              version.dwFileVersionLS >> 16,
+                              version.dwFileVersionLS & 0xFFFF);
+  }
 }
 
 

--- a/src/shared/util.cpp
+++ b/src/shared/util.cpp
@@ -174,5 +174,33 @@ VS_FIXEDFILEINFO GetFileVersion(const std::wstring &fileName)
   }
 }
 
+std::wstring GetFileVersionString(const std::wstring &fileName)
+{
+  DWORD handle = 0UL;
+  DWORD size = ::GetFileVersionInfoSizeW(fileName.c_str(), &handle);
+  if (size == 0) {
+    throw windows_error("failed to determine file version info size");
+  }
+
+  boost::scoped_array<char> buffer(new char[size]);
+  try {
+    handle = 0UL;
+    if (!::GetFileVersionInfoW(fileName.c_str(), handle, size, buffer.get())) {
+      throw windows_error("failed to determine file version info");
+    }
+
+    LPVOID strBuffer = nullptr;
+    UINT strLength = 0;
+    if (!::VerQueryValue(buffer.get(), L"\\StringFileInfo\\040904B0\\ProductVersion", &strBuffer, &strLength)) {
+      throw windows_error("failed to determine file version");
+    }
+
+    return std::wstring((LPCTSTR)strBuffer);
+  }
+  catch (...) {
+    throw;
+  }
+}
+
 
 } // namespace MOShared

--- a/src/shared/util.h
+++ b/src/shared/util.h
@@ -45,6 +45,7 @@ std::wstring ToLower(const std::wstring &text);
 bool CaseInsensitiveEqual(const std::wstring &lhs, const std::wstring &rhs);
 
 VS_FIXEDFILEINFO GetFileVersion(const std::wstring &fileName);
+std::wstring GetFileVersionString(const std::wstring &fileName);
 
 } // namespace MOShared
 

--- a/src/version.rc
+++ b/src/version.rc
@@ -1,7 +1,10 @@
 #include "Winver.h"
 
+// If VS_FF_PRERELEASE is not set, MO labels the build as a release and uses VER_FILEVERSION to determine version number.
+// Otherwise, if letters are used in VER_FILEVERSION_STR, uses the full MOBase::VersionInfo parser
+// Otherwise, uses the numbers from VER_FILEVERSION and sets the release type as pre-alpha
 #define VER_FILEVERSION     2,1,4
-#define VER_FILEVERSION_STR "2.1.4-dev\0"
+#define VER_FILEVERSION_STR "2.1.4\0"
 
 VS_VERSION_INFO VERSIONINFO
 FILEVERSION     VER_FILEVERSION


### PR DESCRIPTION
Add support for useful version tagging so that we can prove when users are lying about where they got their build.