### PR TITLE
Share context menu between conflict lists

### DIFF
--- a/src/modinfodialog.cpp
+++ b/src/modinfodialog.cpp
@@ -1743,10 +1743,8 @@ void ModInfoDialog::previewDataFile(const QTreeWidgetItem* item)
     return;
   }
 
-  const int originId = (m_Origin ? m_Origin->getID() : -1);
-
   QString fileName = QDir::fromNativeSeparators(item->data(0, Qt::UserRole).toString());
-  m_OrganizerCore->previewFileWithAlternatives(this, fileName, originId);
+  m_OrganizerCore->previewFileWithAlternatives(this, fileName);
 }
 
 bool ModInfoDialog::canPreviewFile(bool isArchive, const QString& filename) const

--- a/src/modinfodialog.cpp
+++ b/src/modinfodialog.cpp
@@ -1740,8 +1740,10 @@ void ModInfoDialog::previewDataFile(const QTreeWidgetItem* item)
     return;
   }
 
+  const int originId = (m_Origin ? m_Origin->getID() : -1);
+
   QString fileName = QDir::fromNativeSeparators(item->data(0, Qt::UserRole).toString());
-  m_OrganizerCore->previewFileWithAlternatives(this, fileName);
+  m_OrganizerCore->previewFileWithAlternatives(this, fileName, originId);
 }
 
 bool ModInfoDialog::canPreviewFile(bool isArchive, const QString& filename) const

