### PR TITLE
Add link to upcoming FNISTool repo

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -49,6 +49,7 @@ Here is a complete list:
 * https://github.com/Modorganizer2/modorganizer-check_fnis
 * https://github.com/Modorganizer2/modorganizer-diagnose_basic
 * https://github.com/Modorganizer2/modorganizer-esptk
+* https://github.com/ModOrganizer2/modorganizer-fnistool
 * https://github.com/Modorganizer2/modorganizer-helper
 * https://github.com/Modorganizer2/modorganizer-game_fallout3
 * https://github.com/Modorganizer2/modorganizer-game_fallout4


### PR DESCRIPTION
DO NOT MERGE UNTIL https://github.com/ModOrganizer2/modorganizer-umbrella/pull/31 IS HANDLED.

The linked repo doesn't actually exist yet.