### PR TITLE
Lock the active profile directory from deletion.

### DIFF
--- a/src/profile.h
+++ b/src/profile.h
@@ -36,6 +36,7 @@ along with Mod Organizer.  If not, see <http://www.gnu.org/licenses/>.
 #include <string>
 #include <tuple>
 #include <vector>
+#include <memory>
 
 
 namespace MOBase { class IPluginGame; }
@@ -351,6 +352,12 @@ private:
   unsigned int m_NumRegularMods;
 
   MOBase::DelayedFileWriter m_ModListWriter;
+  
+  struct FileLockDeleter {
+      void operator()(void* h);
+  };
+  using FileLock = std::unique_ptr<void, FileLockDeleter>;
+  FileLock m_lock;
 
 };
 


### PR DESCRIPTION
Mirrors https://github.com/ModOrganizer/modorganizer/commit/35224fb25dd51d2488b3de81ac9bd5febb032b06

Uses the win32 API to prevent the profile directory from being deleted while the profile is active.
Attempts to delete the directory(but NOT it's contents) through Windows Explorer will display a message that the folder is in use.

This lock is released when the Profile object is destroyed.