### PR TITLE
fix crash when changing file visibility from the filetree

### DIFF
--- a/src/modinfodialog.cpp
+++ b/src/modinfodialog.cpp
@@ -1396,7 +1396,9 @@ void ModInfoDialog::changeFiletreeVisibility(bool hide)
 
   if (changed) {
     qDebug().nospace() << "triggering refresh";
-    emit originModified(m_Origin->getID());
+    if (m_Origin) {
+      emit originModified(m_Origin->getID());
+    }
     refreshLists();
   }
 }
@@ -1677,7 +1679,9 @@ void ModInfoDialog::changeConflictFilesVisibility(bool hide)
 
   if (changed) {
     qDebug().nospace() << "triggering refresh";
-    emit originModified(m_Origin->getID());
+    if (m_Origin) {
+      emit originModified(m_Origin->getID());
+    }
     refreshLists();
   }
 }


### PR DESCRIPTION
I copied the code from conflict lists to the filetree so that lists will refresh correctly. Before that, changing files in the filetree would not update the conflict lists. I did not realize that m_Origin could be null in the filetree (when the mod has been installed, but not enabled, I think), which can crash. This didn't happen in the conflict tab, from which I copied this code, because that tab is disabled when m_Origin is null. I've added a test in both places, although the second one is redundant.