### PR TITLE
Add "Open Mods folder" item to the Open Folders menu

### DIFF
--- a/src/mainwindow.cpp
+++ b/src/mainwindow.cpp
@@ -3269,6 +3269,11 @@ void MainWindow::openDownloadsFolder()
 	::ShellExecuteW(nullptr, L"explore", ToWString(m_OrganizerCore.settings().getDownloadDirectory()).c_str(), nullptr, nullptr, SW_SHOWNORMAL);
 }
 
+void MainWindow::openModsFolder()
+{
+	::ShellExecuteW(nullptr, L"explore", ToWString(m_OrganizerCore.settings().getModDirectory()).c_str(), nullptr, nullptr, SW_SHOWNORMAL);
+}
+
 void MainWindow::openGameFolder()
 {
 	::ShellExecuteW(nullptr, L"explore", ToWString(m_OrganizerCore.managedGame()->gameDirectory().absolutePath()).c_str(), nullptr, nullptr, SW_SHOWNORMAL);
@@ -3465,6 +3470,8 @@ QMenu *MainWindow::openFolderMenu()
 	FolderMenu->addAction(tr("Open Profile folder"), this, SLOT(openProfileFolder()));
 
 	FolderMenu->addAction(tr("Open Downloads folder"), this, SLOT(openDownloadsFolder()));
+
+	FolderMenu->addAction(tr("Open Mods folder"), this, SLOT(openModsFolder()));
 
 	FolderMenu->addSeparator();
 


### PR DESCRIPTION
I enjoy the Open Folders menu very much, but I often find that a shortcut for the "mods" folder is missing, and it can be a bit cumbersome to rightclick a mod, open in explorer, and then navigate a level up… would be nice to just be able to go there from the same place as the other "open folder" shortcuts.

Note: This has not been tested (as I don't know how to build MO from Linux, and I have no particular interest in setting up a dev. environment on Windows), but it's basically just a copy/paste and slight edit of existing functionality.