### PR TITLE
Add preview to filetree, some refactoring

### DIFF
--- a/src/downloadmanager.cpp
+++ b/src/downloadmanager.cpp
@@ -1030,10 +1030,10 @@ void DownloadManager::openFile(int index)
     reportError(tr("OpenFile: invalid download index %1").arg(index));
     return;
   }
+
   QDir path = QDir(m_OutputDirectory);
   if (path.exists(getFileName(index))) {
-
-    ::ShellExecuteW(nullptr, L"open", ToWString(QDir::toNativeSeparators(getFilePath(index))).c_str(), nullptr, nullptr, SW_SHOWNORMAL);
+    shell::OpenFile(getFilePath(index));
     return;
   }
 

--- a/src/downloadmanager.cpp
+++ b/src/downloadmanager.cpp
@@ -1037,7 +1037,7 @@ void DownloadManager::openFile(int index)
     return;
   }
 
-  ::ShellExecuteW(nullptr, L"explore", ToWString(QDir::toNativeSeparators(m_OutputDirectory)).c_str(), nullptr, nullptr, SW_SHOWNORMAL);
+  ExploreFile(m_OutputDirectory);
   return;
 }
 
@@ -1047,23 +1047,22 @@ void DownloadManager::openInDownloadsFolder(int index)
     reportError(tr("OpenFileInDownloadsFolder: invalid download index %1").arg(index));
     return;
   }
-  QString params = "/select,\"";
-  QDir path = QDir(m_OutputDirectory);
-  if (path.exists(getFileName(index))) {
-    params = params + QDir::toNativeSeparators(getFilePath(index)) + "\"";
 
-    ::ShellExecuteW(nullptr, nullptr, L"explorer", ToWString(params).c_str(), nullptr, SW_SHOWNORMAL);
+  const auto path = getFilePath(index);
+
+  if (QFile::exists(path)) {
+    ExploreFile(path);
     return;
   }
-  else if (path.exists(getFileName(index) + ".unfinished")) {
-    params = params + QDir::toNativeSeparators(getFilePath(index)+".unfinished") + "\"";
-
-    ::ShellExecuteW(nullptr, nullptr, L"explorer", ToWString(params).c_str(), nullptr, SW_SHOWNORMAL);
-    return;
+  else {
+    const auto unfinished = path + ".unfinished";
+    if (QFile::exists(unfinished)) {
+      ExploreFile(unfinished);
+      return;
+    }
   }
 
-  ::ShellExecuteW(nullptr, L"explore", ToWString(QDir::toNativeSeparators(m_OutputDirectory)).c_str(), nullptr, nullptr, SW_SHOWNORMAL);
-  return;
+  ExploreFile(m_OutputDirectory);
 }
 
 

--- a/src/downloadmanager.cpp
+++ b/src/downloadmanager.cpp
@@ -1037,7 +1037,7 @@ void DownloadManager::openFile(int index)
     return;
   }
 
-  ExploreFile(m_OutputDirectory);
+  shell::ExploreFile(m_OutputDirectory);
   return;
 }
 
@@ -1051,18 +1051,18 @@ void DownloadManager::openInDownloadsFolder(int index)
   const auto path = getFilePath(index);
 
   if (QFile::exists(path)) {
-    ExploreFile(path);
+    shell::ExploreFile(path);
     return;
   }
   else {
     const auto unfinished = path + ".unfinished";
     if (QFile::exists(unfinished)) {
-      ExploreFile(unfinished);
+      shell::ExploreFile(unfinished);
       return;
     }
   }
 
-  ExploreFile(m_OutputDirectory);
+  shell::ExploreFile(m_OutputDirectory);
 }
 
 

--- a/src/mainwindow.cpp
+++ b/src/mainwindow.cpp
@@ -3241,12 +3241,12 @@ void MainWindow::openExplorer_clicked()
   if (selection->hasSelection() && selection->selectedRows().count() > 1) {
     for (QModelIndex idx : selection->selectedRows()) {
       ModInfo::Ptr info = ModInfo::getByIndex(idx.data(Qt::UserRole + 1).toInt());
-      ::ShellExecuteW(nullptr, L"explore", ToWString(info->absolutePath()).c_str(), nullptr, nullptr, SW_SHOWNORMAL);
+      ExploreFile(info->absolutePath());
     }
   }
   else {
     ModInfo::Ptr modInfo = ModInfo::getByIndex(m_ContextRow);
-    ::ShellExecuteW(nullptr, L"explore", ToWString(modInfo->absolutePath()).c_str(), nullptr, nullptr, SW_SHOWNORMAL);
+    ExploreFile(modInfo->absolutePath());
   }
 }
 
@@ -3261,18 +3261,14 @@ void MainWindow::openOriginExplorer_clicked()
         continue;
       }
       ModInfo::Ptr modInfo = ModInfo::getByIndex(modIndex);
-      std::vector<ModInfo::EFlag> flags = modInfo->getFlags();
-
-      ::ShellExecuteW(nullptr, L"explore", ToWString(modInfo->absolutePath()).c_str(), nullptr, nullptr, SW_SHOWNORMAL);
+      ExploreFile(modInfo->absolutePath());
     }
   }
   else {
     QModelIndex idx = selection->currentIndex();
     QString fileName = idx.data().toString();
     ModInfo::Ptr modInfo = ModInfo::getByIndex(ModInfo::getIndex(m_OrganizerCore.pluginList()->origin(fileName)));
-    std::vector<ModInfo::EFlag> flags = modInfo->getFlags();
-
-    ::ShellExecuteW(nullptr, L"explore", ToWString(modInfo->absolutePath()).c_str(), nullptr, nullptr, SW_SHOWNORMAL);
+    ExploreFile(modInfo->absolutePath());
   }
 }
 
@@ -3287,7 +3283,7 @@ void MainWindow::openExplorer_activated()
 			std::vector<ModInfo::EFlag> flags = modInfo->getFlags();
 
 			if (modInfo->isRegular() || (std::find(flags.begin(), flags.end(), ModInfo::FLAG_OVERWRITE) != flags.end())) {
-				::ShellExecuteW(nullptr, L"explore", ToWString(modInfo->absolutePath()).c_str(), nullptr, nullptr, SW_SHOWNORMAL);
+				ExploreFile(modInfo->absolutePath());
 			}
 
 		}
