### PR TITLE
Fix a memory leak in updateToolBar

### DIFF
--- a/src/mainwindow.h
+++ b/src/mainwindow.h
@@ -304,6 +304,8 @@ private:
 
   Ui::MainWindow *ui;
 
+  QAction *m_Sep; // Executable Shortcuts are added after this. Non owning.
+
   bool m_WasVisible;
 
   MOBase::TutorialControl m_Tutorial;


### PR DESCRIPTION
updateToolBar was creating new QActions and QWidgets every call, without cleaning them up.

The spacer, help widgets, and toolbuttons only need to be created once.
Those have been moved out into the MainWindow constructor

updateToolBar is called in various places, importantly when adding/removing executable shortcuts.

Also adds a deleteLater() call to clean up executable shortcut actions.