### PR TITLE
Added Missing URL for Nexus Info Tab in ModInfoDialog Window

### DIFF
--- a/src/modinfodialog.cpp
+++ b/src/modinfodialog.cpp
@@ -857,6 +857,7 @@ void ModInfoDialog::activateNexusTab()
     QLabel *visitNexusLabel = findChild<QLabel*>("visitNexusLabel");
     visitNexusLabel->setText(tr("<a href=\"%1\">Visit on Nexus</a>").arg(nexusLink));
     visitNexusLabel->setToolTip(nexusLink);
+    m_ModInfo->setURL(nexusLink);
 
     if (m_ModInfo->getNexusDescription().isEmpty() || QDateTime::currentDateTimeUtc() >= m_ModInfo->getLastNexusQuery().addDays(1)) {
       refreshNexusData(modID);


### PR DESCRIPTION
This URL was previously missing on my build of MO2.  The QLineEdit widget gets the URL text by the getURL() function, but the URL variable was not being set before.

![modurl](https://user-images.githubusercontent.com/36657294/56089048-83a1d700-5e5a-11e9-9fae-261f575bfbc2.png)