@@ -3308,7 +3304,7 @@ void MainWindow::openExplorer_activated()
         std::vector<ModInfo::EFlag> flags = modInfo->getFlags();
 
         if (modInfo->isRegular() || (std::find(flags.begin(), flags.end(), ModInfo::FLAG_OVERWRITE) != flags.end())) {
-          ::ShellExecuteW(nullptr, L"explore", ToWString(modInfo->absolutePath()).c_str(), nullptr, nullptr, SW_SHOWNORMAL);
+          ExploreFile(modInfo->absolutePath());
         }
       }
 		}
@@ -4275,64 +4271,61 @@ void MainWindow::disableVisibleMods()
 void MainWindow::openInstanceFolder()
 {
   QString dataPath = qApp->property("dataPath").toString();
-  ::ShellExecuteW(nullptr, L"explore", ToWString(dataPath).c_str(), nullptr, nullptr, SW_SHOWNORMAL);
-
-  //opens BaseDirectory instead
-	//::ShellExecuteW(nullptr, L"explore", ToWString(m_OrganizerCore.settings().getBaseDirectory()).c_str(), nullptr, nullptr, SW_SHOWNORMAL);
+  ExploreFile(dataPath);
 }
 
 void MainWindow::openLogsFolder()
 {
 	QString logsPath = qApp->property("dataPath").toString() + "/" + QString::fromStdWString(AppConfig::logPath());
-	::ShellExecuteW(nullptr, L"explore", ToWString(logsPath).c_str(), nullptr, nullptr, SW_SHOWNORMAL);
+  ExploreFile(logsPath);
 }
 
 void MainWindow::openInstallFolder()
 {
-	::ShellExecuteW(nullptr, L"explore", ToWString(qApp->applicationDirPath()).c_str(), nullptr, nullptr, SW_SHOWNORMAL);
+  ExploreFile(qApp->applicationDirPath());
 }
 
 void MainWindow::openPluginsFolder()
 {
 	QString pluginsPath = QCoreApplication::applicationDirPath() + "/" + ToQString(AppConfig::pluginPath());
-	::ShellExecuteW(nullptr, L"explore", ToWString(pluginsPath).c_str(), nullptr, nullptr, SW_SHOWNORMAL);
+  ExploreFile(pluginsPath);
 }
 
 
 void MainWindow::openProfileFolder()
 {
-	::ShellExecuteW(nullptr, L"explore", ToWString(m_OrganizerCore.currentProfile()->absolutePath()).c_str(), nullptr, nullptr, SW_SHOWNORMAL);
+  ExploreFile(m_OrganizerCore.currentProfile()->absolutePath());
 }
 
 void MainWindow::openIniFolder()
 {
   if (m_OrganizerCore.currentProfile()->localSettingsEnabled())
   {
-    ::ShellExecuteW(nullptr, L"explore", ToWString(m_OrganizerCore.currentProfile()->absolutePath()).c_str(), nullptr, nullptr, SW_SHOWNORMAL);
+    ExploreFile(m_OrganizerCore.currentProfile()->absolutePath());
   }
   else {
-    ::ShellExecuteW(nullptr, L"explore", ToWString(m_OrganizerCore.managedGame()->documentsDirectory().absolutePath()).c_str(), nullptr, nullptr, SW_SHOWNORMAL);
+    ExploreFile(m_OrganizerCore.managedGame()->documentsDirectory());
   }
 }
 
 void MainWindow::openDownloadsFolder()
 {
-	::ShellExecuteW(nullptr, L"explore", ToWString(m_OrganizerCore.settings().getDownloadDirectory()).c_str(), nullptr, nullptr, SW_SHOWNORMAL);
+  ExploreFile(m_OrganizerCore.settings().getDownloadDirectory());
 }
 
 void MainWindow::openModsFolder()
 {
-  ::ShellExecuteW(nullptr, L"explore", ToWString(m_OrganizerCore.settings().getModDirectory()).c_str(), nullptr, nullptr, SW_SHOWNORMAL);
+  ExploreFile(m_OrganizerCore.settings().getModDirectory());
 }
 
 void MainWindow::openGameFolder()
 {
-	::ShellExecuteW(nullptr, L"explore", ToWString(m_OrganizerCore.managedGame()->gameDirectory().absolutePath()).c_str(), nullptr, nullptr, SW_SHOWNORMAL);
+  ExploreFile(m_OrganizerCore.managedGame()->gameDirectory());
 }
 
 void MainWindow::openMyGamesFolder()
 {
-	::ShellExecuteW(nullptr, L"explore", ToWString(m_OrganizerCore.managedGame()->documentsDirectory().absolutePath()).c_str(), nullptr, nullptr, SW_SHOWNORMAL);
+  ExploreFile(m_OrganizerCore.managedGame()->documentsDirectory());
 }
 
 
@@ -5164,7 +5157,7 @@ void MainWindow::addAsExecutable()
   QString arguments;
   FileExecutionTypes type;
 
