### PR TITLE
New conflict list, new "go to" conflict menu item

### DIFF
--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -115,6 +115,7 @@ SET(organizer_SRCS
     lcdnumber.cpp
     forcedloaddialog.cpp
     forcedloaddialogwidget.cpp
+	filterwidget.cpp
 
     shared/windows_error.cpp
     shared/error_report.cpp
@@ -211,6 +212,7 @@ SET(organizer_HDRS
     lcdnumber.h
     forcedloaddialog.h
     forcedloaddialogwidget.h
+	filterwidget.h
 
     shared/windows_error.h
     shared/error_report.h
@@ -391,6 +393,7 @@ set(utilities
 set(widgets
 	descriptionpage
 	genericicondelegate
+	filterwidget
 	icondelegate
 	lcdnumber
 	logbuffer

--- a/src/filterwidget.cpp
+++ b/src/filterwidget.cpp
@@ -1,0 +1,88 @@
+#include "filterwidget.h"
+#include "eventfilter.h"
+
+FilterWidget::FilterWidget()
+  : m_edit(nullptr), m_clear(nullptr), m_buddy(nullptr)
+{
+}
+
+void FilterWidget::set(QLineEdit* edit)
+{
+  if (m_clear) {
+    delete m_clear;
+    m_clear = nullptr;
+  }
+
+  m_edit = edit;
+  if (!m_edit) {
+    return;
+  }
+
+  createClear();
+  hookEvents();
+}
+
+void FilterWidget::clear()
+{
+  if (!m_edit) {
+    return;
+  }
+
+  m_edit->clear();
+}
+
+void FilterWidget::createClear()
+{
+  m_clear = new QToolButton(m_edit);
+
+  QPixmap pixmap(":/MO/gui/edit_clear");
+  m_clear->setIcon(QIcon(pixmap));
+  m_clear->setIconSize(pixmap.size());
+  m_clear->setCursor(Qt::ArrowCursor);
+  m_clear->setStyleSheet("QToolButton { border: none; padding: 0px; }");
+  m_clear->hide();
+
+  QObject::connect(m_clear, &QToolButton::clicked, [&]{ clear(); });
+  QObject::connect(m_edit, &QLineEdit::textChanged, [&]{ onTextChanged(); });
+
+  repositionClearButton();
+}
+
+void FilterWidget::hookEvents()
+{
+  auto* f = new EventFilter(m_edit, [&](auto* w, auto* e) {
+    if (e->type() == QEvent::Resize) {
+      onResized();
+    }
+
+    return false;
+  });
+
+  m_edit->installEventFilter(f);
+}
+
+void FilterWidget::onTextChanged()
+{
+  m_clear->setVisible(!m_edit->text().isEmpty());
+}
+
+void FilterWidget::onResized()
+{
+  repositionClearButton();
+}
+
+void FilterWidget::repositionClearButton()
+{
+  if (!m_clear) {
+    return;
+  }
+
+  const QSize sz = m_clear->sizeHint();
+  const int frame = m_edit->style()->pixelMetric(QStyle::PM_DefaultFrameWidth);
+  const auto r = m_edit->rect();
+
+  const auto x = r.right() - frame - sz.width();
+  const auto y = (r.bottom() + 1 - sz.height()) / 2;
+
+  m_clear->move(x, y);
+}

--- a/src/filterwidget.h
+++ b/src/filterwidget.h
@@ -1,21 +1,27 @@
 #ifndef FILTERWIDGET_H
 #define FILTERWIDGET_H
 
+class EventFilter;
+
 class FilterWidget
 {
 public:
+  std::function<void ()> changed;
+
   FilterWidget();
 
   void set(QLineEdit* edit);
-  void buddy(QWidget* w);
-
   void clear();
+
+  bool matches(const QString& s) const;
 
 private:
   QLineEdit* m_edit;
+  EventFilter* m_eventFilter;
   QToolButton* m_clear;
-  QWidget* m_buddy;
+  QString m_text;
 
+  void unhook();
   void createClear();
   void hookEvents();
   void repositionClearButton();

--- a/src/filterwidget.h
+++ b/src/filterwidget.h
@@ -13,7 +13,7 @@ public:
   void set(QLineEdit* edit);
   void clear();
 
-  bool matches(const QString& s) const;
+  bool matches(std::function<bool (const QString& what)> pred) const;
 
 private:
   QLineEdit* m_edit;

--- a/src/filterwidget.h
+++ b/src/filterwidget.h
@@ -1,0 +1,27 @@
+#ifndef FILTERWIDGET_H
+#define FILTERWIDGET_H
+
+class FilterWidget
+{
+public:
+  FilterWidget();
+
+  void set(QLineEdit* edit);
+  void buddy(QWidget* w);
+
+  void clear();
+
+private:
+  QLineEdit* m_edit;
+  QToolButton* m_clear;
+  QWidget* m_buddy;
+
+  void createClear();
+  void hookEvents();
+  void repositionClearButton();
+
+  void onTextChanged();
+  void onResized();
+};
+
+#endif // FILTERWIDGET_H

--- a/src/modinfodialog.cpp
+++ b/src/modinfodialog.cpp
@@ -553,13 +553,13 @@ int ModInfoDialog::tabIndex(const QString &tabId)
 void ModInfoDialog::saveState(Settings& s) const
 {
   s.directInterface().setValue("mod_info_tabs", saveTabState());
-  s.directInterface().setValue("mod_info_conflict_expanders", saveConflictExpandersState());
+  s.directInterface().setValue("mod_info_conflicts", saveConflictsState());
 }
 
 void ModInfoDialog::restoreState(const Settings& s)
 {
   restoreTabState(s.directInterface().value("mod_info_tabs").toByteArray());
-  restoreConflictExpandersState(s.directInterface().value("mod_info_conflict_expanders").toByteArray());
+  restoreConflictsState(s.directInterface().value("mod_info_conflicts").toByteArray());
 }
 
 void ModInfoDialog::restoreTabState(const QByteArray &state)
@@ -593,7 +593,7 @@ void ModInfoDialog::restoreTabState(const QByteArray &state)
   ui->tabWidget->blockSignals(false);
 }
 
-void ModInfoDialog::restoreConflictExpandersState(const QByteArray &state)
+void ModInfoDialog::restoreConflictsState(const QByteArray &state)
 {
   QDataStream stream(state);
 
@@ -607,6 +607,20 @@ void ModInfoDialog::restoreConflictExpandersState(const QByteArray &state)
     m_overwriteExpander.toggle(overwriteExpanded);
     m_overwrittenExpander.toggle(overwrittenExpanded);
     m_nonconflictExpander.toggle(noConflictExpanded);
+  }
+
+  int index = 0;
+  bool noConflictChecked = false;
+  bool showAllChecked = false;
+  bool showNearestChecked = false;
+
+  stream >> index >> noConflictChecked >> showAllChecked >> showNearestChecked;
+
+  if (stream.status() == QDataStream::Ok) {
+    ui->tabConflictsTabs->setCurrentIndex(index);
+    ui->conflictsAdvancedShowNoConflict->setChecked(noConflictChecked);
+    ui->conflictsAdvancedShowAll->setChecked(showAllChecked);
+    ui->conflictsAdvancedShowNearest->setChecked(showNearestChecked);
   }
 }
 
@@ -622,7 +636,7 @@ QByteArray ModInfoDialog::saveTabState() const
   return result;
 }
 
-QByteArray ModInfoDialog::saveConflictExpandersState() const
+QByteArray ModInfoDialog::saveConflictsState() const
 {
   QByteArray result;
   QDataStream stream(&result, QIODevice::WriteOnly);
@@ -630,7 +644,11 @@ QByteArray ModInfoDialog::saveConflictExpandersState() const
   stream
     << m_overwriteExpander.opened()
     << m_overwrittenExpander.opened()
-    << m_nonconflictExpander.opened();
+    << m_nonconflictExpander.opened()
+    << ui->tabConflictsTabs->currentIndex()
+    << ui->conflictsAdvancedShowNoConflict->isChecked()
+    << ui->conflictsAdvancedShowAll->isChecked()
+    << ui->conflictsAdvancedShowNearest->isChecked();
 
   return result;
 }

--- a/src/modinfodialog.cpp
+++ b/src/modinfodialog.cpp
@@ -453,6 +453,8 @@ ModInfoDialog::ModInfoDialog(ModInfo::Ptr modInfo, const DirectoryEntry *directo
   m_nonconflictExpander.set(ui->noConflictExpander, ui->noConflictTree);
 
 
+  m_advancedConflictFilter.set(ui->conflictsAdvancedFilter);
+
   // left-elide the overwrites column so that the nearest are visible
   ui->conflictsAdvancedList->setItemDelegateForColumn(
     0, new ElideLeftDelegate(ui->conflictsAdvancedList));

--- a/src/modinfodialog.cpp
+++ b/src/modinfodialog.cpp
@@ -623,67 +623,21 @@ void ModInfoDialog::refreshConflictLists()
         const auto& alternatives = file->getAlternatives();
 
         if (!alternatives.empty()) {
-          QString altString;
+          ui->overwriteTree->addTopLevelItem(createOverwriteItem(
+            archive, fileName, relativeName, alternatives));
 
-          for (const auto& alt : alternatives) {
-            if (!altString.isEmpty()) {
-              altString += ", ";
-            }
-
-            altString += ToQString(m_Directory->getOriginByID(alt.first).getName());
-          }
-
-          QStringList fields(relativeName);
-          fields.append(altString);
-
-          QTreeWidgetItem *item = new QTreeWidgetItem(fields);
-          item->setData(0, Qt::UserRole, fileName);
-          item->setData(1, Qt::UserRole, ToQString(m_Directory->getOriginByID(alternatives.back().first).getName()));
-          item->setData(1, Qt::UserRole + 1, alternatives.back().first);
-          item->setData(1, Qt::UserRole + 2, archive);
-
-          if (archive) {
-            QFont font = item->font(0);
-            font.setItalic(true);
-            item->setFont(0, font);
-            item->setFont(1, font);
-          }
-
-          ui->overwriteTree->addTopLevelItem(item);
           ++numOverwrite;
         } else {
           // otherwise, put the file in the nonconflict tree
-          QTreeWidgetItem *item = new QTreeWidgetItem(QStringList({relativeName}));
-          item->setData(0, Qt::UserRole, fileName);
+          ui->noConflictTree->addTopLevelItem(createNoConflictItem(
+            archive, fileName, relativeName));
 
-          if (archive) {
-            QFont font = item->font(0);
-            font.setItalic(true);
-            item->setFont(0, font);
-          }
-
-          ui->noConflictTree->addTopLevelItem(item);
           ++numNonConflicting;
         }
       } else {
-        const FilesOrigin &realOrigin = m_Directory->getOriginByID(file->getOrigin(archive));
+        ui->overwrittenTree->addTopLevelItem(createOverwrittenItem(
+          file, archive, fileName, relativeName));
 
-        QStringList fields(relativeName);
-        fields.append(ToQString(realOrigin.getName()));
-
-        QTreeWidgetItem *item = new QTreeWidgetItem(fields);
-        item->setData(0, Qt::UserRole, fileName);
-        item->setData(1, Qt::UserRole, ToQString(realOrigin.getName()));
-        item->setData(1, Qt::UserRole + 2, archive);
-
-        if (archive) {
-          QFont font = item->font(0);
-          font.setItalic(true);
-          item->setFont(0, font);
-          item->setFont(1, font);
-        }
-
-        ui->overwrittenTree->addTopLevelItem(item);
         ++numOverwritten;
       }
     }
@@ -692,6 +646,78 @@ void ModInfoDialog::refreshConflictLists()
   ui->overwriteCount->display(numOverwrite);
   ui->overwrittenCount->display(numOverwritten);
   ui->noConflictCount->display(numNonConflicting);
+}
+
+QTreeWidgetItem* ModInfoDialog::createOverwriteItem(
+  bool archive, const QString& fileName, const QString& relativeName,
+  const FileEntry::AlternativesVector& alternatives)
+{
+  QString altString;
+
+  for (const auto& alt : alternatives) {
+    if (!altString.isEmpty()) {
+      altString += ", ";
+    }
+
+    altString += ToQString(m_Directory->getOriginByID(alt.first).getName());
+  }
+
+  QStringList fields(relativeName);
+  fields.append(altString);
+
+  QTreeWidgetItem *item = new QTreeWidgetItem(fields);
+  item->setData(0, Qt::UserRole, fileName);
+  item->setData(1, Qt::UserRole, ToQString(m_Directory->getOriginByID(alternatives.back().first).getName()));
+  item->setData(1, Qt::UserRole + 1, alternatives.back().first);
+  item->setData(1, Qt::UserRole + 2, archive);
+
+  if (archive) {
+    QFont font = item->font(0);
+    font.setItalic(true);
+    item->setFont(0, font);
+    item->setFont(1, font);
+  }
+
+  return item;
+}
+
+QTreeWidgetItem* ModInfoDialog::createNoConflictItem(
+  bool archive, const QString& fileName, const QString& relativeName)
+{
+  QTreeWidgetItem *item = new QTreeWidgetItem(QStringList({relativeName}));
+  item->setData(0, Qt::UserRole, fileName);
+
+  if (archive) {
+    QFont font = item->font(0);
+    font.setItalic(true);
+    item->setFont(0, font);
+  }
+
+  return item;
+}
+
+QTreeWidgetItem* ModInfoDialog::createOverwrittenItem(
+  const MOShared::FileEntry::Ptr& file,
+  bool archive, const QString& fileName, const QString& relativeName)
+{
+  const FilesOrigin &realOrigin = m_Directory->getOriginByID(file->getOrigin(archive));
+
+  QStringList fields(relativeName);
+  fields.append(ToQString(realOrigin.getName()));
+
+  QTreeWidgetItem *item = new QTreeWidgetItem(fields);
+  item->setData(0, Qt::UserRole, fileName);
+  item->setData(1, Qt::UserRole, ToQString(realOrigin.getName()));
+  item->setData(1, Qt::UserRole + 2, archive);
+
+  if (archive) {
+    QFont font = item->font(0);
+    font.setItalic(true);
+    item->setFont(0, font);
+    item->setFont(1, font);
+  }
+
+  return item;
 }
 
 void ModInfoDialog::refreshFiles()

