### PR TITLE
Add new "Open File" right-click dialog for Downloads

### DIFF
--- a/src/downloadlistwidget.cpp
+++ b/src/downloadlistwidget.cpp
@@ -272,6 +272,11 @@ void DownloadListWidgetDelegate::issueVisitOnNexus()
 	emit visitOnNexus(m_ContextRow);
 }
 
+void DownloadListWidgetDelegate::issueOpenFile()
+{
+  emit openFile(m_ContextRow);
+}
+
 void DownloadListWidgetDelegate::issueOpenInDownloadsFolder()
 {
   emit openInDownloadsFolder(m_ContextRow);
@@ -375,6 +380,7 @@ bool DownloadListWidgetDelegate::editorEvent(QEvent *event, QAbstractItemModel *
               menu.addAction(tr("Visit on Nexus"), this,SLOT(issueVisitOnNexus()));
             }
 
+            menu.addAction(tr("Open File"), this, SLOT(issueOpenFile()));
             menu.addAction(tr("Show in Folder"), this, SLOT(issueOpenInDownloadsFolder()));
             
             menu.addSeparator();

--- a/src/downloadlistwidget.h
+++ b/src/downloadlistwidget.h
@@ -72,6 +72,7 @@ signals:
   void pauseDownload(int index);
   void resumeDownload(int index);
   void visitOnNexus(int index);
+  void openFile(int index);
   void openInDownloadsFolder(int index);
 
 protected:
@@ -93,6 +94,7 @@ private slots:
   void issueRestoreToView();
   void issueRestoreToViewAll();
   void issueVisitOnNexus();
+  void issueOpenFile();
   void issueOpenInDownloadsFolder();
   void issueCancel();
   void issuePause();

--- a/src/downloadlistwidgetcompact.cpp
+++ b/src/downloadlistwidgetcompact.cpp
@@ -247,6 +247,11 @@ void DownloadListWidgetCompactDelegate::issueVisitOnNexus()
 	emit visitOnNexus(m_ContextIndex.row());
 }
 
+void DownloadListWidgetDelegate::issueOpenFile()
+{
+  emit openFile(m_ContextIndex.row());
+}
+
 void DownloadListWidgetCompactDelegate::issueOpenInDownloadsFolder()
 {
   emit openInDownloadsFolder(m_ContextIndex.row());
@@ -361,6 +366,7 @@ bool DownloadListWidgetCompactDelegate::editorEvent(QEvent *event, QAbstractItem
             }else {
               menu.addAction(tr("Visit on Nexus"), this, SLOT(issueVisitOnNexus()));
             }
+            menu.addAction(tr("Open File"), this, SLOT(issueOpenFile()));
             menu.addAction(tr("Show in Folder"), this, SLOT(issueOpenInDownloadsFolder()));
             menu.addSeparator();
             menu.addAction(tr("Delete"), this, SLOT(issueDelete()));

--- a/src/downloadlistwidgetcompact.h
+++ b/src/downloadlistwidgetcompact.h
@@ -70,6 +70,7 @@ signals:
   void pauseDownload(int index);
   void resumeDownload(int index);
   void visitOnNexus(int index);
+  void openFile(int index);
   void openInDownloadsFolder(int index);
 
 protected:
@@ -92,6 +93,7 @@ private slots:
   void issueRestoreToView();
   void issueRestoreToViewAll();
   void issueVisitOnNexus();
+  void issueOpenFile();
   void issueOpenInDownloadsFolder();
   void issueCancel();
   void issuePause();

--- a/src/downloadmanager.cpp
+++ b/src/downloadmanager.cpp
@@ -927,6 +927,31 @@ void DownloadManager::visitOnNexus(int index)
   }
 }
 
+void DownloadManager::openFile(int index)
+{
+  if ((index < 0) || (index >= m_ActiveDownloads.size())) {
+    reportError(tr("VisitNexus: invalid download index %1").arg(index));
+    return;
+  }
+  QString params = "/select,\"";
+  QDir path = QDir(m_OutputDirectory);
+  if (path.exists(getFileName(index))) {
+    params = params + QDir::toNativeSeparators(getFilePath(index)) + "\"";
+
+    ::ShellExecuteW(nullptr, nullptr, L"open", ToWString(params).c_str(), nullptr, SW_SHOWNORMAL);
+    return;
+  }
+  else if (path.exists(getFileName(index) + ".unfinished")) {
+    params = params + QDir::toNativeSeparators(getFilePath(index)+".unfinished") + "\"";
+
+    ::ShellExecuteW(nullptr, nullptr, L"open", ToWString(params).c_str(), nullptr, SW_SHOWNORMAL);
+    return;
+  }
+
+  ::ShellExecuteW(nullptr, L"open", ToWString(QDir::toNativeSeparators(m_OutputDirectory)).c_str(), nullptr, nullptr, SW_SHOWNORMAL);
+  return;
+}
+
 void DownloadManager::openInDownloadsFolder(int index)
 {
   if ((index < 0) || (index >= m_ActiveDownloads.size())) {

--- a/src/downloadmanager.cpp
+++ b/src/downloadmanager.cpp
@@ -930,19 +930,12 @@ void DownloadManager::visitOnNexus(int index)
 void DownloadManager::openFile(int index)
 {
   if ((index < 0) || (index >= m_ActiveDownloads.size())) {
-    reportError(tr("VisitNexus: invalid download index %1").arg(index));
+    reportError(tr("OpenFile: invalid download index %1").arg(index));
     return;
   }
-  QString params = "/select,\"";
   QDir path = QDir(m_OutputDirectory);
   if (path.exists(getFileName(index))) {
     params = params + QDir::toNativeSeparators(getFilePath(index)) + "\"";
-
-    ::ShellExecuteW(nullptr, nullptr, L"open", ToWString(params).c_str(), nullptr, SW_SHOWNORMAL);
-    return;
-  }
-  else if (path.exists(getFileName(index) + ".unfinished")) {
-    params = params + QDir::toNativeSeparators(getFilePath(index)+".unfinished") + "\"";
 
     ::ShellExecuteW(nullptr, nullptr, L"open", ToWString(params).c_str(), nullptr, SW_SHOWNORMAL);
     return;

--- a/src/downloadmanager.h
+++ b/src/downloadmanager.h
@@ -445,6 +445,8 @@ public slots:
 
 	void visitOnNexus(int index);
 
+  void openFile(int index);
+
   void openInDownloadsFolder(int index);
 
   void nxmDescriptionAvailable(QString gameName, int modID, QVariant userData, QVariant resultData, int requestID);


### PR DESCRIPTION
This enables the user to directly open the downloaded archived/file which can be useful for e.g., inspection of what's inside or if they need to copy files from inside the archive to somewhere else. Saves a step compared to "Show in Folder" and then opening the file.

**Note:** I don't have a build environment for building Mod Organizer, so this patch has not been tested. Please let me know any changes I need to make.