--- a/src/modinfodialog.cpp
+++ b/src/modinfodialog.cpp
@@ -1637,16 +1637,18 @@ FileRenamer::RenameResults ModInfoDialog::unhideFile(FileRenamer& renamer, const
 }
 
 void ModInfoDialog::changeConflictItemsVisibility(
-  const QList<QTreeWidgetItem*>& items, bool hide)
+  const QList<QTreeWidgetItem*>& items, bool visible)
 {
   bool changed = false;
   bool stop = false;
 
   qDebug().nospace()
-    << (hide ? "hiding" : "unhiding") << " "
+    << (visible ? "unhiding" : "hiding") << " "
     << items.size() << " conflict files";
 
-  QFlags<FileRenamer::RenameFlags> flags = (hide ? FileRenamer::HIDE : FileRenamer::UNHIDE);
+  QFlags<FileRenamer::RenameFlags> flags =
+    (visible ? FileRenamer::UNHIDE : FileRenamer::HIDE);
+
   if (items.size() > 1) {
     flags |= FileRenamer::MULTIPLE;
   }
@@ -1660,19 +1662,19 @@ void ModInfoDialog::changeConflictItemsVisibility(
 
     auto result = FileRenamer::RESULT_CANCEL;
 
-    if (hide) {
-      if (!canHideConflictItem(item)) {
-        qDebug().nospace() << "cannot hide " << item->text(0) << ", skipping";
-        continue;
-      }
-      result = hideFile(renamer, item->data(0, Qt::UserRole).toString());
-
-    } else {
+    if (visible) {
       if (!canUnhideConflictItem(item)) {
         qDebug().nospace() << "cannot unhide " << item->text(0) << ", skipping";
         continue;
       }
       result = unhideFile(renamer, item->data(0, Qt::UserRole).toString());
+
+    } else {
+      if (!canHideConflictItem(item)) {
+        qDebug().nospace() << "cannot hide " << item->text(0) << ", skipping";
+        continue;
+      }
+      result = hideFile(renamer, item->data(0, Qt::UserRole).toString());
     }
 
     switch (result) {
@@ -1695,7 +1697,7 @@ void ModInfoDialog::changeConflictItemsVisibility(
     }
   }
 
-  qDebug().nospace() << (hide ? "hiding" : "unhiding") << " conflict files done";
+  qDebug().nospace() << (visible ? "unhiding" : "hiding") << " conflict files done";
 
   if (changed) {
     qDebug().nospace() << "triggering refresh";

--- a/src/modinfodialog.cpp
+++ b/src/modinfodialog.cpp
@@ -1326,25 +1326,27 @@ void ModInfoDialog::renameTriggered()
 
 void ModInfoDialog::hideTriggered()
 {
-  changeFiletreeVisibility(true);
+  changeFiletreeVisibility(false);
 }
 
 
 void ModInfoDialog::unhideTriggered()
 {
-  changeFiletreeVisibility(false);
+  changeFiletreeVisibility(true);
 }
 
-void ModInfoDialog::changeFiletreeVisibility(bool hide)
+void ModInfoDialog::changeFiletreeVisibility(bool visible)
 {
   bool changed = false;
   bool stop = false;
 
   qDebug().nospace()
-    << (hide ? "hiding" : "unhiding") << " "
+    << (visible ? "unhiding" : "hiding") << " "
     << m_FileSelection.size() << " filetree files";
 
-  QFlags<FileRenamer::RenameFlags> flags = (hide ? FileRenamer::HIDE : FileRenamer::UNHIDE);
+  QFlags<FileRenamer::RenameFlags> flags =
+    (visible ? FileRenamer::UNHIDE : FileRenamer::HIDE);
+
   if (m_FileSelection.size() > 1) {
     flags |= FileRenamer::MULTIPLE;
   }
@@ -1359,19 +1361,18 @@ void ModInfoDialog::changeFiletreeVisibility(bool hide)
     const QString path = m_FileSystemModel->filePath(index);
     auto result = FileRenamer::RESULT_CANCEL;
 
-    if (hide) {
-      if (!canHideFile(false, path)) {
-        qDebug().nospace() << "cannot hide " << path << ", skipping";
-        continue;
-      }
-      result = hideFile(renamer, path);
-
-    } else {
+    if (visible) {
       if (!canUnhideFile(false, path)) {
         qDebug().nospace() << "cannot unhide " << path << ", skipping";
         continue;
       }
       result = unhideFile(renamer, path);
+    } else {
+      if (!canHideFile(false, path)) {
+        qDebug().nospace() << "cannot hide " << path << ", skipping";
+        continue;
+      }
+      result = hideFile(renamer, path);
     }
 
     switch (result) {
@@ -1394,7 +1395,7 @@ void ModInfoDialog::changeFiletreeVisibility(bool hide)
     }
   }
 
-  qDebug().nospace() << (hide ? "hiding" : "unhiding") << " filetree files done";
+  qDebug().nospace() << (visible ? "unhiding" : "hiding") << " filetree files done";
 
   if (changed) {
     qDebug().nospace() << "triggering refresh";

--- a/src/modinfodialog.cpp
+++ b/src/modinfodialog.cpp
@@ -1636,12 +1636,11 @@ FileRenamer::RenameResults ModInfoDialog::unhideFile(FileRenamer& renamer, const
   return renamer.rename(oldName, newName);
 }
 
-void ModInfoDialog::changeConflictFilesVisibility(bool hide)
+void ModInfoDialog::changeConflictItemsVisibility(
+  const QList<QTreeWidgetItem*>& items, bool hide)
 {
   bool changed = false;
   bool stop = false;
-
-  const auto items = ui->overwriteTree->selectedItems();
 
   qDebug().nospace()
     << (hide ? "hiding" : "unhiding") << " "
@@ -1707,63 +1706,21 @@ void ModInfoDialog::changeConflictFilesVisibility(bool hide)
   }
 }
 
-void ModInfoDialog::hideConflictFiles()
+void ModInfoDialog::openConflictItems(const QList<QTreeWidgetItem*>& items)
 {
-  changeConflictFilesVisibility(true);
-}
-
-void ModInfoDialog::unhideConflictFiles()
-{
-  changeConflictFilesVisibility(false);
-}
-
-void ModInfoDialog::previewOverwriteDataFile()
-{
-  // the menu item is only shown for a single selection, but check just in case
-  const auto selection = ui->overwriteTree->selectedItems();
-  if (!selection.empty()) {
-    previewDataFile(selection[0]);
+  // the menu item is only shown for a single selection, but handle all of them
+  // in case this changes
+  for (auto* item : items) {
+    openDataFile(item);
   }
 }
 
-void ModInfoDialog::openOverwriteDataFile()
+void ModInfoDialog::previewConflictItems(const QList<QTreeWidgetItem*>& items)
 {
-  // the menu item is only shown for a single selection, but check just in case
-  const auto selection = ui->overwriteTree->selectedItems();
-  if (!selection.empty()) {
-    openDataFile(selection[0]);
-  }
-}
-
-void ModInfoDialog::previewOverwrittenDataFile()
-{
-  const auto selection = ui->overwrittenTree->selectedItems();
-  if (!selection.empty()) {
-    previewDataFile(selection[0]);
-  }
-}
-
-void ModInfoDialog::openOverwrittenDataFile()
-{
-  const auto selection = ui->overwrittenTree->selectedItems();
-  if (!selection.empty()) {
-    openDataFile(selection[0]);
-  }
-}
-
-void ModInfoDialog::previewNoConflictDataFile()
-{
-  const auto selection = ui->noConflictTree->selectedItems();
-  if (!selection.empty()) {
-    previewDataFile(selection[0]);
-  }
-}
-
-void ModInfoDialog::openNoConflictDataFile()
-{
-  const auto selection = ui->noConflictTree->selectedItems();
-  if (!selection.empty()) {
-    openDataFile(selection[0]);
+  // the menu item is only shown for a single selection, but handle all of them
+  // in case this changes
+  for (auto* item : items) {
+    previewDataFile(item);
   }
 }
 
@@ -1846,17 +1803,71 @@ bool ModInfoDialog::canPreviewConflictItem(const QTreeWidgetItem* item) const
 
 void ModInfoDialog::on_overwriteTree_customContextMenuRequested(const QPoint &pos)
 {
-  const auto selection = ui->overwriteTree->selectedItems();
-  if (selection.empty()) {
+  showConflictMenu(pos, ui->overwriteTree);
+}
+
+void ModInfoDialog::on_overwrittenTree_customContextMenuRequested(const QPoint &pos)
+{
+  showConflictMenu(pos, ui->overwrittenTree);
+}
+
+void ModInfoDialog::on_noConflictTree_customContextMenuRequested(const QPoint &pos)
+{
+  showConflictMenu(pos, ui->noConflictTree);
+}
+
+void ModInfoDialog::showConflictMenu(const QPoint &pos, QTreeWidget* tree)
+{
+  auto actions = createConflictMenuActions(tree->selectedItems());
+
+  QMenu menu;
+
+  if (actions.open) {
+    connect(actions.open, &QAction::triggered, [&]{
+      openConflictItems(tree->selectedItems());
+    });
+
+    menu.addAction(actions.open);
+  }
+
+  if (actions.preview) {
+    connect(actions.preview, &QAction::triggered, [&]{
+      previewConflictItems(tree->selectedItems());
+    });
+
+    menu.addAction(actions.preview);
+  }
+
+  if (actions.hide) {
+    connect(actions.hide, &QAction::triggered, [&]{
+      changeConflictItemsVisibility(tree->selectedItems(), false);
+    });
+
+    menu.addAction(actions.hide);
+  }
+
+  if (actions.unhide) {
+    connect(actions.unhide, &QAction::triggered, [&]{
+      changeConflictItemsVisibility(tree->selectedItems(), true);
+    });
+
+    menu.addAction(actions.unhide);
+  }
+
+  if (menu.isEmpty()) {
     return;
   }
 
-  // for a single selection, hide/unhide is not shown for files from
-  // archives and whether the action is hide or unhide depends on the current
-  // state
-  //
-  // for multiple selection, both actions are shown unconditionally and
-  // handled in hideConflictFiles() and unhideConflictFiles()
+  menu.exec(tree->viewport()->mapToGlobal(pos));
+}
+
+ModInfoDialog::ConflictActions ModInfoDialog::createConflictMenuActions(
+  const QList<QTreeWidgetItem*> selection)
+{
+  if (selection.empty()) {
+    return {};
+  }
+
   bool enableHide = true;
   bool enableUnhide = true;
   bool enableOpen = true;
@@ -1866,7 +1877,7 @@ void ModInfoDialog::on_overwriteTree_customContextMenuRequested(const QPoint &po
     // this is a single selection
     const auto* item = selection[0];
     if (!item) {
-      return;
+      return {};
     }
 
     enableHide = canHideConflictItem(item);
@@ -1903,66 +1914,27 @@ void ModInfoDialog::on_overwriteTree_customContextMenuRequested(const QPoint &po
     }
   }
 
-
-  QMenu menu;
+  ConflictActions actions;
 
   if (enableHide) {
-    menu.addAction(tr("Hide"), this, SLOT(hideConflictFiles()));
+    actions.hide = new QAction(tr("Hide"));
   }
 
   // note that it is possible for hidden files to appear if they override other
   // hidden files from another mod
   if (enableUnhide) {
-    menu.addAction(tr("Unhide"), this, SLOT(unhideConflictFiles()));
+    actions.unhide = new QAction(tr("Unhide"));
   }
 
   if (enableOpen) {
-	  menu.addAction(tr("Open/Execute"), this, SLOT(openOverwriteDataFile()));
+    actions.open = new QAction(tr("Open/Execute"));
   }
 
   if (enablePreview) {
-    menu.addAction(tr("Preview"), this, SLOT(previewOverwriteDataFile()));
+    actions.preview = new QAction(tr("Preview"));
   }
 
-  menu.exec(ui->overwriteTree->viewport()->mapToGlobal(pos));
-}
-
-void ModInfoDialog::on_overwrittenTree_customContextMenuRequested(const QPoint &pos)
-{
-	auto* item = ui->overwrittenTree->itemAt(pos.x(), pos.y());
-
-	if (item != nullptr) {
-		if (!item->data(1, Qt::UserRole + 2).toBool()) {
-			QMenu menu;
-
-			menu.addAction(tr("Open/Execute"), this, SLOT(openOverwrittenDataFile()));
-
-      if (canPreviewConflictItem(item)) {
-				menu.addAction(tr("Preview"), this, SLOT(previewOverwrittenDataFile()));
-			}
-
-			menu.exec(ui->overwrittenTree->viewport()->mapToGlobal(pos));
-		}
-	}
-}
-
-void ModInfoDialog::on_noConflictTree_customContextMenuRequested(const QPoint &pos)
-{
-  auto* item = ui->noConflictTree->itemAt(pos.x(), pos.y());
-
-  if (item != nullptr) {
-    if (!item->data(1, Qt::UserRole + 2).toBool()) {
-      QMenu menu;
-
-      menu.addAction(tr("Open/Execute"), this, SLOT(openNoConflictDataFile()));
-
-      if (canPreviewConflictItem(item)) {
-        menu.addAction(tr("Preview"), this, SLOT(previewNoConflictDataFile()));
-      }
-
-      menu.exec(ui->noConflictTree->viewport()->mapToGlobal(pos));
-    }
-  }
+  return actions;
 }
 
 void ModInfoDialog::on_overwrittenTree_itemDoubleClicked(QTreeWidgetItem *item, int)

--- a/src/modinfodialog.h
+++ b/src/modinfodialog.h
@@ -397,7 +397,6 @@ private:
   Ui::ModInfoDialog *ui;
 
   ModInfo::Ptr m_ModInfo;
-  int m_OriginID;
 
   QSignalMapper m_ThumbnailMapper;
   QString m_RootPath;

--- a/src/modinfodialog.h
+++ b/src/modinfodialog.h
@@ -329,18 +329,6 @@ private:
   int tabIndex(const QString &tabId);
 
 private slots:
-
-  void hideConflictFiles();
-  void unhideConflictFiles();
-  void previewOverwriteDataFile();
-  void openOverwriteDataFile();
-
-  void previewOverwrittenDataFile();
-  void openOverwrittenDataFile();
-
-  void previewNoConflictDataFile();
-  void openNoConflictDataFile();
-
   void thumbnailClicked(const QString &fileName);
   void linkClicked(const QUrl &url);
   void linkClicked(QString url);
@@ -393,6 +381,18 @@ private slots:
 
   void createTweak();
 private:
+  struct ConflictActions
+  {
+    QAction* hide;
+    QAction* unhide;
+    QAction* open;
+    QAction* preview;
+
+    ConflictActions()
+      : hide(nullptr), unhide(nullptr), open(nullptr), preview(nullptr)
+    {
+    }
+  };
 
   Ui::ModInfoDialog *ui;
 
@@ -442,12 +442,21 @@ private:
 
   void openDataFile(const QTreeWidgetItem* item);
   void previewDataFile(const QTreeWidgetItem* item);
-  void changeConflictFilesVisibility(bool hide);
-  void changeFiletreeVisibility(bool hide);
+  void changeFiletreeVisibility(bool visible);
+
+  void openConflictItems(const QList<QTreeWidgetItem*>& items);
+  void previewConflictItems(const QList<QTreeWidgetItem*>& items);
+  void changeConflictItemsVisibility(
+    const QList<QTreeWidgetItem*>& items, bool visible);
 
   bool canPreviewFile(bool isArchive, const QString& filename) const;
   bool canHideFile(bool isArchive, const QString& filename) const;
   bool canUnhideFile(bool isArchive, const QString& filename) const;
+
+  void showConflictMenu(const QPoint &pos, QTreeWidget* tree);
+
+  ConflictActions createConflictMenuActions(
+    const QList<QTreeWidgetItem*> selection);
 };
 
 #endif // MODINFODIALOG_H

--- a/src/modinfodialog.ui
+++ b/src/modinfodialog.ui
@@ -453,23 +453,20 @@ text-align: left;</string>
          <property name="textElideMode">
           <enum>Qt::ElideLeft</enum>
          </property>
+         <property name="uniformRowHeights">
+          <bool>true</bool>
+         </property>
          <property name="sortingEnabled">
           <bool>true</bool>
          </property>
          <property name="animated">
           <bool>true</bool>
          </property>
-         <property name="headerHidden">
-          <bool>false</bool>
-         </property>
          <property name="columnCount">
           <number>2</number>
          </property>
          <attribute name="headerDefaultSectionSize">
           <number>365</number>
-         </attribute>
-         <attribute name="headerHighlightSections">
-          <bool>false</bool>
          </attribute>
          <attribute name="headerMinimumSectionSize">
           <number>200</number>
@@ -526,8 +523,14 @@ text-align: left;</string>
          <property name="contextMenuPolicy">
           <enum>Qt::CustomContextMenu</enum>
          </property>
+         <property name="selectionMode">
+          <enum>QAbstractItemView::ExtendedSelection</enum>
+         </property>
          <property name="textElideMode">
           <enum>Qt::ElideLeft</enum>
+         </property>
+         <property name="uniformRowHeights">
+          <bool>true</bool>
          </property>
          <property name="sortingEnabled">
           <bool>true</bool>
@@ -596,8 +599,14 @@ text-align: left;</string>
          <property name="contextMenuPolicy">
           <enum>Qt::CustomContextMenu</enum>
          </property>
+         <property name="selectionMode">
+          <enum>QAbstractItemView::ExtendedSelection</enum>
+         </property>
          <property name="textElideMode">
           <enum>Qt::ElideLeft</enum>
+         </property>
+         <property name="uniformRowHeights">
+          <bool>true</bool>
          </property>
          <property name="sortingEnabled">
           <bool>true</bool>

--- a/src/organizercore.h
+++ b/src/organizercore.h
@@ -152,7 +152,7 @@ public:
     QFileInfo &binaryInfo, QString &arguments, FileExecutionTypes& type);
 
   bool executeFileVirtualized(QWidget* parent, const QFileInfo& targetInfo);
-  bool previewFileWithAlternatives(QWidget* parent, QString filename);
+  bool previewFileWithAlternatives(QWidget* parent, QString filename, int selectedOrigin=-1);
   bool previewFile(QWidget* parent, const QString& originName, const QString& path);
 
   void spawnBinary(const QFileInfo &binary, const QString &arguments = "",


### PR DESCRIPTION
 - added multiple selection to lists
 - added a central `createConflictMenuActions()` that creates a bunch of actions and `showConflictMenu()` that plugs in the handlers and shows the menu; this is used by all three lists
 - changed the `bool` parameter of both `changeConflictItemsVisibility()` and `changeFiletreeVisibility()` from `hide` to `visible`, _inversing its meaning_, because `true` meaning "visible" makes much more sense in my head than `true` meaning "hide"

I initially changed the preview behaviour for overwritten files to show that mod's file first in the preview dialog instead of the winning file. I reverted that because it changes a long-standing behaviour for no good reason. However, I did leave the code to select an origin in `OrganizerCore::previewFileWithAlternatives()` because it works and could be useful in the future.