--- a/src/modinfodialog.cpp
+++ b/src/modinfodialog.cpp
@@ -874,10 +874,15 @@ QTreeWidgetItem* ModInfoDialog::createAdvancedConflictItem(
     }
   }
 
-  if (!m_advancedConflictFilter.matches(before) &&
-      !m_advancedConflictFilter.matches(relativeName) &&
-      !m_advancedConflictFilter.matches(after)) {
-      return nullptr;
+  bool matched = m_advancedConflictFilter.matches([&](auto&& what) {
+    return
+      before.contains(what, Qt::CaseInsensitive) ||
+      relativeName.contains(what, Qt::CaseInsensitive) ||
+      after.contains(what, Qt::CaseInsensitive);
+  });
+
+  if (!matched) {
+     return nullptr;
   }
 
   QTreeWidgetItem* item = new QTreeWidgetItem;

--- a/src/modinfodialog.cpp
+++ b/src/modinfodialog.cpp
@@ -319,6 +319,20 @@ bool ExpanderWidget::opened() const
 }
 
 
+class ElideLeftDelegate : public QStyledItemDelegate
+{
+public:
+  using QStyledItemDelegate::QStyledItemDelegate;
+
+protected:
+  void initStyleOption(QStyleOptionViewItem *option, const QModelIndex &index) const
+  {
+    QStyledItemDelegate::initStyleOption(option, index);
+    option->textElideMode = Qt::ElideLeft;
+  }
+};
+
+
 ModInfoDialog::ModInfoDialog(ModInfo::Ptr modInfo, const DirectoryEntry *directory, bool unmanaged, OrganizerCore *organizerCore, PluginContainer *pluginContainer, QWidget *parent)
   : TutorableDialog("ModInfoDialog", parent), ui(new Ui::ModInfoDialog), m_ModInfo(modInfo),
   m_ThumbnailMapper(this), m_RequestStarted(false),
