### PR TITLE
Downloads tab: fix for freezes and greatly improved performance and responsiveness

### DIFF
--- a/src/downloadmanager.h
+++ b/src/downloadmanager.h
@@ -148,12 +148,12 @@ public:
 	* @brief disables feedback from the downlods fileSystemWhatcher untill disableDownloadsWatcherEnd() is called
 	* 
 	**/
-	void startDisableDirWatcher();
+	static void startDisableDirWatcher();
 
 	/**
 	* @brief re-enables feedback from the downlods fileSystemWhatcher after disableDownloadsWatcherStart() was called
 	**/
-	void endDisableDirWatcher();
+	static void endDisableDirWatcher();
 
   /**
    * @return current download directory
@@ -533,7 +533,8 @@ private:
 	//The dirWatcher is actually triggering off normal Mo operations such as deleting downloads or editing .meta files
 	//so it needs to be disabled during operations that are known to cause the creation or deletion of files in the Downloads folder.
 	//Notably using QSettings to edit a file creates a temporarily .lock file that causes the Watcher to trigger multiple listRefreshes freezing the ui. 
-	int m_DirWatcherDisabler; 
+	static int m_DirWatcherDisabler;
+
 
   std::map<QString, int> m_DownloadFails;
 

--- a/src/downloadmanager.h
+++ b/src/downloadmanager.h
@@ -144,6 +144,17 @@ public:
    **/
   void setOutputDirectory(const QString &outputDirectory);
 
+	/**
+	* @brief disables feedback from the downlods fileSystemWhatcher untill disableDownloadsWatcherEnd() is called
+	* 
+	**/
+	void startDisableDirWatcher();
+
+	/**
+	* @brief re-enables feedback from the downlods fileSystemWhatcher after disableDownloadsWatcherStart() was called
+	**/
+	void endDisableDirWatcher();
+
   /**
    * @return current download directory
    **/
@@ -518,6 +529,11 @@ private:
   QVector<int> m_AlphabeticalTranslation;
 
   QFileSystemWatcher m_DirWatcher;
+
+	//The dirWatcher is actually triggering off normal Mo operations such as deleting downloads or editing .meta files
+	//so it needs to be disabled during operations that are known to cause the creation or deletion of files in the Downloads folder.
+	//Notably using QSettings to edit a file creates a temporarily .lock file that causes the Watcher to trigger multiple listRefreshes freezing the ui. 
+	int m_DirWatcherDisabler; 
 
   std::map<QString, int> m_DownloadFails;
 


### PR DESCRIPTION
DirWatcher disabling while performing file changing operations.
Added check before setting an already hidden file to hidden.
Added refreshes to avoid showing of incorrect data.
Results in much smother responsiveness.