-  if (!m_OrganizerCore.getFileExecutionContext(this, targetInfo, binaryInfo, arguments, type)) {
+  if (!GetFileExecutionContext(this, targetInfo, binaryInfo, arguments, type)) {
     return;
   }
 

--- a/src/mainwindow.cpp
+++ b/src/mainwindow.cpp
@@ -5163,7 +5163,7 @@ void MainWindow::addAsExecutable()
 
   switch (type)
   {
-    case FileExecutionTypes::executable: {
+    case FileExecutionTypes::Executable: {
         QString name = QInputDialog::getText(this, tr("Enter Name"),
               tr("Please enter a name for the executable"), QLineEdit::Normal,
               targetInfo.baseName());
@@ -5182,7 +5182,7 @@ void MainWindow::addAsExecutable()
         break;
       }
 
-    case FileExecutionTypes::other:  // fall-through
+    case FileExecutionTypes::Other:  // fall-through
     default: {
         QMessageBox::information(this, tr("Not an executable"), tr("This is not a recognized executable."));
         break;

--- a/src/mainwindow.cpp
+++ b/src/mainwindow.cpp
@@ -5152,12 +5152,14 @@ void MainWindow::addAsExecutable()
     return;
   }
 
+  using FileExecutionTypes = OrganizerCore::FileExecutionTypes;
+
   QFileInfo targetInfo(m_ContextItem->data(0, Qt::UserRole).toString());
   QFileInfo binaryInfo;
   QString arguments;
   FileExecutionTypes type;
 
-  if (!GetFileExecutionContext(this, targetInfo, binaryInfo, arguments, type)) {
+  if (!OrganizerCore::getFileExecutionContext(this, targetInfo, binaryInfo, arguments, type)) {
     return;
   }
 

--- a/src/mainwindow.h
+++ b/src/mainwindow.h
@@ -260,7 +260,6 @@ private:
 
   size_t checkForProblems();
 
-  int getBinaryExecuteInfo(const QFileInfo &targetInfo, QFileInfo &binaryInfo, QString &arguments);
   QTreeWidgetItem *addFilterItem(QTreeWidgetItem *root, const QString &name, int categoryID, ModListSortProxy::FilterType type);
   void addContentFilters();
   void addCategoryFilters(QTreeWidgetItem *root, const std::set<int> &categoriesUsed, int targetID);

--- a/src/modinfodialog.cpp
+++ b/src/modinfodialog.cpp
@@ -1075,10 +1075,9 @@ void ModInfoDialog::linkClicked(const QUrl &url)
   //Ideally we'd ask the mod for the game and the web service then pass the game
   //and URL to the web service
   if (NexusInterface::instance(m_PluginContainer)->isURLGameRelated(url)) {
-
     emit linkActivated(url.toString());
   } else {
-    ::ShellExecuteW(nullptr, L"open", ToWString(url.toString()).c_str(), nullptr, nullptr, SW_SHOWNORMAL);
+    shell::OpenLink(url);
   }
 }
 

--- a/src/modinfodialog.cpp
+++ b/src/modinfodialog.cpp
@@ -322,7 +322,8 @@ bool ExpanderWidget::opened() const
 ModInfoDialog::ModInfoDialog(ModInfo::Ptr modInfo, const DirectoryEntry *directory, bool unmanaged, OrganizerCore *organizerCore, PluginContainer *pluginContainer, QWidget *parent)
   : TutorableDialog("ModInfoDialog", parent), ui(new Ui::ModInfoDialog), m_ModInfo(modInfo),
   m_ThumbnailMapper(this), m_RequestStarted(false),
-  m_DeleteAction(nullptr), m_RenameAction(nullptr), m_OpenAction(nullptr),
+  m_NewFolderAction(nullptr), m_OpenAction(nullptr), m_RenameAction(nullptr),
+  m_DeleteAction(nullptr), m_HideAction(nullptr), m_UnhideAction(nullptr),
   m_Directory(directory), m_Origin(nullptr),
   m_OrganizerCore(organizerCore), m_PluginContainer(pluginContainer)
 {
@@ -480,16 +481,17 @@ void ModInfoDialog::initFiletree(ModInfo::Ptr modInfo)
   ui->fileTree->setRootIndex(m_FileSystemModel->index(m_RootPath));
   ui->fileTree->setColumnWidth(0, 300);
 
-  m_DeleteAction = new QAction(tr("&Delete"), ui->fileTree);
+  m_NewFolderAction = new QAction(tr("&New Folder"), ui->fileTree);
+  m_OpenAction = new QAction(tr("&Open"), ui->fileTree);
   m_RenameAction = new QAction(tr("&Rename"), ui->fileTree);
+  m_DeleteAction = new QAction(tr("&Delete"), ui->fileTree);
   m_HideAction = new QAction(tr("&Hide"), ui->fileTree);
   m_UnhideAction = new QAction(tr("&Unhide"), ui->fileTree);
-  m_OpenAction = new QAction(tr("&Open"), ui->fileTree);
-  m_NewFolderAction = new QAction(tr("&New Folder"), ui->fileTree);
-  QObject::connect(m_DeleteAction, SIGNAL(triggered()), this, SLOT(deleteTriggered()));
-  QObject::connect(m_RenameAction, SIGNAL(triggered()), this, SLOT(renameTriggered()));
-  QObject::connect(m_OpenAction, SIGNAL(triggered()), this, SLOT(openTriggered()));
+
   QObject::connect(m_NewFolderAction, SIGNAL(triggered()), this, SLOT(createDirectoryTriggered()));
+  QObject::connect(m_OpenAction, SIGNAL(triggered()), this, SLOT(openTriggered()));
+  QObject::connect(m_RenameAction, SIGNAL(triggered()), this, SLOT(renameTriggered()));
+  QObject::connect(m_DeleteAction, SIGNAL(triggered()), this, SLOT(deleteTriggered()));
   QObject::connect(m_HideAction, SIGNAL(triggered()), this, SLOT(hideTriggered()));
   connect(m_UnhideAction, SIGNAL(triggered()), this, SLOT(unhideTriggered()));
 }

--- a/src/modinfodialog.cpp
+++ b/src/modinfodialog.cpp
@@ -1242,7 +1242,7 @@ bool ModInfoDialog::recursiveDelete(const QModelIndex &index)
 
 void ModInfoDialog::on_openInExplorerButton_clicked()
 {
-	::ShellExecuteW(nullptr, L"explore", ToWString(m_ModInfo->absolutePath()).c_str(), nullptr, nullptr, SW_SHOWNORMAL);
+  ExploreFile(m_ModInfo->absolutePath());
 }
 
 void ModInfoDialog::deleteFile(const QModelIndex &index)

--- a/src/modinfodialog.h
+++ b/src/modinfodialog.h
@@ -313,7 +313,6 @@ private:
   QString getFileCategory(int categoryID);
   bool recursiveDelete(const QModelIndex &index);
   void deleteFile(const QModelIndex &index);
-  void openFile(const QModelIndex &index);
   void saveIniTweaks();
   void saveCategories(QTreeWidgetItem *currentNode);
   void saveCurrentTextFile();
@@ -348,10 +347,11 @@ private slots:
 
   void delete_activated();
 
-  void deleteTriggered();
-  void renameTriggered();
-  void openTriggered();
   void createDirectoryTriggered();
+  void openTriggered();
+  void previewTriggered();
+  void renameTriggered();
+  void deleteTriggered();
   void hideTriggered();
   void unhideTriggered();
 
@@ -416,6 +416,7 @@ private:
 
   QAction *m_NewFolderAction;
   QAction *m_OpenAction;
+  QAction *m_PreviewAction;
   QAction *m_RenameAction;
   QAction *m_DeleteAction;
   QAction *m_HideAction;
@@ -439,11 +440,12 @@ private:
   bool canUnhideConflictItem(const QTreeWidgetItem* item) const;
   bool canPreviewConflictItem(const QTreeWidgetItem* item) const;
 
-  void previewDataFile(const QTreeWidgetItem* item);
   void openDataFile(const QTreeWidgetItem* item);
+  void previewDataFile(const QTreeWidgetItem* item);
   void changeConflictFilesVisibility(bool hide);
   void changeFiletreeVisibility(bool hide);
 
+  bool canPreviewFile(bool isArchive, const QString& filename) const;
   bool canHideFile(bool isArchive, const QString& filename) const;
   bool canUnhideFile(bool isArchive, const QString& filename) const;
 };

--- a/src/modinfodialog.h
+++ b/src/modinfodialog.h
@@ -414,10 +414,10 @@ private:
   std::set<int> m_RequestIDs;
   bool m_RequestStarted;
 
-  QAction *m_DeleteAction;
-  QAction *m_RenameAction;
-  QAction *m_OpenAction;
   QAction *m_NewFolderAction;
+  QAction *m_OpenAction;
+  QAction *m_RenameAction;
+  QAction *m_DeleteAction;
   QAction *m_HideAction;
   QAction *m_UnhideAction;
 

--- a/src/modinfodialog.h
+++ b/src/modinfodialog.h
@@ -335,7 +335,6 @@ private slots:
   void unhideConflictFiles();
   void previewOverwriteDataFile();
   void openOverwriteDataFile();
-  int getBinaryExecuteInfo(const QFileInfo &targetInfo, QFileInfo &binaryInfo, QString &arguments);
 
   void previewOverwrittenDataFile();
   void openOverwrittenDataFile();

--- a/src/motddialog.cpp
+++ b/src/motddialog.cpp
@@ -21,6 +21,7 @@ along with Mod Organizer.  If not, see <http://www.gnu.org/licenses/>.
 #include "bbcode.h"
 #include "utility.h"
 #include "ui_motddialog.h"
+#include "organizercore.h"
 #include <Shlwapi.h>
 
 MotDDialog::MotDDialog(const QString &message, QWidget *parent)
@@ -43,5 +44,5 @@ void MotDDialog::on_okButton_clicked()
 
 void MotDDialog::linkClicked(const QUrl &url)
 {
-  ::ShellExecuteW(nullptr, L"open", MOBase::ToWString(url.toString()).c_str(), nullptr, nullptr, SW_SHOWNORMAL);
+  shell::OpenLink(url);
 }

--- a/src/organizercore.cpp
+++ b/src/organizercore.cpp
@@ -1220,6 +1220,102 @@ QStringList OrganizerCore::modsSortedByProfilePriority() const
   return res;
 }
 
+
+bool OrganizerCore::getFileExecutionContext(
+  QWidget* parent, const QFileInfo &targetInfo,
+  QFileInfo &binaryInfo, QString &arguments, FileExecutionTypes& type)
+{
+  QString extension = targetInfo.suffix();
+  if ((extension.compare("cmd", Qt::CaseInsensitive) == 0) ||
+    (extension.compare("com", Qt::CaseInsensitive) == 0) ||
+    (extension.compare("bat", Qt::CaseInsensitive) == 0)) {
+    binaryInfo = QFileInfo("C:\\Windows\\System32\\cmd.exe");
+    arguments = QString("/C \"%1\"").arg(QDir::toNativeSeparators(targetInfo.absoluteFilePath()));
+    type = FileExecutionTypes::executable;
+    return true;
+  } else if (extension.compare("exe", Qt::CaseInsensitive) == 0) {
+    binaryInfo = targetInfo;
+    type = FileExecutionTypes::executable;
+    return true;
+  } else if (extension.compare("jar", Qt::CaseInsensitive) == 0) {
+    // types that need to be injected into
+    std::wstring targetPathW = ToWString(targetInfo.absoluteFilePath());
+    QString binaryPath;
+
+    { // try to find java automatically
+      WCHAR buffer[MAX_PATH];
+      if (::FindExecutableW(targetPathW.c_str(), nullptr, buffer) > (HINSTANCE)32) {
+        DWORD binaryType = 0UL;
+        if (!::GetBinaryTypeW(buffer, &binaryType)) {
+          qDebug("failed to determine binary type of \"%ls\": %lu", buffer, ::GetLastError());
+        } else if (binaryType == SCS_32BIT_BINARY) {
+          binaryPath = ToQString(buffer);
+        }
+      }
+    }
+    if (binaryPath.isEmpty() && (extension == "jar")) {
+      // second attempt: look to the registry
+      QSettings javaReg("HKEY_LOCAL_MACHINE\\Software\\JavaSoft\\Java Runtime Environment", QSettings::NativeFormat);
+      if (javaReg.contains("CurrentVersion")) {
+        QString currentVersion = javaReg.value("CurrentVersion").toString();
+        binaryPath = javaReg.value(QString("%1/JavaHome").arg(currentVersion)).toString().append("\\bin\\javaw.exe");
+      }
+    }
+    if (binaryPath.isEmpty()) {
+      binaryPath = QFileDialog::getOpenFileName(
+        parent, QObject::tr("Select binary"), QString(), QObject::tr("Binary") + " (*.exe)");
+    }
+    if (binaryPath.isEmpty()) {
+      return false;
+    }
+    binaryInfo = QFileInfo(binaryPath);
+    if (extension == "jar") {
+      arguments = QString("-jar \"%1\"").arg(QDir::toNativeSeparators(targetInfo.absoluteFilePath()));
+    } else {
+      arguments = QString("\"%1\"").arg(QDir::toNativeSeparators(targetInfo.absoluteFilePath()));
+    }
+
+    type = FileExecutionTypes::executable;
+    return true;
+  } else {
+    type = FileExecutionTypes::other;
+    return true;
+  }
+}
+
+bool OrganizerCore::executeFile(QWidget* parent, const QFileInfo& targetInfo)
+{
+  QFileInfo binaryInfo;
+  QString arguments;
+  FileExecutionTypes type;
+
+  if (!getFileExecutionContext(parent, targetInfo, binaryInfo, arguments, type)) {
+    return false;
+  }
+
+  switch (type)
+  {
+    case FileExecutionTypes::executable: {
+      spawnBinaryDirect(
+        binaryInfo, arguments, currentProfile()->name(),
+        targetInfo.absolutePath(), "", "");
+
+      return true;
+    }
+
+    case FileExecutionTypes::other: {
+      ::ShellExecuteW(nullptr, L"open",
+        ToWString(targetInfo.absoluteFilePath()).c_str(),
+        nullptr, nullptr, SW_SHOWNORMAL);
+
+      return true;
+    }
+  }
+
+  // nop
+  return false;
+}
+
 void OrganizerCore::spawnBinary(const QFileInfo &binary,
                                 const QString &arguments,
                                 const QDir &currentDirectory,

--- a/src/organizercore.cpp
+++ b/src/organizercore.cpp
@@ -267,6 +267,91 @@ bool checkService()
   return serviceRunning;
 }
 
+
+bool GetFileExecutionContext(
+  QWidget* parent, const QFileInfo &targetInfo,
+  QFileInfo &binaryInfo, QString &arguments, FileExecutionTypes& type)
+{
+  QString extension = targetInfo.suffix();
+  if ((extension.compare("cmd", Qt::CaseInsensitive) == 0) ||
+    (extension.compare("com", Qt::CaseInsensitive) == 0) ||
+    (extension.compare("bat", Qt::CaseInsensitive) == 0)) {
+    binaryInfo = QFileInfo("C:\\Windows\\System32\\cmd.exe");
+    arguments = QString("/C \"%1\"").arg(QDir::toNativeSeparators(targetInfo.absoluteFilePath()));
+    type = FileExecutionTypes::executable;
+    return true;
+  } else if (extension.compare("exe", Qt::CaseInsensitive) == 0) {
+    binaryInfo = targetInfo;
+    type = FileExecutionTypes::executable;
+    return true;
+  } else if (extension.compare("jar", Qt::CaseInsensitive) == 0) {
+    // types that need to be injected into
+    std::wstring targetPathW = targetInfo.absoluteFilePath().toStdWString();
+    QString binaryPath;
+
+    { // try to find java automatically
+      WCHAR buffer[MAX_PATH];
+      if (::FindExecutableW(targetPathW.c_str(), nullptr, buffer) > (HINSTANCE)32) {
+        DWORD binaryType = 0UL;
+        if (!::GetBinaryTypeW(buffer, &binaryType)) {
+          qDebug("failed to determine binary type of \"%ls\": %lu", buffer, ::GetLastError());
+        } else if (binaryType == SCS_32BIT_BINARY) {
+          binaryPath = QString::fromWCharArray(buffer);
+        }
+      }
+    }
+    if (binaryPath.isEmpty() && (extension == "jar")) {
+      // second attempt: look to the registry
+      QSettings javaReg("HKEY_LOCAL_MACHINE\\Software\\JavaSoft\\Java Runtime Environment", QSettings::NativeFormat);
+      if (javaReg.contains("CurrentVersion")) {
+        QString currentVersion = javaReg.value("CurrentVersion").toString();
+        binaryPath = javaReg.value(QString("%1/JavaHome").arg(currentVersion)).toString().append("\\bin\\javaw.exe");
+      }
+    }
+    if (binaryPath.isEmpty()) {
+      binaryPath = QFileDialog::getOpenFileName(
+        parent, QObject::tr("Select binary"), QString(), QObject::tr("Binary") + " (*.exe)");
+    }
+    if (binaryPath.isEmpty()) {
+      return false;
+    }
+    binaryInfo = QFileInfo(binaryPath);
+    if (extension == "jar") {
+      arguments = QString("-jar \"%1\"").arg(QDir::toNativeSeparators(targetInfo.absoluteFilePath()));
+    } else {
+      arguments = QString("\"%1\"").arg(QDir::toNativeSeparators(targetInfo.absoluteFilePath()));
+    }
+
+    type = FileExecutionTypes::executable;
+    return true;
+  } else {
+    type = FileExecutionTypes::other;
+    return true;
+  }
+}
+
+bool ExploreFile(const QString& path)
+{
+  const auto ws = path.toStdWString();
+
+  const auto h = ::ShellExecuteW(
+    nullptr, L"explore", ws.c_str(), nullptr, nullptr, SW_SHOWNORMAL);
+
+  // anything <= 32 is not an actual HINSTANCE and signals failure
+  return (h > reinterpret_cast<HINSTANCE>(32));
+}
+
+bool ExploreFile(const QFileInfo& info)
+{
+  return ExploreFile(info.absolutePath());
+}
+
+bool ExploreFile(const QDir& dir)
+{
+  return ExploreFile(dir.absolutePath());
+}
+
+
 OrganizerCore::OrganizerCore(const QSettings &initSettings)
   : m_UserInterface(nullptr)
   , m_PluginContainer(nullptr)
@@ -1220,76 +1305,13 @@ QStringList OrganizerCore::modsSortedByProfilePriority() const
   return res;
 }
 