@@ -437,6 +451,17 @@ ModInfoDialog::ModInfoDialog(ModInfo::Ptr modInfo, const DirectoryEntry *directo
   m_overwriteExpander.set(ui->overwriteExpander, ui->overwriteTree, true);
   m_overwrittenExpander.set(ui->overwrittenExpander, ui->overwrittenTree, true);
   m_nonconflictExpander.set(ui->noConflictExpander, ui->noConflictTree);
+
+
+  // left-elide the overwrites column so that the nearest are visible
+  ui->conflictsAdvancedList->setItemDelegateForColumn(
+    0, new ElideLeftDelegate(ui->conflictsAdvancedList));
+
+  // left-elide the file column to see filenames
+  ui->conflictsAdvancedList->setItemDelegateForColumn(
+    1, new ElideLeftDelegate(ui->conflictsAdvancedList));
+
+  // don't elide the overwritten by column so that the nearest are visible
 
   connect(ui->conflictsAdvancedShowNoConflict, &QCheckBox::clicked, [&] {
     refreshConflictLists(false, true);

--- a/src/modinfodialog.cpp
+++ b/src/modinfodialog.cpp
@@ -597,6 +597,12 @@ QByteArray ModInfoDialog::saveConflictExpandersState() const
 
 void ModInfoDialog::refreshLists()
 {
+  refreshConflictLists();
+  refreshFiles();
+}
+
+void ModInfoDialog::refreshConflictLists()
+{
   int numNonConflicting = 0;
   int numOverwrite = 0;
   int numOverwritten = 0;
@@ -616,7 +622,7 @@ void ModInfoDialog::refreshLists()
         if (!alternatives.empty()) {
           std::wostringstream altString;
           for (std::vector<std::pair<int, std::pair<std::wstring, int>>>::iterator altIter = alternatives.begin();
-               altIter != alternatives.end(); ++altIter) {
+            altIter != alternatives.end(); ++altIter) {
             if (altIter != alternatives.begin()) {
               altString << ", ";
             }
@@ -669,6 +675,13 @@ void ModInfoDialog::refreshLists()
     }
   }
 
+  ui->overwriteCount->display(numOverwrite);
+  ui->overwrittenCount->display(numOverwritten);
+  ui->noConflictCount->display(numNonConflicting);
+}
+
+void ModInfoDialog::refreshFiles()
+{
   if (m_RootPath.length() > 0) {
     QDirIterator dirIterator(m_RootPath, QDir::Files, QDirIterator::Subdirectories);
     while (dirIterator.hasNext()) {
@@ -677,7 +690,7 @@ void ModInfoDialog::refreshLists()
       if (fileName.endsWith(".txt", Qt::CaseInsensitive)) {
         ui->textFileList->addItem(fileName.mid(m_RootPath.length() + 1));
       } else if ((fileName.endsWith(".ini", Qt::CaseInsensitive) || fileName.endsWith(".cfg", Qt::CaseInsensitive)) &&
-                 !fileName.endsWith("meta.ini")) {
+        !fileName.endsWith("meta.ini")) {
         QString namePart = fileName.mid(m_RootPath.length() + 1);
         if (namePart.startsWith("INI Tweaks", Qt::CaseInsensitive)) {
           QListWidgetItem *newItem = new QListWidgetItem(namePart.mid(11), ui->iniTweaksList);
@@ -689,8 +702,8 @@ void ModInfoDialog::refreshLists()
           ui->iniFileList->addItem(namePart);
         }
       } else if (fileName.endsWith(".esp", Qt::CaseInsensitive) ||
-                 fileName.endsWith(".esm", Qt::CaseInsensitive) ||
-                 fileName.endsWith(".esl", Qt::CaseInsensitive)) {
+        fileName.endsWith(".esm", Qt::CaseInsensitive) ||
+        fileName.endsWith(".esl", Qt::CaseInsensitive)) {
         QString relativePath = fileName.mid(m_RootPath.length() + 1);
         if (relativePath.contains('/')) {
           QFileInfo fileInfo(fileName);
@@ -701,7 +714,7 @@ void ModInfoDialog::refreshLists()
           ui->activeESPList->addItem(relativePath);
         }
       } else if ((fileName.endsWith(".png", Qt::CaseInsensitive)) ||
-                 (fileName.endsWith(".jpg", Qt::CaseInsensitive))) {
+        (fileName.endsWith(".jpg", Qt::CaseInsensitive))) {
         QImage image = QImage(fileName);
         if (!image.isNull()) {
           if (static_cast<float>(image.width()) / static_cast<float>(image.height()) > 1.34) {
@@ -719,12 +732,7 @@ void ModInfoDialog::refreshLists()
       }
     }
   }
-
-  ui->overwriteCount->display(numOverwrite);
-  ui->overwrittenCount->display(numOverwritten);
-  ui->noConflictCount->display(numNonConflicting);
 }
-
 
 void ModInfoDialog::addCategories(const CategoryFactory &factory, const std::set<int> &enabledCategories, QTreeWidgetItem *root, int rootLevel)
 {

--- a/src/modinfodialog.cpp
+++ b/src/modinfodialog.cpp
@@ -441,6 +441,14 @@ ModInfoDialog::ModInfoDialog(ModInfo::Ptr modInfo, const DirectoryEntry *directo
   connect(ui->conflictsAdvancedShowNoConflict, &QCheckBox::clicked, [&] {
     refreshConflictLists(false, true);
   });
+
+  connect(ui->conflictsAdvancedShowAll, &QRadioButton::clicked, [&] {
+    refreshConflictLists(false, true);
+    });
+
+  connect(ui->conflictsAdvancedShowNearest, &QRadioButton::clicked, [&] {
+    refreshConflictLists(false, true);
+  });
 }
 
 
@@ -760,26 +768,46 @@ QTreeWidgetItem* ModInfoDialog::createAdvancedConflictItem(
     {
       auto altOrigin = m_Directory->getOriginByID(alt.first);
 
-      if (altOrigin.getPriority() > beforePrio) {
+      if (ui->conflictsAdvancedShowAll->isChecked()) {
         if (altOrigin.getPriority() < m_Origin->getPriority()) {
-          before = ToQString(altOrigin.getName());
-          beforePrio = altOrigin.getPriority();
-        }
-      }
+          if (!before.isEmpty()) {
+            before += ", ";
+          }
 
-      if (altOrigin.getPriority() < afterPrio) {
-        if (altOrigin.getPriority() > m_Origin->getPriority()) {
-          after = ToQString(altOrigin.getName());
-          afterPrio = altOrigin.getPriority();
+          before += ToQString(altOrigin.getName());
+        } else if (altOrigin.getPriority() > m_Origin->getPriority()) {
+          if (!after.isEmpty()) {
+            after += ", ";
+          }
+
+          after += ToQString(altOrigin.getName());
+        }
+      } else {
+        if (altOrigin.getPriority() > beforePrio) {
+          if (altOrigin.getPriority() < m_Origin->getPriority()) {
+            before = ToQString(altOrigin.getName());
+            beforePrio = altOrigin.getPriority();
+          }
+        }
+
+        if (altOrigin.getPriority() < afterPrio) {
+          if (altOrigin.getPriority() > m_Origin->getPriority()) {
+            after = ToQString(altOrigin.getName());
+            afterPrio = altOrigin.getPriority();
+          }
         }
       }
     }
 
-    if (after.isEmpty()) {
+    if (after.isEmpty() || ui->conflictsAdvancedShowAll->isChecked()) {
       FilesOrigin &realOrigin = m_Directory->getOriginByID(fileOrigin);
 
       if (realOrigin.getID() != m_Origin->getID()) {
-        after = ToQString(realOrigin.getName());
+        if (!after.isEmpty()) {
+          after += ", ";
+        }
+
+        after += ToQString(realOrigin.getName());
       }
     }
   }

--- a/src/modinfodialog.cpp
+++ b/src/modinfodialog.cpp
@@ -454,6 +454,7 @@ ModInfoDialog::ModInfoDialog(ModInfo::Ptr modInfo, const DirectoryEntry *directo
 
 
   m_advancedConflictFilter.set(ui->conflictsAdvancedFilter);
+  m_advancedConflictFilter.changed = [&]{ refreshConflictLists(false, true); };
 
   // left-elide the overwrites column so that the nearest are visible
   ui->conflictsAdvancedList->setItemDelegateForColumn(
@@ -871,6 +872,12 @@ QTreeWidgetItem* ModInfoDialog::createAdvancedConflictItem(
     if (before.isEmpty() && after.isEmpty()) {
       return nullptr;
     }
+  }
+
+  if (!m_advancedConflictFilter.matches(before) &&
+      !m_advancedConflictFilter.matches(relativeName) &&
+      !m_advancedConflictFilter.matches(after)) {
+      return nullptr;
   }
 
   QTreeWidgetItem* item = new QTreeWidgetItem;

--- a/src/modinfodialog.cpp
+++ b/src/modinfodialog.cpp
@@ -397,8 +397,6 @@ ModInfoDialog::ModInfoDialog(ModInfo::Ptr modInfo, const DirectoryEntry *directo
     }
   }
 
-  refreshLists();
-
   if (modInfo->hasFlag(ModInfo::FLAG_SEPARATOR))
   {
     ui->tabWidget->setTabEnabled(TAB_TEXTFILES, false);
@@ -501,6 +499,12 @@ ModInfoDialog::~ModInfoDialog()
 }
 
 
+int ModInfoDialog::exec()
+{
+  refreshLists();
+  return TutorableDialog::exec();
+}
+
 void ModInfoDialog::initINITweaks()
 {
   int numTweaks = m_Settings->beginReadArray("INI Tweaks");
@@ -558,12 +562,40 @@ void ModInfoDialog::saveState(Settings& s) const
 {
   s.directInterface().setValue("mod_info_tabs", saveTabState());
   s.directInterface().setValue("mod_info_conflicts", saveConflictsState());
+
+  s.directInterface().setValue(
+    "mod_info_conflicts_overwrite",
+    ui->overwriteTree->header()->saveState());
+
+  s.directInterface().setValue(
+    "mod_info_conflicts_noconflict",
+    ui->noConflictTree->header()->saveState());
+
+  s.directInterface().setValue(
+    "mod_info_conflicts_overwritten",
+    ui->overwrittenTree->header()->saveState());
+
+  s.directInterface().setValue(
+    "mod_info_advanced_conflicts",
+    ui->conflictsAdvancedList->header()->saveState());
 }
 
 void ModInfoDialog::restoreState(const Settings& s)
 {
   restoreTabState(s.directInterface().value("mod_info_tabs").toByteArray());
   restoreConflictsState(s.directInterface().value("mod_info_conflicts").toByteArray());
+
+  ui->overwriteTree->header()->restoreState(
+    s.directInterface().value("mod_info_conflicts_overwrite").toByteArray());
+
+  ui->noConflictTree->header()->restoreState(
+    s.directInterface().value("mod_info_conflicts_noconflict").toByteArray());
+
+  ui->overwrittenTree->header()->restoreState(
+    s.directInterface().value("mod_info_conflicts_overwritten").toByteArray());
+
+  ui->conflictsAdvancedList->header()->restoreState(
+    s.directInterface().value("mod_info_advanced_conflicts").toByteArray());
 }
 
 void ModInfoDialog::restoreTabState(const QByteArray &state)

--- a/src/modinfodialog.cpp
+++ b/src/modinfodialog.cpp
@@ -2000,6 +2000,12 @@ bool ModInfoDialog::canPreviewFile(bool isArchive, const QString& filename) cons
   return m_PluginContainer->previewGenerator().previewSupported(ext);
 }
 
+bool ModInfoDialog::canOpenFile(bool isArchive, const QString&) const
+{
+  // can open anything as long as it's not in an archive
+  return !isArchive;
+}
+
 bool ModInfoDialog::canHideFile(bool isArchive, const QString& filename) const
 {
   if (isArchive) {
@@ -2038,6 +2044,11 @@ bool ModInfoDialog::canHideConflictItem(const QTreeWidgetItem* item) const
 bool ModInfoDialog::canUnhideConflictItem(const QTreeWidgetItem* item) const
 {
   return canUnhideFile(conflictIsArchive(item), conflictFileName(item));
+}
+
+bool ModInfoDialog::canOpenConflictItem(const QTreeWidgetItem* item) const
+{
+  return canOpenFile(conflictIsArchive(item), conflictFileName(item));
 }
 
 bool ModInfoDialog::canPreviewConflictItem(const QTreeWidgetItem* item) const
@@ -2131,8 +2142,8 @@ ModInfoDialog::ConflictActions ModInfoDialog::createConflictMenuActions(
 
     enableHide = canHideConflictItem(item);
     enableUnhide = canUnhideConflictItem(item);
+    enableOpen = canOpenConflictItem(item);
     enablePreview = canPreviewConflictItem(item);
-    // open is always enabled
   }
   else {
     // this is a multiple selection, don't show open/preview so users don't open

--- a/src/modinfodialog.cpp
+++ b/src/modinfodialog.cpp
@@ -399,6 +399,12 @@ ModInfoDialog::ModInfoDialog(ModInfo::Ptr modInfo, const DirectoryEntry *directo
     }
   }
 
+  // refresh everything but the conflict lists, which are done in exec() because
+  // they depend on restoring the state to some widgets; this refresh has to be
+  // done here because some of the checks below depend on the ui to decide which
+  // tabs to enable
+  refreshFiles();
+
   if (modInfo->hasFlag(ModInfo::FLAG_SEPARATOR))
   {
     ui->tabWidget->setTabEnabled(TAB_TEXTFILES, false);
@@ -503,7 +509,8 @@ ModInfoDialog::~ModInfoDialog()
 
 int ModInfoDialog::exec()
 {
-  refreshLists();
+  // no need to refresh the other stuff, that was done in the constructor
+  refreshConflictLists(true, true);
   return TutorableDialog::exec();
 }
 

--- a/src/modinfodialog.h
+++ b/src/modinfodialog.h
@@ -280,6 +280,8 @@ public:
    **/
   void openTab(int tab);
 
+  int exec() override;
+
   void saveState(Settings& s) const;
   void restoreState(const Settings& s);
 

--- a/src/modinfodialog.h
+++ b/src/modinfodialog.h
@@ -25,6 +25,7 @@ along with Mod Organizer.  If not, see <http://www.gnu.org/licenses/>.
 #include "tutorabledialog.h"
 #include "plugincontainer.h"
 #include "organizercore.h"
+#include "filterwidget.h"
 
 #include <QDialog>
 #include <QSignalMapper>
@@ -427,6 +428,7 @@ private:
   std::map<int, int> m_RealTabPos;
 
   ExpanderWidget m_overwriteExpander, m_overwrittenExpander, m_nonconflictExpander;
+  FilterWidget m_advancedConflictFilter;
 
 
   void refreshConflictLists(bool refreshGeneral, bool refreshAdvanced);
@@ -447,6 +449,7 @@ private:
     int fileOrigin, bool archive,
     const QString& fileName, const QString& relativeName,
     const MOShared::FileEntry::AlternativesVector& alternatives);
+
 
   void restoreTabState(const QByteArray &state);
   void restoreConflictExpandersState(const QByteArray &state);

--- a/src/modinfodialog.h
+++ b/src/modinfodialog.h
@@ -429,6 +429,9 @@ private:
   ExpanderWidget m_overwriteExpander, m_overwrittenExpander, m_nonconflictExpander;
 
 
+  void refreshConflictLists();
+  void refreshFiles();
+
   void restoreTabState(const QByteArray &state);
   void restoreConflictExpandersState(const QByteArray &state);
 

--- a/src/modinfodialog.h
+++ b/src/modinfodialog.h
@@ -429,7 +429,7 @@ private:
   ExpanderWidget m_overwriteExpander, m_overwrittenExpander, m_nonconflictExpander;
 
 
-  void refreshConflictLists();
+  void refreshConflictLists(bool refreshGeneral, bool refreshAdvanced);
   void refreshFiles();
 
   QTreeWidgetItem* createOverwriteItem(
@@ -440,8 +440,13 @@ private:
     bool archive, const QString& fileName, const QString& relativeName);
 
   QTreeWidgetItem* createOverwrittenItem(
-    const MOShared::FileEntry::Ptr& file,
-    bool archive, const QString& fileName, const QString& relativeName);
+    int fileOrigin, bool archive,
+    const QString& fileName, const QString& relativeName);
+
+  QTreeWidgetItem* createAdvancedConflictItem(
+    int fileOrigin, bool archive,
+    const QString& fileName, const QString& relativeName,
+    const MOShared::FileEntry::AlternativesVector& alternatives);
 
   void restoreTabState(const QByteArray &state);
   void restoreConflictExpandersState(const QByteArray &state);

--- a/src/modinfodialog.h
+++ b/src/modinfodialog.h
@@ -368,6 +368,7 @@ private slots:
   void on_overwriteTree_customContextMenuRequested(const QPoint &pos);
   void on_overwrittenTree_customContextMenuRequested(const QPoint &pos);
   void on_noConflictTree_customContextMenuRequested(const QPoint &pos);
+  void on_conflictsAdvancedList_customContextMenuRequested(const QPoint &pos);
   void on_fileTree_customContextMenuRequested(const QPoint &pos);
 
   void on_refreshButton_clicked();
@@ -450,6 +451,13 @@ private:
     const QString& fileName, const QString& relativeName,
     const MOShared::FileEntry::AlternativesVector& alternatives);
 
+  void setConflictItem(
+    QTreeWidgetItem* item,
+    const QString& fileName, const QString& origin, bool archive) const;
+
+  QString conflictFileName(const QTreeWidgetItem* conflictItem) const;
+  QString conflictOrigin(const QTreeWidgetItem* conflictItem) const;
+  bool conflictIsArchive(const QTreeWidgetItem* conflictItem) const;
 
   void restoreTabState(const QByteArray &state);
   void restoreConflictsState(const QByteArray &state);
@@ -461,8 +469,6 @@ private:
   bool canUnhideConflictItem(const QTreeWidgetItem* item) const;
   bool canPreviewConflictItem(const QTreeWidgetItem* item) const;
 
-  void openDataFile(const QTreeWidgetItem* item);
-  void previewDataFile(const QTreeWidgetItem* item);
   void changeFiletreeVisibility(bool visible);
 
   void openConflictItems(const QList<QTreeWidgetItem*>& items);

--- a/src/modinfodialog.h
+++ b/src/modinfodialog.h
@@ -467,6 +467,7 @@ private:
 
   bool canHideConflictItem(const QTreeWidgetItem* item) const;
   bool canUnhideConflictItem(const QTreeWidgetItem* item) const;
+  bool canOpenConflictItem(const QTreeWidgetItem* item) const;
   bool canPreviewConflictItem(const QTreeWidgetItem* item) const;
 
   void changeFiletreeVisibility(bool visible);
@@ -477,6 +478,7 @@ private:
     const QList<QTreeWidgetItem*>& items, bool visible);
 
   bool canPreviewFile(bool isArchive, const QString& filename) const;
+  bool canOpenFile(bool isArchive, const QString& filename) const;
   bool canHideFile(bool isArchive, const QString& filename) const;
   bool canUnhideFile(bool isArchive, const QString& filename) const;
 

--- a/src/modinfodialog.h
+++ b/src/modinfodialog.h
@@ -432,6 +432,17 @@ private:
   void refreshConflictLists();
   void refreshFiles();
 
+  QTreeWidgetItem* createOverwriteItem(
+    bool archive, const QString& fileName, const QString& relativeName,
+    const MOShared::FileEntry::AlternativesVector& alternatives);
+
+  QTreeWidgetItem* createNoConflictItem(
+    bool archive, const QString& fileName, const QString& relativeName);
+
+  QTreeWidgetItem* createOverwrittenItem(
+    const MOShared::FileEntry::Ptr& file,
+    bool archive, const QString& fileName, const QString& relativeName);
+
   void restoreTabState(const QByteArray &state);
   void restoreConflictExpandersState(const QByteArray &state);
 

--- a/src/modinfodialog.h
+++ b/src/modinfodialog.h
@@ -452,10 +452,10 @@ private:
 
 
   void restoreTabState(const QByteArray &state);
-  void restoreConflictExpandersState(const QByteArray &state);
+  void restoreConflictsState(const QByteArray &state);
 
   QByteArray saveTabState() const;
-  QByteArray saveConflictExpandersState() const;
+  QByteArray saveConflictsState() const;
 
   bool canHideConflictItem(const QTreeWidgetItem* item) const;
   bool canUnhideConflictItem(const QTreeWidgetItem* item) const;

--- a/src/modinfodialog.h
+++ b/src/modinfodialog.h
@@ -385,15 +385,20 @@ private slots:
 
   void createTweak();
 private:
+  using FileEntry = MOShared::FileEntry;
+
   struct ConflictActions
   {
     QAction* hide;
     QAction* unhide;
     QAction* open;
     QAction* preview;
+    QMenu* gotoMenu;
+    std::vector<QAction*> gotoActions;
 
-    ConflictActions()
-      : hide(nullptr), unhide(nullptr), open(nullptr), preview(nullptr)
+    ConflictActions() :
+      hide(nullptr), unhide(nullptr), open(nullptr), preview(nullptr),
+      gotoMenu(nullptr)
     {
     }
   };
@@ -438,28 +443,33 @@ private:
   void refreshFiles();
 
   QTreeWidgetItem* createOverwriteItem(
-    bool archive, const QString& fileName, const QString& relativeName,
+    FileEntry::Index index, bool archive,
+    const QString& fileName, const QString& relativeName,
     const MOShared::FileEntry::AlternativesVector& alternatives);
 
   QTreeWidgetItem* createNoConflictItem(
-    bool archive, const QString& fileName, const QString& relativeName);
+    FileEntry::Index index, bool archive,
+    const QString& fileName, const QString& relativeName);
 
   QTreeWidgetItem* createOverwrittenItem(
-    int fileOrigin, bool archive,
+    FileEntry::Index index, int fileOrigin, bool archive,
     const QString& fileName, const QString& relativeName);
 
   QTreeWidgetItem* createAdvancedConflictItem(
-    int fileOrigin, bool archive,
+    FileEntry::Index index, int fileOrigin, bool archive,
     const QString& fileName, const QString& relativeName,
     const MOShared::FileEntry::AlternativesVector& alternatives);
 
   void setConflictItem(
-    QTreeWidgetItem* item,
-    const QString& fileName, const QString& origin, bool archive) const;
+    QTreeWidgetItem* item, FileEntry::Index index,
+    const QString& fileName, bool hasAltOrigins, const QString& altOrigin,
+    bool archive) const;
 
   QString conflictFileName(const QTreeWidgetItem* conflictItem) const;
-  QString conflictOrigin(const QTreeWidgetItem* conflictItem) const;
+  QString conflictAltOrigin(const QTreeWidgetItem* conflictItem) const;
+  bool conflictHasAlts(const QTreeWidgetItem* conflictItem) const;
   bool conflictIsArchive(const QTreeWidgetItem* conflictItem) const;
+  FileEntry::Index conflictFileIndex(const QTreeWidgetItem* conflictItem) const;
 
   void restoreTabState(const QByteArray &state);
   void restoreConflictsState(const QByteArray &state);
@@ -487,7 +497,10 @@ private:
   void showConflictMenu(const QPoint &pos, QTreeWidget* tree);
 
   ConflictActions createConflictMenuActions(
-    const QList<QTreeWidgetItem*> selection);
+    const QList<QTreeWidgetItem*>& selection);
+
+  std::vector<QAction*> createGotoActions(
+    const QList<QTreeWidgetItem*>& selection);
 };
 
 #endif // MODINFODIALOG_H

--- a/src/modinfodialog.ui
+++ b/src/modinfodialog.ui
@@ -404,7 +404,7 @@ Most mods do not have optional esps, so chances are good you are looking at an e
        <item>
         <widget class="QTabWidget" name="tabConflictsTabs">
          <property name="currentIndex">
-          <number>1</number>
+          <number>0</number>
          </property>
          <widget class="QWidget" name="tab">
           <attribute name="title">
@@ -481,23 +481,20 @@ text-align: left;</string>
                 <property name="textElideMode">
                  <enum>Qt::ElideLeft</enum>
                 </property>
+                <property name="uniformRowHeights">
+                 <bool>true</bool>
+                </property>
                 <property name="sortingEnabled">
                  <bool>true</bool>
                 </property>
                 <property name="animated">
                  <bool>true</bool>
                 </property>
-                <property name="headerHidden">
-                 <bool>false</bool>
-                </property>
                 <property name="columnCount">
                  <number>2</number>
                 </property>
                 <attribute name="headerDefaultSectionSize">
                  <number>365</number>
-                </attribute>
-                <attribute name="headerHighlightSections">
-                 <bool>false</bool>
                 </attribute>
                 <attribute name="headerMinimumSectionSize">
                  <number>200</number>
@@ -554,8 +551,14 @@ text-align: left;</string>
                 <property name="contextMenuPolicy">
                  <enum>Qt::CustomContextMenu</enum>
                 </property>
+                <property name="selectionMode">
+                 <enum>QAbstractItemView::ExtendedSelection</enum>
+                </property>
                 <property name="textElideMode">
                  <enum>Qt::ElideLeft</enum>
+                </property>
+                <property name="uniformRowHeights">
+                 <bool>true</bool>
                 </property>
                 <property name="sortingEnabled">
                  <bool>true</bool>
@@ -624,8 +627,14 @@ text-align: left;</string>
                 <property name="contextMenuPolicy">
                  <enum>Qt::CustomContextMenu</enum>
                 </property>
+                <property name="selectionMode">
+                 <enum>QAbstractItemView::ExtendedSelection</enum>
+                </property>
                 <property name="textElideMode">
                  <enum>Qt::ElideLeft</enum>
+                </property>
+                <property name="uniformRowHeights">
+                 <bool>true</bool>
                 </property>
                 <property name="sortingEnabled">
                  <bool>true</bool>

--- a/src/modinfodialog.ui
+++ b/src/modinfodialog.ui
@@ -750,6 +750,23 @@ text-align: left;</string>
                   </widget>
                  </item>
                  <item>
+                  <widget class="QRadioButton" name="conflictsAdvancedShowAll">
+                   <property name="text">
+                    <string>Show all conflicting mods</string>
+                   </property>
+                   <property name="checked">
+                    <bool>true</bool>
+                   </property>
+                  </widget>
+                 </item>
+                 <item>
+                  <widget class="QRadioButton" name="conflictsAdvancedShowNearest">
+                   <property name="text">
+                    <string>Show nearest conflicting mod</string>
+                   </property>
+                  </widget>
+                 </item>
+                 <item>
                   <widget class="QWidget" name="widget_5" native="true">
                    <layout class="QHBoxLayout" name="horizontalLayout_8">
                     <property name="leftMargin">

--- a/src/modinfodialog.ui
+++ b/src/modinfodialog.ui
@@ -402,7 +402,7 @@ Most mods do not have optional esps, so chances are good you are looking at an e
       </attribute>
       <layout class="QVBoxLayout" name="verticalLayout_8" stretch="0">
        <item>
-        <widget class="QTabWidget" name="tabWidget_2">
+        <widget class="QTabWidget" name="tabConflictsTabs">
          <property name="currentIndex">
           <number>1</number>
          </property>

--- a/src/modinfodialog.ui
+++ b/src/modinfodialog.ui
@@ -744,6 +744,9 @@ text-align: left;</string>
                    <property name="text">
                     <string>Show files that have no conflicts</string>
                    </property>
+                   <property name="checked">
+                    <bool>true</bool>
+                   </property>
                   </widget>
                  </item>
                  <item>

--- a/src/modinfodialog.ui
+++ b/src/modinfodialog.ui
@@ -400,242 +400,257 @@ Most mods do not have optional esps, so chances are good you are looking at an e
       <attribute name="title">
        <string>Conflicts</string>
       </attribute>
-      <layout class="QVBoxLayout" name="verticalLayout_8" stretch="0,1,0,1,0,1,0">
+      <layout class="QVBoxLayout" name="verticalLayout_8" stretch="0">
        <property name="bottomMargin">
         <number>0</number>
        </property>
        <item>
-        <layout class="QVBoxLayout" name="overwriteRoot">
-         <item>
-          <layout class="QHBoxLayout" name="overwriteHeader" stretch="1,0">
-           <item>
-            <widget class="QToolButton" name="overwriteExpander">
-             <property name="sizePolicy">
-              <sizepolicy hsizetype="Preferred" vsizetype="Preferred">
-               <horstretch>0</horstretch>
-               <verstretch>0</verstretch>
-              </sizepolicy>
-             </property>
-             <property name="styleSheet">
-              <string notr="true">border: none;
-text-align: left;</string>
-             </property>
-             <property name="text">
-              <string>The following conflicted files are provided by this mod</string>
-             </property>
-            </widget>
-           </item>
-           <item>
-            <widget class="QLCDNumber" name="overwriteCount">
-             <property name="frameShadow">
-              <enum>QFrame::Sunken</enum>
-             </property>
-             <property name="lineWidth">
-              <number>1</number>
-             </property>
-             <property name="segmentStyle">
-              <enum>QLCDNumber::Flat</enum>
-             </property>
-            </widget>
-           </item>
-          </layout>
-         </item>
-        </layout>
-       </item>
-       <item>
-        <widget class="QTreeWidget" name="overwriteTree">
-         <property name="contextMenuPolicy">
-          <enum>Qt::CustomContextMenu</enum>
-         </property>
-         <property name="selectionMode">
-          <enum>QAbstractItemView::ExtendedSelection</enum>
-         </property>
-         <property name="textElideMode">
-          <enum>Qt::ElideLeft</enum>
-         </property>
-         <property name="uniformRowHeights">
-          <bool>true</bool>
-         </property>
-         <property name="sortingEnabled">
-          <bool>true</bool>
-         </property>
-         <property name="animated">
-          <bool>true</bool>
-         </property>
-         <property name="columnCount">
-          <number>2</number>
-         </property>
-         <attribute name="headerDefaultSectionSize">
-          <number>365</number>
-         </attribute>
-         <attribute name="headerMinimumSectionSize">
-          <number>200</number>
-         </attribute>
-         <column>
-          <property name="text">
-           <string>File</string>
-          </property>
-         </column>
-         <column>
-          <property name="text">
-           <string>Overwritten Mods</string>
-          </property>
-         </column>
-        </widget>
-       </item>
-       <item>
-        <layout class="QVBoxLayout" name="overwrittenRoot">
-         <item>
-          <layout class="QHBoxLayout" name="overwrittenHeader" stretch="1,0">
-           <item>
-            <widget class="QToolButton" name="overwrittenExpander">
-             <property name="sizePolicy">
-              <sizepolicy hsizetype="Preferred" vsizetype="Preferred">
-               <horstretch>0</horstretch>
-               <verstretch>0</verstretch>
-              </sizepolicy>
-             </property>
-             <property name="styleSheet">
-              <string notr="true">border: none;
-text-align: left;</string>
-             </property>
-             <property name="text">
-              <string>The following conflicted files are provided by other mods</string>
-             </property>
-            </widget>
-           </item>
-           <item>
-            <widget class="QLCDNumber" name="overwrittenCount">
-             <property name="frameShadow">
-              <enum>QFrame::Sunken</enum>
-             </property>
-             <property name="segmentStyle">
-              <enum>QLCDNumber::Flat</enum>
-             </property>
-            </widget>
-           </item>
-          </layout>
-         </item>
-        </layout>
-       </item>
-       <item>
-        <widget class="QTreeWidget" name="overwrittenTree">
-         <property name="contextMenuPolicy">
-          <enum>Qt::CustomContextMenu</enum>
-         </property>
-         <property name="selectionMode">
-          <enum>QAbstractItemView::ExtendedSelection</enum>
-         </property>
-         <property name="textElideMode">
-          <enum>Qt::ElideLeft</enum>
-         </property>
-         <property name="uniformRowHeights">
-          <bool>true</bool>
-         </property>
-         <property name="sortingEnabled">
-          <bool>true</bool>
-         </property>
-         <property name="animated">
-          <bool>true</bool>
-         </property>
-         <property name="columnCount">
-          <number>2</number>
-         </property>
-         <attribute name="headerDefaultSectionSize">
-          <number>365</number>
-         </attribute>
-         <attribute name="headerMinimumSectionSize">
-          <number>200</number>
-         </attribute>
-         <column>
-          <property name="text">
-           <string>File</string>
-          </property>
-         </column>
-         <column>
-          <property name="text">
-           <string>Providing Mod</string>
-          </property>
-         </column>
-        </widget>
-       </item>
-       <item>
-        <layout class="QVBoxLayout" name="noConflictRoot">
-         <item>
-          <layout class="QHBoxLayout" name="noConflictHeader" stretch="1,0">
-           <item>
-            <widget class="QToolButton" name="noConflictExpander">
-             <property name="sizePolicy">
-              <sizepolicy hsizetype="Preferred" vsizetype="Preferred">
-               <horstretch>0</horstretch>
-               <verstretch>0</verstretch>
-              </sizepolicy>
-             </property>
-             <property name="styleSheet">
-              <string notr="true">border: none;
-text-align: left;</string>
-             </property>
-             <property name="text">
-              <string>The following files have no conflicts</string>
-             </property>
-            </widget>
-           </item>
-           <item>
-            <widget class="QLCDNumber" name="noConflictCount">
-             <property name="frameShadow">
-              <enum>QFrame::Sunken</enum>
-             </property>
-             <property name="segmentStyle">
-              <enum>QLCDNumber::Flat</enum>
-             </property>
-            </widget>
-           </item>
-          </layout>
-         </item>
-        </layout>
-       </item>
-       <item>
-        <widget class="QTreeWidget" name="noConflictTree">
-         <property name="contextMenuPolicy">
-          <enum>Qt::CustomContextMenu</enum>
-         </property>
-         <property name="selectionMode">
-          <enum>QAbstractItemView::ExtendedSelection</enum>
-         </property>
-         <property name="textElideMode">
-          <enum>Qt::ElideLeft</enum>
-         </property>
-         <property name="uniformRowHeights">
-          <bool>true</bool>
-         </property>
-         <property name="sortingEnabled">
-          <bool>true</bool>
-         </property>
-         <property name="animated">
-          <bool>true</bool>
-         </property>
-         <property name="columnCount">
-          <number>1</number>
-         </property>
-         <column>
-          <property name="text">
-           <string>File</string>
-          </property>
-         </column>
-        </widget>
-       </item>
-       <item>
-        <spacer name="verticalSpacer">
-         <property name="orientation">
-          <enum>Qt::Vertical</enum>
-         </property>
-         <property name="sizeHint" stdset="0">
+        <widget class="QWidget" name="widget" native="true">
+         <property name="minimumSize">
           <size>
-           <width>20</width>
-           <height>0</height>
+           <width>0</width>
+           <height>100</height>
           </size>
          </property>
-        </spacer>
+         <layout class="QVBoxLayout" name="verticalLayout_11" stretch="0,1,0,1,0,1,0">
+          <property name="leftMargin">
+           <number>0</number>
+          </property>
+          <property name="topMargin">
+           <number>0</number>
+          </property>
+          <property name="rightMargin">
+           <number>0</number>
+          </property>
+          <property name="bottomMargin">
+           <number>0</number>
+          </property>
+          <item>
+           <layout class="QVBoxLayout" name="overwriteRoot">
+            <item>
+             <layout class="QHBoxLayout" name="overwriteHeader" stretch="1,0">
+              <item>
+               <widget class="QToolButton" name="overwriteExpander">
+                <property name="sizePolicy">
+                 <sizepolicy hsizetype="Preferred" vsizetype="Preferred">
+                  <horstretch>0</horstretch>
+                  <verstretch>0</verstretch>
+                 </sizepolicy>
+                </property>
+                <property name="styleSheet">
+                 <string notr="true">border: none;
+text-align: left;</string>
+                </property>
+                <property name="text">
+                 <string>The following conflicted files are provided by this mod</string>
+                </property>
+               </widget>
+              </item>
+              <item>
+               <widget class="QLCDNumber" name="overwriteCount">
+                <property name="frameShadow">
+                 <enum>QFrame::Sunken</enum>
+                </property>
+                <property name="lineWidth">
+                 <number>1</number>
+                </property>
+                <property name="segmentStyle">
+                 <enum>QLCDNumber::Flat</enum>
+                </property>
+               </widget>
+              </item>
+             </layout>
+            </item>
+           </layout>
+          </item>
+          <item>
+           <widget class="QTreeWidget" name="overwriteTree">
+            <property name="contextMenuPolicy">
+             <enum>Qt::CustomContextMenu</enum>
+            </property>
+            <property name="selectionMode">
+             <enum>QAbstractItemView::ExtendedSelection</enum>
+            </property>
+            <property name="textElideMode">
+             <enum>Qt::ElideLeft</enum>
+            </property>
+            <property name="sortingEnabled">
+             <bool>true</bool>
+            </property>
+            <property name="animated">
+             <bool>true</bool>
+            </property>
+            <property name="headerHidden">
+             <bool>false</bool>
+            </property>
+            <property name="columnCount">
+             <number>2</number>
+            </property>
+            <attribute name="headerDefaultSectionSize">
+             <number>365</number>
+            </attribute>
+            <attribute name="headerHighlightSections">
+             <bool>false</bool>
+            </attribute>
+            <attribute name="headerMinimumSectionSize">
+             <number>200</number>
+            </attribute>
+            <column>
+             <property name="text">
+              <string>File</string>
+             </property>
+            </column>
+            <column>
+             <property name="text">
+              <string>Overwritten Mods</string>
+             </property>
+            </column>
+           </widget>
+          </item>
+          <item>
+           <layout class="QVBoxLayout" name="overwrittenRoot">
+            <item>
+             <layout class="QHBoxLayout" name="overwrittenHeader" stretch="1,0">
+              <item>
+               <widget class="QToolButton" name="overwrittenExpander">
+                <property name="sizePolicy">
+                 <sizepolicy hsizetype="Preferred" vsizetype="Preferred">
+                  <horstretch>0</horstretch>
+                  <verstretch>0</verstretch>
+                 </sizepolicy>
+                </property>
+                <property name="styleSheet">
+                 <string notr="true">border: none;
+text-align: left;</string>
+                </property>
+                <property name="text">
+                 <string>The following conflicted files are provided by other mods</string>
+                </property>
+               </widget>
+              </item>
+              <item>
+               <widget class="QLCDNumber" name="overwrittenCount">
+                <property name="frameShadow">
+                 <enum>QFrame::Sunken</enum>
+                </property>
+                <property name="segmentStyle">
+                 <enum>QLCDNumber::Flat</enum>
+                </property>
+               </widget>
+              </item>
+             </layout>
+            </item>
+           </layout>
+          </item>
+          <item>
+           <widget class="QTreeWidget" name="overwrittenTree">
+            <property name="contextMenuPolicy">
+             <enum>Qt::CustomContextMenu</enum>
+            </property>
+            <property name="textElideMode">
+             <enum>Qt::ElideLeft</enum>
+            </property>
+            <property name="sortingEnabled">
+             <bool>true</bool>
+            </property>
+            <property name="animated">
+             <bool>true</bool>
+            </property>
+            <property name="columnCount">
+             <number>2</number>
+            </property>
+            <attribute name="headerDefaultSectionSize">
+             <number>365</number>
+            </attribute>
+            <attribute name="headerMinimumSectionSize">
+             <number>200</number>
+            </attribute>
+            <column>
+             <property name="text">
+              <string>File</string>
+             </property>
+            </column>
+            <column>
+             <property name="text">
+              <string>Providing Mod</string>
+             </property>
+            </column>
+           </widget>
+          </item>
+          <item>
+           <layout class="QVBoxLayout" name="noConflictRoot">
+            <item>
+             <layout class="QHBoxLayout" name="noConflictHeader" stretch="1,0">
+              <item>
+               <widget class="QToolButton" name="noConflictExpander">
+                <property name="sizePolicy">
+                 <sizepolicy hsizetype="Preferred" vsizetype="Preferred">
+                  <horstretch>0</horstretch>
+                  <verstretch>0</verstretch>
+                 </sizepolicy>
+                </property>
+                <property name="styleSheet">
+                 <string notr="true">border: none;
+text-align: left;</string>
+                </property>
+                <property name="text">
+                 <string>The following files have no conflicts</string>
+                </property>
+               </widget>
+              </item>
+              <item>
+               <widget class="QLCDNumber" name="noConflictCount">
+                <property name="frameShadow">
+                 <enum>QFrame::Sunken</enum>
+                </property>
+                <property name="segmentStyle">
+                 <enum>QLCDNumber::Flat</enum>
+                </property>
+               </widget>
+              </item>
+             </layout>
+            </item>
+           </layout>
+          </item>
+          <item>
+           <widget class="QTreeWidget" name="noConflictTree">
+            <property name="contextMenuPolicy">
+             <enum>Qt::CustomContextMenu</enum>
+            </property>
+            <property name="textElideMode">
+             <enum>Qt::ElideLeft</enum>
+            </property>
+            <property name="sortingEnabled">
+             <bool>true</bool>
+            </property>
+            <property name="animated">
+             <bool>true</bool>
+            </property>
+            <property name="columnCount">
+             <number>1</number>
+            </property>
+            <column>
+             <property name="text">
+              <string>File</string>
+             </property>
+            </column>
+           </widget>
+          </item>
+          <item>
+           <spacer name="verticalSpacer">
+            <property name="orientation">
+             <enum>Qt::Vertical</enum>
+            </property>
+            <property name="sizeHint" stdset="0">
+             <size>
+              <width>20</width>
+              <height>0</height>
+             </size>
+            </property>
+           </spacer>
+          </item>
+         </layout>
+        </widget>
        </item>
       </layout>
      </widget>

--- a/src/modinfodialog.ui
+++ b/src/modinfodialog.ui
@@ -782,7 +782,7 @@ text-align: left;</string>
                      <number>0</number>
                     </property>
                     <item>
-                     <widget class="MOBase::LineEditClear" name="conflictsAdvancedFilter">
+                     <widget class="QLineEdit" name="conflictsAdvancedFilter">
                       <property name="placeholderText">
                        <string>Filter</string>
                       </property>
@@ -1200,11 +1200,6 @@ p, li { white-space: pre-wrap; }
    <class>ModIDLineEdit</class>
    <extends>QLineEdit</extends>
    <header>modidlineedit.h</header>
-  </customwidget>
-  <customwidget>
-   <class>MOBase::LineEditClear</class>
-   <extends>QLineEdit</extends>
-   <header>lineeditclear.h</header>
   </customwidget>
  </customwidgets>
  <resources>

--- a/src/modinfodialog.ui
+++ b/src/modinfodialog.ui
@@ -401,255 +401,384 @@ Most mods do not have optional esps, so chances are good you are looking at an e
        <string>Conflicts</string>
       </attribute>
       <layout class="QVBoxLayout" name="verticalLayout_8" stretch="0">
-       <property name="bottomMargin">
-        <number>0</number>
-       </property>
        <item>
-        <widget class="QWidget" name="widget" native="true">
-         <property name="minimumSize">
-          <size>
-           <width>0</width>
-           <height>100</height>
-          </size>
+        <widget class="QTabWidget" name="tabWidget_2">
+         <property name="currentIndex">
+          <number>1</number>
          </property>
-         <layout class="QVBoxLayout" name="verticalLayout_11" stretch="0,1,0,1,0,1,0">
-          <property name="leftMargin">
-           <number>0</number>
-          </property>
-          <property name="topMargin">
-           <number>0</number>
-          </property>
-          <property name="rightMargin">
-           <number>0</number>
-          </property>
-          <property name="bottomMargin">
-           <number>0</number>
-          </property>
-          <item>
-           <layout class="QVBoxLayout" name="overwriteRoot">
-            <item>
-             <layout class="QHBoxLayout" name="overwriteHeader" stretch="1,0">
+         <widget class="QWidget" name="tab">
+          <attribute name="title">
+           <string>General</string>
+          </attribute>
+          <layout class="QVBoxLayout" name="verticalLayout_12">
+           <item>
+            <widget class="QWidget" name="widget" native="true">
+             <property name="minimumSize">
+              <size>
+               <width>0</width>
+               <height>100</height>
+              </size>
+             </property>
+             <layout class="QVBoxLayout" name="verticalLayout_11" stretch="0,1,0,1,0,1,0">
+              <property name="leftMargin">
+               <number>0</number>
+              </property>
+              <property name="topMargin">
+               <number>0</number>
+              </property>
+              <property name="rightMargin">
+               <number>0</number>
+              </property>
+              <property name="bottomMargin">
+               <number>0</number>
+              </property>
               <item>
-               <widget class="QToolButton" name="overwriteExpander">
-                <property name="sizePolicy">
-                 <sizepolicy hsizetype="Preferred" vsizetype="Preferred">
-                  <horstretch>0</horstretch>
-                  <verstretch>0</verstretch>
-                 </sizepolicy>
-                </property>
-                <property name="styleSheet">
-                 <string notr="true">border: none;
+               <layout class="QVBoxLayout" name="overwriteRoot">
+                <item>
+                 <layout class="QHBoxLayout" name="overwriteHeader" stretch="1,0">
+                  <item>
+                   <widget class="QToolButton" name="overwriteExpander">
+                    <property name="sizePolicy">
+                     <sizepolicy hsizetype="Preferred" vsizetype="Preferred">
+                      <horstretch>0</horstretch>
+                      <verstretch>0</verstretch>
+                     </sizepolicy>
+                    </property>
+                    <property name="styleSheet">
+                     <string notr="true">border: none;
 text-align: left;</string>
+                    </property>
+                    <property name="text">
+                     <string>The following conflicted files are provided by this mod</string>
+                    </property>
+                   </widget>
+                  </item>
+                  <item>
+                   <widget class="QLCDNumber" name="overwriteCount">
+                    <property name="frameShadow">
+                     <enum>QFrame::Sunken</enum>
+                    </property>
+                    <property name="lineWidth">
+                     <number>1</number>
+                    </property>
+                    <property name="segmentStyle">
+                     <enum>QLCDNumber::Flat</enum>
+                    </property>
+                   </widget>
+                  </item>
+                 </layout>
+                </item>
+               </layout>
+              </item>
+              <item>
+               <widget class="QTreeWidget" name="overwriteTree">
+                <property name="contextMenuPolicy">
+                 <enum>Qt::CustomContextMenu</enum>
                 </property>
-                <property name="text">
-                 <string>The following conflicted files are provided by this mod</string>
+                <property name="selectionMode">
+                 <enum>QAbstractItemView::ExtendedSelection</enum>
                 </property>
+                <property name="textElideMode">
+                 <enum>Qt::ElideLeft</enum>
+                </property>
+                <property name="sortingEnabled">
+                 <bool>true</bool>
+                </property>
+                <property name="animated">
+                 <bool>true</bool>
+                </property>
+                <property name="headerHidden">
+                 <bool>false</bool>
+                </property>
+                <property name="columnCount">
+                 <number>2</number>
+                </property>
+                <attribute name="headerDefaultSectionSize">
+                 <number>365</number>
+                </attribute>
+                <attribute name="headerHighlightSections">
+                 <bool>false</bool>
+                </attribute>
+                <attribute name="headerMinimumSectionSize">
+                 <number>200</number>
+                </attribute>
+                <column>
+                 <property name="text">
+                  <string>File</string>
+                 </property>
+                </column>
+                <column>
+                 <property name="text">
+                  <string>Overwritten Mods</string>
+                 </property>
+                </column>
                </widget>
               </item>
               <item>
-               <widget class="QLCDNumber" name="overwriteCount">
-                <property name="frameShadow">
-                 <enum>QFrame::Sunken</enum>
+               <layout class="QVBoxLayout" name="overwrittenRoot">
+                <item>
+                 <layout class="QHBoxLayout" name="overwrittenHeader" stretch="1,0">
+                  <item>
+                   <widget class="QToolButton" name="overwrittenExpander">
+                    <property name="sizePolicy">
+                     <sizepolicy hsizetype="Preferred" vsizetype="Preferred">
+                      <horstretch>0</horstretch>
+                      <verstretch>0</verstretch>
+                     </sizepolicy>
+                    </property>
+                    <property name="styleSheet">
+                     <string notr="true">border: none;
+text-align: left;</string>
+                    </property>
+                    <property name="text">
+                     <string>The following conflicted files are provided by other mods</string>
+                    </property>
+                   </widget>
+                  </item>
+                  <item>
+                   <widget class="QLCDNumber" name="overwrittenCount">
+                    <property name="frameShadow">
+                     <enum>QFrame::Sunken</enum>
+                    </property>
+                    <property name="segmentStyle">
+                     <enum>QLCDNumber::Flat</enum>
+                    </property>
+                   </widget>
+                  </item>
+                 </layout>
+                </item>
+               </layout>
+              </item>
+              <item>
+               <widget class="QTreeWidget" name="overwrittenTree">
+                <property name="contextMenuPolicy">
+                 <enum>Qt::CustomContextMenu</enum>
                 </property>
-                <property name="lineWidth">
+                <property name="textElideMode">
+                 <enum>Qt::ElideLeft</enum>
+                </property>
+                <property name="sortingEnabled">
+                 <bool>true</bool>
+                </property>
+                <property name="animated">
+                 <bool>true</bool>
+                </property>
+                <property name="columnCount">
+                 <number>2</number>
+                </property>
+                <attribute name="headerDefaultSectionSize">
+                 <number>365</number>
+                </attribute>
+                <attribute name="headerMinimumSectionSize">
+                 <number>200</number>
+                </attribute>
+                <column>
+                 <property name="text">
+                  <string>File</string>
+                 </property>
+                </column>
+                <column>
+                 <property name="text">
+                  <string>Providing Mod</string>
+                 </property>
+                </column>
+               </widget>
+              </item>
+              <item>
+               <layout class="QVBoxLayout" name="noConflictRoot">
+                <item>
+                 <layout class="QHBoxLayout" name="noConflictHeader" stretch="1,0">
+                  <item>
+                   <widget class="QToolButton" name="noConflictExpander">
+                    <property name="sizePolicy">
+                     <sizepolicy hsizetype="Preferred" vsizetype="Preferred">
+                      <horstretch>0</horstretch>
+                      <verstretch>0</verstretch>
+                     </sizepolicy>
+                    </property>
+                    <property name="styleSheet">
+                     <string notr="true">border: none;
+text-align: left;</string>
+                    </property>
+                    <property name="text">
+                     <string>The following files have no conflicts</string>
+                    </property>
+                   </widget>
+                  </item>
+                  <item>
+                   <widget class="QLCDNumber" name="noConflictCount">
+                    <property name="frameShadow">
+                     <enum>QFrame::Sunken</enum>
+                    </property>
+                    <property name="segmentStyle">
+                     <enum>QLCDNumber::Flat</enum>
+                    </property>
+                   </widget>
+                  </item>
+                 </layout>
+                </item>
+               </layout>
+              </item>
+              <item>
+               <widget class="QTreeWidget" name="noConflictTree">
+                <property name="contextMenuPolicy">
+                 <enum>Qt::CustomContextMenu</enum>
+                </property>
+                <property name="textElideMode">
+                 <enum>Qt::ElideLeft</enum>
+                </property>
+                <property name="sortingEnabled">
+                 <bool>true</bool>
+                </property>
+                <property name="animated">
+                 <bool>true</bool>
+                </property>
+                <property name="columnCount">
                  <number>1</number>
                 </property>
-                <property name="segmentStyle">
-                 <enum>QLCDNumber::Flat</enum>
+                <column>
+                 <property name="text">
+                  <string>File</string>
+                 </property>
+                </column>
+               </widget>
+              </item>
+              <item>
+               <spacer name="verticalSpacer">
+                <property name="orientation">
+                 <enum>Qt::Vertical</enum>
                 </property>
+                <property name="sizeHint" stdset="0">
+                 <size>
+                  <width>20</width>
+                  <height>0</height>
+                 </size>
+                </property>
+               </spacer>
+              </item>
+             </layout>
+            </widget>
+           </item>
+          </layout>
+         </widget>
+         <widget class="QWidget" name="tab_2">
+          <attribute name="title">
+           <string>Advanced</string>
+          </attribute>
+          <layout class="QVBoxLayout" name="verticalLayout_13">
+           <item>
+            <widget class="QWidget" name="widget_2" native="true">
+             <layout class="QVBoxLayout" name="verticalLayout_14">
+              <property name="leftMargin">
+               <number>0</number>
+              </property>
+              <property name="topMargin">
+               <number>0</number>
+              </property>
+              <property name="rightMargin">
+               <number>0</number>
+              </property>
+              <property name="bottomMargin">
+               <number>0</number>
+              </property>
+              <item>
+               <widget class="QWidget" name="widget_3" native="true">
+                <layout class="QHBoxLayout" name="horizontalLayout_10">
+                 <property name="leftMargin">
+                  <number>0</number>
+                 </property>
+                 <property name="topMargin">
+                  <number>0</number>
+                 </property>
+                 <property name="rightMargin">
+                  <number>0</number>
+                 </property>
+                 <property name="bottomMargin">
+                  <number>0</number>
+                 </property>
+                 <item>
+                  <widget class="QTreeWidget" name="conflictsAdvancedList">
+                   <property name="columnCount">
+                    <number>3</number>
+                   </property>
+                   <attribute name="headerDefaultSectionSize">
+                    <number>243</number>
+                   </attribute>
+                   <column>
+                    <property name="text">
+                     <string>Overwrites</string>
+                    </property>
+                   </column>
+                   <column>
+                    <property name="text">
+                     <string>File</string>
+                    </property>
+                   </column>
+                   <column>
+                    <property name="text">
+                     <string>Overwritten by</string>
+                    </property>
+                   </column>
+                  </widget>
+                 </item>
+                </layout>
+               </widget>
+              </item>
+              <item>
+               <widget class="QWidget" name="widget_4" native="true">
+                <layout class="QHBoxLayout" name="horizontalLayout_9">
+                 <property name="leftMargin">
+                  <number>0</number>
+                 </property>
+                 <property name="topMargin">
+                  <number>0</number>
+                 </property>
+                 <property name="rightMargin">
+                  <number>0</number>
+                 </property>
+                 <property name="bottomMargin">
+                  <number>0</number>
+                 </property>
+                 <item>
+                  <widget class="QCheckBox" name="conflictsAdvancedShowNoConflict">
+                   <property name="text">
+                    <string>Show files that have no conflicts</string>
+                   </property>
+                  </widget>
+                 </item>
+                 <item>
+                  <widget class="QWidget" name="widget_5" native="true">
+                   <layout class="QHBoxLayout" name="horizontalLayout_8">
+                    <property name="leftMargin">
+                     <number>20</number>
+                    </property>
+                    <property name="topMargin">
+                     <number>0</number>
+                    </property>
+                    <property name="rightMargin">
+                     <number>0</number>
+                    </property>
+                    <property name="bottomMargin">
+                     <number>0</number>
+                    </property>
+                    <item>
+                     <widget class="MOBase::LineEditClear" name="conflictsAdvancedFilter">
+                      <property name="placeholderText">
+                       <string>Filter</string>
+                      </property>
+                     </widget>
+                    </item>
+                   </layout>
+                  </widget>
+                 </item>
+                </layout>
                </widget>
               </item>
              </layout>
-            </item>
-           </layout>
-          </item>
-          <item>
-           <widget class="QTreeWidget" name="overwriteTree">
-            <property name="contextMenuPolicy">
-             <enum>Qt::CustomContextMenu</enum>
-            </property>
-            <property name="selectionMode">
-             <enum>QAbstractItemView::ExtendedSelection</enum>
-            </property>
-            <property name="textElideMode">
-             <enum>Qt::ElideLeft</enum>
-            </property>
-            <property name="sortingEnabled">
-             <bool>true</bool>
-            </property>
-            <property name="animated">
-             <bool>true</bool>
-            </property>
-            <property name="headerHidden">
-             <bool>false</bool>
-            </property>
-            <property name="columnCount">
-             <number>2</number>
-            </property>
-            <attribute name="headerDefaultSectionSize">
-             <number>365</number>
-            </attribute>
-            <attribute name="headerHighlightSections">
-             <bool>false</bool>
-            </attribute>
-            <attribute name="headerMinimumSectionSize">
-             <number>200</number>
-            </attribute>
-            <column>
-             <property name="text">
-              <string>File</string>
-             </property>
-            </column>
-            <column>
-             <property name="text">
-              <string>Overwritten Mods</string>
-             </property>
-            </column>
-           </widget>
-          </item>
-          <item>
-           <layout class="QVBoxLayout" name="overwrittenRoot">
-            <item>
-             <layout class="QHBoxLayout" name="overwrittenHeader" stretch="1,0">
-              <item>
-               <widget class="QToolButton" name="overwrittenExpander">
-                <property name="sizePolicy">
-                 <sizepolicy hsizetype="Preferred" vsizetype="Preferred">
-                  <horstretch>0</horstretch>
-                  <verstretch>0</verstretch>
-                 </sizepolicy>
-                </property>
-                <property name="styleSheet">
-                 <string notr="true">border: none;
-text-align: left;</string>
-                </property>
-                <property name="text">
-                 <string>The following conflicted files are provided by other mods</string>
-                </property>
-               </widget>
-              </item>
-              <item>
-               <widget class="QLCDNumber" name="overwrittenCount">
-                <property name="frameShadow">
-                 <enum>QFrame::Sunken</enum>
-                </property>
-                <property name="segmentStyle">
-                 <enum>QLCDNumber::Flat</enum>
-                </property>
-               </widget>
-              </item>
-             </layout>
-            </item>
-           </layout>
-          </item>
-          <item>
-           <widget class="QTreeWidget" name="overwrittenTree">
-            <property name="contextMenuPolicy">
-             <enum>Qt::CustomContextMenu</enum>
-            </property>
-            <property name="textElideMode">
-             <enum>Qt::ElideLeft</enum>
-            </property>
-            <property name="sortingEnabled">
-             <bool>true</bool>
-            </property>
-            <property name="animated">
-             <bool>true</bool>
-            </property>
-            <property name="columnCount">
-             <number>2</number>
-            </property>
-            <attribute name="headerDefaultSectionSize">
-             <number>365</number>
-            </attribute>
-            <attribute name="headerMinimumSectionSize">
-             <number>200</number>
-            </attribute>
-            <column>
-             <property name="text">
-              <string>File</string>
-             </property>
-            </column>
-            <column>
-             <property name="text">
-              <string>Providing Mod</string>
-             </property>
-            </column>
-           </widget>
-          </item>
-          <item>
-           <layout class="QVBoxLayout" name="noConflictRoot">
-            <item>
-             <layout class="QHBoxLayout" name="noConflictHeader" stretch="1,0">
-              <item>
-               <widget class="QToolButton" name="noConflictExpander">
-                <property name="sizePolicy">
-                 <sizepolicy hsizetype="Preferred" vsizetype="Preferred">
-                  <horstretch>0</horstretch>
-                  <verstretch>0</verstretch>
-                 </sizepolicy>
-                </property>
-                <property name="styleSheet">
-                 <string notr="true">border: none;
-text-align: left;</string>
-                </property>
-                <property name="text">
-                 <string>The following files have no conflicts</string>
-                </property>
-               </widget>
-              </item>
-              <item>
-               <widget class="QLCDNumber" name="noConflictCount">
-                <property name="frameShadow">
-                 <enum>QFrame::Sunken</enum>
-                </property>
-                <property name="segmentStyle">
-                 <enum>QLCDNumber::Flat</enum>
-                </property>
-               </widget>
-              </item>
-             </layout>
-            </item>
-           </layout>
-          </item>
-          <item>
-           <widget class="QTreeWidget" name="noConflictTree">
-            <property name="contextMenuPolicy">
-             <enum>Qt::CustomContextMenu</enum>
-            </property>
-            <property name="textElideMode">
-             <enum>Qt::ElideLeft</enum>
-            </property>
-            <property name="sortingEnabled">
-             <bool>true</bool>
-            </property>
-            <property name="animated">
-             <bool>true</bool>
-            </property>
-            <property name="columnCount">
-             <number>1</number>
-            </property>
-            <column>
-             <property name="text">
-              <string>File</string>
-             </property>
-            </column>
-           </widget>
-          </item>
-          <item>
-           <spacer name="verticalSpacer">
-            <property name="orientation">
-             <enum>Qt::Vertical</enum>
-            </property>
-            <property name="sizeHint" stdset="0">
-             <size>
-              <width>20</width>
-              <height>0</height>
-             </size>
-            </property>
-           </spacer>
-          </item>
-         </layout>
+            </widget>
+           </item>
+          </layout>
+         </widget>
         </widget>
        </item>
       </layout>
@@ -1051,6 +1180,11 @@ p, li { white-space: pre-wrap; }
    <class>ModIDLineEdit</class>
    <extends>QLineEdit</extends>
    <header>modidlineedit.h</header>
+  </customwidget>
+  <customwidget>
+   <class>MOBase::LineEditClear</class>
+   <extends>QLineEdit</extends>
+   <header>lineeditclear.h</header>
   </customwidget>
  </customwidgets>
  <resources>

--- a/src/modinfodialog.ui
+++ b/src/modinfodialog.ui
@@ -707,6 +707,15 @@ text-align: left;</string>
                  </property>
                  <item>
                   <widget class="QTreeWidget" name="conflictsAdvancedList">
+                   <property name="contextMenuPolicy">
+                    <enum>Qt::CustomContextMenu</enum>
+                   </property>
+                   <property name="selectionMode">
+                    <enum>QAbstractItemView::ExtendedSelection</enum>
+                   </property>
+                   <property name="uniformRowHeights">
+                    <bool>true</bool>
+                   </property>
                    <property name="columnCount">
                     <number>3</number>
                    </property>

--- a/src/modinfodialog.ui
+++ b/src/modinfodialog.ui
@@ -716,6 +716,9 @@ text-align: left;</string>
                    <property name="uniformRowHeights">
                     <bool>true</bool>
                    </property>
+                   <property name="sortingEnabled">
+                    <bool>true</bool>
+                   </property>
                    <property name="columnCount">
                     <number>3</number>
                    </property>

--- a/src/modinfodialog.ui
+++ b/src/modinfodialog.ui
@@ -762,6 +762,9 @@ text-align: left;</string>
                  </property>
                  <item>
                   <widget class="QCheckBox" name="conflictsAdvancedShowNoConflict">
+                   <property name="toolTip">
+                    <string>Whether files that have no conflicts should be visible in the list</string>
+                   </property>
                    <property name="text">
                     <string>Show files that have no conflicts</string>
                    </property>
@@ -772,6 +775,9 @@ text-align: left;</string>
                  </item>
                  <item>
                   <widget class="QRadioButton" name="conflictsAdvancedShowAll">
+                   <property name="toolTip">
+                    <string>Shows all mods overwriting or being overwritten by this mod</string>
+                   </property>
                    <property name="text">
                     <string>Show all conflicting mods</string>
                    </property>
@@ -782,6 +788,9 @@ text-align: left;</string>
                  </item>
                  <item>
                   <widget class="QRadioButton" name="conflictsAdvancedShowNearest">
+                   <property name="toolTip">
+                    <string>Shows only the nearest conflicting mods, in order of priority</string>
+                   </property>
                    <property name="text">
                     <string>Show nearest conflicting mod</string>
                    </property>

--- a/src/organizercore.cpp
+++ b/src/organizercore.cpp
@@ -1321,6 +1321,8 @@ bool OrganizerCore::executeFileVirtualized(
 bool OrganizerCore::previewFileWithAlternatives(
   QWidget* parent, QString fileName, int selectedOrigin)
 {
+  fileName = QDir::fromNativeSeparators(fileName);
+
   // what we have is an absolute path to the file in its actual location (for the primary origin)
   // what we want is the path relative to the virtual data directory
 

--- a/src/shared/directoryentry.cpp
+++ b/src/shared/directoryentry.cpp
@@ -220,6 +220,11 @@ std::vector<FileEntry::Ptr> FilesOrigin::getFiles() const
   return result;
 }
 
+FileEntry::Ptr FilesOrigin::findFile(FileEntry::Index index) const
+{
+  return m_FileRegister.lock()->getFile(index);
+}
+
 bool FilesOrigin::containsArchive(std::wstring archiveName)
 {
   for (FileEntry::Index fileIdx : m_Files)

--- a/src/shared/directoryentry.h
+++ b/src/shared/directoryentry.h
@@ -49,8 +49,8 @@ class FileEntry {
 public:
 
   typedef unsigned int Index;
-
   typedef boost::shared_ptr<FileEntry> Ptr;
+  typedef std::vector<std::pair<int, std::pair<std::wstring, int>>> AlternativesVector;
 
 public:
 
@@ -72,7 +72,7 @@ public:
 
   // gets the list of alternative origins (origins with lower priority than the primary one).
   // if sortOrigins has been called, it is sorted by priority (ascending)
-  const std::vector<std::pair<int, std::pair<std::wstring, int>>> &getAlternatives() const { return m_Alternatives; }
+  const AlternativesVector &getAlternatives() const { return m_Alternatives; }
 
   const std::wstring &getName() const { return m_Name; }
   int getOrigin() const { return m_Origin; }
@@ -98,7 +98,7 @@ private:
   std::wstring m_Name;
   int m_Origin = -1;
   std::pair<std::wstring, int> m_Archive;
-  std::vector<std::pair<int, std::pair<std::wstring, int>>> m_Alternatives;
+  AlternativesVector m_Alternatives;
   DirectoryEntry *m_Parent;
   mutable FILETIME m_FileTime;
 

--- a/src/shared/directoryentry.h
+++ b/src/shared/directoryentry.h
@@ -135,6 +135,7 @@ public:
   const std::wstring &getPath() const { return m_Path; }
 
   std::vector<FileEntry::Ptr> getFiles() const;
+  FileEntry::Ptr findFile(FileEntry::Index index) const;
 
   void enable(bool enabled, time_t notAfter = LONG_MAX);
   bool isDisabled() const { return m_Disabled; }


### PR DESCRIPTION
- Added a new "advanced" conflict list with three columns, which required adding a new tab widget to hold the old lists and the new one.
- Split `refreshLists()` so that only one tab can be refreshed at a time if needed. Split list item creation into one function per list (`createOverwriteItem()`, `createNoConflictItem()`, etc.)
- Added a new `FilterWidget` that combines `LineEditClear` and the copy/pasted logic to clear the textbox and parse the boolean expressions. Only used in the new conflict list for now, but should replace all the filter edits eventually.
- Refactored all the `UserRole` data for conflict items into one place, `setConflictItem()`. This makes the common context menu work with all four lists.
- All four lists now have their state saved and restored.
- Added a "go to" menu item that lists all the mods involved in conflicts for a file.