### PR TITLE
Extend version field to 12 characters

### DIFF
--- a/src/modinfodialog.ui
+++ b/src/modinfodialog.ui
@@ -682,7 +682,7 @@ p, li { white-space: pre-wrap; }
             </size>
            </property>
            <property name="maxLength">
-            <number>10</number>
+            <number>12</number>
            </property>
           </widget>
          </item>


### PR DESCRIPTION
This is needed because some mods out there have version strings longer than 10 characters. For example, the current version string of [SSE Engine Fixes (skse64 plugin)](https://www.nexusmods.com/skyrimspecialedition/mods/17230) is "2.12.1.5.50" -- 11 characters in total.

12 should hopefully be enough.