### PR TITLE
Permissive flag

### DIFF
--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -333,7 +333,7 @@ TARGET_LINK_LIBRARIES(ModOrganizer
                       Dbghelp advapi32 Version Shlwapi liblz4 Crypt32)
 
 IF (MSVC)
-  SET_TARGET_PROPERTIES(ModOrganizer PROPERTIES COMPILE_FLAGS "/std:c++latest")
+  SET_TARGET_PROPERTIES(ModOrganizer PROPERTIES COMPILE_FLAGS "/std:c++latest /permissive-")
 ENDIF()
 IF (MSVC AND "${CMAKE_SIZEOF_VOID_P}" EQUAL 4)
   # 32 bits

--- a/src/forcedloaddialogwidget.cpp
+++ b/src/forcedloaddialogwidget.cpp
@@ -54,12 +54,12 @@ void ForcedLoadDialogWidget::setForced(bool forced)
   ui->processEdit->setEnabled(!forced);
 }
 
-void ForcedLoadDialogWidget::setLibraryPath(QString &path)
+void ForcedLoadDialogWidget::setLibraryPath(const QString &path)
 {
   ui->libraryPathEdit->setText(path);
 }
 
-void ForcedLoadDialogWidget::setProcess(QString &name)
+void ForcedLoadDialogWidget::setProcess(const QString &name)
 {
   ui->processEdit->setText(name);
 }
@@ -71,7 +71,7 @@ void ForcedLoadDialogWidget::on_enabledBox_toggled()
 
 void ForcedLoadDialogWidget::on_libraryPathBrowseButton_clicked()
 {
-  QDir gameDir(m_GamePlugin->gameDirectory()); 
+  QDir gameDir(m_GamePlugin->gameDirectory());
   QString startPath = gameDir.absolutePath();
   QString result = QFileDialog::getOpenFileName(nullptr, "Select a library...", startPath, "Dynamic link library (*.dll)", nullptr, QFileDialog::ReadOnly);
   if (!result.isEmpty()) {
@@ -100,7 +100,7 @@ void ForcedLoadDialogWidget::on_processBrowseButton_clicked()
     QString fileName = fileInfo.fileName();
 
     if (fileInfo.exists()) {
-      ui->processEdit->setText(fileName);  
+      ui->processEdit->setText(fileName);
     } else {
       qCritical("%ls does not exist", fileInfo.filePath().toStdWString().c_str());
     }

--- a/src/forcedloaddialogwidget.h
+++ b/src/forcedloaddialogwidget.h
@@ -23,8 +23,8 @@ public:
 
     void setEnabled(bool enabled);
     void setForced(bool forced);
-    void setLibraryPath(QString &path);
-    void setProcess(QString &name);
+    void setLibraryPath(const QString &path);
+    void setProcess(const QString &name);
 
 private slots:
     void on_enabledBox_toggled();

--- a/src/instancemanager.cpp
+++ b/src/instancemanager.cpp
@@ -227,7 +227,7 @@ QString InstanceManager::chooseInstance(const QStringList &instanceList) const
   if (choice.type() == QVariant::String) {
     return choice.toString();
   } else {
-    switch (choice.value<uint8_t>()) {
+    switch (static_cast<Special>(choice.value<uint8_t>())) {
       case Special::NewInstance: return queryInstanceName(instanceList);
       case Special::Portable: return QString();
       case Special::Manage: {

--- a/src/organizercore.cpp
+++ b/src/organizercore.cpp
@@ -111,7 +111,7 @@ static bool renameFile(const QString &oldName, const QString &newName,
 static std::wstring getProcessName(HANDLE process)
 {
   wchar_t buffer[MAX_PATH];
-  wchar_t *fileName = L"unknown";
+  const wchar_t *fileName = L"unknown";
 
   if (process == nullptr) return fileName;
 

--- a/src/settingsdialog.cpp
+++ b/src/settingsdialog.cpp
@@ -88,7 +88,7 @@ QString SettingsDialog::getColoredButtonStyleSheet() const
     "}");
 }
 
-void SettingsDialog::setButtonColor(QPushButton *button, QColor &color)
+void SettingsDialog::setButtonColor(QPushButton *button, const QColor &color)
 {
   button->setStyleSheet(
     QString("QPushButton {"

--- a/src/settingsdialog.h
+++ b/src/settingsdialog.h
@@ -53,7 +53,7 @@ public:
   */
   QString getColoredButtonStyleSheet() const;
 
-  void setButtonColor(QPushButton *button, QColor &color);
+  void setButtonColor(QPushButton *button, const QColor &color);
 
 public slots:
 

--- a/src/usvfsconnector.cpp
+++ b/src/usvfsconnector.cpp
@@ -92,7 +92,7 @@ void LogWorker::exit()
 
 LogLevel logLevel(int level)
 {
-  switch (level) {
+  switch (static_cast<LogLevel>(level)) {
     case LogLevel::Info:
       return LogLevel::Info;
     case LogLevel::Warning:
@@ -106,7 +106,7 @@ LogLevel logLevel(int level)
 
 CrashDumpsType crashDumpsType(int type)
 {
-  switch (type) {
+  switch (static_cast<CrashDumpsType>(type)) {
   case CrashDumpsType::Mini:
     return CrashDumpsType::Mini;
   case CrashDumpsType::Data:


### PR DESCRIPTION
Added `/permissive-` to the modorganizer project, which eliminates some of the long standing MSVC-isms. There were surprisingly few problems to fix:

- Some switches were over `int`s while `case`s used an `enum class`; there are no implicit conversions for enum classes
- Can't bind rvalues to non-const references: these were temporaries passed to functions taking `T&`, which you can't do. All of them now take a `const T&`.
- String literals are `const`: can't convert `L"a"` to `wchar_t*`.

There also seems to be a few trailing spaces that were removed automatically by my editor.