### PR TITLE
Move improved version parsing to util.h and use it everywhere.

### DIFF
--- a/src/main.cpp
+++ b/src/main.cpp
@@ -446,11 +446,7 @@ static void preloadSsl()
 
 static QString getVersionDisplayString()
 {
-  VS_FIXEDFILEINFO version = GetFileVersion(ToWString(QApplication::applicationFilePath()));
-  return VersionInfo(version.dwFileVersionMS >> 16,
-    version.dwFileVersionMS & 0xFFFF,
-    version.dwFileVersionLS >> 16,
-    version.dwFileVersionLS & 0xFFFF).displayString();
+  return createVersionInfo().displayString();
 }
 
 int runApplication(MOApplication &application, SingleInstance &instance,

--- a/src/nexusinterface.cpp
+++ b/src/nexusinterface.cpp
@@ -147,10 +147,7 @@ QAtomicInt NexusInterface::NXMRequestInfo::s_NextID(0);
 NexusInterface::NexusInterface(PluginContainer *pluginContainer)
   : m_NMMVersion(), m_PluginContainer(pluginContainer)
 {
-  VS_FIXEDFILEINFO version = GetFileVersion(ToWString(QApplication::applicationFilePath()));
-  m_MOVersion = VersionInfo(version.dwFileVersionMS >> 16,
-                            version.dwFileVersionMS & 0xFFFF,
-                            version.dwFileVersionLS >> 16);
+  m_MOVersion = createVersionInfo();
 
   m_AccessManager = new NXMAccessManager(this, m_MOVersion.displayString());
   m_DiskCache = new QNetworkDiskCache(this);

--- a/src/selfupdater.cpp
+++ b/src/selfupdater.cpp
@@ -102,47 +102,7 @@ SelfUpdater::SelfUpdater(NexusInterface *nexusInterface)
     throw MyException(InstallationManager::getErrorString(m_ArchiveHandler->getLastError()));
   }
 
-  VS_FIXEDFILEINFO version = GetFileVersion(ToWString(QApplication::applicationFilePath()));
-
-  if (version.dwFileFlags | VS_FF_PRERELEASE)
-  {
-    // Pre-release builds need annotating
-    QString versionString = QString::fromStdWString(GetFileVersionString(ToWString(QApplication::applicationFilePath())));
-
-    // The pre-release flag can be set without the string specifying what type of pre-release
-    bool noLetters = true;
-    for (QChar character : versionString)
-    {
-      if (character.isLetter())
-      {
-        noLetters = false;
-        break;
-      }
-    }
-
-    if (noLetters)
-    {
-      // Default to pre-alpha when release type is unspecified
-      m_MOVersion = VersionInfo(version.dwFileVersionMS >> 16,
-                                version.dwFileVersionMS & 0xFFFF,
-                                version.dwFileVersionLS >> 16,
-                                version.dwFileVersionLS & 0xFFFF,
-                                VersionInfo::RELEASE_PREALPHA);
-    }
-    else
-    {
-      // Trust the string to make sense
-      m_MOVersion = VersionInfo(versionString);
-    }
-  }
-  else
-  {
-    // Non-pre-release builds just need their version numbers reading
-    m_MOVersion = VersionInfo(version.dwFileVersionMS >> 16,
-                              version.dwFileVersionMS & 0xFFFF,
-                              version.dwFileVersionLS >> 16,
-                              version.dwFileVersionLS & 0xFFFF);
-  }
+  m_MOVersion = createVersionInfo();
 }
 
 

--- a/src/shared/util.h
+++ b/src/shared/util.h
@@ -25,6 +25,8 @@ along with Mod Organizer.  If not, see <http://www.gnu.org/licenses/>.
 #define WIN32_LEAN_AND_MEAN
 #include <Windows.h>
 
+#include <versioninfo.h>
+
 namespace MOShared {
 
 /// Test if a file (or directory) by the specified name exists
@@ -46,6 +48,7 @@ bool CaseInsensitiveEqual(const std::wstring &lhs, const std::wstring &rhs);
 
 VS_FIXEDFILEINFO GetFileVersion(const std::wstring &fileName);
 std::wstring GetFileVersionString(const std::wstring &fileName);
+MOBase::VersionInfo createVersionInfo();
 
 } // namespace MOShared
 


### PR DESCRIPTION
This means the release type is displayed in the logs even if I don't put the qDebug call there manually.