-
-bool OrganizerCore::getFileExecutionContext(
-  QWidget* parent, const QFileInfo &targetInfo,
-  QFileInfo &binaryInfo, QString &arguments, FileExecutionTypes& type)
-{
-  QString extension = targetInfo.suffix();
-  if ((extension.compare("cmd", Qt::CaseInsensitive) == 0) ||
-    (extension.compare("com", Qt::CaseInsensitive) == 0) ||
-    (extension.compare("bat", Qt::CaseInsensitive) == 0)) {
-    binaryInfo = QFileInfo("C:\\Windows\\System32\\cmd.exe");
-    arguments = QString("/C \"%1\"").arg(QDir::toNativeSeparators(targetInfo.absoluteFilePath()));
-    type = FileExecutionTypes::executable;
-    return true;
-  } else if (extension.compare("exe", Qt::CaseInsensitive) == 0) {
-    binaryInfo = targetInfo;
-    type = FileExecutionTypes::executable;
-    return true;
-  } else if (extension.compare("jar", Qt::CaseInsensitive) == 0) {
-    // types that need to be injected into
-    std::wstring targetPathW = ToWString(targetInfo.absoluteFilePath());
-    QString binaryPath;
-
-    { // try to find java automatically
-      WCHAR buffer[MAX_PATH];
-      if (::FindExecutableW(targetPathW.c_str(), nullptr, buffer) > (HINSTANCE)32) {
-        DWORD binaryType = 0UL;
-        if (!::GetBinaryTypeW(buffer, &binaryType)) {
-          qDebug("failed to determine binary type of \"%ls\": %lu", buffer, ::GetLastError());
-        } else if (binaryType == SCS_32BIT_BINARY) {
-          binaryPath = ToQString(buffer);
-        }
-      }
-    }
-    if (binaryPath.isEmpty() && (extension == "jar")) {
-      // second attempt: look to the registry
-      QSettings javaReg("HKEY_LOCAL_MACHINE\\Software\\JavaSoft\\Java Runtime Environment", QSettings::NativeFormat);
-      if (javaReg.contains("CurrentVersion")) {
-        QString currentVersion = javaReg.value("CurrentVersion").toString();
-        binaryPath = javaReg.value(QString("%1/JavaHome").arg(currentVersion)).toString().append("\\bin\\javaw.exe");
-      }
-    }
-    if (binaryPath.isEmpty()) {
-      binaryPath = QFileDialog::getOpenFileName(
-        parent, QObject::tr("Select binary"), QString(), QObject::tr("Binary") + " (*.exe)");
-    }
-    if (binaryPath.isEmpty()) {
-      return false;
-    }
-    binaryInfo = QFileInfo(binaryPath);
-    if (extension == "jar") {
-      arguments = QString("-jar \"%1\"").arg(QDir::toNativeSeparators(targetInfo.absoluteFilePath()));
-    } else {
-      arguments = QString("\"%1\"").arg(QDir::toNativeSeparators(targetInfo.absoluteFilePath()));
-    }
-
-    type = FileExecutionTypes::executable;
-    return true;
-  } else {
-    type = FileExecutionTypes::other;
-    return true;
-  }
-}
-
 bool OrganizerCore::executeFile(QWidget* parent, const QFileInfo& targetInfo)
 {
   QFileInfo binaryInfo;
   QString arguments;
   FileExecutionTypes type;
 
-  if (!getFileExecutionContext(parent, targetInfo, binaryInfo, arguments, type)) {
+  if (!GetFileExecutionContext(parent, targetInfo, binaryInfo, arguments, type)) {
     return false;
   }
 

--- a/src/organizercore.cpp
+++ b/src/organizercore.cpp
@@ -478,6 +478,20 @@ bool OpenFile(const QString& path)
   return ShellExecuteWrapper(L"open", ws_path.c_str(), nullptr);
 }
 
+bool OpenLink(const QUrl& url)
+{
+  const auto ws_url = url.toString().toStdWString();
+  return ShellExecuteWrapper(L"open", ws_url.c_str(), nullptr);
+}
+
+bool Execute(const QString& program, const QString& params)
+{
+  const auto program_ws = program.toStdWString();
+  const auto params_ws = params.toStdWString();
+
+  return ShellExecuteWrapper(L"open", program_ws.c_str(), params_ws.c_str());
+}
+
 } // namespace shell
 
 

