### PR TITLE
fixes a crash when highlighting plugins

### DIFF
--- a/src/pluginlist.cpp
+++ b/src/pluginlist.cpp
@@ -139,7 +139,7 @@ void PluginList::highlightPlugins(const QItemSelectionModel *selection, const MO
       if (plugins.size() > 0) {
         for (auto plugin : plugins) {
           MOShared::FileEntry::Ptr file = directoryEntry.findFile(plugin.toStdWString());
-          if (file->getOrigin() != origin.getID()) {
+          if (file && file->getOrigin() != origin.getID()) {
             const std::vector<std::pair<int, std::pair<std::wstring, int>>> alternatives = file->getAlternatives();
             if (std::find_if(alternatives.begin(), alternatives.end(), [&](const std::pair<int, std::pair<std::wstring, int>>& element) { return element.first == origin.getID(); }) == alternatives.end())
               continue;


### PR DESCRIPTION
I have no idea in which circumstances `findFile()` can return null, but it seems to do so. I've added a quick check, but there might be something else wrong with this. The user reports the problem as being fixed with this (for now). LD also says: "If I had to guess, there's a directory refresh going on and the GUI isn't being locked down. Though checking for the null should fix it for that specific instance"