### PR TITLE
Update mainwindow.cpp to lock UI when loading.

### DIFF
--- a/src/mainwindow.cpp
+++ b/src/mainwindow.cpp
@@ -2011,15 +2011,20 @@ void MainWindow::setESPListSorting(int index)
 
 void MainWindow::refresher_progress(int percent)
 {
-  if (percent == 100) {
-    m_RefreshProgress->setVisible(false);
-    statusBar()->hide();
-  } else if (!m_RefreshProgress->isVisible()) {
-    statusBar()->show();
-    m_RefreshProgress->setVisible(true);
-    m_RefreshProgress->setRange(0, 100);
-    m_RefreshProgress->setValue(percent);
-  }
+	if (percent == 100)
+	{
+		m_RefreshProgress->setVisible(false);
+		statusBar()->hide();
+		this->setEnabled(true);
+	}
+	else if (!m_RefreshProgress->isVisible())
+	{
+		this->setEnabled(false);
+		statusBar()->show();
+		m_RefreshProgress->setVisible(true);
+		m_RefreshProgress->setRange(0, 100);
+		m_RefreshProgress->setValue(percent);
+	}
 }
 
 void MainWindow::directory_refreshed()


### PR DESCRIPTION
When MO2 is loading, users can still execute actions causing Qt to throw exceptions and in some cases crash the application.