--- a/src/organizercore.cpp
+++ b/src/organizercore.cpp
@@ -279,11 +279,11 @@ bool GetFileExecutionContext(
     (extension.compare("bat", Qt::CaseInsensitive) == 0)) {
     binaryInfo = QFileInfo("C:\\Windows\\System32\\cmd.exe");
     arguments = QString("/C \"%1\"").arg(QDir::toNativeSeparators(targetInfo.absoluteFilePath()));
-    type = FileExecutionTypes::executable;
+    type = FileExecutionTypes::Executable;
     return true;
   } else if (extension.compare("exe", Qt::CaseInsensitive) == 0) {
     binaryInfo = targetInfo;
-    type = FileExecutionTypes::executable;
+    type = FileExecutionTypes::Executable;
     return true;
   } else if (extension.compare("jar", Qt::CaseInsensitive) == 0) {
     // types that need to be injected into
@@ -323,10 +323,10 @@ bool GetFileExecutionContext(
       arguments = QString("\"%1\"").arg(QDir::toNativeSeparators(targetInfo.absoluteFilePath()));
     }
 
-    type = FileExecutionTypes::executable;
+    type = FileExecutionTypes::Executable;
     return true;
   } else {
-    type = FileExecutionTypes::other;
+    type = FileExecutionTypes::Other;
     return true;
   }
 }
