### PR TITLE
Sort by game and fix for instance names

### DIFF
--- a/src/instancemanager.cpp
+++ b/src/instancemanager.cpp
@@ -146,7 +146,7 @@ QString InstanceManager::queryInstanceName(const QStringList &instanceList) cons
     if (dialog.exec() == QDialog::Rejected) {
       throw MOBase::MyException(QObject::tr("Canceled"));
     }
-    instanceId = dialog.textValue().replace(QRegExp("[^0-9a-zA-Z ]"), "");
+    instanceId = dialog.textValue().replace(QRegExp("[^0-9a-zA-Z ]"), "").remove(QRegExp("( )*$"));
 
     bool alreadyExists=false;
     for (const QString &instance : instanceList) {

--- a/src/modlistsortproxy.cpp
+++ b/src/modlistsortproxy.cpp
@@ -208,6 +208,16 @@ bool ModListSortProxy::lessThan(const QModelIndex &left,
       if (leftTime != rightTime)
         return leftTime < rightTime;
     } break;
+    case ModList::COL_GAME: {
+      if (leftMod->getGameName() != rightMod->getGameName()) {
+        lt = leftMod->getGameName() < rightMod->getGameName();
+      }
+      else {
+        int comp = QString::compare(leftMod->name(), rightMod->name(), Qt::CaseInsensitive);
+        if (comp != 0)
+          lt = comp < 0;
+       }
+    } break;
     case ModList::COL_PRIORITY: {
       // nop, already compared by priority
     } break;


### PR DESCRIPTION
Change to modlistsortproxy.cpp allows you to sort by source game with a secondary sort by mod name.  

Change to instancemanager.cpp removes spaces from the end of an instance name.  Spaces are not allowed at the end of a Windows directory even if Qt will happily allow them. This prevents issues with Windows and MO2 accessing the instance directory as "foo" is treated the same as "foo    ", except when it's inconvenient. 