@@ -1461,7 +1461,7 @@ bool OrganizerCore::executeFileVirtualized(
 
   switch (type)
   {
-    case FileExecutionTypes::executable: {
+    case FileExecutionTypes::Executable: {
       spawnBinaryDirect(
         binaryInfo, arguments, currentProfile()->name(),
         targetInfo.absolutePath(), "", "");
@@ -1469,7 +1469,7 @@ bool OrganizerCore::executeFileVirtualized(
       return true;
     }
 
-    case FileExecutionTypes::other: {
+    case FileExecutionTypes::Other: {
       ::ShellExecuteW(nullptr, L"open",
         ToWString(targetInfo.absoluteFilePath()).c_str(),
         nullptr, nullptr, SW_SHOWNORMAL);

--- a/src/organizercore.h
+++ b/src/organizercore.h
@@ -56,6 +56,13 @@ namespace MOBase {
   class IPluginGame;
 }
 
+enum class FileExecutionTypes
+{
+  executable = 1,
+  other = 2
+};
+
+
 class OrganizerCore : public QObject, public MOBase::IPluginDiagnose
 {
 
@@ -139,6 +146,12 @@ public:
   void updateModsInDirectoryStructure(QMap<unsigned int, ModInfo::Ptr> modInfos);
 
   void doAfterLogin(const std::function<void()> &function) { m_PostLoginTasks.append(function); }
+
+  static bool getFileExecutionContext(
+    QWidget* parent,  const QFileInfo &targetInfo,
+    QFileInfo &binaryInfo, QString &arguments, FileExecutionTypes& type);
+
+  bool executeFile(QWidget* parent, const QFileInfo& targetInfo);
 
   void spawnBinary(const QFileInfo &binary, const QString &arguments = "",
                    const QDir &currentDirectory = QDir(),

--- a/src/organizercore.h
+++ b/src/organizercore.h
@@ -74,6 +74,9 @@ namespace shell
   bool ExploreFile(const QDir& dir);
 
   bool OpenFile(const QString& path);
+  bool OpenLink(const QUrl& url);
+
+  bool Execute(const QString& program, const QString& params);
 }
 
 

--- a/src/organizercore.h
+++ b/src/organizercore.h
@@ -56,11 +56,20 @@ namespace MOBase {
   class IPluginGame;
 }
 
+
 enum class FileExecutionTypes
 {
   executable = 1,
   other = 2
 };
+
+bool GetFileExecutionContext(
+  QWidget* parent,  const QFileInfo &targetInfo,
+  QFileInfo &binaryInfo, QString &arguments, FileExecutionTypes& type);
+
+bool ExploreFile(const QString& path);
+bool ExploreFile(const QFileInfo& info);
+bool ExploreFile(const QDir& dir);
 
 
 class OrganizerCore : public QObject, public MOBase::IPluginDiagnose
@@ -146,10 +155,6 @@ public:
   void updateModsInDirectoryStructure(QMap<unsigned int, ModInfo::Ptr> modInfos);
 
   void doAfterLogin(const std::function<void()> &function) { m_PostLoginTasks.append(function); }
-
-  static bool getFileExecutionContext(
-    QWidget* parent,  const QFileInfo &targetInfo,
-    QFileInfo &binaryInfo, QString &arguments, FileExecutionTypes& type);
 
   bool executeFile(QWidget* parent, const QFileInfo& targetInfo);
 

--- a/src/organizercore.h
+++ b/src/organizercore.h
@@ -67,9 +67,14 @@ bool GetFileExecutionContext(
   QWidget* parent,  const QFileInfo &targetInfo,
   QFileInfo &binaryInfo, QString &arguments, FileExecutionTypes& type);
 
-bool ExploreFile(const QFileInfo& info);
-bool ExploreFile(const QString& path);
-bool ExploreFile(const QDir& dir);
+namespace shell
+{
+  bool ExploreFile(const QFileInfo& info);
+  bool ExploreFile(const QString& path);
+  bool ExploreFile(const QDir& dir);
+
+  bool OpenFile(const QString& path);
+}
 
 
 class OrganizerCore : public QObject, public MOBase::IPluginDiagnose
@@ -156,7 +161,9 @@ public:
 
   void doAfterLogin(const std::function<void()> &function) { m_PostLoginTasks.append(function); }
 
-  bool executeFile(QWidget* parent, const QFileInfo& targetInfo);
+  bool executeFileVirtualized(QWidget* parent, const QFileInfo& targetInfo);
+  bool previewFileWithAlternatives(QWidget* parent, QString filename);
+  bool previewFile(QWidget* parent, const QString& originName, const QString& path);
 
   void spawnBinary(const QFileInfo &binary, const QString &arguments = "",
                    const QDir &currentDirectory = QDir(),

--- a/src/organizercore.h
+++ b/src/organizercore.h
@@ -67,8 +67,8 @@ bool GetFileExecutionContext(
   QWidget* parent,  const QFileInfo &targetInfo,
   QFileInfo &binaryInfo, QString &arguments, FileExecutionTypes& type);
 
-bool ExploreFile(const QString& path);
 bool ExploreFile(const QFileInfo& info);
+bool ExploreFile(const QString& path);
 bool ExploreFile(const QDir& dir);
 
 

--- a/src/organizercore.h
+++ b/src/organizercore.h
@@ -57,16 +57,6 @@ namespace MOBase {
 }
 
 
-enum class FileExecutionTypes
-{
-  Executable = 1,
-  Other = 2
-};
-
-bool GetFileExecutionContext(
-  QWidget* parent,  const QFileInfo &targetInfo,
-  QFileInfo &binaryInfo, QString &arguments, FileExecutionTypes& type);
-
 namespace shell
 {
   bool ExploreFile(const QFileInfo& info);
@@ -111,6 +101,12 @@ private:
   typedef boost::signals2::signal<void (const QString&)> SignalModInstalled;
 
 public:
+  enum class FileExecutionTypes
+  {
+    Executable = 1,
+    Other = 2
+  };
+
   static bool isNxmLink(const QString &link) { return link.startsWith("nxm://", Qt::CaseInsensitive); }
 
   OrganizerCore(const QSettings &initSettings);
@@ -163,6 +159,10 @@ public:
   void updateModsInDirectoryStructure(QMap<unsigned int, ModInfo::Ptr> modInfos);
 
   void doAfterLogin(const std::function<void()> &function) { m_PostLoginTasks.append(function); }
+
+  static bool getFileExecutionContext(
+    QWidget* parent,  const QFileInfo &targetInfo,
+    QFileInfo &binaryInfo, QString &arguments, FileExecutionTypes& type);
 
   bool executeFileVirtualized(QWidget* parent, const QFileInfo& targetInfo);
   bool previewFileWithAlternatives(QWidget* parent, QString filename);

--- a/src/organizercore.h
+++ b/src/organizercore.h
@@ -59,8 +59,8 @@ namespace MOBase {
 
 enum class FileExecutionTypes
 {
-  executable = 1,
-  other = 2
+  Executable = 1,
+  Other = 2
 };
 
 bool GetFileExecutionContext(

--- a/src/overwriteinfodialog.cpp
+++ b/src/overwriteinfodialog.cpp
@@ -218,12 +218,7 @@ void OverwriteInfoDialog::renameTriggered()
 
 void OverwriteInfoDialog::openFile(const QModelIndex &index)
 {
-  QString fileName = m_FileSystemModel->filePath(index);
-
-  HINSTANCE res = ::ShellExecuteW(nullptr, L"open", ToWString(fileName).c_str(), nullptr, nullptr, SW_SHOW);
-  if ((INT_PTR)res <= 32) {
-    qCritical("failed to invoke %s: %d", qUtf8Printable(fileName), res);
-  }
+  shell::OpenFile(m_FileSystemModel->filePath(index));
 }
 
 

--- a/src/overwriteinfodialog.cpp
+++ b/src/overwriteinfodialog.cpp
@@ -264,7 +264,7 @@ void OverwriteInfoDialog::createDirectoryTriggered()
 
 void OverwriteInfoDialog::on_explorerButton_clicked()
 {
-  ExploreFile(m_ModInfo->absolutePath());
+  shell::ExploreFile(m_ModInfo->absolutePath());
 }
 
 void OverwriteInfoDialog::on_filesView_customContextMenuRequested(const QPoint &pos)

--- a/src/overwriteinfodialog.cpp
+++ b/src/overwriteinfodialog.cpp
@@ -21,6 +21,7 @@ along with Mod Organizer.  If not, see <http://www.gnu.org/licenses/>.
 #include "ui_overwriteinfodialog.h"
 #include "report.h"
 #include "utility.h"
+#include "organizercore.h"
 #include <QMessageBox>
 #include <QMenu>
 #include <QShortcut>
@@ -263,7 +264,7 @@ void OverwriteInfoDialog::createDirectoryTriggered()
 
 void OverwriteInfoDialog::on_explorerButton_clicked()
 {
-  ::ShellExecuteW(nullptr, L"explore", ToWString(m_ModInfo->absolutePath()).c_str(), nullptr, nullptr, SW_SHOWNORMAL);
+  ExploreFile(m_ModInfo->absolutePath());
 }
 
 void OverwriteInfoDialog::on_filesView_customContextMenuRequested(const QPoint &pos)

--- a/src/problemsdialog.cpp
+++ b/src/problemsdialog.cpp
@@ -1,5 +1,6 @@
 #include "problemsdialog.h"
 #include "ui_problemsdialog.h"
+#include "organizercore.h"
 #include <utility.h>
 #include <iplugin.h>
 #include <iplugindiagnose.h>
@@ -87,5 +88,5 @@ void ProblemsDialog::startFix()
 
 void ProblemsDialog::urlClicked(const QUrl &url)
 {
-  ::ShellExecuteW(nullptr, L"open", ToWString(url.toString()).c_str(), nullptr, nullptr, SW_SHOWNORMAL);
+  shell::OpenLink(url);
 }

--- a/src/selfupdater.cpp
+++ b/src/selfupdater.cpp
@@ -31,6 +31,7 @@ along with Mod Organizer.  If not, see <http://www.gnu.org/licenses/>.
 #include "settings.h"
 #include "bbcode.h"
 #include "plugincontainer.h"
+#include "organizercore.h"
 #include <versioninfo.h>
 #include <report.h>
 #include <util.h>
@@ -178,7 +179,7 @@ void SelfUpdater::startUpdate()
                     tr("New update available (%1)")
                         .arg(m_UpdateCandidate["tag_name"].toString()), tr("Do you want to install update? All your mods and setup will be left untouched.\nSelect Show Details option to see the full change-log."),
                     QMessageBox::Yes | QMessageBox::Cancel, m_Parent);
-	
+
   query.setDetailedText(m_UpdateCandidate["body"].toString());
   query.button(QMessageBox::Yes)->setText(tr("Install"));
 
@@ -329,22 +330,14 @@ void SelfUpdater::downloadCancel()
 
 void SelfUpdater::installUpdate()
 {
-  const QString mopath
-      = QDir::fromNativeSeparators(qApp->property("dataPath").toString());
+  const QString parameters = "/DIR=\"" + qApp->applicationDirPath() + "\" ";
 
-  std::wstring parameters = ToWString("/DIR=\"" + qApp->applicationDirPath() + "\" ");
-
-  HINSTANCE res = ::ShellExecuteW(
-      nullptr, L"open", m_UpdateFile.fileName().toStdWString().c_str(), parameters.c_str(),
-      nullptr, SW_SHOW);
-
-  if (res > (HINSTANCE)32) {
+  if (shell::Execute(m_UpdateFile.fileName(), parameters)) {
     QCoreApplication::quit();
   } else {
-    reportError(tr("Failed to start %1: %2")
-                    .arg(m_UpdateFile.fileName())
-                    .arg((INT_PTR)res));
+    reportError(tr("Failed to start %1").arg(m_UpdateFile.fileName()));
   }
+
   m_UpdateFile.remove();
 }
 

--- a/src/settings.cpp
+++ b/src/settings.cpp
@@ -130,18 +130,19 @@ bool Settings::pluginBlacklisted(const QString &fileName) const
 
 void Settings::registerAsNXMHandler(bool force)
 {
-  std::wstring nxmPath = ToWString(QCoreApplication::applicationDirPath() + "/nxmhandler.exe");
-  std::wstring executable = ToWString(QCoreApplication::applicationFilePath());
-  std::wstring mode = force ? L"forcereg" : L"reg";
-  std::wstring parameters = mode + L" " + m_GamePlugin->gameShortName().toStdWString();
-  for (QString altGame : m_GamePlugin->validShortNames()) {
-    parameters += L"," + altGame.toStdWString();
+  const auto nxmPath = QCoreApplication::applicationDirPath() + "/nxmhandler.exe";
+  const auto executable = QCoreApplication::applicationFilePath();
+
+  QString mode = force ? "forcereg" : "reg";
+  QString parameters = mode + " " + m_GamePlugin->gameShortName();
+  for (const QString& altGame : m_GamePlugin->validShortNames()) {
+    parameters += "," + altGame;
   }
-  parameters += L" \"" + executable + L"\"";
-  HINSTANCE res = ::ShellExecuteW(nullptr, L"open", nxmPath.c_str(), parameters.c_str(), nullptr, SW_SHOWNORMAL);
-  if ((INT_PTR)res <= 32) {
-    QMessageBox::critical(nullptr, tr("Failed"),
-                          tr("Sorry, failed to start the helper application"));
+  parameters += " \"" + executable + "\"";
+
+  if (!shell::Execute(nxmPath, parameters)) {
+    QMessageBox::critical(
+      nullptr, tr("Failed"), tr("Failed to start the helper application"));
   }
 }
 


### PR DESCRIPTION
This started as a fix for #630 to add a "preview" context menu item to the mod filetree. It has become a largish PR that is mostly refactoring.

I found three large, copy/pasted functions in both `MainWindow` and `ModInfoDialog` that I moved to OrganizerCore: `getBinaryExecuteInfo()`, `openDataFile()` and `previewDataFile()`.

I then started refactoring a few calls to `ShellExecuteW()` into new functions again in OrganizerCore in a new namespace `shell`. It now has `ExploreFile()`, `OpenFile()`, `OpenLink()` and `Execute()`, which ended up replacing _all_ `ShellExecuteW()` calls, except for a few that were too custom.

I added better logging on failure for `ShellExecuteW()` and tested every single replacement I made.