### PR TITLE
Standard menu and toolbars

### DIFF
--- a/src/mainwindow.cpp
+++ b/src/mainwindow.cpp
@@ -255,7 +255,7 @@ MainWindow::MainWindow(QSettings &initSettings
   setupActionMenu(ui->actionEndorseMO);
 
   createHelpMenu();
-  createEndorseWidget();
+  createEndorseMenu();
 
   toggleMO2EndorseState();
 
@@ -722,22 +722,23 @@ void MainWindow::about()
 }
 
 
-void MainWindow::createEndorseWidget()
+void MainWindow::createEndorseMenu()
 {
-  QToolButton *toolBtn = qobject_cast<QToolButton*>(ui->toolBar->widgetForAction(ui->actionEndorseMO));
-  QMenu *buttonMenu = toolBtn->menu();
-  if (buttonMenu == nullptr) {
+  auto* menu = ui->actionEndorseMO->menu();
+  if (!menu) {
+    // shouldn't happen
     return;
   }
-  buttonMenu->clear();
 
-  QAction *endorseAction = new QAction(tr("Endorse"), buttonMenu);
+  menu->clear();
+
+  QAction *endorseAction = new QAction(tr("Endorse"), menu);
   connect(endorseAction, SIGNAL(triggered()), this, SLOT(actionEndorseMO()));
-  buttonMenu->addAction(endorseAction);
+  menu->addAction(endorseAction);
 
-  QAction *wontEndorseAction = new QAction(tr("Won't Endorse"), buttonMenu);
+  QAction *wontEndorseAction = new QAction(tr("Won't Endorse"), menu);
   connect(wontEndorseAction, SIGNAL(triggered()), this, SLOT(actionWontEndorseMO()));
-  buttonMenu->addAction(wontEndorseAction);
+  menu->addAction(wontEndorseAction);
 }
 
 
@@ -5021,6 +5022,8 @@ void MainWindow::on_actionSettings_triggered()
 
   m_OrganizerCore.updateVFSParams(settings.logLevel(), settings.crashDumpsType(), settings.executablesBlacklist());
   m_OrganizerCore.cycleDiagnostics();
+
+  toggleMO2EndorseState();
 }
 
 
@@ -5473,20 +5476,19 @@ void MainWindow::modUpdateCheck(std::multimap<QString, int> IDs)
 
 void MainWindow::toggleMO2EndorseState()
 {
-  QToolButton *toolBtn = qobject_cast<QToolButton*>(ui->toolBar->widgetForAction(ui->actionEndorseMO));
   if (Settings::instance().endorsementIntegration()) {
     ui->actionEndorseMO->setVisible(true);
     if (Settings::instance().directInterface().contains("endorse_state")) {
-      ui->actionEndorseMO->setEnabled(false);
+      ui->actionEndorseMO->menu()->setEnabled(false);
       if (Settings::instance().directInterface().value("endorse_state").toString() == "Endorsed") {
         ui->actionEndorseMO->setToolTip(tr("Thank you for endorsing MO2! :)"));
-        toolBtn->setToolTip(tr("Thank you for endorsing MO2! :)"));
+        ui->actionEndorseMO->setStatusTip(tr("Thank you for endorsing MO2! :)"));
       } else if (Settings::instance().directInterface().value("endorse_state").toString() == "Abstained") {
         ui->actionEndorseMO->setToolTip(tr("Please reconsider endorsing MO2 on Nexus!"));
-        toolBtn->setToolTip(tr("Please reconsider endorsing MO2 on Nexus!"));
+        ui->actionEndorseMO->setStatusTip(tr("Please reconsider endorsing MO2 on Nexus!"));
       }
     } else {
-      ui->actionEndorseMO->setEnabled(true);
+      ui->actionEndorseMO->menu()->setEnabled(true);
     }
   } else
     ui->actionEndorseMO->setVisible(false);

--- a/src/mainwindow.cpp
+++ b/src/mainwindow.cpp
@@ -189,6 +189,9 @@ along with Mod Organizer.  If not, see <http://www.gnu.org/licenses/>.
 using namespace MOBase;
 using namespace MOShared;
 
+const QSize SmallToolbarSize(24, 24);
+const QSize LargeToolbarSize(42, 36);
+
 
 MainWindow::MainWindow(QSettings &initSettings
                        , OrganizerCore &organizerCore
@@ -635,6 +638,61 @@ void MainWindow::updateToolBar()
 
   // don't show the toolbar if there are no links
   ui->linksToolBar->setVisible(hasLinks);
+}
+
+QMenu* MainWindow::createPopupMenu()
+{
+  auto* m = QMainWindow::createPopupMenu();
+
+  m->addSeparator();
+
+  auto* a = new QAction(tr("Small Icons"), m);
+  connect(a, &QAction::triggered, [&]{ setToolbarSize(SmallToolbarSize); });
+  a->setCheckable(true);
+  a->setChecked(ui->toolBar->iconSize() == SmallToolbarSize);
+  m->addAction(a);
+
+  a = new QAction(tr("Large Icons"), m);
+  connect(a, &QAction::triggered, [&]{ setToolbarSize(LargeToolbarSize); });
+  a->setCheckable(true);
+  a->setChecked(ui->toolBar->iconSize() == LargeToolbarSize);
+  m->addAction(a);
+
+  m->addSeparator();
+
+  a = new QAction(tr("Icons only"), m);
+  connect(a, &QAction::triggered, [&]{ setToolbarButtonStyle(Qt::ToolButtonIconOnly); });
+  a->setCheckable(true);
+  a->setChecked(ui->toolBar->toolButtonStyle() == Qt::ToolButtonIconOnly);
+  m->addAction(a);
+
+  a = new QAction(tr("Text only"), m);
+  connect(a, &QAction::triggered, [&]{ setToolbarButtonStyle(Qt::ToolButtonTextOnly); });
+  a->setCheckable(true);
+  a->setChecked(ui->toolBar->toolButtonStyle() == Qt::ToolButtonTextOnly);
+  m->addAction(a);
+
+  a = new QAction(tr("Text and Icons"), m);
+  connect(a, &QAction::triggered, [&]{ setToolbarButtonStyle(Qt::ToolButtonTextUnderIcon); });
+  a->setCheckable(true);
+  a->setChecked(ui->toolBar->toolButtonStyle() == Qt::ToolButtonTextUnderIcon);
+  m->addAction(a);
+
+  return m;
+}
+
+void MainWindow::setToolbarSize(const QSize& s)
+{
+  for (auto* tb : findChildren<QToolBar*>()) {
+    tb->setIconSize(s);
+  }
+}
+
+void MainWindow::setToolbarButtonStyle(Qt::ToolButtonStyle s)
+{
+  for (auto* tb : findChildren<QToolBar*>()) {
+    tb->setToolButtonStyle(s);
+  }
 }
 
 void MainWindow::scheduleUpdateButton()
@@ -1832,6 +1890,15 @@ void MainWindow::readSettings()
     restoreState(settings.value("window_state").toByteArray());
   }
 
+  if (settings.contains("toolbar_size")) {
+    setToolbarSize(settings.value("toolbar_size").toSize());
+  }
+
+  if (settings.contains("toolbar_button_style")) {
+    setToolbarButtonStyle(static_cast<Qt::ToolButtonStyle>(
+      settings.value("toolbar_button_style").toInt()));
+  }
+
   if (settings.contains("window_split")) {
     ui->splitter->restoreState(settings.value("window_split").toByteArray());
   }
@@ -1909,6 +1976,8 @@ void MainWindow::storeSettings(QSettings &settings) {
   if (settings.value("reset_geometry", false).toBool()) {
     settings.remove("window_geometry");
     settings.remove("window_state");
+    settings.remove("toolbar_size");
+    settings.remove("toolbar_button_style");
     settings.remove("window_split");
     settings.remove("log_split");
     settings.remove("filters_visible");
@@ -1918,6 +1987,8 @@ void MainWindow::storeSettings(QSettings &settings) {
   } else {
     settings.setValue("window_geometry", saveGeometry());
     settings.setValue("window_state", saveState());
+    settings.setValue("toolbar_size", ui->toolBar->iconSize());
+    settings.setValue("toolbar_button_style", static_cast<int>(ui->toolBar->toolButtonStyle()));
     settings.setValue("window_split", ui->splitter->saveState());
     settings.setValue("log_split", ui->topLevelSplitter->saveState());
     settings.setValue("browser_geometry", m_IntegratedBrowser.saveGeometry());

--- a/src/mainwindow.cpp
+++ b/src/mainwindow.cpp
@@ -190,6 +190,7 @@ using namespace MOBase;
 using namespace MOShared;
 
 const QSize SmallToolbarSize(24, 24);
+const QSize MediumToolbarSize(32, 32);
 const QSize LargeToolbarSize(42, 36);
 
 
@@ -655,8 +656,9 @@ void MainWindow::toolbarMenu_aboutToShow()
   ui->actionToolBarMainToggle->setChecked(ui->toolBar->isVisible());
   ui->actionToolBarLinksToggle->setChecked(ui->linksToolBar->isVisible());
 
-  ui->actionToolBarLargeIcons->setChecked(ui->toolBar->iconSize() == LargeToolbarSize);
   ui->actionToolBarSmallIcons->setChecked(ui->toolBar->iconSize() == SmallToolbarSize);
+  ui->actionToolBarMediumIcons->setChecked(ui->toolBar->iconSize() == MediumToolbarSize);
+  ui->actionToolBarLargeIcons->setChecked(ui->toolBar->iconSize() == LargeToolbarSize);
 
   ui->actionToolBarIconsOnly->setChecked(ui->toolBar->toolButtonStyle() == Qt::ToolButtonIconOnly);
   ui->actionToolBarTextOnly->setChecked(ui->toolBar->toolButtonStyle() == Qt::ToolButtonTextOnly);
@@ -678,14 +680,19 @@ void MainWindow::on_actionToolBarLinksToggle_triggered()
   ui->linksToolBar->setVisible(!ui->linksToolBar->isVisible());
 }
 
-void MainWindow::on_actionToolBarLargeIcons_triggered()
-{
-  setToolbarSize(LargeToolbarSize);
-}
-
 void MainWindow::on_actionToolBarSmallIcons_triggered()
 {
   setToolbarSize(SmallToolbarSize);
+}
+
+void MainWindow::on_actionToolBarMediumIcons_triggered()
+{
+  setToolbarSize(MediumToolbarSize);
+}
+
+void MainWindow::on_actionToolBarLargeIcons_triggered()
+{
+  setToolbarSize(LargeToolbarSize);
 }
 
 void MainWindow::on_actionToolBarIconsOnly_triggered()

--- a/src/mainwindow.h
+++ b/src/mainwindow.h
@@ -635,8 +635,9 @@ private slots: // ui slots
   void on_actionExit_triggered();
   void on_actionToolBarMainToggle_triggered();
   void on_actionToolBarLinksToggle_triggered();
-  void on_actionToolBarLargeIcons_triggered();
   void on_actionToolBarSmallIcons_triggered();
+  void on_actionToolBarMediumIcons_triggered();
+  void on_actionToolBarLargeIcons_triggered();
   void on_actionToolBarIconsOnly_triggered();
   void on_actionToolBarTextOnly_triggered();
   void on_actionToolBarIconsAndText_triggered();

--- a/src/mainwindow.h
+++ b/src/mainwindow.h
@@ -208,7 +208,7 @@ private:
 
   void setupActionMenu(QAction* a);
   void createHelpMenu();
-  void createEndorseWidget();
+  void createEndorseMenu();
 
   void updateToolBar();
   void activateSelectedProfile();

--- a/src/mainwindow.h
+++ b/src/mainwindow.h
@@ -211,6 +211,9 @@ private:
   void createEndorseMenu();
 
   void updateToolBar();
+  void setToolbarSize(const QSize& s);
+  void setToolbarButtonStyle(Qt::ToolButtonStyle s);
+  QMenu* createPopupMenu() override;
   void activateSelectedProfile();
 
   void setExecutableIndex(int index);

--- a/src/mainwindow.h
+++ b/src/mainwindow.h
@@ -316,8 +316,6 @@ private:
 
   Ui::MainWindow *ui;
 
-  QAction *m_Sep; // Executable Shortcuts are added after this. Non owning.
-
   bool m_WasVisible;
 
   MOBase::TutorialControl m_Tutorial;
@@ -594,7 +592,7 @@ private slots:
    */
   void allowListResize();
 
-  void toolBar_customContextMenuRequested(const QPoint &point);
+  void linksToolBar_customContextMenuRequested(const QPoint &point);
   void removeFromToolbar();
   void overwriteClosed(int);
 

--- a/src/mainwindow.h
+++ b/src/mainwindow.h
@@ -213,6 +213,8 @@ private:
   void updateToolBar();
   void setToolbarSize(const QSize& s);
   void setToolbarButtonStyle(Qt::ToolButtonStyle s);
+  void toolbarMenu_aboutToShow();
+
   QMenu* createPopupMenu() override;
   void activateSelectedProfile();
 
@@ -631,6 +633,14 @@ private slots: // ui slots
   void on_actionSettings_triggered();
   void on_actionUpdate_triggered();
   void on_actionExit_triggered();
+  void on_actionToolBarMainToggle_triggered();
+  void on_actionToolBarLinksToggle_triggered();
+  void on_actionToolBarLargeIcons_triggered();
+  void on_actionToolBarSmallIcons_triggered();
+  void on_actionToolBarIconsOnly_triggered();
+  void on_actionToolBarTextOnly_triggered();
+  void on_actionToolBarIconsAndText_triggered();
+
 
   void on_bsaList_customContextMenuRequested(const QPoint &pos);
   void on_clearFiltersButton_clicked();

--- a/src/mainwindow.h
+++ b/src/mainwindow.h
@@ -206,7 +206,9 @@ private:
 
   void cleanup();
 
-  void actionToToolButton(QAction *&sourceAction);
+  void setupActionMenu(QAction* a);
+  void createHelpMenu();
+  void createEndorseWidget();
 
   void updateToolBar();
   void activateSelectedProfile();
@@ -254,9 +256,6 @@ private:
 
   // remove invalid category-references from mods
   void fixCategories();
-
-  void createEndorseWidget();
-  void createHelpWidget();
 
   bool extractProgress(QProgressDialog &extractProgress, int percentage, std::string fileName);
 
@@ -342,6 +341,8 @@ private:
   QPersistentModelIndex m_ContextIdx;
   QTreeWidgetItem *m_ContextItem;
   QAction *m_ContextAction;
+
+  QAction* m_browseModPage;
 
   CategoryFactory &m_CategoryFactory;
 

--- a/src/mainwindow.h
+++ b/src/mainwindow.h
@@ -153,6 +153,8 @@ public:
 
   void displayModInformation(ModInfo::Ptr modInfo, unsigned int index, int tab);
 
+  bool exit();
+
   virtual bool closeWindow();
   virtual void setWindowEnabled(bool enabled);
 
@@ -626,6 +628,7 @@ private slots: // ui slots
   void on_actionNotifications_triggered();
   void on_actionSettings_triggered();
   void on_actionUpdate_triggered();
+  void on_actionExit_triggered();
 
   void on_bsaList_customContextMenuRequested(const QPoint &pos);
   void on_clearFiltersButton_clicked();

--- a/src/mainwindow.ui
+++ b/src/mainwindow.ui
@@ -1407,6 +1407,7 @@ p, li { white-space: pre-wrap; }
     <addaction name="separator"/>
     <addaction name="actionModify_Executables"/>
     <addaction name="actionTool"/>
+    <addaction name="separator"/>
     <addaction name="actionSettings"/>
    </widget>
    <widget class="QMenu" name="menu_Help">
@@ -1785,6 +1786,9 @@ p, li { white-space: pre-wrap; }
    </property>
   </action>
   <action name="actionToolBarMediumIcons">
+   <property name="checkable">
+    <bool>true</bool>
+   </property>
    <property name="text">
     <string>M&amp;edium Icons</string>
    </property>

--- a/src/mainwindow.ui
+++ b/src/mainwindow.ui
@@ -1358,9 +1358,6 @@ p, li { white-space: pre-wrap; }
      <height>36</height>
     </size>
    </property>
-   <property name="toolButtonStyle">
-    <enum>Qt::ToolButtonTextUnderIcon</enum>
-   </property>
    <attribute name="toolBarArea">
     <enum>TopToolBarArea</enum>
    </attribute>
@@ -1438,6 +1435,7 @@ p, li { white-space: pre-wrap; }
      <addaction name="actionToolBarLinksToggle"/>
      <addaction name="separator"/>
      <addaction name="actionToolBarSmallIcons"/>
+     <addaction name="actionToolBarMediumIcons"/>
      <addaction name="actionToolBarLargeIcons"/>
      <addaction name="separator"/>
      <addaction name="actionToolBarIconsOnly"/>
@@ -1784,6 +1782,11 @@ p, li { white-space: pre-wrap; }
    </property>
    <property name="text">
     <string>I&amp;cons and Text</string>
+   </property>
+  </action>
+  <action name="actionToolBarMediumIcons">
+   <property name="text">
+    <string>M&amp;edium Icons</string>
    </property>
   </action>
  </widget>

--- a/src/mainwindow.ui
+++ b/src/mainwindow.ui
@@ -1358,6 +1358,9 @@ p, li { white-space: pre-wrap; }
      <height>36</height>
     </size>
    </property>
+   <property name="toolButtonStyle">
+    <enum>Qt::ToolButtonTextUnderIcon</enum>
+   </property>
    <attribute name="toolBarArea">
     <enum>TopToolBarArea</enum>
    </attribute>
@@ -1405,10 +1408,8 @@ p, li { white-space: pre-wrap; }
     </property>
     <addaction name="actionNexus"/>
     <addaction name="separator"/>
-    <addaction name="actionNotifications"/>
     <addaction name="actionModify_Executables"/>
     <addaction name="actionTool"/>
-    <addaction name="separator"/>
     <addaction name="actionSettings"/>
    </widget>
    <widget class="QMenu" name="menu_Help">
@@ -1425,8 +1426,30 @@ p, li { white-space: pre-wrap; }
     </property>
     <addaction name="actionCopy_Log_to_Clipboard"/>
    </widget>
+   <widget class="QMenu" name="menuView">
+    <property name="title">
+     <string>View</string>
+    </property>
+    <widget class="QMenu" name="menuToolbars">
+     <property name="title">
+      <string>Toolbars</string>
+     </property>
+     <addaction name="actionToolBarMainToggle"/>
+     <addaction name="actionToolBarLinksToggle"/>
+     <addaction name="separator"/>
+     <addaction name="actionToolBarSmallIcons"/>
+     <addaction name="actionToolBarLargeIcons"/>
+     <addaction name="separator"/>
+     <addaction name="actionToolBarIconsOnly"/>
+     <addaction name="actionToolBarTextOnly"/>
+     <addaction name="actionToolBarIconsAndText"/>
+    </widget>
+    <addaction name="menuToolbars"/>
+    <addaction name="actionNotifications"/>
+   </widget>
    <addaction name="menu_File"/>
    <addaction name="menu_Edit"/>
+   <addaction name="menuView"/>
    <addaction name="menu_Tools"/>
    <addaction name="menu_Help"/>
   </widget>
@@ -1695,6 +1718,72 @@ p, li { white-space: pre-wrap; }
    </property>
    <property name="statusTip">
     <string>Exits Mod Organizer</string>
+   </property>
+  </action>
+  <action name="actionToolbar_Size">
+   <property name="text">
+    <string>Toolbar Size</string>
+   </property>
+  </action>
+  <action name="actionToolbar_style">
+   <property name="text">
+    <string>Toolbar Buttons</string>
+   </property>
+  </action>
+  <action name="actionToolBarMainToggle">
+   <property name="checkable">
+    <bool>true</bool>
+   </property>
+   <property name="text">
+    <string>&amp;Main</string>
+   </property>
+  </action>
+  <action name="actionToolBarLinksToggle">
+   <property name="checkable">
+    <bool>true</bool>
+   </property>
+   <property name="text">
+    <string>&amp;Links</string>
+   </property>
+  </action>
+  <action name="actionToolBarSmallIcons">
+   <property name="checkable">
+    <bool>true</bool>
+   </property>
+   <property name="text">
+    <string>&amp;Small Icons</string>
+   </property>
+  </action>
+  <action name="actionToolBarLargeIcons">
+   <property name="checkable">
+    <bool>true</bool>
+   </property>
+   <property name="text">
+    <string>Lar&amp;ge Icons</string>
+   </property>
+  </action>
+  <action name="actionToolBarIconsOnly">
+   <property name="checkable">
+    <bool>true</bool>
+   </property>
+   <property name="text">
+    <string>&amp;Icons Only</string>
+   </property>
+  </action>
+  <action name="actionToolBarTextOnly">
+   <property name="checkable">
+    <bool>true</bool>
+   </property>
+   <property name="text">
+    <string>&amp;Text Only</string>
+   </property>
+  </action>
+  <action name="actionToolBarIconsAndText">
+   <property name="checkable">
+    <bool>true</bool>
+   </property>
+   <property name="text">
+    <string>I&amp;cons and Text</string>
    </property>
   </action>
  </widget>

--- a/src/mainwindow.ui
+++ b/src/mainwindow.ui
@@ -1417,8 +1417,11 @@ p, li { white-space: pre-wrap; }
      <string>&amp;Tools</string>
     </property>
     <addaction name="actionNexus"/>
+    <addaction name="separator"/>
+    <addaction name="actionNotifications"/>
     <addaction name="actionModify_Executables"/>
     <addaction name="actionTool"/>
+    <addaction name="separator"/>
     <addaction name="actionSettings"/>
    </widget>
    <widget class="QMenu" name="menu_Help">
@@ -1427,13 +1430,7 @@ p, li { white-space: pre-wrap; }
     </property>
     <addaction name="actionHelp"/>
     <addaction name="actionUpdate"/>
-    <addaction name="actionEndorseMOMenu"/>
-   </widget>
-   <widget class="QMenu" name="menu_View">
-    <property name="title">
-     <string>&amp;View</string>
-    </property>
-    <addaction name="actionNotifications"/>
+    <addaction name="actionEndorseMO"/>
    </widget>
    <widget class="QMenu" name="menu_Edit">
     <property name="title">
@@ -1443,7 +1440,6 @@ p, li { white-space: pre-wrap; }
    </widget>
    <addaction name="menu_File"/>
    <addaction name="menu_Edit"/>
-   <addaction name="menu_View"/>
    <addaction name="menu_Tools"/>
    <addaction name="menu_Help"/>
   </widget>
@@ -1692,14 +1688,6 @@ p, li { white-space: pre-wrap; }
    </property>
    <property name="statusTip">
     <string>Exits Mod Organizer</string>
-   </property>
-  </action>
-  <action name="actionEndorseMOMenu">
-   <property name="enabled">
-    <bool>false</bool>
-   </property>
-   <property name="text">
-    <string>Endorse Mod Organizer</string>
    </property>
   </action>
  </widget>

--- a/src/mainwindow.ui
+++ b/src/mainwindow.ui
@@ -1426,11 +1426,11 @@ p, li { white-space: pre-wrap; }
    </widget>
    <widget class="QMenu" name="menuView">
     <property name="title">
-     <string>View</string>
+     <string>&amp;View</string>
     </property>
     <widget class="QMenu" name="menuToolbars">
      <property name="title">
-      <string>Toolbars</string>
+      <string>&amp;Toolbars</string>
      </property>
      <addaction name="actionToolBarMainToggle"/>
      <addaction name="actionToolBarLinksToggle"/>
@@ -1622,7 +1622,7 @@ p, li { white-space: pre-wrap; }
      <normaloff>:/MO/gui/warning</normaloff>:/MO/gui/warning</iconset>
    </property>
    <property name="text">
-    <string>Notifications...</string>
+    <string>&amp;Notifications...</string>
    </property>
    <property name="toolTip">
     <string>Open the notifications dialog</string>

--- a/src/mainwindow.ui
+++ b/src/mainwindow.ui
@@ -31,6 +31,18 @@
     </sizepolicy>
    </property>
    <layout class="QHBoxLayout" name="horizontalLayout_8">
+    <property name="leftMargin">
+     <number>6</number>
+    </property>
+    <property name="topMargin">
+     <number>6</number>
+    </property>
+    <property name="rightMargin">
+     <number>6</number>
+    </property>
+    <property name="bottomMargin">
+     <number>0</number>
+    </property>
     <item>
      <widget class="QSplitter" name="topLevelSplitter">
       <property name="orientation">
@@ -1381,18 +1393,75 @@ p, li { white-space: pre-wrap; }
    <addaction name="actionHelp"/>
   </widget>
   <widget class="QStatusBar" name="statusBar"/>
+  <widget class="QMenuBar" name="menuBar">
+   <property name="geometry">
+    <rect>
+     <x>0</x>
+     <y>0</y>
+     <width>926</width>
+     <height>21</height>
+    </rect>
+   </property>
+   <widget class="QMenu" name="menu_File">
+    <property name="title">
+     <string>&amp;File</string>
+    </property>
+    <addaction name="actionChange_Game"/>
+    <addaction name="actionInstallMod"/>
+    <addaction name="actionAdd_Profile"/>
+    <addaction name="separator"/>
+    <addaction name="actionExit"/>
+   </widget>
+   <widget class="QMenu" name="menu_Tools">
+    <property name="title">
+     <string>&amp;Tools</string>
+    </property>
+    <addaction name="actionNexus"/>
+    <addaction name="actionModify_Executables"/>
+    <addaction name="actionToolMenu"/>
+    <addaction name="actionSettings"/>
+   </widget>
+   <widget class="QMenu" name="menu_Help">
+    <property name="title">
+     <string>&amp;Help</string>
+    </property>
+    <addaction name="actionHelpMenu"/>
+    <addaction name="actionUpdate"/>
+    <addaction name="actionEndorseMOMenu"/>
+   </widget>
+   <widget class="QMenu" name="menu_View">
+    <property name="title">
+     <string>&amp;View</string>
+    </property>
+    <addaction name="actionNotifications"/>
+   </widget>
+   <widget class="QMenu" name="menu_Edit">
+    <property name="title">
+     <string>&amp;Edit</string>
+    </property>
+    <addaction name="actionCopy_Log_to_Clipboard"/>
+   </widget>
+   <addaction name="menu_File"/>
+   <addaction name="menu_Edit"/>
+   <addaction name="menu_View"/>
+   <addaction name="menu_Tools"/>
+   <addaction name="menu_Help"/>
+  </widget>
   <action name="actionInstallMod">
    <property name="icon">
     <iconset resource="resources.qrc">
      <normaloff>:/MO/gui/resources/system-installer.png</normaloff>:/MO/gui/resources/system-installer.png</iconset>
    </property>
    <property name="text">
-    <string>Install Mod</string>
+    <string>Install &amp;Mod...</string>
    </property>
    <property name="iconText">
     <string>Install &amp;Mod</string>
    </property>
    <property name="toolTip">
+    <string>Install a new mod from an archive</string>
+   </property>
+   <property name="statusTip">
     <string>Install a new mod from an archive</string>
    </property>
    <property name="shortcut">
@@ -1405,13 +1474,16 @@ p, li { white-space: pre-wrap; }
      <normaloff>:/MO/gui/profiles</normaloff>:/MO/gui/profiles</iconset>
    </property>
    <property name="text">
-    <string>Profiles</string>
+    <string>&amp;Profiles...</string>
    </property>
    <property name="iconText">
     <string>&amp;Profiles</string>
    </property>
    <property name="toolTip">
-    <string>Configure Profiles</string>
+    <string>Configure profiles</string>
+   </property>
+   <property name="statusTip">
+    <string>Configure profiles</string>
    </property>
    <property name="shortcut">
     <string>Ctrl+P</string>
@@ -1423,12 +1495,15 @@ p, li { white-space: pre-wrap; }
      <normaloff>:/MO/gui/icon_executable</normaloff>:/MO/gui/icon_executable</iconset>
    </property>
    <property name="text">
-    <string>Executables</string>
+    <string>&amp;Executables...</string>
    </property>
    <property name="iconText">
     <string>&amp;Executables</string>
    </property>
    <property name="toolTip">
+    <string>Configure the executables that can be started through Mod Organizer</string>
+   </property>
+   <property name="statusTip">
     <string>Configure the executables that can be started through Mod Organizer</string>
    </property>
    <property name="shortcut">
@@ -1441,7 +1516,7 @@ p, li { white-space: pre-wrap; }
      <normaloff>:/MO/gui/plugins</normaloff>:/MO/gui/plugins</iconset>
    </property>
    <property name="text">
-    <string>Tools</string>
+    <string>&amp;Tools</string>
    </property>
    <property name="iconText">
     <string>&amp;Tools</string>
@@ -1459,12 +1534,15 @@ p, li { white-space: pre-wrap; }
      <normaloff>:/MO/gui/settings</normaloff>:/MO/gui/settings</iconset>
    </property>
    <property name="text">
-    <string>Settings</string>
+    <string>&amp;Settings...</string>
    </property>
    <property name="iconText">
     <string>&amp;Settings</string>
    </property>
    <property name="toolTip">
+    <string>Configure settings and workarounds</string>
+   </property>
+   <property name="statusTip">
     <string>Configure settings and workarounds</string>
    </property>
    <property name="shortcut">
@@ -1477,10 +1555,16 @@ p, li { white-space: pre-wrap; }
      <normaloff>:/MO/gui/resources/internet-web-browser.png</normaloff>:/MO/gui/resources/internet-web-browser.png</iconset>
    </property>
    <property name="text">
-    <string>Nexus</string>
+    <string>Visit &amp;Nexus</string>
+   </property>
+   <property name="iconText">
+    <string>Visit &amp;Nexus</string>
    </property>
    <property name="toolTip">
-    <string>Search nexus network for more mods</string>
+    <string>Visit the Nexus website in your browser for more mods</string>
+   </property>
+   <property name="statusTip">
+    <string>Visit the Nexus website in your browser for more mods</string>
    </property>
    <property name="shortcut">
     <string>Ctrl+N</string>
@@ -1495,25 +1579,34 @@ p, li { white-space: pre-wrap; }
      <normaloff>:/MO/gui/update</normaloff>:/MO/gui/update</iconset>
    </property>
    <property name="text">
-    <string>Update</string>
+    <string>&amp;Update Mod Organizer</string>
+   </property>
+   <property name="iconText">
+    <string>&amp;Update Mod Organizer</string>
    </property>
    <property name="toolTip">
     <string>Mod Organizer is up-to-date</string>
    </property>
+   <property name="statusTip">
+    <string>Mod Organizer is up-to-date</string>
+   </property>
   </action>
   <action name="actionNotifications">
-   <property name="enabled">
-    <bool>false</bool>
-   </property>
    <property name="icon">
     <iconset resource="resources.qrc">
      <normaloff>:/MO/gui/warning</normaloff>:/MO/gui/warning</iconset>
    </property>
    <property name="text">
-    <string>No Notifications</string>
+    <string>Notifications...</string>
+   </property>
+   <property name="toolTip">
+    <string>Open the notifications dialog</string>
+   </property>
+   <property name="statusTip">
+    <string>Open the notifications dialog</string>
    </property>
    <property name="whatsThis">
-    <string>This button will be highlighted if MO discovered potential problems in your setup and provide tips on how to fix them.</string>
+    <string>This button will be highlighted on the toolbar if MO discovered potential problems in your setup and provide tips on how to fix them.</string>
    </property>
   </action>
   <action name="actionHelp">
@@ -1522,7 +1615,10 @@ p, li { white-space: pre-wrap; }
      <normaloff>:/MO/gui/help</normaloff>:/MO/gui/help</iconset>
    </property>
    <property name="text">
-    <string>Help</string>
+    <string>&amp;Help</string>
+   </property>
+   <property name="iconText">
+    <string>&amp;Help</string>
    </property>
    <property name="toolTip">
     <string>Help</string>
@@ -1537,15 +1633,30 @@ p, li { white-space: pre-wrap; }
      <normaloff>:/MO/gui/icon_favorite</normaloff>:/MO/gui/icon_favorite</iconset>
    </property>
    <property name="text">
-    <string>Endorse MO</string>
+    <string>&amp;Endorse ModOrganizer</string>
+   </property>
+   <property name="iconText">
+    <string>&amp;Endorse ModOrganizer</string>
    </property>
    <property name="toolTip">
+    <string>Endorse Mod Organizer</string>
+   </property>
+   <property name="statusTip">
     <string>Endorse Mod Organizer</string>
    </property>
   </action>
   <action name="actionCopy_Log_to_Clipboard">
    <property name="text">
-    <string>Copy Log to Clipboard</string>
+    <string>Copy &amp;Log</string>
+   </property>
+   <property name="iconText">
+    <string>Copy &amp;Log</string>
+   </property>
+   <property name="toolTip">
+    <string>Copy log to clipboard</string>
+   </property>
+   <property name="statusTip">
+    <string>Copy log to clipboard</string>
    </property>
   </action>
   <action name="actionChange_Game">
@@ -1554,10 +1665,58 @@ p, li { white-space: pre-wrap; }
      <normaloff>:/MO/gui/instance_switch</normaloff>:/MO/gui/instance_switch</iconset>
    </property>
    <property name="text">
-    <string>Change Game</string>
+    <string>&amp;Change Game...</string>
+   </property>
+   <property name="iconText">
+    <string>&amp;Change Game</string>
    </property>
    <property name="toolTip">
     <string>Open the Instance selection dialog to manage a different Game</string>
+   </property>
+   <property name="statusTip">
+    <string>Open the Instance selection dialog to manage a different Game</string>
+   </property>
+  </action>
+  <action name="actionExit">
+   <property name="text">
+    <string>E&amp;xit</string>
+   </property>
+   <property name="iconText">
+    <string>E&amp;xit</string>
+   </property>
+   <property name="toolTip">
+    <string>Exits Mod Organizer</string>
+   </property>
+   <property name="statusTip">
+    <string>Exits Mod Organizer</string>
+   </property>
+  </action>
+  <action name="actionToolMenu">
+   <property name="enabled">
+    <bool>false</bool>
+   </property>
+   <property name="icon">
+    <iconset resource="resources.qrc">
+     <normaloff>:/MO/gui/plugins</normaloff>:/MO/gui/plugins</iconset>
+   </property>
+   <property name="text">
+    <string>&amp;Tools</string>
+   </property>
+  </action>
+  <action name="actionHelpMenu">
+   <property name="enabled">
+    <bool>false</bool>
+   </property>
+   <property name="text">
+    <string>&amp;Help menu</string>
+   </property>
+  </action>
+  <action name="actionEndorseMOMenu">
+   <property name="enabled">
+    <bool>false</bool>
+   </property>
+   <property name="text">
+    <string>Endorse Mod Organizer</string>
    </property>
   </action>
  </widget>

--- a/src/mainwindow.ui
+++ b/src/mainwindow.ui
@@ -1418,14 +1418,14 @@ p, li { white-space: pre-wrap; }
     </property>
     <addaction name="actionNexus"/>
     <addaction name="actionModify_Executables"/>
-    <addaction name="actionToolMenu"/>
+    <addaction name="actionTool"/>
     <addaction name="actionSettings"/>
    </widget>
    <widget class="QMenu" name="menu_Help">
     <property name="title">
      <string>&amp;Help</string>
     </property>
-    <addaction name="actionHelpMenu"/>
+    <addaction name="actionHelp"/>
     <addaction name="actionUpdate"/>
     <addaction name="actionEndorseMOMenu"/>
    </widget>
@@ -1621,7 +1621,10 @@ p, li { white-space: pre-wrap; }
     <string>&amp;Help</string>
    </property>
    <property name="toolTip">
-    <string>Help</string>
+    <string>Show help options</string>
+   </property>
+   <property name="statusTip">
+    <string>Show help options</string>
    </property>
    <property name="shortcut">
     <string>Ctrl+H</string>
@@ -1689,26 +1692,6 @@ p, li { white-space: pre-wrap; }
    </property>
    <property name="statusTip">
     <string>Exits Mod Organizer</string>
-   </property>
-  </action>
-  <action name="actionToolMenu">
-   <property name="enabled">
-    <bool>false</bool>
-   </property>
-   <property name="icon">
-    <iconset resource="resources.qrc">
-     <normaloff>:/MO/gui/plugins</normaloff>:/MO/gui/plugins</iconset>
-   </property>
-   <property name="text">
-    <string>&amp;Tools</string>
-   </property>
-  </action>
-  <action name="actionHelpMenu">
-   <property name="enabled">
-    <bool>false</bool>
-   </property>
-   <property name="text">
-    <string>&amp;Help menu</string>
    </property>
   </action>
   <action name="actionEndorseMOMenu">

--- a/src/mainwindow.ui
+++ b/src/mainwindow.ui
@@ -1349,29 +1349,14 @@ p, li { white-space: pre-wrap; }
    </layout>
   </widget>
   <widget class="QToolBar" name="toolBar">
-   <property name="enabled">
-    <bool>true</bool>
-   </property>
-   <property name="contextMenuPolicy">
-    <enum>Qt::CustomContextMenu</enum>
-   </property>
    <property name="windowTitle">
-    <string>Tool Bar</string>
-   </property>
-   <property name="movable">
-    <bool>false</bool>
+    <string>Main ToolBar</string>
    </property>
    <property name="iconSize">
     <size>
      <width>42</width>
      <height>36</height>
     </size>
-   </property>
-   <property name="toolButtonStyle">
-    <enum>Qt::ToolButtonIconOnly</enum>
-   </property>
-   <property name="floatable">
-    <bool>false</bool>
    </property>
    <attribute name="toolBarArea">
     <enum>TopToolBarArea</enum>
@@ -1380,9 +1365,11 @@ p, li { white-space: pre-wrap; }
     <bool>false</bool>
    </attribute>
    <addaction name="actionChange_Game"/>
-   <addaction name="actionInstallMod"/>
-   <addaction name="actionNexus"/>
    <addaction name="actionAdd_Profile"/>
+   <addaction name="separator"/>
+   <addaction name="actionNexus"/>
+   <addaction name="actionInstallMod"/>
+   <addaction name="separator"/>
    <addaction name="actionModify_Executables"/>
    <addaction name="actionTool"/>
    <addaction name="actionSettings"/>
@@ -1442,6 +1429,26 @@ p, li { white-space: pre-wrap; }
    <addaction name="menu_Edit"/>
    <addaction name="menu_Tools"/>
    <addaction name="menu_Help"/>
+  </widget>
+  <widget class="QToolBar" name="linksToolBar">
+   <property name="contextMenuPolicy">
+    <enum>Qt::CustomContextMenu</enum>
+   </property>
+   <property name="windowTitle">
+    <string>Links ToolBar</string>
+   </property>
+   <property name="iconSize">
+    <size>
+     <width>42</width>
+     <height>36</height>
+    </size>
+   </property>
+   <attribute name="toolBarArea">
+    <enum>TopToolBarArea</enum>
+   </attribute>
+   <attribute name="toolBarBreak">
+    <bool>false</bool>
+   </attribute>
   </widget>
   <action name="actionInstallMod">
    <property name="icon">

--- a/src/problemsdialog.h
+++ b/src/problemsdialog.h
@@ -21,20 +21,20 @@ public:
   ~ProblemsDialog();
 
   bool hasProblems() const;
-private:
 
+private:
   void runDiagnosis();
 
 private slots:
-
   void selectionChanged();
   void urlClicked(const QUrl &url);
 
   void startFix();
-private:
 
+private:
   Ui::ProblemsDialog *ui;
   std::vector<QObject *> m_PluginObjects;
+  bool m_hasProblems;
 };
 
 #endif // PROBLEMSDIALOG_H

--- a/src/stylesheets/Night Eyes.qss
+++ b/src/stylesheets/Night Eyes.qss
@@ -106,15 +106,15 @@ QTreeView::item:selected
 	color: #FFCC88;
 }
 
-QTreeView::branch:has-children:!has-siblings:closed, 
+QTreeView::branch:has-children:!has-siblings:closed,
 QTreeView::branch:closed:has-children:has-siblings
 {
 	image: url(:/stylesheet/branch-closed.png);
 	border: 0px;
 }
 
-QTreeView::branch:open:has-children:!has-siblings, 
-QTreeView::branch:open:has-children:has-siblings 
+QTreeView::branch:open:has-children:!has-siblings,
+QTreeView::branch:open:has-children:has-siblings
 {
 	image: url(:/stylesheet/branch-open.png);
 	border: 0px;
@@ -342,41 +342,41 @@ QScrollBar::sub-line:vertical
 
 /* Combined */
 
-QScrollBar::handle:horizontal:hover, 
+QScrollBar::handle:horizontal:hover,
 QScrollBar::handle:vertical:hover,
-QScrollBar::add-line:horizontal:hover, 
-QScrollBar::sub-line:horizontal:hover, 
-QScrollBar::add-line:vertical:hover, 
+QScrollBar::add-line:horizontal:hover,
+QScrollBar::sub-line:horizontal:hover,
+QScrollBar::add-line:vertical:hover,
 QScrollBar::sub-line:vertical:hover
 {
 	background: #242424;
 }
 
-QScrollBar::handle:horizontal:pressed, 
+QScrollBar::handle:horizontal:pressed,
 QScrollBar::handle:vertical:pressed,
-QScrollBar::add-line:horizontal:pressed, 
-QScrollBar::sub-line:horizontal:pressed, 
-QScrollBar::add-line:vertical:pressed, 
+QScrollBar::add-line:horizontal:pressed,
+QScrollBar::sub-line:horizontal:pressed,
+QScrollBar::add-line:vertical:pressed,
 QScrollBar::sub-line:vertical:pressed
 {
 	background: #181818;
 }
 
-QScrollBar::add-page:horizontal, 
-QScrollBar::sub-page:horizontal, 
-QScrollBar::add-page:vertical, 
+QScrollBar::add-page:horizontal,
+QScrollBar::sub-page:horizontal,
+QScrollBar::add-page:vertical,
 QScrollBar::sub-page:vertical
 {
     background: transparent;
 }
 
-QScrollBar::up-arrow:vertical, 
+QScrollBar::up-arrow:vertical,
 QScrollBar::right-arrow:horizontal,
-QScrollBar::down-arrow:vertical,  
+QScrollBar::down-arrow:vertical,
 QScrollBar::left-arrow:horizontal
 {
 	height: 1px;
-    width: 1px;  
+    width: 1px;
 	border: 1px solid #181818;
 }
 
@@ -425,6 +425,16 @@ QHeaderView::down-arrow
 
 
 /* Context Menus, Toolbar Dropdowns, & Tooltips ------------------------------- */
+
+QMenuBar {
+	background: #181818;
+	border: 1px solid #181818;
+}
+
+QMenuBar::item:selected {
+	background: #242424;
+	color: #FFCC88;
+}
 
 QMenu
 {
@@ -615,8 +625,8 @@ QWidget#downloadTab QAbstractScrollArea
 	background: #242424;
 }
 
-DownloadListWidget QFrame, 
-DownloadListWidgetCompact, 
+DownloadListWidget QFrame,
+DownloadListWidgetCompact,
 DownloadListWidgetCompact QLabel
 {
 	/* an entry on the Downloads tab */
@@ -641,7 +651,7 @@ DownloadListWidget QFrame:clicked
 
 /* compact downloads view */
 
-DownloadListWidgetCompact, 
+DownloadListWidgetCompact,
 DownloadListWidgetCompact QLabel
 {
 	/* an entry on the Downloads tab */

--- a/src/stylesheets/Paper Automata.qss
+++ b/src/stylesheets/Paper Automata.qss
@@ -593,6 +593,16 @@ QHeaderView::section:last {
 
 /* Right Click Menus, Toolbar Dropdown Menus, & Tooltips */
 
+QMenuBar {
+	background: #DAD4BB;
+	border: 2px solid #CDC8B0;
+}
+
+QMenuBar::item:selected {
+	background: #B4AF9A;
+	border: none;
+}
+
 QMenu {
 	/* right click menu */
 	background: #DAD4BB;

--- a/src/stylesheets/Paper Dark by 6788.qss
+++ b/src/stylesheets/Paper Dark by 6788.qss
@@ -588,6 +588,18 @@ QHeaderView::down-arrow {
 
 /* Right Click Menus, Toolbar Dropdown Menus, & Tooltips */
 
+QMenuBar {
+	background: #242424;
+	border: 1px solid #242424;
+}
+
+QMenuBar::item:selected {
+	background: #006868;
+	color: #FFFFFF;
+	border: 0px;
+	border-radius: 4px;
+}
+
 QMenu {
 	/* right click menu */
 	background: #141414;

--- a/src/stylesheets/Paper Light by 6788.qss
+++ b/src/stylesheets/Paper Light by 6788.qss
@@ -590,6 +590,18 @@ QHeaderView::down-arrow {
 
 /* Right Click Menus, Toolbar Dropdown Menus, & Tooltips */
 
+QMenuBar {
+	background: #EBEBEB;
+	border: 1px solid #EBEBEB;
+}
+
+QMenuBar::item:selected {
+	background: #008484;
+	color: #FFFFFF;
+	border: 0px;
+	border-radius: 4px;
+}
+
 QMenu {
 	/* right click menu */
 	background: #FFFFFF;

--- a/src/stylesheets/Parchment v1.1 by Bob.qss
+++ b/src/stylesheets/Parchment v1.1 by Bob.qss
@@ -95,7 +95,7 @@ QTreeView {
 }
 
 QTreeView::branch:hover {
-	background: #008F8F; 
+	background: #008F8F;
 	color: #F7F6CF;
 }
 
@@ -109,13 +109,13 @@ QTreeView::item:selected {
 	color: #F7F6CF;
 }
 
-QTreeView::branch:has-children:!has-siblings:closed, 
-QTreeView::branch:closed:has-children:has-siblings {	
+QTreeView::branch:has-children:!has-siblings:closed,
+QTreeView::branch:closed:has-children:has-siblings {
 	image: url(:/stylesheet/branch-closed.png);
 	border: 0px;
 }
 
-QTreeView::branch:open:has-children:!has-siblings, 
+QTreeView::branch:open:has-children:!has-siblings,
 QTreeView::branch:open:has-children:has-siblings  {
 	image: url(:/stylesheet/branch-open.png);
 	border: 0px;
@@ -168,7 +168,7 @@ QCheckBox::indicator {
   background-color: transparent;
   border: none;
   width: 14px;
-  height: 14px; 
+  height: 14px;
 }
 
 QGroupBox::indicator:checked, QGroupBox::indicator:indeterminate,
@@ -177,7 +177,7 @@ QTreeView::indicator:indeterminate,
 QCheckBox::indicator:checked,
 
 QCheckBox::indicator:indeterminate {
-	image: url(./Parchment/checkbox-checked.png); 
+	image: url(./Parchment/checkbox-checked.png);
 }
 
 QGroupBox::indicator:checked:hover, QGroupBox::indicator:indeterminate:hover,
@@ -186,7 +186,7 @@ QTreeView::indicator:indeterminate:hover,
 QCheckBox::indicator:checked:hover,
 
 QCheckBox::indicator:indeterminate:hover {
-	image: url(./Parchment/checkbox-checked-hover.png); 
+	image: url(./Parchment/checkbox-checked-hover.png);
 }
 
     QGroupBox::indicator:checked:disabled, QGroupBox::indicator:indeterminate:disabled,
@@ -195,28 +195,28 @@ QCheckBox::indicator:indeterminate:hover {
     QCheckBox::indicator:checked:disabled,
 
     QCheckBox::indicator:indeterminate:disabled {
-      image: url(./Parchment/checkbox-checked-disabled.png); 
+      image: url(./Parchment/checkbox-checked-disabled.png);
 }
 
   QGroupBox::indicator:unchecked,
   QTreeView::indicator:unchecked,
 
   QCheckBox::indicator:unchecked {
-    image: url(./Parchment/checkbox.png); 
+    image: url(./Parchment/checkbox.png);
 }
 
     QGroupBox::indicator:unchecked:hover,
     QTreeView::indicator:unchecked:hover,
 
     QCheckBox::indicator:unchecked:hover {
-      image: url(./Parchment/checkbox-hover.png); 
+      image: url(./Parchment/checkbox-hover.png);
 }
 
     QGroupBox::indicator:unchecked:disabled,
     QTreeView::indicator:unchecked:disabled,
 
     QCheckBox::indicator:unchecked:disabled {
-	image: url(./Parchment/checkbox-disabled.png); 
+	image: url(./Parchment/checkbox-disabled.png);
 }
 
 /* Search Boxes */
@@ -323,7 +323,7 @@ QScrollBar::add-line:horizontal {
 	margin: 0px -2px -2px 0px;
 }
 
-QScrollBar::sub-line:horizontal {	
+QScrollBar::sub-line:horizontal {
 	background: #F7F6CF;
 	width: 23px;
 	subcontrol-position: left;
@@ -359,7 +359,7 @@ QScrollBar::add-line:vertical {
 	margin: 0px -2px -2px 0px;
 }
 
-QScrollBar::sub-line:vertical {    
+QScrollBar::sub-line:vertical {
     background: #F7F6CF;
     height: 23px;
     subcontrol-position: top;
@@ -371,37 +371,37 @@ QScrollBar::sub-line:vertical {
 
 /* Combined */
 
-QScrollBar::handle:horizontal:hover, 
+QScrollBar::handle:horizontal:hover,
 QScrollBar::handle:vertical:hover,
-QScrollBar::add-line:horizontal:hover, 
-QScrollBar::sub-line:horizontal:hover, 
-QScrollBar::add-line:vertical:hover, 
+QScrollBar::add-line:horizontal:hover,
+QScrollBar::sub-line:horizontal:hover,
+QScrollBar::add-line:vertical:hover,
 QScrollBar::sub-line:vertical:hover {
 	background: #008F8F;
 }
 
-QScrollBar::handle:horizontal:pressed, 
+QScrollBar::handle:horizontal:pressed,
 QScrollBar::handle:vertical:pressed,
-QScrollBar::add-line:horizontal:pressed, 
-QScrollBar::sub-line:horizontal:pressed, 
-QScrollBar::add-line:vertical:pressed, 
+QScrollBar::add-line:horizontal:pressed,
+QScrollBar::sub-line:horizontal:pressed,
+QScrollBar::add-line:vertical:pressed,
 QScrollBar::sub-line:vertical:pressed {
 	background: #0CA6FF;
 }
 
-QScrollBar::add-page:horizontal, 
-QScrollBar::sub-page:horizontal, 
-QScrollBar::add-page:vertical, 
+QScrollBar::add-page:horizontal,
+QScrollBar::sub-page:horizontal,
+QScrollBar::add-page:vertical,
 QScrollBar::sub-page:vertical {
     background: transparent;
 }
 
-QScrollBar::up-arrow:vertical, 
+QScrollBar::up-arrow:vertical,
 QScrollBar::right-arrow:horizontal,
-QScrollBar::down-arrow:vertical,  
+QScrollBar::down-arrow:vertical,
 QScrollBar::left-arrow:horizontal {
 	height: 1px;
-    width: 1px;  
+    width: 1px;
 	border: 1px solid #DBD399;
 }
 
@@ -443,6 +443,16 @@ QHeaderView::down-arrow {
 
 /* Context Menus, Toolbar Dropdowns, & Tooltips */
 
+QMenuBar {
+	background: #DBD399;
+	border: 1px solid #DBD399;
+}
+
+QMenuBar::item:selected {
+	background: #008F8F;
+	color: #F7F6CF;
+}
+
 QMenu {
 	background: #F7F6CF;
 	selection-color: #F7F6CF;
@@ -465,7 +475,7 @@ QMenu::item:disabled {
 	color: #444444;
 }
 
-QMenu::separator {   
+QMenu::separator {
     background: #DBD399;
 	height: 2px;
 }
@@ -483,7 +493,7 @@ QToolTip {
 
 /* Progress Bars (Downloads) */
 
-QProgressBar {  
+QProgressBar {
 	background: #F7F6CF;
     text-align: center;
     border: 0px;

--- a/src/stylesheets/Transparent-Style-101-Green.qss
+++ b/src/stylesheets/Transparent-Style-101-Green.qss
@@ -1,1 +1,489 @@
-#centralWidget { 	border-image: url(./Transparent-Style/Green/vault-101.png) 0 0 0 0 stretch stretch; 	} QDialog,Qmenu { 	border: none; } QWidget 	{ 		color: #fff; 		background-color: rgb(0, 204, 0, 5); 		alternate-background-color: rgb(0, 204, 0, 10); 	} QAbstractItemView 	{ 		color: #fff; 		background-color: rgb(0, 204, 0, 5); 		alternate-background-color: rgb(0, 204, 0, 10); 		border: 1px solid #001a00; 		border-style:outset; 		border-radius: 3px; 		selection-color: #001a00; 		outline: none; 	} 	#ProblemsDialog,#TransferSavesDialog,#SettingsDialog,#ProblemsDialog, 	#ModInfoDialog,#TextViewer,#PyCfgDialog,#InstallDialog 	{ 		border-image:url(./Transparent-Style/Green/vault-tec-full.png) 0 0 0 0 stretch stretch; 	} 	#EditExecutablesDialog 	{ 		border-image: url(./Transparent-Style/Green/vault-tec.png) 0 0 0 0 stretch stretch; 	} 	#SimpleInstallDialog,#LockedDialog,QMenu 	{ 		border-image: url(./Transparent-Style/Green/vault-tec-small.png) 0 0 0 0 stretch stretch; 	}	 	#nameLabel 	{ 		background-color: rgb(0, 0, 0, 20); 		border-top:1px solid black; 		border-bottom:1px solid black; 	} 	#ProfilesDialog,#FomodInstallerDialog 	{ 		border-image: url(./Transparent-Style/Green/vault-tec-profiles.png) 0 0 0 0 stretch stretch; 	} 	#filesView 	{ 	border-image: url(./Transparent-Style/Green/vault-tec-overwrite.png) 0 0 0 0 stretch stretch; 	}  /* ******************************************** */ /* Main Navigation Button Bar at top of window 	*/ /* ******************************************** */ QToolBar 	{ 	border: none; 	} 	QToolBar::separator 		{ 		image: url(./Transparent-Style/Green/Vault-101-vault-boy.png); 		} 	QToolButton 	{ 		border:2px ridge None; 		border-radius: 6px; 		margin: 3px; 		padding-left: 8px; 		padding-right: 8px; 		padding-top: 0px; 		padding-bottom: 2px; 	} 	QToolButton:hover 	{ 		border: 2px ridge #fff; 		background-color: QLinearGradient( x1: 0, y1: 0, x2: 0, y2: 1, stop: 0 #697670, stop: 1 #484F53); 	} 	QToolButton:pressed 	{ 		background: black; 	} QTabWidget::pane 	{ 		background-color: transparent; 		border:transparent; 	} QTabWidget::tab-bar { 	alignment: center; } /* **************************************** */ /*	 	Tabs on top of Treeview				*/ /* **************************************** */ QTabBar 	{ 		text-transform: uppercase; 		max-height: 22px; 		padding-bottom: 5px; 	}	 	QTabBar::tab 	{ 		border: none; 		border-bottom-style: none; 		background-color: QLinearGradient( x1: 0, y1: 0, x2: 0, y2: 1, stop: 0 #697670, stop: 1 #484F53); 		padding-left: 15px; 		padding-right: 15px; 		padding-top: 3px; 		padding-bottom: 3px; 		margin-right: 2px; 		border-top-left-radius: 4px; 		border-top-right-radius: 4px; 		border-bottom-left-radius: 4px; 		border-bottom-right-radius: 4px; 	} 	QTabBar::tab:selected 	{ 		color: #fff; 		background-color: #00cc00; 	} 	QTabBar::tab:!selected 	{ 		color: #00cc00; 		margin-top: 0px; 	} 	QTabBar::tab:disabled 	{ 		color: #bbbbbb; 		border-bottom-style: none; 		margin-top: 0px; 		background-color: #000; 	} #deactivateESP,#activateESP 	{ 		border:px #00cc00; 		background:QLinearGradient( x1: 0, y1: 0, x2: 0, y2: 1, stop: 0 #697670, stop: 1 #484F53); 	} QToolButton::menu-indicator:pressed,QToolButton::menu-indicator:open 	{ 		border:2px ridge #00cc00; 		image: url(./Transparent-Style/Green/arrow-right.png); 	} QTabBar QToolButton 	{ 		border:2px ridge #00cc00; 		background-color: QLinearGradient( x1: 0, y1: 0, x2: 0, y2: 1, stop: 0 #697670, stop: 1 #484F53); 		padding: 1px; 		margin: 0; 		 	} QTabBar QToolButton::right-arrow 	{ 		image: url(./Transparent-Style/Green/arrow-right.png); 	} QTabBar QToolButton::left-arrow 	{ 		image: url(./Transparent-Style/Green/arrow-left.png); 	} 	 	 	 /* **************************************** */ /*	 	Column names of TreeView			*/ /* **************************************** */ QTableView 	{ 		color:#fff; 		background-color: QLinearGradient( x1: 0, y1: 0, x2: 0, y2: 1, stop: 0 #697670, stop: 1 #484F53); 	} 	QHeaderView::section 	{ 		color: #00cc00; 		background-color: QLinearGradient( x1: 0, y1: 0, x2: 0, y2: 1, stop: 0 #697670, stop: 1 #484F53); 		border-radius: 6px; 		padding: 4px; 		padding-left: 5px; 		padding-right: 0px; 	} 	 QHeaderView::section:hover 	{ 		background: #121212; 		border: 2px solid #ff0000; 		padding: 0px;     } QHeaderView::up-arrow,QHeaderView::down-arrow 	{ 		subcontrol-origin: content; 		subcontrol-position: center right; 		width: 7px; 		height: 7px; 		margin-right: 7px; 	} QHeaderView::up-arrow 	{ 		image: url(./Transparent-Style/Green/arrow-up.png); 	} QHeaderView::down-arrow 	{ 		image: url(./Transparent-Style/Green/arrow-down.png); 	}	 /* **************************************** */ /*	 				Hover					*/ /* **************************************** */ QMenu:item:hover,QTreeView#espList::item:hover,QTreeWidget#categoriesList::item:hover,QListView::item:hover,QTreeWidget::item:hover 	{ 		color:#fff; 		border-top:1px solid #b9d7fc; 		border-bottom:1px solid #b9d7fc; 		background-color:#000; 	} QAbstractItemView::item:hover 	{ 		border-top:1px solid #b9d7fc; 		border-bottom:1px solid #b9d7fc; 		background-color:#000; 		padding: 3px; 	} #deactivateESP:hover,#activateESP:hover,QPushButton:hover,QTableView:hover,QHeaderView::selected:hover,QTabBar::tab:!selected:hover,QComboBox:hover 	{ 		border: 1px solid #ff0000; 		padding: 1px; 		text-align: center; 	} /* **************************************** */ /* Context menus, toolbar dropdowns #QMenu  */ /* **************************************** */ QMenu 	{ 		border-width: 3px; 		border-style: solid; 	} QMenu::item 	{ 		padding: 6px 20px; 	} QMenu::item:selected 	{ 		color:#fff; 		background-color: #001a00; 		border-top:1px solid #b9d7fc; 		border-bottom:1px solid #b9d7fc; 	} QMenu::right-arrow 	{ 		image: url(./Transparent-Style/Green/arrow-right.png); 		subcontrol-origin: padding; 		subcontrol-position: center right; 		padding-right: 0.5em; 	} /* ********************* */ /*		 LCD Counter	 */ /* ********************* */ QLCDNumber 	{ 		Background:#000; 		border-color: #00cc00; 		border-style: solid; 		border-width: 1px; 		border-radius: 5px; 	} /* **************************************** */ /*		Launch application Drop down Box 	*/ /* **************************************** */ QComboBox {     background-color: QLinearGradient( x1: 0, y1: 0, x2: 0, y2: 1, stop: 0 #697670, stop: 1 #484F53);     border:1px outset #00cc00;     height: 20px; 	width: 15px; 	padding: 3px; 	padding-left:3px;     border-radius: 5px; } 	QComboBox::drop-down{ 		subcontrol-origin: padding; 		subcontrol-position: top right; 		width: 15px; 		padding:4px; 		border-radius: 5px; 	} 	QComboBox::down-arrow{ 		image:url(./Transparent-Style/Green/arrow-down.png); 	} 	QComboBox::item{ 		border:3px;padding: 3px; 	} /* **************************************************************** */ /* 							Action Buttons     						*/ /*																	*/ /* Open list, Rextore Backup, Create Backup, RUN, Shortcut Button 	*/ /* Sort, Load order backup, Load Order Restore 						*/ /* **************************************************************** */ QPushButton 	{ 		color: #00cc00;	 		background-color: QLinearGradient( x1: 0, y1: 0, x2: 0, y2: 1, stop: 0 #697670, stop: 1 #484F53); 		border-width: 1px; 		border-color: 1px outset #00cc00; 		border-style: solid; 		border-radius: 4px; 		padding:5px; 		padding-right: 10px; 		padding-left: 5px; 	} 	QDialog QPushButton 	{ 		min-width: 3em; 		min-height: 1em; 		padding-left: 1em; 		padding-right: 1em; 	} 	QPushButton::menu-indicator 		{ 			image: url(./Transparent-Style/Green/arrow-down.png); 			background: transparent; 			subcontrol-origin: padding; 			subcontrol-position: center right; 			padding-right: 5%; 		} 	QPushButton:open 		{ 			background-color: rgb(0, 204, 0, 100); 		} 	QPushButton:!enabled 		{ 		border: 1px grey; 			color: grey; 			background: black; 		} QPushButton#displayCategoriesBtn 	{ 		min-width: 20px; 	} /* **************************************** */ /*	 			Scroll bar 					*/ /* **************************************** */ QScrollBar 	{ 		height:20px; 		width:20px; 		background-color:transparent; 	} 	QScrollBar::handle 	{ 		border: 1px solid #aaa; 		border-radius: 4px; 	} 	QScrollBar::handle:vertical 	{ 		margin: 1px 4px; 		min-height:20px; 		min-width: 10px; 		background-color:qlineargradient(x1: 0, y1: 0, x2: 1, y2: 0, stop:0 #33ff33, stop:1 #000000); 	} 		QScrollBar::handle:vertical:hover 	{ 		background-color:qlineargradient(x1: 0, y1: 0, x2: 1, y2: 0, stop:0 #000000, stop:1 #33ff33); 	} 	QScrollBar::handle:horizontal 	{ 		min-height:10px;min-width:20px;margin:4px 1px; 		background-color:qlineargradient(x1: 0, y1: 0, x2: 0, y2: 1, stop:0 #33ff33, stop:1 #000000); 	} 	QScrollBar::handle:horizontal:hover 	{ 		background-color:qlineargradient(x1: 0, y1: 0, x2: 0, y2: 1, stop:0 #000000, stop:1 #33ff33); 	} 	QScrollBar::add-page:vertical, QScrollBar::sub-page:vertical,QScrollBar::add-page:horizontal, QScrollBar::sub-page:horizontal 	{ 		background-color: transparent; 	} 	QScrollBar::add-line:vertical,QScrollBar::sub-line:vertical,QScrollBar::add-line:horizontal,QScrollBar::sub-line:horizontal 	{ 		height:0; 		width:0; 	} /* ******************************************************** */ /*		Main Tree View Inherated from QAbstractItemView 	*/ /* ******************************************************** */ QTreeView { } QTreeView:item 	{ 		padding:4px; 	} QTreeView:item:selected 	{ 		color: #001a00; 		border: none;outline: none; 		border-radius: 5px; 		border-top:1px solid #b9d7fc; 		border-bottom:1px solid #b9d7fc; 		background-color: rgb(0, 204, 0, 100); 	} 	QTreeView::branch:has-siblings:!adjoins-item 	{ 		background:url(Vault-101/Vault-101-item-line-v.png) center center no-repeat; 	} 	QTreeView::branch:has-siblings 	{  		background:url(Vault-101/Vault-101-itemB-line.png) center center no-repeat; 	} 	QTreeView::branch:!has-children:!has-siblings:adjoins-item 	{ 		background:url(Vault-101/Vault-101-itemB-end.png) center center no-repeat; 	} 	QTreeView::branch:closed:has-children:has-siblings 	{ 		background:url(Vault-101/Vault-101-itemB-close.png) center center no-repeat; 	} 	QTreeView::branch:closed:has-children:!has-siblings 	{ 		background:url(Vault-101/Vault-101-itemB-close-last.png) center center no-repeat; 	} 	QTreeView::branch:open:has-children:has-siblings 	{ 		background:url(Vault-101/Vault-101-itemB-open.png) center center no-repeat; 	} 	QTreeView::branch:open:has-children:!has-siblings 	{ 		background:url(Vault-101/Vault-101-itemB-open-last.png) center center no-repeat; 	}	 /* **************************************************************** */ /* Checkboxes and Radio buttons common #QCheckBox, #QRadioButton 	*/ /*							common									*/ /* **************************************************************** */ QGroupBox::indicator,QTreeView::indicator,QCheckBox::indicator 	{ 		outline: none; 		border: none; 		width: 20px; 		height: 20px; 	} QGroupBox::indicator:checked,QGroupBox::indicator:indeterminate,QTreeView::indicator:checked,QTreeView::indicator:indeterminate,QCheckBox::indicator:checked,QCheckBox::indicator:indeterminate 	{ 		image: url(./Transparent-Style/Green/checkbox-checked.png); 	} QGroupBox::indicator:checked:hover,QGroupBox::indicator:indeterminate:hover,QTreeView::indicator:checked:hover,QTreeView::indicator:indeterminate:hover,QCheckBox::indicator:checked:hover,QCheckBox::indicator:indeterminate:hover 	{ 		image: url(./Transparent-Style/Green/checkbox-hover.png); 	} QGroupBox::indicator:checked:disabled,QGroupBox::indicator:indeterminate:disabled,QTreeView::indicator:checked:disabled,QTreeView::indicator:indeterminate:disabled,QCheckBox::indicator:checked:disabled,QCheckBox::indicator:indeterminate:disabled 	{ 		image: url(./Transparent-Style/Green/checkbox-checked-disabled.png); 	} QGroupBox::indicator:unchecked,QTreeView::indicator:unchecked,QCheckBox::indicator:unchecked 	{ 		image: url(./Transparent-Style/Green/checkbox.png); 	} QGroupBox::indicator:unchecked:hover,QTreeView::indicator:unchecked:hover,QCheckBox::indicator:unchecked:hover 	{ 		image: url(./Transparent-Style/Green/checkbox-checked-hover.png); 	} QGroupBox::indicator:unchecked:disabled,QTreeView::indicator:unchecked:disabled,QCheckBox::indicator:unchecked:disabled 	{ 		image: url(./Transparent-Style/Green/checkbox-checked-disabled.png); 	} 		QTreeWidget#categoriesList::item:has-children 	{ 		background-image: url(./Transparent-Style/Green/arrow-right.png); 	} QTreeWidget#categoriesList::item:has-children:open 	{ 		background-image: url(./Transparent-Style/Green/branch-opened.png); 	} /* ******************************** */ /* 		Special styles 				*/ /* increase categories tab width 	*/ /* ******************************** */ QTreeView#modList::item,QTreeWidget#categoriesTree::item,#tabConflicts QTreeWidget::item,QListView::item,QTreeView#espList::item,QTreeView#treeContent::item 	{ 		padding: .3em 0; 	} QTreeWidget#categoriesGroup,QTreeWidget#categoriesList 	{ 		min-width: 200px; } 		QTreeWidget#categoriesList::item { 		background-position: center left; 		background-repeat: no-repeat; 		padding: 0.35em 4px; 	} /* ********************* */ /* Display Radio Button	 */ /* ********************* */ QRadioButton::indicator 	{ 		width: 16px; 		height: 16px; 	} QRadioButton::indicator::checked 	{ 		image: url(./Transparent-Style/Green/radio-checked.png); 	} QRadioButton::indicator::unchecked 	{ 		image: url(./Transparent-Style/Green/radio.png); 	} QRadioButton::indicator::unchecked:hover 	{ 		image: url(./Transparent-Style/Green/radio-hover.png); 	} /* **************************************** */ /*	 Spinners #QSpinBox, #QDoubleSpinBox 	*/ /* **************************************** */ QAbstractSpinBox 	{ 		min-height: 24px; 		 	} QAbstractSpinBox::up-button,QAbstractSpinBox::down-button 	{ 		border-style: solid; 		border-width: 1px; 		subcontrol-origin: padding; 	} QAbstractSpinBox::up-button:hover,QAbstractSpinBox::down-button:hover 	{ 		background-color: #141414; 	} QAbstractSpinBox::up-button 	{ 		subcontrol-position: top right; 	} QAbstractSpinBox::down-button 	{ 		subcontrol-position: bottom right; 	} QAbstractSpinBox::up-arrow 	{ 		image: url(./Transparent-Style/Green/arrow-up.png); 	} QAbstractSpinBox::down-arrow 	{ 		image: url(./Transparent-Style/Green/arrow-down.png); 	} /* **************************************** */ /* 	Tooltips #QToolTip, #SaveGameInfoWidget	*/ /* **************************************** */ QToolTip 	{ 		background-color:transparent; 		color:#C0C0C0; 		padding:0px; 		border-width:7px; 		border-style:solid; 		border-color:transparent; 		border-image:url(./Transparent-Style/Green/border-image.png) 27 repeat repeat; 	} SaveGameInfoWidget 	{ 		background-color:#121212; 		color:#C0C0C0; 	} /* **************************** */ /* 	Handles Web, Nexus info tab	*/ /* **************************** */ QWebView 	{ 		background-color: Black; 	} QLineEdit 	{ 		font-family: Source Sans Pro; 		background:#000; 		border-width: 1px; 		border-radius:5px; 		margin: 0px; 		padding-left:2px; 		selection-background-color: rgb(0, 204, 0, 10); 	} 	/* Font size */ QLabel, QMenu, QPushButton, QTabBar, QTextEdit, QLineEdit, QWebView, QComboBox, QComboBox:editable, QAbstractSpinBox, QGroupBox, QCheckBox, QRadioButton 	{ 		color: #cccccc; 		font-family: Source Sans Pro; 		font-size: 14px; 	} QAbstractItemView 	{ 		color: #cccccc; 		font-family: Source Sans Pro; 		font-size: 14px; 	}
+#centralWidget {
+     border-image: url(./Transparent-Style/Green/vault-101.png) 0 0 0 0 stretch stretch;
+}
+ QDialog,Qmenu {
+     border: none;
+}
+ QWidget {
+     color: #fff;
+     background-color: rgb(0, 204, 0, 5);
+     alternate-background-color: rgb(0, 204, 0, 10);
+}
+ QAbstractItemView {
+     color: #fff;
+     background-color: rgb(0, 204, 0, 5);
+     alternate-background-color: rgb(0, 204, 0, 10);
+     border: 1px solid #001a00;
+     border-style:outset;
+     border-radius: 3px;
+     selection-color: #001a00;
+     outline: none;
+}
+ #ProblemsDialog,#TransferSavesDialog,#SettingsDialog,#ProblemsDialog, #ModInfoDialog,#TextViewer,#PyCfgDialog,#InstallDialog {
+     border-image:url(./Transparent-Style/Green/vault-tec-full.png) 0 0 0 0 stretch stretch;
+}
+ #EditExecutablesDialog {
+     border-image: url(./Transparent-Style/Green/vault-tec.png) 0 0 0 0 stretch stretch;
+}
+ #SimpleInstallDialog,#LockedDialog,QMenu {
+     border-image: url(./Transparent-Style/Green/vault-tec-small.png) 0 0 0 0 stretch stretch;
+}
+ #nameLabel {
+     background-color: rgb(0, 0, 0, 20);
+     border-top:1px solid black;
+     border-bottom:1px solid black;
+}
+ #ProfilesDialog,#FomodInstallerDialog {
+     border-image: url(./Transparent-Style/Green/vault-tec-profiles.png) 0 0 0 0 stretch stretch;
+}
+ #filesView {
+     border-image: url(./Transparent-Style/Green/vault-tec-overwrite.png) 0 0 0 0 stretch stretch;
+}
+/* ******************************************** */
+/* Main Navigation Button Bar at top of window */
+/* ******************************************** */
+ QToolBar {
+     border: none;
+}
+ QToolBar::separator {
+     image: url(./Transparent-Style/Green/Vault-101-vault-boy.png);
+}
+ QToolButton {
+     border:2px ridge None;
+     border-radius: 6px;
+     margin: 3px;
+     padding-left: 8px;
+     padding-right: 8px;
+     padding-top: 0px;
+     padding-bottom: 2px;
+}
+ QToolButton:hover {
+     border: 2px ridge #fff;
+     background-color: QLinearGradient( x1: 0, y1: 0, x2: 0, y2: 1, stop: 0 #697670, stop: 1 #484F53);
+}
+ QToolButton:pressed {
+     background: black;
+}
+ QTabWidget::pane {
+     background-color: transparent;
+     border:transparent;
+}
+ QTabWidget::tab-bar {
+     alignment: center;
+}
+/* **************************************** */
+/* Tabs on top of Treeview */
+/* **************************************** */
+ QTabBar {
+     text-transform: uppercase;
+     max-height: 22px;
+     padding-bottom: 5px;
+}
+ QTabBar::tab {
+     border: none;
+     border-bottom-style: none;
+     background-color: QLinearGradient( x1: 0, y1: 0, x2: 0, y2: 1, stop: 0 #697670, stop: 1 #484F53);
+     padding-left: 15px;
+     padding-right: 15px;
+     padding-top: 3px;
+     padding-bottom: 3px;
+     margin-right: 2px;
+     border-top-left-radius: 4px;
+     border-top-right-radius: 4px;
+     border-bottom-left-radius: 4px;
+     border-bottom-right-radius: 4px;
+}
+ QTabBar::tab:selected {
+     color: #fff;
+     background-color: #00cc00;
+}
+ QTabBar::tab:!selected {
+     color: #00cc00;
+     margin-top: 0px;
+}
+ QTabBar::tab:disabled {
+     color: #bbbbbb;
+     border-bottom-style: none;
+     margin-top: 0px;
+     background-color: #000;
+}
+ #deactivateESP,#activateESP {
+     border:px #00cc00;
+     background:QLinearGradient( x1: 0, y1: 0, x2: 0, y2: 1, stop: 0 #697670, stop: 1 #484F53);
+}
+ QToolButton::menu-indicator:pressed,QToolButton::menu-indicator:open {
+     border:2px ridge #00cc00;
+     image: url(./Transparent-Style/Green/arrow-right.png);
+}
+ QTabBar QToolButton {
+     border:2px ridge #00cc00;
+     background-color: QLinearGradient( x1: 0, y1: 0, x2: 0, y2: 1, stop: 0 #697670, stop: 1 #484F53);
+     padding: 1px;
+     margin: 0;
+}
+ QTabBar QToolButton::right-arrow {
+     image: url(./Transparent-Style/Green/arrow-right.png);
+}
+ QTabBar QToolButton::left-arrow {
+     image: url(./Transparent-Style/Green/arrow-left.png);
+}
+/* **************************************** */
+/* Column names of TreeView */
+/* **************************************** */
+ QTableView {
+     color:#fff;
+     background-color: QLinearGradient( x1: 0, y1: 0, x2: 0, y2: 1, stop: 0 #697670, stop: 1 #484F53);
+}
+ QHeaderView::section {
+     color: #00cc00;
+     background-color: QLinearGradient( x1: 0, y1: 0, x2: 0, y2: 1, stop: 0 #697670, stop: 1 #484F53);
+     border-radius: 6px;
+     padding: 4px;
+     padding-left: 5px;
+     padding-right: 0px;
+}
+ QHeaderView::section:hover {
+     background: #121212;
+     border: 2px solid #ff0000;
+     padding: 0px;
+}
+ QHeaderView::up-arrow,QHeaderView::down-arrow {
+     subcontrol-origin: content;
+     subcontrol-position: center right;
+     width: 7px;
+     height: 7px;
+     margin-right: 7px;
+}
+ QHeaderView::up-arrow {
+     image: url(./Transparent-Style/Green/arrow-up.png);
+}
+ QHeaderView::down-arrow {
+     image: url(./Transparent-Style/Green/arrow-down.png);
+}
+/* **************************************** */
+/* Hover */
+/* **************************************** */
+ QMenu:item:hover,QMenuBar:item:selected,QTreeView#espList::item:hover,QTreeWidget#categoriesList::item:hover,QListView::item:hover,QTreeWidget::item:hover {
+     color:#fff;
+     border-top:1px solid #b9d7fc;
+     border-bottom:1px solid #b9d7fc;
+     background-color:#000;
+}
+ QAbstractItemView::item:hover {
+     border-top:1px solid #b9d7fc;
+     border-bottom:1px solid #b9d7fc;
+     background-color:#000;
+     padding: 3px;
+}
+ #deactivateESP:hover,#activateESP:hover,QPushButton:hover,QTableView:hover,QHeaderView::selected:hover,QTabBar::tab:!selected:hover,QComboBox:hover {
+     border: 1px solid #ff0000;
+     padding: 1px;
+     text-align: center;
+}
+/* **************************************** */
+/* Context menus, toolbar dropdowns #QMenu */
+/* **************************************** */
+ QMenu {
+     border-width: 3px;
+     border-style: solid;
+}
+ QMenu::item {
+     padding: 6px 20px;
+}
+ QMenu::item:selected {
+     color:#fff;
+     background-color: #001a00;
+     border-top:1px solid #b9d7fc;
+     border-bottom:1px solid #b9d7fc;
+}
+ QMenu::right-arrow {
+     image: url(./Transparent-Style/Green/arrow-right.png);
+     subcontrol-origin: padding;
+     subcontrol-position: center right;
+     padding-right: 0.5em;
+}
+/* ********************* */
+/* LCD Counter */
+/* ********************* */
+ QLCDNumber {
+     Background:#000;
+     border-color: #00cc00;
+     border-style: solid;
+     border-width: 1px;
+     border-radius: 5px;
+}
+/* **************************************** */
+/* Launch application Drop down Box */
+/* **************************************** */
+ QComboBox {
+     background-color: QLinearGradient( x1: 0, y1: 0, x2: 0, y2: 1, stop: 0 #697670, stop: 1 #484F53);
+     border:1px outset #00cc00;
+     height: 20px;
+     width: 15px;
+     padding: 3px;
+     padding-left:3px;
+     border-radius: 5px;
+}
+ QComboBox::drop-down{
+     subcontrol-origin: padding;
+     subcontrol-position: top right;
+     width: 15px;
+     padding:4px;
+     border-radius: 5px;
+}
+ QComboBox::down-arrow{
+     image:url(./Transparent-Style/Green/arrow-down.png);
+}
+ QComboBox::item{
+     border:3px;
+    padding: 3px;
+}
+/* **************************************************************** */
+/* Action Buttons */
+/* */
+/* Open list, Rextore Backup, Create Backup, RUN, Shortcut Button */
+/* Sort, Load order backup, Load Order Restore */
+/* **************************************************************** */
+ QPushButton {
+     color: #00cc00;
+     background-color: QLinearGradient( x1: 0, y1: 0, x2: 0, y2: 1, stop: 0 #697670, stop: 1 #484F53);
+     border-width: 1px;
+     border-color: 1px outset #00cc00;
+     border-style: solid;
+     border-radius: 4px;
+     padding:5px;
+     padding-right: 10px;
+     padding-left: 5px;
+}
+ QDialog QPushButton {
+     min-width: 3em;
+     min-height: 1em;
+     padding-left: 1em;
+     padding-right: 1em;
+}
+ QPushButton::menu-indicator {
+     image: url(./Transparent-Style/Green/arrow-down.png);
+     background: transparent;
+     subcontrol-origin: padding;
+     subcontrol-position: center right;
+     padding-right: 5%;
+}
+ QPushButton:open {
+     background-color: rgb(0, 204, 0, 100);
+}
+ QPushButton:!enabled {
+     border: 1px grey;
+     color: grey;
+     background: black;
+}
+ QPushButton#displayCategoriesBtn {
+     min-width: 20px;
+}
+/* **************************************** */
+/* Scroll bar */
+/* **************************************** */
+ QScrollBar {
+     height:20px;
+     width:20px;
+     background-color:transparent;
+}
+ QScrollBar::handle {
+     border: 1px solid #aaa;
+     border-radius: 4px;
+}
+ QScrollBar::handle:vertical {
+     margin: 1px 4px;
+     min-height:20px;
+     min-width: 10px;
+     background-color:qlineargradient(x1: 0, y1: 0, x2: 1, y2: 0, stop:0 #33ff33, stop:1 #000000);
+}
+ QScrollBar::handle:vertical:hover {
+     background-color:qlineargradient(x1: 0, y1: 0, x2: 1, y2: 0, stop:0 #000000, stop:1 #33ff33);
+}
+ QScrollBar::handle:horizontal {
+     min-height:10px;
+    min-width:20px;
+    margin:4px 1px;
+     background-color:qlineargradient(x1: 0, y1: 0, x2: 0, y2: 1, stop:0 #33ff33, stop:1 #000000);
+}
+ QScrollBar::handle:horizontal:hover {
+     background-color:qlineargradient(x1: 0, y1: 0, x2: 0, y2: 1, stop:0 #000000, stop:1 #33ff33);
+}
+ QScrollBar::add-page:vertical, QScrollBar::sub-page:vertical,QScrollBar::add-page:horizontal, QScrollBar::sub-page:horizontal {
+     background-color: transparent;
+}
+ QScrollBar::add-line:vertical,QScrollBar::sub-line:vertical,QScrollBar::add-line:horizontal,QScrollBar::sub-line:horizontal {
+     height:0;
+     width:0;
+}
+/* ******************************************************** */
+/* Main Tree View Inherated from QAbstractItemView */
+/* ******************************************************** */
+ QTreeView {
+}
+ QTreeView:item {
+     padding:4px;
+}
+ QTreeView:item:selected {
+     color: #001a00;
+     border: none;
+    outline: none;
+     border-radius: 5px;
+     border-top:1px solid #b9d7fc;
+     border-bottom:1px solid #b9d7fc;
+     background-color: rgb(0, 204, 0, 100);
+}
+ QTreeView::branch:has-siblings:!adjoins-item {
+     background:url(Vault-101/Vault-101-item-line-v.png) center center no-repeat;
+}
+ QTreeView::branch:has-siblings {
+     background:url(Vault-101/Vault-101-itemB-line.png) center center no-repeat;
+}
+ QTreeView::branch:!has-children:!has-siblings:adjoins-item {
+     background:url(Vault-101/Vault-101-itemB-end.png) center center no-repeat;
+}
+ QTreeView::branch:closed:has-children:has-siblings {
+     background:url(Vault-101/Vault-101-itemB-close.png) center center no-repeat;
+}
+ QTreeView::branch:closed:has-children:!has-siblings {
+     background:url(Vault-101/Vault-101-itemB-close-last.png) center center no-repeat;
+}
+ QTreeView::branch:open:has-children:has-siblings {
+     background:url(Vault-101/Vault-101-itemB-open.png) center center no-repeat;
+}
+ QTreeView::branch:open:has-children:!has-siblings {
+     background:url(Vault-101/Vault-101-itemB-open-last.png) center center no-repeat;
+}
+/* **************************************************************** */
+/* Checkboxes and Radio buttons common #QCheckBox, #QRadioButton */
+/* common */
+/* **************************************************************** */
+ QGroupBox::indicator,QTreeView::indicator,QCheckBox::indicator {
+     outline: none;
+     border: none;
+     width: 20px;
+     height: 20px;
+}
+ QGroupBox::indicator:checked,QGroupBox::indicator:indeterminate,QTreeView::indicator:checked,QTreeView::indicator:indeterminate,QCheckBox::indicator:checked,QCheckBox::indicator:indeterminate {
+     image: url(./Transparent-Style/Green/checkbox-checked.png);
+}
+ QGroupBox::indicator:checked:hover,QGroupBox::indicator:indeterminate:hover,QTreeView::indicator:checked:hover,QTreeView::indicator:indeterminate:hover,QCheckBox::indicator:checked:hover,QCheckBox::indicator:indeterminate:hover {
+     image: url(./Transparent-Style/Green/checkbox-hover.png);
+}
+ QGroupBox::indicator:checked:disabled,QGroupBox::indicator:indeterminate:disabled,QTreeView::indicator:checked:disabled,QTreeView::indicator:indeterminate:disabled,QCheckBox::indicator:checked:disabled,QCheckBox::indicator:indeterminate:disabled {
+     image: url(./Transparent-Style/Green/checkbox-checked-disabled.png);
+}
+ QGroupBox::indicator:unchecked,QTreeView::indicator:unchecked,QCheckBox::indicator:unchecked {
+     image: url(./Transparent-Style/Green/checkbox.png);
+}
+ QGroupBox::indicator:unchecked:hover,QTreeView::indicator:unchecked:hover,QCheckBox::indicator:unchecked:hover {
+     image: url(./Transparent-Style/Green/checkbox-checked-hover.png);
+}
+ QGroupBox::indicator:unchecked:disabled,QTreeView::indicator:unchecked:disabled,QCheckBox::indicator:unchecked:disabled {
+     image: url(./Transparent-Style/Green/checkbox-checked-disabled.png);
+}
+ QTreeWidget#categoriesList::item:has-children {
+     background-image: url(./Transparent-Style/Green/arrow-right.png);
+}
+ QTreeWidget#categoriesList::item:has-children:open {
+     background-image: url(./Transparent-Style/Green/branch-opened.png);
+}
+/* ******************************** */
+/* Special styles */
+/* increase categories tab width */
+/* ******************************** */
+ QTreeView#modList::item,QTreeWidget#categoriesTree::item,#tabConflicts QTreeWidget::item,QListView::item,QTreeView#espList::item,QTreeView#treeContent::item {
+     padding: .3em 0;
+}
+ QTreeWidget#categoriesGroup,QTreeWidget#categoriesList {
+     min-width: 200px;
+}
+ QTreeWidget#categoriesList::item {
+     background-position: center left;
+     background-repeat: no-repeat;
+     padding: 0.35em 4px;
+}
+/* ********************* */
+/* Display Radio Button */
+/* ********************* */
+ QRadioButton::indicator {
+     width: 16px;
+     height: 16px;
+}
+ QRadioButton::indicator::checked {
+     image: url(./Transparent-Style/Green/radio-checked.png);
+}
+ QRadioButton::indicator::unchecked {
+     image: url(./Transparent-Style/Green/radio.png);
+}
+ QRadioButton::indicator::unchecked:hover {
+     image: url(./Transparent-Style/Green/radio-hover.png);
+}
+/* **************************************** */
+/* Spinners #QSpinBox, #QDoubleSpinBox */
+/* **************************************** */
+ QAbstractSpinBox {
+     min-height: 24px;
+}
+ QAbstractSpinBox::up-button,QAbstractSpinBox::down-button {
+     border-style: solid;
+     border-width: 1px;
+     subcontrol-origin: padding;
+}
+ QAbstractSpinBox::up-button:hover,QAbstractSpinBox::down-button:hover {
+     background-color: #141414;
+}
+ QAbstractSpinBox::up-button {
+     subcontrol-position: top right;
+}
+ QAbstractSpinBox::down-button {
+     subcontrol-position: bottom right;
+}
+ QAbstractSpinBox::up-arrow {
+     image: url(./Transparent-Style/Green/arrow-up.png);
+}
+ QAbstractSpinBox::down-arrow {
+     image: url(./Transparent-Style/Green/arrow-down.png);
+}
+/* **************************************** */
+/* Tooltips #QToolTip, #SaveGameInfoWidget */
+/* **************************************** */
+ QToolTip {
+     background-color:transparent;
+     color:#C0C0C0;
+     padding:0px;
+     border-width:7px;
+     border-style:solid;
+     border-color:transparent;
+     border-image:url(./Transparent-Style/Green/border-image.png) 27 repeat repeat;
+}
+ SaveGameInfoWidget {
+     background-color:#121212;
+     color:#C0C0C0;
+}
+/* **************************** */
+/* Handles Web, Nexus info tab */
+/* **************************** */
+ QWebView {
+     background-color: Black;
+}
+ QLineEdit {
+     font-family: Source Sans Pro;
+     background:#000;
+     border-width: 1px;
+     border-radius:5px;
+     margin: 0px;
+     padding-left:2px;
+     selection-background-color: rgb(0, 204, 0, 10);
+}
+/* Font size */
+ QLabel, QMenu, QPushButton, QTabBar, QTextEdit, QLineEdit, QWebView, QComboBox, QComboBox:editable, QAbstractSpinBox, QGroupBox, QCheckBox, QRadioButton {
+     color: #cccccc;
+     font-family: Source Sans Pro;
+     font-size: 14px;
+}
+ QAbstractItemView {
+     color: #cccccc;
+     font-family: Source Sans Pro;
+     font-size: 14px;
+}

--- a/src/stylesheets/Transparent-Style-BOS.qss
+++ b/src/stylesheets/Transparent-Style-BOS.qss
@@ -1,1 +1,742 @@
-#centralWidget { 	border-image: url(./Transparent-Style/Fallout-BOS.png) 0 0 0 0 stretch stretch; } QWidget#TextViewer{ } QWidget{ 	color: #fff; 	background-color: rgba(45,45,48,30); 	alternate-background-color: rgba(38,38,38,30); } QWidget:disabled{ } QAbstractItemView{ 	color: #dcdcdc; 	background-color: rgb(45,45,48,30); 	alternate-background-color: rgb(38,38,38,50); 	border: 1px solid #3F3F46; /* Grey - Blue*/ 	border-style:outset; 	border-radius: 3px; 	selection-color: #3F3F46; /* Grey - Blue*/ 	outline: none; 	padding-left:0; } #problemsWidget,#TransferSavesDialog,#SettingsDialog,#ProblemsDialog,#ModInfoDialog,#TextViewer,#PyCfgDialog,#InstallDialog { 	border-image:url(./Transparent-Style/Vault-BOS-Main.png) 0 0 0 0 stretch stretch; } #toolBarArea{ 	border-image: url(./Transparent-Style/vault-BOS-Main.png) 0 0 0 0 stretch stretch; } #EditExecutablesDialog{ 	border-image: url(./Transparent-Style/vault-BOS-Main.png) 0 0 0 0 stretch stretch; } #SimpleInstallDialog,#LockedDialog,QMenu{ 	border-image: url(./Transparent-Style/vault-BOS-Main.png) 0 0 0 0 stretch stretch; }	 #nameLabel{ 	border-image: url(./Transparent-Style/vault-BOS-Main.png) 0 0 0 0 stretch stretch; 	border-top:1px solid #b9d7fc; 	border-bottom:1px solid #b9d7fc; 	background-color:rgba(154,154,0,0.3); 	color:#fff; } #ProfilesDialog,#FomodInstallerDialog{ 	border-image: url(./Transparent-Style/vault-BOS-Main.png) 0 0 0 0 stretch stretch; } #filesView{ 	border-image: url(./Transparent-Style/vault-BOS-Main.png) 0 0 0 0 stretch stretch; } /* ******************************************** */ /* Main Navigation Button Bar at top of window 	*/ /* ******************************************** */ QToolBar{ 	/*border: none;*/ } QToolBar::separator{ 	/*image: url(./Transparent-Style/Vault-101-vault-logo.png);*/ } QToolButton{ 	border:2px solid None; 	border-radius: 6px; 	margin: 3px; 	padding-left: 8px; 	padding-right: 8px; 	padding-top: 0px; 	padding-bottom: 2px; } QToolButton:hover{ 	 	border-radius: 3px; 	border: 0px; 	padding: 0px; 	background: trANSPARENT; 	border: 0px ridge #9A9A00; 	background-color: QLinearGradient( x1: 0, y1: 0, x2: 0, y2: 1, stop: 0 #9A9A00, stop: 1 #484F53); } QToolButton:pressed{ 	background: black; } /* **************************************** */ /*	 	Tabs on top of Treeview				*/ /* **************************************** */ QTabWidget::pane{ 	border-color:#3F3F46; /* Grey - Blue*/ /*	border-top-color:#9A9A00; */ 	top: 0px; 	border-style:hidden; 	border-width:1px; } QTabWidget::tab-bar{ 	alignment: center; } QTabBar{ 	color: #cccccc; 	font-family: Segoe UI; 	font-size: 16px; 	text-transform: none; 	min-height:auto; 	padding-bottom: 5px; } QTabBar::tab{ 	border: none; 	border-bottom-style: none; 	background-color: rgba(154,154,0,0.3); 	padding-left: 9px; 	padding-right: 9px; 	padding-top: 3px; 	padding-bottom: 3px; 	margin-right: 2px; 	border-top-left-radius: 4px; 	border-top-right-radius: 4px; 	border-bottom-left-radius: 4px; 	border-bottom-right-radius: 4px; } QTabBar::tab:disabled{ 	color: #404040; 	background-color: #000; 	margin-top: 0px; } QTabBar::tab:selected{ 	color: #dcdcdc; 	background-color: #9A9A00; /*Yellow opaque*/ } QTabBar::tab:!selected:hover{ 	border-radius: 3px; 	border-top:3px double #9A9A00; 	border-bottom:3px double #9A9A00; 	padding: 1px; 	text-align: center; 	background-color: #9A9A00; 	color:#fff; 	Height: 20%; } /* QTabBar::tab:!selected{ 	color: #808080; 	background-color: #404040; 	margin-top: 0px; } */ #deactivateESP,#activateESP{ 	border:#b30000; 	background:#333337; } /* **************************************** */ /*	  <More View> on top of Treeview		*/ /* **************************************** */ QTabBar QToolButton{ 	border-radius: 0px; 	border: 0px; 	padding: 0px; 	background: transparent; } QToolButton::menu-indicator:pressed,QToolButton::menu-indicator:open{ 	image: url(./Transparent-Style/arrow-up.png); } QToolButton::menu-indicator:!pressed,QToolButton::menu-indicator:!open{ 	image: url(./Transparent-Style/arrow-down.png); } QTabBar QToolButton::right-arrow{ 	image: url(./Transparent-Style/narrow-arrow-right.png); } QTabBar QToolButton::left-arrow{ 	image: url(./Transparent-Style/narrow-arrow-left.png); } /* **************************************** */ /*	 	Column names of TreeView			*/ /* **************************************** */ QTableView{ 	gridline-color:#3F3F46; 	selection-background-color:#9A9A00; 	selection-color:#F1F1F1; /* White */ 	text-align: center; 	min-height:24px; } QHeaderView{ 	min-height:24px; /*Top Bar on menus*/ 	padding: 3px; } QHeaderView::section{ /*	color: #cc3333;  */ 	background-color: #252526; 	border-radius: 0px; 	padding: 0px; 	padding-left: 5px; } QHeaderView::section:hover{ 	background: rgba(154,154,0,0.3); 	border: 1px solid #9a9a00; 	padding: 0px;	 	padding-left: 5px; } QHeaderView::up-arrow,QHeaderView::down-arrow{ 	min-height:Auto; 	min-width:Auto; } QHeaderView::up-arrow{ 	image: url(./Transparent-Style/arrow-up.png); 	min-height:25px; 	min-width:15px; 	padding-right: 0px; }QHeaderView::down-arrow{ 	image: url(./Transparent-Style/arrow-down.png); }	 /* **************************************** */ /*	 				Hover					*/ /* **************************************** */ QMenu:item:hover,QTreeView#espList::item:hover,QTreeWidget#categoriesList::item:hover,QListView::item:hover,QTreeWidget::item:hover{ 	color:#fff; 	border-top:1px solid #b9d7fc; 	border-bottom:1px solid #b9d7fc; 	background-color:rgba(154,154,0,0.3); } QAbstractItemView::item:hover{ 	border-top:1px solid #b9d7fc; 	border-bottom:1px solid #b9d7fc; 	background-color:rgba(154,154,0,0.3); 	padding: 3px; } /*#DownloadListWidget{ }*/ #DownloadListWidget{   outline: 1px solid #e8e8e8;   border: 0px solid #9a9a00; } #deactivateESP:hover,#activateESP:hover,QTableView:hover,QHeaderView::selected:hover{ 	border: 1px solid #9a9a00; 	padding: 1px; 	text-align: center; 	color:#fff; } /* **************************************** */ /* Context menus, toolbar dropdowns #QMenu  */ /* **************************************** */ QMenu{ 	border-width: 3px; 	border-style: solid; }QMenu::item{ 	padding: 6px 20px; }QMenu::item:selected{ 	color:#fff; 	background-color: #3F3F46; /* Grey - Blue*/ 	border-top:1px solid #9A9A00; 	border-bottom:1px solid #9A9A00; } QMenu::right-arrow{ 	image: url(./Transparent-Style/arrow-right.png);  /* right click main menu top option*/ 	subcontrol-origin: padding; 	subcontrol-position: center right; 	width: 18px; 	height: 18px; 	border:0px outset #3F3F46; /* Grey - Blue*/ } /* ********************* */ /*		 LCD Counter	 */ /* ********************* */ QLCDNumber{ 	color: #9A9A00; 	Background: #000; 	border-color: #3F3F46; /* Grey - Blue*/ 	border-style: solid; 	border-width: 1px; 	border-radius: 5px; } /* **************************************** */ /*		Launch application Drop down Box 	*/ /* **************************************** */ QComboBox{ 	background-color: #333337; 	padding: 3px 5px 5px 5px; 	height: 26px; 	 	border-radius: 5px; 	border-top:1px solid #9A9A00; 	border-bottom:1px solid #9A9A00; } QComboBox:on{ 	padding: 3px 5px 5px 5px;     color: white;     background-color: #3F3F46; /* Grey - Blue*/ } QComboBox:hover{ 	border-radius: 3px; 	border-top:3px double #9A9A00; 	border-bottom:3px double #9A9A00; /*	padding: 0px; */ } QComboBox::drop-down{ 	/* Down arrow in combo box */ 	outline: none; 	border: none; 	border-width: 1px; } QComboBox::menu-indicator{ 	image: url(./Transparent-Style/arrow-down.png); 	subcontrol-origin: padding; 	subcontrol-position: center right; 	width: 18px; 	height: 18px; 	border:1px outset #3F3F46; /* Grey - Blue*/ } /* ************************* */ /* QComboBox::down-arrow:on, */ /* ************************* */ QComboBox::down-arrow:hover,QComboBox::down-arrow:focus {     image: url(./Transparent-Style/arrow-down-hover.png); } QComboBox::up-arrow:hover,QComboBox::up-arrow:focus {     image: url(./Transparent-Style/arrow-up-hover.png); } QComboBox::down-arrow{ 	image:url(./Transparent-Style/arrow-down.png); 	subcontrol-origin: padding; 	subcontrol-position: center right; 	width: 18px; 	height: 18px; } QComboBox::down-arrow:on{ 	image:url(./Transparent-Style/arrow-up.png); } QComboBox:editable { 	background: black; /*    color: pink; */ } QComboBox::item{ } QComboBox QAbstractItemView{ 	selection-color:#fff; 	outline: 1px solid #9a9a00; 	selection-background-color:#3F3F46; /* Grey - Blue*/ 	border-top:1px solid #9a9a00; 	border-bottom:1px solid #9a9a00; 	padding: 5px; } /* **************************************************************** */ /* 							Action Buttons     						*/ /*																	*/ /* Open list, Restore Backup, Create Backup, RUN, Shortcut Button 	*/ /* Sort, Load order backup, Load Order Restore 						*/ /* **************************************************************** */ QPushButton{ 	background-color: #333337; 	min-height:26px; 	padding:1px 5%; 	text-align: center; 	border-radius: 5px; 	border-top:1px solid #9A9A00; 	border-bottom:1px solid #9A9A00; } QPushButton::menu-indicator{ 	image: url(./Transparent-Style/arrow-down.png); 	subcontrol-origin: padding; 	subcontrol-position: center right; 	width: 18px; 	height: 18px; 	border:1px hidden #3F3F46; /* Grey - Blue*/ } QPushButton::menu-indicator:Hover{	     image: url(./Transparent-Style/arrow-down-hover.png); } QPushButton:focus{ } QPushButton:on,QPushButton:checked,QPushButton:pressed,QPushButton:checked:hover{     background: #3F3F46; /* Grey - Blue*/ 	border-radius: 1px; 	border: 1px solid #9a9a00; } QPushButton:hover{ 	border-radius: 3px; 	border-top:3px double #9A9A00; 	border-bottom:3px double #9A9A00; } QDialog QPushButton,QSlider::handle:horizontal,QSlider::handle:vertical{ 	color:#fff; 	border-color:#707070; 	border-style:solid; 	border-width:1px; } QPushButton:disabled{ } QPushButton:open{ } QPushButton:!enabled{ } 		 /* **************************************** */ /*	 			Filter Button				*/ /* **************************************** */		 		 QPushButton#displayCategoriesBtn{ 	min-width: 20px; 	background:transparent; 	color: transparent; 	border: 1px hidden #9a9a00; } QPushButton#displayCategoriesBtn:checked{ 	image: url(./Transparent-Style/arrow-left.png); } QPushButton#displayCategoriesBtn:!checked{ 	image: url(./Transparent-Style/arrow-right.png); } QPushButton#displayCategoriesBtn:checked:hover{ 	image: url(./Transparent-Style/arrow-left-hover.png); } QPushButton#displayCategoriesBtn:!checked:hover{ 	image: url(./Transparent-Style/arrow-right-hover.png); } /* **************************************** */ /*	 			Scroll bar 					*/ /* **************************************** */ QScrollBar{ 	height:20px; 	width:20px; 	background-color:transparent; } QScrollBar::handle{ 	border: 1px solid #aaa; 	border-radius: 4px; } QScrollBar::handle:vertical{ 	margin: 1px 4px; 	min-height:20px; 	min-width: 10px; 	background-color:qlineargradient(x1: 0, y1: 0, x2: 1, y2: 0, stop:0 #9A9A00, stop:1 #000000); } QScrollBar::handle:vertical:hover{ 	background-color:qlineargradient(x1: 0, y1: 0, x2: 1, y2: 0, stop:0 #000000, stop:1 #9A9A00); } QScrollBar::handle:horizontal{ 	min-height:10px;min-width:20px;margin:4px 1px; 	background-color:qlineargradient(x1: 0, y1: 0, x2: 0, y2: 1, stop:0 #9A9A00, stop:1 #000000); } QScrollBar::handle:horizontal:hover{ 	background-color:qlineargradient(x1: 0, y1: 0, x2: 0, y2: 1, stop:0 #000000, stop:1 #9A9A00); } QScrollBar::add-page:vertical, QScrollBar::sub-page:vertical,QScrollBar::add-page:horizontal, QScrollBar::sub-page:horizontal{ 	background-color: transparent; } QScrollBar::add-line:vertical,QScrollBar::sub-line:vertical,QScrollBar::add-line:horizontal,QScrollBar::sub-line:horizontal{ height:0; width:0; } /* ******************************************************** */ /*		Main Tree View Inherited from QAbstractItemView 	*/ /* ******************************************************** */ QTreeView { } QTreeView:item{ 	padding: 3px; 	font-size: 16px; 	height: 18px; 	/*Bottom text Box*/ } QTreeView:item:selected{ 	color:#fff; 	padding: 0px; 	background-color: #3F3F46; /* Grey - Blue*/ 	border-top:1px solid #9A9A00; 	border-bottom:1px solid #9A9A00; } QTreeView:item QLineEdit{ 	outline: none; 	border: none; 	padding: 0px; 	margin: 0px; } QTreeView::branch:has-siblings:!adjoins-item{ 	background:url(Transparent-Style/vault-101-item-line-v.png) center center no-repeat; } QTreeView::branch:has-siblings{  	background:url(Transparent-Style/vault-101-itemB-line.png) center center no-repeat; } QTreeView::branch:!has-children:!has-siblings:adjoins-item{ 	background:url(Transparent-Style/vault-101-itemB-end.png) center center no-repeat; } QTreeView::branch:closed:has-children:has-siblings{ 	background:url(Transparent-Style/vault-101-itemB-close.png) center center no-repeat; } QTreeView::branch:closed:has-children:!has-siblings{ 	background:url(Transparent-Style/vault-101-itemB-close-last.png) center center no-repeat; } QTreeView::branch:open:has-children:has-siblings{ 	background:url(Transparent-Style/vault-101-itemB-open.png) center center no-repeat; } QTreeView::branch:open:has-children:!has-siblings{ 	background:url(Transparent-Style/vault-101-itemB-open-last.png) center center no-repeat; } /* **************************************************************** */ /* Checkboxes and Radio buttons common #QCheckBox, #QRadioButton 	*/ /*							common									*/ /* **************************************************************** */ QTreeView::indicator,QCheckBox::indicator{ 	outline: none; 	border: none; 	padding: 0px; 	width: 24px; 	height: 24px; } QGroupBox::indicator:checked,QGroupBox::indicator:indeterminate,QTreeView::indicator:checked,QTreeView::indicator:indeterminate,QCheckBox::indicator:checked,QCheckBox::indicator:indeterminate{ 	image: url(./Transparent-Style/checkbox-checked.png); } QGroupBox::indicator:checked:hover,QGroupBox::indicator:indeterminate:hover,QTreeView::indicator:checked:hover,QTreeView::indicator:indeterminate:hover,QCheckBox::indicator:checked:hover,QCheckBox::indicator:indeterminate:hover{ 	image: url(./Transparent-Style/checkbox-hover.png); } QGroupBox::indicator:checked:disabled,QGroupBox::indicator:indeterminate:disabled,QTreeView::indicator:checked:disabled,QTreeView::indicator:indeterminate:disabled,QCheckBox::indicator:checked:disabled,QCheckBox::indicator:indeterminate:disabled{ 	image: url(./Transparent-Style/checkbox-checked-disabled.png); } QGroupBox::indicator:unchecked,QTreeView::indicator:unchecked,QCheckBox::indicator:unchecked{ 	image: url(./Transparent-Style/checkbox.png); } QGroupBox::indicator:unchecked:hover,QTreeView::indicator:unchecked:hover,QCheckBox::indicator:unchecked:hover{ 	image: url(./Transparent-Style/checkbox-checked-hover.png); } QGroupBox::indicator:unchecked:disabled,QTreeView::indicator:unchecked:disabled,QCheckBox::indicator:unchecked:disabled{ 	image: url(./Transparent-Style/checkbox-checked-disabled.png); } QTreeWidget#categoriesList::item:has-children{ 	background-image: url(./Transparent-Style/arrow-right-small.png); } QTreeWidget#categoriesList::item:has-children:open{ 	background-image: url(./Transparent-Style/branch-opened.png); } /* ******************************** */ /* 		Special styles 				*/ /* increase categories tab width 	*/ /* ******************************** */ QTreeView#modList::item,QTreeWidget#categoriesTree::item,#tabConflicts QTreeWidget::item,QListView::item,QTreeView#espList::item,QTreeView#treeContent::item{ 	padding: .3em 0em; } QTreeView#modList::item,QTreeWidget#categoriesTree::item,#tabConflicts QTreeWidget::item,QListView::item,QTreeView#espList::item,QTreeView#treeContent::item{ 	padding: .3em 0em; } QTreeWidget#categoriesGroup,QTreeWidget#categoriesList{ 	min-width: 200px; } QTreeWidget#categoriesList::item { 	background-position: center left; 	background-repeat: no-repeat; 	padding: 0.35em 4px; } /* ********************* */ /* Display Radio Button	 */ /* ********************* */ QRadioButton::indicator{ 	width: 16px; 	height: 16px; } QRadioButton::indicator::checked{ 	image: url(./Transparent-Style/radio-BOS-checked.png); } QRadioButton::indicator::unchecked{ 	image: url(./Transparent-Style/radio-BOS.png); } QRadioButton::indicator::unchecked:hover{ 	image: url(./Transparent-Style/radio-BOS-hover.png); } /* **************************************** */ /*	 Spinners #QSpinBox, #QDoubleSpinBox 	*/ /* **************************************** */ QAbstractSpinBox{     padding: 5px; 	background-color: transparent;     color: #eff0f1;     border-radius: 2px;     min-width: Auto; } QAbstractSpinBox::up-button,QAbstractSpinBox::down-button{ 	border-style: solid; 	border-width: 1px; 	subcontrol-origin: border; } QAbstractSpinBox::up-button:hover,QAbstractSpinBox::down-button:hover{ 	background-color: transparent; } QAbstractSpinBox::up-button{     background-color: transparent;     subcontrol-origin: border;     subcontrol-position: center right;     padding-right: 5px; /*	subcontrol-position: top right; */ } QAbstractSpinBox::down-button{     background-color: transparent;     subcontrol-origin: border;     subcontrol-position: center left; 	padding-left: 5px; /*	subcontrol-position: bottom right; */ } QAbstractSpinBox::up-arrow{ 	border-image: url(./Transparent-Style/narrow-arrow-right.png); }QAbstractSpinBox::down-arrow{ 	border-image: url(./Transparent-Style/narrow-arrow-left.png); }/*	QTextEdit,QWebView,QLineEdit,QComboBox{ border-color:#3F3F46; /* Grey - Blue*/ /*}*/ /* **************************************** */ /* 	Tooltips #QToolTip, #SaveGameInfoWidget	*/ /* **************************************** */ QToolTip{ 	background-color:#121212; 	color:#C0C0C0; 	padding:0px; 	border-color:#9A9A00; 	border-radius: 3px; 	border-width:1px; 	border-style:solid; } SaveGameInfoWidget{ 	font-size: 16px; 	background-color:#121212; 	color:#C0C0C0; 	padding:0px; 	border-color:#9A9A00; 	border-radius: 3px; 	border-width:1px; 	border-style:solid; } /* **************************** */ /* 	Handles Web, Nexus info tab	*/ /* **************************** */ QWebView{ 	background-color: Black; } QLineEdit{ 	font-family: Segoe UI; 	min-height: 20px; 	font-size: 16px; 	background-color:#3F3F46; 	selection-background-color: rgba(154,154,0,0.6);border-color:#9A9A00; 	border-radius: 3px; 	border-width:1px; 	border-style:solid; } QTextEdit{ 	color: #cccccc; 	font-family: Segoe UI; 	font-size: 16px; /*	background-color:#000; */ 	selection-background-color: rgba(154,154,0,0.6); 	border-color:#9A9A00; 	border-radius: 3px; 	border-width:1px; 	border-style:solid; } /* Font size */ QLabel,QMenu,QPushButton,QAbstractSpinBox,QGroupBox,QCheckBox,QRadioButton{ 	color: #cccccc; 	font-family: Segoe UI; 	font-size: 16px;  /* was 14px Profile font size */ } QAbstractItemView{ 	color: #cccccc; 	font-family: Segoe UI; /*	font-family: Source Sans Pro; */ 	font-size: 16px; /* Body font size*/ } QRadioButton{ 	color: #cccccc;	 	font-family: Segoe UI; /*	font-family: Source Sans Pro; */ 	font-size: 16px; } QWebView,QComboBox,QComboBox:editable{ 	font-family:Segoe UI; 	font-style: normal; 	font-weight: normal; 	font-size: 16px; 	background-color:#000; /*	border-color:#3F3F46; /* Grey - Blue*/ 	color: #cccccc; 	font-family: Arial; 	font-size: 16px; /* Filter Name*/ } QHeaderView::section{ /*	font-family: Source Sans Pro; */ 	font-family: Segoe UI; 	font-size: 16px;  /*Top Bar on menus font*/ } QListView::item{ 	color:#F1F1F1; /* White */ } QGroupBox { } QGroupBox::title { 	subcontrol-origin: margin; 	subcontrol-position: top center; } QGroupBox::indicator { 	subcontrol-origin: margin; 	subcontrol-position: top center; } QLabel { 	color: #cccccc; /*	color: #F1F1F1; /* White */ /*	border: none;outline: none; 	border-radius: 5px; 	border-top:1px solid #9A9A00; 	border-bottom:1px solid #9A9A00;*/ }
+#centralWidget {
+     border-image: url(./Transparent-Style/Fallout-BOS.png) 0 0 0 0 stretch stretch;
+}
+ QWidget#TextViewer{
+}
+ QWidget{
+     color: #fff;
+     background-color: rgba(45,45,48,30);
+     alternate-background-color: rgba(38,38,38,30);
+}
+ QWidget:disabled{
+}
+ QAbstractItemView{
+     color: #dcdcdc;
+     background-color: rgb(45,45,48,30);
+     alternate-background-color: rgb(38,38,38,50);
+     border: 1px solid #3F3F46;
+    /* Grey - Blue*/
+     border-style:outset;
+     border-radius: 3px;
+     selection-color: #3F3F46;
+    /* Grey - Blue*/
+     outline: none;
+     padding-left:0;
+}
+ #problemsWidget,#TransferSavesDialog,#SettingsDialog,#ProblemsDialog,#ModInfoDialog,#TextViewer,#PyCfgDialog,#InstallDialog {
+     border-image:url(./Transparent-Style/Vault-BOS-Main.png) 0 0 0 0 stretch stretch;
+}
+ #toolBarArea{
+     border-image: url(./Transparent-Style/vault-BOS-Main.png) 0 0 0 0 stretch stretch;
+}
+ #EditExecutablesDialog{
+     border-image: url(./Transparent-Style/vault-BOS-Main.png) 0 0 0 0 stretch stretch;
+}
+ #SimpleInstallDialog,#LockedDialog,QMenu{
+     border-image: url(./Transparent-Style/vault-BOS-Main.png) 0 0 0 0 stretch stretch;
+}
+ #nameLabel{
+     border-image: url(./Transparent-Style/vault-BOS-Main.png) 0 0 0 0 stretch stretch;
+     border-top:1px solid #b9d7fc;
+     border-bottom:1px solid #b9d7fc;
+     background-color:rgba(154,154,0,0.3);
+     color:#fff;
+}
+ #ProfilesDialog,#FomodInstallerDialog{
+     border-image: url(./Transparent-Style/vault-BOS-Main.png) 0 0 0 0 stretch stretch;
+}
+ #filesView{
+     border-image: url(./Transparent-Style/vault-BOS-Main.png) 0 0 0 0 stretch stretch;
+}
+/* ******************************************** */
+/* Main Navigation Button Bar at top of window */
+/* ******************************************** */
+ QToolBar{
+    /*border: none;
+    */
+}
+ QToolBar::separator{
+    /*image: url(./Transparent-Style/Vault-101-vault-logo.png);
+    */
+}
+ QToolButton{
+     border:2px solid None;
+     border-radius: 6px;
+     margin: 3px;
+     padding-left: 8px;
+     padding-right: 8px;
+     padding-top: 0px;
+     padding-bottom: 2px;
+}
+ QToolButton:hover{
+     border-radius: 3px;
+     border: 0px;
+     padding: 0px;
+     background: trANSPARENT;
+     border: 0px ridge #9A9A00;
+     background-color: QLinearGradient( x1: 0, y1: 0, x2: 0, y2: 1, stop: 0 #9A9A00, stop: 1 #484F53);
+}
+ QToolButton:pressed{
+     background: black;
+}
+/* **************************************** */
+/* Tabs on top of Treeview */
+/* **************************************** */
+ QTabWidget::pane{
+     border-color:#3F3F46;
+    /* Grey - Blue*/
+    /* border-top-color:#9A9A00;
+     */
+     top: 0px;
+     border-style:hidden;
+     border-width:1px;
+}
+ QTabWidget::tab-bar{
+     alignment: center;
+}
+ QTabBar{
+     color: #cccccc;
+     font-family: Segoe UI;
+     font-size: 16px;
+     text-transform: none;
+     min-height:auto;
+     padding-bottom: 5px;
+}
+ QTabBar::tab{
+     border: none;
+     border-bottom-style: none;
+     background-color: rgba(154,154,0,0.3);
+     padding-left: 9px;
+     padding-right: 9px;
+     padding-top: 3px;
+     padding-bottom: 3px;
+     margin-right: 2px;
+     border-top-left-radius: 4px;
+     border-top-right-radius: 4px;
+     border-bottom-left-radius: 4px;
+     border-bottom-right-radius: 4px;
+}
+ QTabBar::tab:disabled{
+     color: #404040;
+     background-color: #000;
+     margin-top: 0px;
+}
+ QTabBar::tab:selected{
+     color: #dcdcdc;
+     background-color: #9A9A00;
+    /*Yellow opaque*/
+}
+ QTabBar::tab:!selected:hover{
+     border-radius: 3px;
+     border-top:3px double #9A9A00;
+     border-bottom:3px double #9A9A00;
+     padding: 1px;
+     text-align: center;
+     background-color: #9A9A00;
+     color:#fff;
+     Height: 20%;
+}
+/* QTabBar::tab:!selected{
+     color: #808080;
+     background-color: #404040;
+     margin-top: 0px;
+}
+ */
+ #deactivateESP,#activateESP{
+     border:#b30000;
+     background:#333337;
+}
+/* **************************************** */
+/* <More View> on top of Treeview */
+/* **************************************** */
+ QTabBar QToolButton{
+     border-radius: 0px;
+     border: 0px;
+     padding: 0px;
+     background: transparent;
+}
+ QToolButton::menu-indicator:pressed,QToolButton::menu-indicator:open{
+     image: url(./Transparent-Style/arrow-up.png);
+}
+ QToolButton::menu-indicator:!pressed,QToolButton::menu-indicator:!open{
+     image: url(./Transparent-Style/arrow-down.png);
+}
+ QTabBar QToolButton::right-arrow{
+     image: url(./Transparent-Style/narrow-arrow-right.png);
+}
+ QTabBar QToolButton::left-arrow{
+     image: url(./Transparent-Style/narrow-arrow-left.png);
+}
+/* **************************************** */
+/* Column names of TreeView */
+/* **************************************** */
+ QTableView{
+     gridline-color:#3F3F46;
+     selection-background-color:#9A9A00;
+     selection-color:#F1F1F1;
+    /* White */
+     text-align: center;
+     min-height:24px;
+}
+ QHeaderView{
+     min-height:24px;
+    /*Top Bar on menus*/
+     padding: 3px;
+}
+ QHeaderView::section{
+    /* color: #cc3333;
+     */
+     background-color: #252526;
+     border-radius: 0px;
+     padding: 0px;
+     padding-left: 5px;
+}
+ QHeaderView::section:hover{
+     background: rgba(154,154,0,0.3);
+     border: 1px solid #9a9a00;
+     padding: 0px;
+     padding-left: 5px;
+}
+ QHeaderView::up-arrow,QHeaderView::down-arrow{
+     min-height:Auto;
+     min-width:Auto;
+}
+ QHeaderView::up-arrow{
+     image: url(./Transparent-Style/arrow-up.png);
+     min-height:25px;
+     min-width:15px;
+     padding-right: 0px;
+}
+QHeaderView::down-arrow{
+     image: url(./Transparent-Style/arrow-down.png);
+}
+/* **************************************** */
+/* Hover */
+/* **************************************** */
+ QMenu:item:hover,QMenuBar::item:selected,QTreeView#espList::item:hover,QTreeWidget#categoriesList::item:hover,QListView::item:hover,QTreeWidget::item:hover{
+     color:#fff;
+     border-top:1px solid #b9d7fc;
+     border-bottom:1px solid #b9d7fc;
+     background-color:rgba(154,154,0,0.3);
+}
+ QAbstractItemView::item:hover{
+     border-top:1px solid #b9d7fc;
+     border-bottom:1px solid #b9d7fc;
+     background-color:rgba(154,154,0,0.3);
+     padding: 3px;
+}
+/*#DownloadListWidget{
+}
+*/
+ #DownloadListWidget{
+     outline: 1px solid #e8e8e8;
+     border: 0px solid #9a9a00;
+}
+ #deactivateESP:hover,#activateESP:hover,QTableView:hover,QHeaderView::selected:hover{
+     border: 1px solid #9a9a00;
+     padding: 1px;
+     text-align: center;
+     color:#fff;
+}
+/* **************************************** */
+/* Context menus, toolbar dropdowns #QMenu */
+/* **************************************** */
+ QMenu{
+     border-width: 3px;
+     border-style: solid;
+}
+QMenu::item{
+     padding: 6px 20px;
+}
+QMenu::item:selected{
+     color:#fff;
+     background-color: #3F3F46;
+    /* Grey - Blue*/
+     border-top:1px solid #9A9A00;
+     border-bottom:1px solid #9A9A00;
+}
+ QMenu::right-arrow{
+     image: url(./Transparent-Style/arrow-right.png);
+    /* right click main menu top option*/
+     subcontrol-origin: padding;
+     subcontrol-position: center right;
+     width: 18px;
+     height: 18px;
+     border:0px outset #3F3F46;
+    /* Grey - Blue*/
+}
+/* ********************* */
+/* LCD Counter */
+/* ********************* */
+ QLCDNumber{
+     color: #9A9A00;
+     Background: #000;
+     border-color: #3F3F46;
+    /* Grey - Blue*/
+     border-style: solid;
+     border-width: 1px;
+     border-radius: 5px;
+}
+/* **************************************** */
+/* Launch application Drop down Box */
+/* **************************************** */
+ QComboBox{
+     background-color: #333337;
+     padding: 3px 5px 5px 5px;
+     height: 26px;
+     border-radius: 5px;
+     border-top:1px solid #9A9A00;
+     border-bottom:1px solid #9A9A00;
+}
+ QComboBox:on{
+     padding: 3px 5px 5px 5px;
+     color: white;
+     background-color: #3F3F46;
+    /* Grey - Blue*/
+}
+ QComboBox:hover{
+     border-radius: 3px;
+     border-top:3px double #9A9A00;
+     border-bottom:3px double #9A9A00;
+    /* padding: 0px;
+     */
+}
+ QComboBox::drop-down{
+    /* Down arrow in combo box */
+     outline: none;
+     border: none;
+     border-width: 1px;
+}
+ QComboBox::menu-indicator{
+     image: url(./Transparent-Style/arrow-down.png);
+     subcontrol-origin: padding;
+     subcontrol-position: center right;
+     width: 18px;
+     height: 18px;
+     border:1px outset #3F3F46;
+    /* Grey - Blue*/
+}
+/* ************************* */
+/* QComboBox::down-arrow:on, */
+/* ************************* */
+ QComboBox::down-arrow:hover,QComboBox::down-arrow:focus {
+     image: url(./Transparent-Style/arrow-down-hover.png);
+}
+ QComboBox::up-arrow:hover,QComboBox::up-arrow:focus {
+     image: url(./Transparent-Style/arrow-up-hover.png);
+}
+ QComboBox::down-arrow{
+     image:url(./Transparent-Style/arrow-down.png);
+     subcontrol-origin: padding;
+     subcontrol-position: center right;
+     width: 18px;
+     height: 18px;
+}
+ QComboBox::down-arrow:on{
+     image:url(./Transparent-Style/arrow-up.png);
+}
+ QComboBox:editable {
+     background: black;
+    /* color: pink;
+     */
+}
+ QComboBox::item{
+}
+ QComboBox QAbstractItemView{
+     selection-color:#fff;
+     outline: 1px solid #9a9a00;
+     selection-background-color:#3F3F46;
+    /* Grey - Blue*/
+     border-top:1px solid #9a9a00;
+     border-bottom:1px solid #9a9a00;
+     padding: 5px;
+}
+/* **************************************************************** */
+/* Action Buttons */
+/* */
+/* Open list, Restore Backup, Create Backup, RUN, Shortcut Button */
+/* Sort, Load order backup, Load Order Restore */
+/* **************************************************************** */
+ QPushButton{
+     background-color: #333337;
+     min-height:26px;
+     padding:1px 5%;
+     text-align: center;
+     border-radius: 5px;
+     border-top:1px solid #9A9A00;
+     border-bottom:1px solid #9A9A00;
+}
+ QPushButton::menu-indicator{
+     image: url(./Transparent-Style/arrow-down.png);
+     subcontrol-origin: padding;
+     subcontrol-position: center right;
+     width: 18px;
+     height: 18px;
+     border:1px hidden #3F3F46;
+    /* Grey - Blue*/
+}
+ QPushButton::menu-indicator:Hover{
+     image: url(./Transparent-Style/arrow-down-hover.png);
+}
+ QPushButton:focus{
+}
+ QPushButton:on,QPushButton:checked,QPushButton:pressed,QPushButton:checked:hover{
+     background: #3F3F46;
+    /* Grey - Blue*/
+     border-radius: 1px;
+     border: 1px solid #9a9a00;
+}
+ QPushButton:hover{
+     border-radius: 3px;
+     border-top:3px double #9A9A00;
+     border-bottom:3px double #9A9A00;
+}
+ QDialog QPushButton,QSlider::handle:horizontal,QSlider::handle:vertical{
+     color:#fff;
+     border-color:#707070;
+     border-style:solid;
+     border-width:1px;
+}
+ QPushButton:disabled{
+}
+ QPushButton:open{
+}
+ QPushButton:!enabled{
+}
+/* **************************************** */
+/* Filter Button */
+/* **************************************** */
+ QPushButton#displayCategoriesBtn{
+     min-width: 20px;
+     background:transparent;
+     color: transparent;
+     border: 1px hidden #9a9a00;
+}
+ QPushButton#displayCategoriesBtn:checked{
+     image: url(./Transparent-Style/arrow-left.png);
+}
+ QPushButton#displayCategoriesBtn:!checked{
+     image: url(./Transparent-Style/arrow-right.png);
+}
+ QPushButton#displayCategoriesBtn:checked:hover{
+     image: url(./Transparent-Style/arrow-left-hover.png);
+}
+ QPushButton#displayCategoriesBtn:!checked:hover{
+     image: url(./Transparent-Style/arrow-right-hover.png);
+}
+/* **************************************** */
+/* Scroll bar */
+/* **************************************** */
+ QScrollBar{
+     height:20px;
+     width:20px;
+     background-color:transparent;
+}
+ QScrollBar::handle{
+     border: 1px solid #aaa;
+     border-radius: 4px;
+}
+ QScrollBar::handle:vertical{
+     margin: 1px 4px;
+     min-height:20px;
+     min-width: 10px;
+     background-color:qlineargradient(x1: 0, y1: 0, x2: 1, y2: 0, stop:0 #9A9A00, stop:1 #000000);
+}
+ QScrollBar::handle:vertical:hover{
+     background-color:qlineargradient(x1: 0, y1: 0, x2: 1, y2: 0, stop:0 #000000, stop:1 #9A9A00);
+}
+ QScrollBar::handle:horizontal{
+     min-height:10px;
+    min-width:20px;
+    margin:4px 1px;
+     background-color:qlineargradient(x1: 0, y1: 0, x2: 0, y2: 1, stop:0 #9A9A00, stop:1 #000000);
+}
+ QScrollBar::handle:horizontal:hover{
+     background-color:qlineargradient(x1: 0, y1: 0, x2: 0, y2: 1, stop:0 #000000, stop:1 #9A9A00);
+}
+ QScrollBar::add-page:vertical, QScrollBar::sub-page:vertical,QScrollBar::add-page:horizontal, QScrollBar::sub-page:horizontal{
+     background-color: transparent;
+}
+ QScrollBar::add-line:vertical,QScrollBar::sub-line:vertical,QScrollBar::add-line:horizontal,QScrollBar::sub-line:horizontal{
+     height:0;
+     width:0;
+}
+/* ******************************************************** */
+/* Main Tree View Inherited from QAbstractItemView */
+/* ******************************************************** */
+ QTreeView {
+}
+ QTreeView:item{
+     padding: 3px;
+     font-size: 16px;
+     height: 18px;
+    /*Bottom text Box*/
+}
+ QTreeView:item:selected{
+     color:#fff;
+     padding: 0px;
+     background-color: #3F3F46;
+    /* Grey - Blue*/
+     border-top:1px solid #9A9A00;
+     border-bottom:1px solid #9A9A00;
+}
+ QTreeView:item QLineEdit{
+     outline: none;
+     border: none;
+     padding: 0px;
+     margin: 0px;
+}
+ QTreeView::branch:has-siblings:!adjoins-item{
+     background:url(Transparent-Style/vault-101-item-line-v.png) center center no-repeat;
+}
+ QTreeView::branch:has-siblings{
+     background:url(Transparent-Style/vault-101-itemB-line.png) center center no-repeat;
+}
+ QTreeView::branch:!has-children:!has-siblings:adjoins-item{
+     background:url(Transparent-Style/vault-101-itemB-end.png) center center no-repeat;
+}
+ QTreeView::branch:closed:has-children:has-siblings{
+     background:url(Transparent-Style/vault-101-itemB-close.png) center center no-repeat;
+}
+ QTreeView::branch:closed:has-children:!has-siblings{
+     background:url(Transparent-Style/vault-101-itemB-close-last.png) center center no-repeat;
+}
+ QTreeView::branch:open:has-children:has-siblings{
+     background:url(Transparent-Style/vault-101-itemB-open.png) center center no-repeat;
+}
+ QTreeView::branch:open:has-children:!has-siblings{
+     background:url(Transparent-Style/vault-101-itemB-open-last.png) center center no-repeat;
+}
+/* **************************************************************** */
+/* Checkboxes and Radio buttons common #QCheckBox, #QRadioButton */
+/* common */
+/* **************************************************************** */
+ QTreeView::indicator,QCheckBox::indicator{
+     outline: none;
+     border: none;
+     padding: 0px;
+     width: 24px;
+     height: 24px;
+}
+ QGroupBox::indicator:checked,QGroupBox::indicator:indeterminate,QTreeView::indicator:checked,QTreeView::indicator:indeterminate,QCheckBox::indicator:checked,QCheckBox::indicator:indeterminate{
+     image: url(./Transparent-Style/checkbox-checked.png);
+}
+ QGroupBox::indicator:checked:hover,QGroupBox::indicator:indeterminate:hover,QTreeView::indicator:checked:hover,QTreeView::indicator:indeterminate:hover,QCheckBox::indicator:checked:hover,QCheckBox::indicator:indeterminate:hover{
+     image: url(./Transparent-Style/checkbox-hover.png);
+}
+ QGroupBox::indicator:checked:disabled,QGroupBox::indicator:indeterminate:disabled,QTreeView::indicator:checked:disabled,QTreeView::indicator:indeterminate:disabled,QCheckBox::indicator:checked:disabled,QCheckBox::indicator:indeterminate:disabled{
+     image: url(./Transparent-Style/checkbox-checked-disabled.png);
+}
+ QGroupBox::indicator:unchecked,QTreeView::indicator:unchecked,QCheckBox::indicator:unchecked{
+     image: url(./Transparent-Style/checkbox.png);
+}
+ QGroupBox::indicator:unchecked:hover,QTreeView::indicator:unchecked:hover,QCheckBox::indicator:unchecked:hover{
+     image: url(./Transparent-Style/checkbox-checked-hover.png);
+}
+ QGroupBox::indicator:unchecked:disabled,QTreeView::indicator:unchecked:disabled,QCheckBox::indicator:unchecked:disabled{
+     image: url(./Transparent-Style/checkbox-checked-disabled.png);
+}
+ QTreeWidget#categoriesList::item:has-children{
+     background-image: url(./Transparent-Style/arrow-right-small.png);
+}
+ QTreeWidget#categoriesList::item:has-children:open{
+     background-image: url(./Transparent-Style/branch-opened.png);
+}
+/* ******************************** */
+/* Special styles */
+/* increase categories tab width */
+/* ******************************** */
+ QTreeView#modList::item,QTreeWidget#categoriesTree::item,#tabConflicts QTreeWidget::item,QListView::item,QTreeView#espList::item,QTreeView#treeContent::item{
+     padding: .3em 0em;
+}
+ QTreeView#modList::item,QTreeWidget#categoriesTree::item,#tabConflicts QTreeWidget::item,QListView::item,QTreeView#espList::item,QTreeView#treeContent::item{
+     padding: .3em 0em;
+}
+ QTreeWidget#categoriesGroup,QTreeWidget#categoriesList{
+     min-width: 200px;
+}
+ QTreeWidget#categoriesList::item {
+     background-position: center left;
+     background-repeat: no-repeat;
+     padding: 0.35em 4px;
+}
+/* ********************* */
+/* Display Radio Button */
+/* ********************* */
+ QRadioButton::indicator{
+     width: 16px;
+     height: 16px;
+}
+ QRadioButton::indicator::checked{
+     image: url(./Transparent-Style/radio-BOS-checked.png);
+}
+ QRadioButton::indicator::unchecked{
+     image: url(./Transparent-Style/radio-BOS.png);
+}
+ QRadioButton::indicator::unchecked:hover{
+     image: url(./Transparent-Style/radio-BOS-hover.png);
+}
+/* **************************************** */
+/* Spinners #QSpinBox, #QDoubleSpinBox */
+/* **************************************** */
+ QAbstractSpinBox{
+     padding: 5px;
+     background-color: transparent;
+     color: #eff0f1;
+     border-radius: 2px;
+     min-width: Auto;
+}
+ QAbstractSpinBox::up-button,QAbstractSpinBox::down-button{
+     border-style: solid;
+     border-width: 1px;
+     subcontrol-origin: border;
+}
+ QAbstractSpinBox::up-button:hover,QAbstractSpinBox::down-button:hover{
+     background-color: transparent;
+}
+ QAbstractSpinBox::up-button{
+     background-color: transparent;
+     subcontrol-origin: border;
+     subcontrol-position: center right;
+     padding-right: 5px;
+    /* subcontrol-position: top right;
+     */
+}
+ QAbstractSpinBox::down-button{
+     background-color: transparent;
+     subcontrol-origin: border;
+     subcontrol-position: center left;
+     padding-left: 5px;
+    /* subcontrol-position: bottom right;
+     */
+}
+ QAbstractSpinBox::up-arrow{
+     border-image: url(./Transparent-Style/narrow-arrow-right.png);
+}
+QAbstractSpinBox::down-arrow{
+     border-image: url(./Transparent-Style/narrow-arrow-left.png);
+}
+/* QTextEdit,QWebView,QLineEdit,QComboBox{
+     border-color:#3F3F46;
+    /* Grey - Blue*/
+    /*
+}
+*/
+/* **************************************** */
+/* Tooltips #QToolTip, #SaveGameInfoWidget */
+/* **************************************** */
+ QToolTip{
+     background-color:#121212;
+     color:#C0C0C0;
+     padding:0px;
+     border-color:#9A9A00;
+     border-radius: 3px;
+     border-width:1px;
+     border-style:solid;
+}
+ SaveGameInfoWidget{
+     font-size: 16px;
+     background-color:#121212;
+     color:#C0C0C0;
+     padding:0px;
+     border-color:#9A9A00;
+     border-radius: 3px;
+     border-width:1px;
+     border-style:solid;
+}
+/* **************************** */
+/* Handles Web, Nexus info tab */
+/* **************************** */
+ QWebView{
+     background-color: Black;
+}
+ QLineEdit{
+     font-family: Segoe UI;
+     min-height: 20px;
+     font-size: 16px;
+     background-color:#3F3F46;
+     selection-background-color: rgba(154,154,0,0.6);
+    border-color:#9A9A00;
+     border-radius: 3px;
+     border-width:1px;
+     border-style:solid;
+}
+ QTextEdit{
+     color: #cccccc;
+     font-family: Segoe UI;
+     font-size: 16px;
+    /* background-color:#000;
+     */
+     selection-background-color: rgba(154,154,0,0.6);
+     border-color:#9A9A00;
+     border-radius: 3px;
+     border-width:1px;
+     border-style:solid;
+}
+/* Font size */
+ QLabel,QMenu,QPushButton,QAbstractSpinBox,QGroupBox,QCheckBox,QRadioButton{
+     color: #cccccc;
+     font-family: Segoe UI;
+     font-size: 16px;
+    /* was 14px Profile font size */
+}
+ QAbstractItemView{
+     color: #cccccc;
+     font-family: Segoe UI;
+    /* font-family: Source Sans Pro;
+     */
+     font-size: 16px;
+    /* Body font size*/
+}
+ QRadioButton{
+     color: #cccccc;
+     font-family: Segoe UI;
+    /* font-family: Source Sans Pro;
+     */
+     font-size: 16px;
+}
+ QWebView,QComboBox,QComboBox:editable{
+     font-family:Segoe UI;
+     font-style: normal;
+     font-weight: normal;
+     font-size: 16px;
+     background-color:#000;
+    /* border-color:#3F3F46;
+    /* Grey - Blue*/
+     color: #cccccc;
+     font-family: Arial;
+     font-size: 16px;
+    /* Filter Name*/
+}
+ QHeaderView::section{
+    /* font-family: Source Sans Pro;
+     */
+     font-family: Segoe UI;
+     font-size: 16px;
+    /*Top Bar on menus font*/
+}
+ QListView::item{
+     color:#F1F1F1;
+    /* White */
+}
+ QGroupBox {
+}
+ QGroupBox::title {
+     subcontrol-origin: margin;
+     subcontrol-position: top center;
+}
+ QGroupBox::indicator {
+     subcontrol-origin: margin;
+     subcontrol-position: top center;
+}
+ QLabel {
+     color: #cccccc;
+    /* color: #F1F1F1;
+    /* White */
+    /* border: none;
+    outline: none;
+     border-radius: 5px;
+     border-top:1px solid #9A9A00;
+     border-bottom:1px solid #9A9A00;
+    */
+}

--- a/src/stylesheets/Transparent-Style-Skyrim.qss
+++ b/src/stylesheets/Transparent-Style-Skyrim.qss
@@ -1,1 +1,742 @@
-#centralWidget { 	border-image: url(./Transparent-Style/Background-skyrim.png) 0 0 0 0 stretch stretch; } QWidget#TextViewer{ } QWidget{ 	color: #fff; 	background-color: rgba(45,45,48,30); 	alternate-background-color: rgba(38,38,38,30); } QWidget:disabled{ } QAbstractItemView{ 	color: #dcdcdc; 	background-color: rgb(45,45,48,30); 	alternate-background-color: rgb(38,38,38,50); 	border: 1px solid #3F3F46; /* Grey - Blue*/ 	border-style:outset; 	border-radius: 3px; 	selection-color: #3F3F46; /* Grey - Blue*/ 	outline: none; 	padding-left:0; } #problemsWidget,#TransferSavesDialog,#SettingsDialog,#ProblemsDialog,#ModInfoDialog,#TextViewer,#PyCfgDialog,#InstallDialog { 	border-image:url(./Transparent-Style/Vault-BOS-Main.png) 0 0 0 0 stretch stretch; } #toolBarArea{ 	border-image: url(./Transparent-Style/vault-BOS-Main.png) 0 0 0 0 stretch stretch; } #EditExecutablesDialog{ 	border-image: url(./Transparent-Style/vault-BOS-Main.png) 0 0 0 0 stretch stretch; } #SimpleInstallDialog,#LockedDialog,QMenu{ 	border-image: url(./Transparent-Style/vault-BOS-Main.png) 0 0 0 0 stretch stretch; }	 #nameLabel{ 	border-image: url(./Transparent-Style/vault-BOS-Main.png) 0 0 0 0 stretch stretch; 	border-top:1px solid #b9d7fc; 	border-bottom:1px solid #b9d7fc; 	background-color:rgba(154,154,0,0.3); 	color:#fff; } #ProfilesDialog,#FomodInstallerDialog{ 	border-image: url(./Transparent-Style/vault-BOS-Main.png) 0 0 0 0 stretch stretch; } #filesView{ 	border-image: url(./Transparent-Style/vault-BOS-Main.png) 0 0 0 0 stretch stretch; } /* ******************************************** */ /* Main Navigation Button Bar at top of window 	*/ /* ******************************************** */ QToolBar{ 	/*border: none;*/ } QToolBar::separator{ 	/*image: url(./Transparent-Style/Vault-101-vault-logo.png);*/ } QToolButton{ 	border:2px solid None; 	border-radius: 6px; 	margin: 3px; 	padding-left: 8px; 	padding-right: 8px; 	padding-top: 0px; 	padding-bottom: 2px; } QToolButton:hover{ 	 	border-radius: 3px; 	border: 0px; 	padding: 0px; 	background: trANSPARENT; 	border: 0px ridge #9A9A00; 	background-color: QLinearGradient( x1: 0, y1: 0, x2: 0, y2: 1, stop: 0 #9A9A00, stop: 1 #484F53); } QToolButton:pressed{ 	background: black; } /* **************************************** */ /*	 	Tabs on top of Treeview				*/ /* **************************************** */ QTabWidget::pane{ 	border-color:#3F3F46; /* Grey - Blue*/ /*	border-top-color:#9A9A00; */ 	top: 0px; 	border-style:hidden; 	border-width:1px; } QTabWidget::tab-bar{ 	alignment: center; } QTabBar{ 	color: #cccccc; 	font-family: Segoe UI; 	font-size: 16px; 	text-transform: none; 	min-height:auto; 	padding-bottom: 5px; } QTabBar::tab{ 	border: none; 	border-bottom-style: none; 	background-color: rgba(154,154,0,0.3); 	padding-left: 9px; 	padding-right: 9px; 	padding-top: 3px; 	padding-bottom: 3px; 	margin-right: 2px; 	border-top-left-radius: 4px; 	border-top-right-radius: 4px; 	border-bottom-left-radius: 4px; 	border-bottom-right-radius: 4px; } QTabBar::tab:disabled{ 	color: #404040; 	background-color: #000; 	margin-top: 0px; } QTabBar::tab:selected{ 	color: #dcdcdc; 	background-color: #9A9A00; /*Yellow opaque*/ } QTabBar::tab:!selected:hover{ 	border-radius: 3px; 	border-top:3px double #9A9A00; 	border-bottom:3px double #9A9A00; 	padding: 1px; 	text-align: center; 	background-color: #9A9A00; 	color:#fff; 	Height: 20%; } /* QTabBar::tab:!selected{ 	color: #808080; 	background-color: #404040; 	margin-top: 0px; } */ #deactivateESP,#activateESP{ 	border:#b30000; 	background:#333337; } /* **************************************** */ /*	  <More View> on top of Treeview		*/ /* **************************************** */ QTabBar QToolButton{ 	border-radius: 0px; 	border: 0px; 	padding: 0px; 	background: transparent; } QToolButton::menu-indicator:pressed,QToolButton::menu-indicator:open{ 	image: url(./Transparent-Style/arrow-up.png); } QToolButton::menu-indicator:!pressed,QToolButton::menu-indicator:!open{ 	image: url(./Transparent-Style/arrow-down.png); } QTabBar QToolButton::right-arrow{ 	image: url(./Transparent-Style/narrow-arrow-right.png); } QTabBar QToolButton::left-arrow{ 	image: url(./Transparent-Style/narrow-arrow-left.png); } /* **************************************** */ /*	 	Column names of TreeView			*/ /* **************************************** */ QTableView{ 	gridline-color:#3F3F46; 	selection-background-color:#9A9A00; 	selection-color:#F1F1F1; /* White */ 	text-align: center; 	min-height:24px; } QHeaderView{ 	min-height:24px; /*Top Bar on menus*/ 	padding: 3px; } QHeaderView::section{ /*	color: #cc3333;  */ 	background-color: #252526; 	border-radius: 0px; 	padding: 0px; 	padding-left: 5px; } QHeaderView::section:hover{ 	background: rgba(154,154,0,0.3); 	border: 1px solid #9a9a00; 	padding: 0px;	 	padding-left: 5px; } QHeaderView::up-arrow,QHeaderView::down-arrow{ 	min-height:Auto; 	min-width:Auto; } QHeaderView::up-arrow{ 	image: url(./Transparent-Style/arrow-up.png); 	min-height:25px; 	min-width:15px; 	padding-right: 0px; }QHeaderView::down-arrow{ 	image: url(./Transparent-Style/arrow-down.png); }	 /* **************************************** */ /*	 				Hover					*/ /* **************************************** */ QMenu:item:hover,QTreeView#espList::item:hover,QTreeWidget#categoriesList::item:hover,QListView::item:hover,QTreeWidget::item:hover{ 	color:#fff; 	border-top:1px solid #b9d7fc; 	border-bottom:1px solid #b9d7fc; 	background-color:rgba(154,154,0,0.3); } QAbstractItemView::item:hover{ 	border-top:1px solid #b9d7fc; 	border-bottom:1px solid #b9d7fc; 	background-color:rgba(154,154,0,0.3); 	padding: 3px; } /*#DownloadListWidget{ }*/ #DownloadListWidget{   outline: 1px solid #e8e8e8;   border: 0px solid #9a9a00; } #deactivateESP:hover,#activateESP:hover,QTableView:hover,QHeaderView::selected:hover{ 	border: 1px solid #9a9a00; 	padding: 1px; 	text-align: center; 	color:#fff; } /* **************************************** */ /* Context menus, toolbar dropdowns #QMenu  */ /* **************************************** */ QMenu{ 	border-width: 3px; 	border-style: solid; }QMenu::item{ 	padding: 6px 20px; }QMenu::item:selected{ 	color:#fff; 	background-color: #3F3F46; /* Grey - Blue*/ 	border-top:1px solid #9A9A00; 	border-bottom:1px solid #9A9A00; } QMenu::right-arrow{ 	image: url(./Transparent-Style/arrow-right.png);  /* right click main menu top option*/ 	subcontrol-origin: padding; 	subcontrol-position: center right; 	width: 18px; 	height: 18px; 	border:0px outset #3F3F46; /* Grey - Blue*/ } /* ********************* */ /*		 LCD Counter	 */ /* ********************* */ QLCDNumber{ 	color: #9A9A00; 	Background: #000; 	border-color: #3F3F46; /* Grey - Blue*/ 	border-style: solid; 	border-width: 1px; 	border-radius: 5px; } /* **************************************** */ /*		Launch application Drop down Box 	*/ /* **************************************** */ QComboBox{ 	background-color: #333337; 	padding: 3px 5px 5px 5px; 	height: 26px; 	 	border-radius: 5px; 	border-top:1px solid #9A9A00; 	border-bottom:1px solid #9A9A00; } QComboBox:on{ 	padding: 3px 5px 5px 5px;     color: white;     background-color: #3F3F46; /* Grey - Blue*/ } QComboBox:hover{ 	border-radius: 3px; 	border-top:3px double #9A9A00; 	border-bottom:3px double #9A9A00; /*	padding: 0px; */ } QComboBox::drop-down{ 	/* Down arrow in combo box */ 	outline: none; 	border: none; 	border-width: 1px; } QComboBox::menu-indicator{ 	image: url(./Transparent-Style/arrow-down.png); 	subcontrol-origin: padding; 	subcontrol-position: center right; 	width: 18px; 	height: 18px; 	border:1px outset #3F3F46; /* Grey - Blue*/ } /* ************************* */ /* QComboBox::down-arrow:on, */ /* ************************* */ QComboBox::down-arrow:hover,QComboBox::down-arrow:focus {     image: url(./Transparent-Style/arrow-down-hover.png); } QComboBox::up-arrow:hover,QComboBox::up-arrow:focus {     image: url(./Transparent-Style/arrow-up-hover.png); } QComboBox::down-arrow{ 	image:url(./Transparent-Style/arrow-down.png); 	subcontrol-origin: padding; 	subcontrol-position: center right; 	width: 18px; 	height: 18px; } QComboBox::down-arrow:on{ 	image:url(./Transparent-Style/arrow-up.png); } QComboBox:editable { 	background: black; /*    color: pink; */ } QComboBox::item{ } QComboBox QAbstractItemView{ 	selection-color:#fff; 	outline: 1px solid #9a9a00; 	selection-background-color:#3F3F46; /* Grey - Blue*/ 	border-top:1px solid #9a9a00; 	border-bottom:1px solid #9a9a00; 	padding: 5px; } /* **************************************************************** */ /* 							Action Buttons     						*/ /*																	*/ /* Open list, Restore Backup, Create Backup, RUN, Shortcut Button 	*/ /* Sort, Load order backup, Load Order Restore 						*/ /* **************************************************************** */ QPushButton{ 	background-color: #333337; 	min-height:26px; 	padding:1px 5%; 	text-align: center; 	border-radius: 5px; 	border-top:1px solid #9A9A00; 	border-bottom:1px solid #9A9A00; } QPushButton::menu-indicator{ 	image: url(./Transparent-Style/arrow-down.png); 	subcontrol-origin: padding; 	subcontrol-position: center right; 	width: 18px; 	height: 18px; 	border:1px hidden #3F3F46; /* Grey - Blue*/ } QPushButton::menu-indicator:Hover{	     image: url(./Transparent-Style/arrow-down-hover.png); } QPushButton:focus{ } QPushButton:on,QPushButton:checked,QPushButton:pressed,QPushButton:checked:hover{     background: #3F3F46; /* Grey - Blue*/ 	border-radius: 1px; 	border: 1px solid #9a9a00; } QPushButton:hover{ 	border-radius: 3px; 	border-top:3px double #9A9A00; 	border-bottom:3px double #9A9A00; } QDialog QPushButton,QSlider::handle:horizontal,QSlider::handle:vertical{ 	color:#fff; 	border-color:#707070; 	border-style:solid; 	border-width:1px; } QPushButton:disabled{ } QPushButton:open{ } QPushButton:!enabled{ } 		 /* **************************************** */ /*	 			Filter Button				*/ /* **************************************** */		 		 QPushButton#displayCategoriesBtn{ 	min-width: 20px; 	background:transparent; 	color: transparent; 	border: 1px hidden #9a9a00; } QPushButton#displayCategoriesBtn:checked{ 	image: url(./Transparent-Style/arrow-left.png); } QPushButton#displayCategoriesBtn:!checked{ 	image: url(./Transparent-Style/arrow-right.png); } QPushButton#displayCategoriesBtn:checked:hover{ 	image: url(./Transparent-Style/arrow-left-hover.png); } QPushButton#displayCategoriesBtn:!checked:hover{ 	image: url(./Transparent-Style/arrow-right-hover.png); } /* **************************************** */ /*	 			Scroll bar 					*/ /* **************************************** */ QScrollBar{ 	height:20px; 	width:20px; 	background-color:transparent; } QScrollBar::handle{ 	border: 1px solid #aaa; 	border-radius: 4px; } QScrollBar::handle:vertical{ 	margin: 1px 4px; 	min-height:20px; 	min-width: 10px; 	background-color:qlineargradient(x1: 0, y1: 0, x2: 1, y2: 0, stop:0 #9A9A00, stop:1 #000000); } QScrollBar::handle:vertical:hover{ 	background-color:qlineargradient(x1: 0, y1: 0, x2: 1, y2: 0, stop:0 #000000, stop:1 #9A9A00); } QScrollBar::handle:horizontal{ 	min-height:10px;min-width:20px;margin:4px 1px; 	background-color:qlineargradient(x1: 0, y1: 0, x2: 0, y2: 1, stop:0 #9A9A00, stop:1 #000000); } QScrollBar::handle:horizontal:hover{ 	background-color:qlineargradient(x1: 0, y1: 0, x2: 0, y2: 1, stop:0 #000000, stop:1 #9A9A00); } QScrollBar::add-page:vertical, QScrollBar::sub-page:vertical,QScrollBar::add-page:horizontal, QScrollBar::sub-page:horizontal{ 	background-color: transparent; } QScrollBar::add-line:vertical,QScrollBar::sub-line:vertical,QScrollBar::add-line:horizontal,QScrollBar::sub-line:horizontal{ height:0; width:0; } /* ******************************************************** */ /*		Main Tree View Inherited from QAbstractItemView 	*/ /* ******************************************************** */ QTreeView { } QTreeView:item{ 	padding: 3px; 	font-size: 16px; 	height: 18px; 	/*Bottom text Box*/ } QTreeView:item:selected{ 	color:#fff; 	padding: 0px; 	background-color: #3F3F46; /* Grey - Blue*/ 	border-top:1px solid #9A9A00; 	border-bottom:1px solid #9A9A00; } QTreeView:item QLineEdit{ 	outline: none; 	border: none; 	padding: 0px; 	margin: 0px; } QTreeView::branch:has-siblings:!adjoins-item{ 	background:url(Transparent-Style/vault-101-item-line-v.png) center center no-repeat; } QTreeView::branch:has-siblings{  	background:url(Transparent-Style/vault-101-itemB-line.png) center center no-repeat; } QTreeView::branch:!has-children:!has-siblings:adjoins-item{ 	background:url(Transparent-Style/vault-101-itemB-end.png) center center no-repeat; } QTreeView::branch:closed:has-children:has-siblings{ 	background:url(Transparent-Style/vault-101-itemB-close.png) center center no-repeat; } QTreeView::branch:closed:has-children:!has-siblings{ 	background:url(Transparent-Style/vault-101-itemB-close-last.png) center center no-repeat; } QTreeView::branch:open:has-children:has-siblings{ 	background:url(Transparent-Style/vault-101-itemB-open.png) center center no-repeat; } QTreeView::branch:open:has-children:!has-siblings{ 	background:url(Transparent-Style/vault-101-itemB-open-last.png) center center no-repeat; } /* **************************************************************** */ /* Checkboxes and Radio buttons common #QCheckBox, #QRadioButton 	*/ /*							common									*/ /* **************************************************************** */ QTreeView::indicator,QCheckBox::indicator{ 	outline: none; 	border: none; 	padding: 0px; 	width: 24px; 	height: 24px; } QGroupBox::indicator:checked,QGroupBox::indicator:indeterminate,QTreeView::indicator:checked,QTreeView::indicator:indeterminate,QCheckBox::indicator:checked,QCheckBox::indicator:indeterminate{ 	image: url(./Transparent-Style/checkbox-checked.png); } QGroupBox::indicator:checked:hover,QGroupBox::indicator:indeterminate:hover,QTreeView::indicator:checked:hover,QTreeView::indicator:indeterminate:hover,QCheckBox::indicator:checked:hover,QCheckBox::indicator:indeterminate:hover{ 	image: url(./Transparent-Style/checkbox-hover.png); } QGroupBox::indicator:checked:disabled,QGroupBox::indicator:indeterminate:disabled,QTreeView::indicator:checked:disabled,QTreeView::indicator:indeterminate:disabled,QCheckBox::indicator:checked:disabled,QCheckBox::indicator:indeterminate:disabled{ 	image: url(./Transparent-Style/checkbox-checked-disabled.png); } QGroupBox::indicator:unchecked,QTreeView::indicator:unchecked,QCheckBox::indicator:unchecked{ 	image: url(./Transparent-Style/checkbox.png); } QGroupBox::indicator:unchecked:hover,QTreeView::indicator:unchecked:hover,QCheckBox::indicator:unchecked:hover{ 	image: url(./Transparent-Style/checkbox-checked-hover.png); } QGroupBox::indicator:unchecked:disabled,QTreeView::indicator:unchecked:disabled,QCheckBox::indicator:unchecked:disabled{ 	image: url(./Transparent-Style/checkbox-checked-disabled.png); } QTreeWidget#categoriesList::item:has-children{ 	background-image: url(./Transparent-Style/arrow-right-small.png); } QTreeWidget#categoriesList::item:has-children:open{ 	background-image: url(./Transparent-Style/branch-opened.png); } /* ******************************** */ /* 		Special styles 				*/ /* increase categories tab width 	*/ /* ******************************** */ QTreeView#modList::item,QTreeWidget#categoriesTree::item,#tabConflicts QTreeWidget::item,QListView::item,QTreeView#espList::item,QTreeView#treeContent::item{ 	padding: .3em 0em; } QTreeView#modList::item,QTreeWidget#categoriesTree::item,#tabConflicts QTreeWidget::item,QListView::item,QTreeView#espList::item,QTreeView#treeContent::item{ 	padding: .3em 0em; } QTreeWidget#categoriesGroup,QTreeWidget#categoriesList{ 	min-width: 200px; } QTreeWidget#categoriesList::item { 	background-position: center left; 	background-repeat: no-repeat; 	padding: 0.35em 4px; } /* ********************* */ /* Display Radio Button	 */ /* ********************* */ QRadioButton::indicator{ 	width: 16px; 	height: 16px; } QRadioButton::indicator::checked{ 	image: url(./Transparent-Style/radio-BOS-checked.png); } QRadioButton::indicator::unchecked{ 	image: url(./Transparent-Style/radio-BOS.png); } QRadioButton::indicator::unchecked:hover{ 	image: url(./Transparent-Style/radio-BOS-hover.png); } /* **************************************** */ /*	 Spinners #QSpinBox, #QDoubleSpinBox 	*/ /* **************************************** */ QAbstractSpinBox{     padding: 5px; 	background-color: transparent;     color: #eff0f1;     border-radius: 2px;     min-width: Auto; } QAbstractSpinBox::up-button,QAbstractSpinBox::down-button{ 	border-style: solid; 	border-width: 1px; 	subcontrol-origin: border; } QAbstractSpinBox::up-button:hover,QAbstractSpinBox::down-button:hover{ 	background-color: transparent; } QAbstractSpinBox::up-button{     background-color: transparent;     subcontrol-origin: border;     subcontrol-position: center right;     padding-right: 5px; /*	subcontrol-position: top right; */ } QAbstractSpinBox::down-button{     background-color: transparent;     subcontrol-origin: border;     subcontrol-position: center left; 	padding-left: 5px; /*	subcontrol-position: bottom right; */ } QAbstractSpinBox::up-arrow{ 	border-image: url(./Transparent-Style/narrow-arrow-right.png); }QAbstractSpinBox::down-arrow{ 	border-image: url(./Transparent-Style/narrow-arrow-left.png); }/*	QTextEdit,QWebView,QLineEdit,QComboBox{ border-color:#3F3F46; /* Grey - Blue*/ /*}*/ /* **************************************** */ /* 	Tooltips #QToolTip, #SaveGameInfoWidget	*/ /* **************************************** */ QToolTip{ 	background-color:#121212; 	color:#C0C0C0; 	padding:0px; 	border-color:#9A9A00; 	border-radius: 3px; 	border-width:1px; 	border-style:solid; } SaveGameInfoWidget{ 	font-size: 16px; 	background-color:#121212; 	color:#C0C0C0; 	padding:0px; 	border-color:#9A9A00; 	border-radius: 3px; 	border-width:1px; 	border-style:solid; } /* **************************** */ /* 	Handles Web, Nexus info tab	*/ /* **************************** */ QWebView{ 	background-color: Black; } QLineEdit{ 	font-family: Segoe UI; 	min-height: 20px; 	font-size: 16px; 	background-color:#3F3F46; 	selection-background-color: rgba(154,154,0,0.6);border-color:#9A9A00; 	border-radius: 3px; 	border-width:1px; 	border-style:solid; } QTextEdit{ 	color: #cccccc; 	font-family: Segoe UI; 	font-size: 16px; /*	background-color:#000; */ 	selection-background-color: rgba(154,154,0,0.6); 	border-color:#9A9A00; 	border-radius: 3px; 	border-width:1px; 	border-style:solid; } /* Font size */ QLabel,QMenu,QPushButton,QAbstractSpinBox,QGroupBox,QCheckBox,QRadioButton{ 	color: #cccccc; 	font-family: Segoe UI; 	font-size: 16px;  /* was 14px Profile font size */ } QAbstractItemView{ 	color: #cccccc; 	font-family: Segoe UI; /*	font-family: Source Sans Pro; */ 	font-size: 16px; /* Body font size*/ } QRadioButton{ 	color: #cccccc;	 	font-family: Segoe UI; /*	font-family: Source Sans Pro; */ 	font-size: 16px; } QWebView,QComboBox,QComboBox:editable{ 	font-family:Segoe UI; 	font-style: normal; 	font-weight: normal; 	font-size: 16px; 	background-color:#000; /*	border-color:#3F3F46; /* Grey - Blue*/ 	color: #cccccc; 	font-family: Arial; 	font-size: 16px; /* Filter Name*/ } QHeaderView::section{ /*	font-family: Source Sans Pro; */ 	font-family: Segoe UI; 	font-size: 16px;  /*Top Bar on menus font*/ } QListView::item{ 	color:#F1F1F1; /* White */ } QGroupBox { } QGroupBox::title { 	subcontrol-origin: margin; 	subcontrol-position: top center; } QGroupBox::indicator { 	subcontrol-origin: margin; 	subcontrol-position: top center; } QLabel { 	color: #cccccc; /*	color: #F1F1F1; /* White */ /*	border: none;outline: none; 	border-radius: 5px; 	border-top:1px solid #9A9A00; 	border-bottom:1px solid #9A9A00;*/ }
+#centralWidget {
+     border-image: url(./Transparent-Style/Background-skyrim.png) 0 0 0 0 stretch stretch;
+}
+ QWidget#TextViewer{
+}
+ QWidget{
+     color: #fff;
+     background-color: rgba(45,45,48,30);
+     alternate-background-color: rgba(38,38,38,30);
+}
+ QWidget:disabled{
+}
+ QAbstractItemView{
+     color: #dcdcdc;
+     background-color: rgb(45,45,48,30);
+     alternate-background-color: rgb(38,38,38,50);
+     border: 1px solid #3F3F46;
+    /* Grey - Blue*/
+     border-style:outset;
+     border-radius: 3px;
+     selection-color: #3F3F46;
+    /* Grey - Blue*/
+     outline: none;
+     padding-left:0;
+}
+ #problemsWidget,#TransferSavesDialog,#SettingsDialog,#ProblemsDialog,#ModInfoDialog,#TextViewer,#PyCfgDialog,#InstallDialog {
+     border-image:url(./Transparent-Style/Vault-BOS-Main.png) 0 0 0 0 stretch stretch;
+}
+ #toolBarArea{
+     border-image: url(./Transparent-Style/vault-BOS-Main.png) 0 0 0 0 stretch stretch;
+}
+ #EditExecutablesDialog{
+     border-image: url(./Transparent-Style/vault-BOS-Main.png) 0 0 0 0 stretch stretch;
+}
+ #SimpleInstallDialog,#LockedDialog,QMenu{
+     border-image: url(./Transparent-Style/vault-BOS-Main.png) 0 0 0 0 stretch stretch;
+}
+ #nameLabel{
+     border-image: url(./Transparent-Style/vault-BOS-Main.png) 0 0 0 0 stretch stretch;
+     border-top:1px solid #b9d7fc;
+     border-bottom:1px solid #b9d7fc;
+     background-color:rgba(154,154,0,0.3);
+     color:#fff;
+}
+ #ProfilesDialog,#FomodInstallerDialog{
+     border-image: url(./Transparent-Style/vault-BOS-Main.png) 0 0 0 0 stretch stretch;
+}
+ #filesView{
+     border-image: url(./Transparent-Style/vault-BOS-Main.png) 0 0 0 0 stretch stretch;
+}
+/* ******************************************** */
+/* Main Navigation Button Bar at top of window */
+/* ******************************************** */
+ QToolBar{
+    /*border: none;
+    */
+}
+ QToolBar::separator{
+    /*image: url(./Transparent-Style/Vault-101-vault-logo.png);
+    */
+}
+ QToolButton{
+     border:2px solid None;
+     border-radius: 6px;
+     margin: 3px;
+     padding-left: 8px;
+     padding-right: 8px;
+     padding-top: 0px;
+     padding-bottom: 2px;
+}
+ QToolButton:hover{
+     border-radius: 3px;
+     border: 0px;
+     padding: 0px;
+     background: trANSPARENT;
+     border: 0px ridge #9A9A00;
+     background-color: QLinearGradient( x1: 0, y1: 0, x2: 0, y2: 1, stop: 0 #9A9A00, stop: 1 #484F53);
+}
+ QToolButton:pressed{
+     background: black;
+}
+/* **************************************** */
+/* Tabs on top of Treeview */
+/* **************************************** */
+ QTabWidget::pane{
+     border-color:#3F3F46;
+    /* Grey - Blue*/
+    /* border-top-color:#9A9A00;
+     */
+     top: 0px;
+     border-style:hidden;
+     border-width:1px;
+}
+ QTabWidget::tab-bar{
+     alignment: center;
+}
+ QTabBar{
+     color: #cccccc;
+     font-family: Segoe UI;
+     font-size: 16px;
+     text-transform: none;
+     min-height:auto;
+     padding-bottom: 5px;
+}
+ QTabBar::tab{
+     border: none;
+     border-bottom-style: none;
+     background-color: rgba(154,154,0,0.3);
+     padding-left: 9px;
+     padding-right: 9px;
+     padding-top: 3px;
+     padding-bottom: 3px;
+     margin-right: 2px;
+     border-top-left-radius: 4px;
+     border-top-right-radius: 4px;
+     border-bottom-left-radius: 4px;
+     border-bottom-right-radius: 4px;
+}
+ QTabBar::tab:disabled{
+     color: #404040;
+     background-color: #000;
+     margin-top: 0px;
+}
+ QTabBar::tab:selected{
+     color: #dcdcdc;
+     background-color: #9A9A00;
+    /*Yellow opaque*/
+}
+ QTabBar::tab:!selected:hover{
+     border-radius: 3px;
+     border-top:3px double #9A9A00;
+     border-bottom:3px double #9A9A00;
+     padding: 1px;
+     text-align: center;
+     background-color: #9A9A00;
+     color:#fff;
+     Height: 20%;
+}
+/* QTabBar::tab:!selected{
+     color: #808080;
+     background-color: #404040;
+     margin-top: 0px;
+}
+ */
+ #deactivateESP,#activateESP{
+     border:#b30000;
+     background:#333337;
+}
+/* **************************************** */
+/* <More View> on top of Treeview */
+/* **************************************** */
+ QTabBar QToolButton{
+     border-radius: 0px;
+     border: 0px;
+     padding: 0px;
+     background: transparent;
+}
+ QToolButton::menu-indicator:pressed,QToolButton::menu-indicator:open{
+     image: url(./Transparent-Style/arrow-up.png);
+}
+ QToolButton::menu-indicator:!pressed,QToolButton::menu-indicator:!open{
+     image: url(./Transparent-Style/arrow-down.png);
+}
+ QTabBar QToolButton::right-arrow{
+     image: url(./Transparent-Style/narrow-arrow-right.png);
+}
+ QTabBar QToolButton::left-arrow{
+     image: url(./Transparent-Style/narrow-arrow-left.png);
+}
+/* **************************************** */
+/* Column names of TreeView */
+/* **************************************** */
+ QTableView{
+     gridline-color:#3F3F46;
+     selection-background-color:#9A9A00;
+     selection-color:#F1F1F1;
+    /* White */
+     text-align: center;
+     min-height:24px;
+}
+ QHeaderView{
+     min-height:24px;
+    /*Top Bar on menus*/
+     padding: 3px;
+}
+ QHeaderView::section{
+    /* color: #cc3333;
+     */
+     background-color: #252526;
+     border-radius: 0px;
+     padding: 0px;
+     padding-left: 5px;
+}
+ QHeaderView::section:hover{
+     background: rgba(154,154,0,0.3);
+     border: 1px solid #9a9a00;
+     padding: 0px;
+     padding-left: 5px;
+}
+ QHeaderView::up-arrow,QHeaderView::down-arrow{
+     min-height:Auto;
+     min-width:Auto;
+}
+ QHeaderView::up-arrow{
+     image: url(./Transparent-Style/arrow-up.png);
+     min-height:25px;
+     min-width:15px;
+     padding-right: 0px;
+}
+QHeaderView::down-arrow{
+     image: url(./Transparent-Style/arrow-down.png);
+}
+/* **************************************** */
+/* Hover */
+/* **************************************** */
+ QMenu:item:hover,QMenuBar::item:selected,QTreeView#espList::item:hover,QTreeWidget#categoriesList::item:hover,QListView::item:hover,QTreeWidget::item:hover{
+     color:#fff;
+     border-top:1px solid #b9d7fc;
+     border-bottom:1px solid #b9d7fc;
+     background-color:rgba(154,154,0,0.3);
+}
+ QAbstractItemView::item:hover{
+     border-top:1px solid #b9d7fc;
+     border-bottom:1px solid #b9d7fc;
+     background-color:rgba(154,154,0,0.3);
+     padding: 3px;
+}
+/*#DownloadListWidget{
+}
+*/
+ #DownloadListWidget{
+     outline: 1px solid #e8e8e8;
+     border: 0px solid #9a9a00;
+}
+ #deactivateESP:hover,#activateESP:hover,QTableView:hover,QHeaderView::selected:hover{
+     border: 1px solid #9a9a00;
+     padding: 1px;
+     text-align: center;
+     color:#fff;
+}
+/* **************************************** */
+/* Context menus, toolbar dropdowns #QMenu */
+/* **************************************** */
+ QMenu{
+     border-width: 3px;
+     border-style: solid;
+}
+QMenu::item{
+     padding: 6px 20px;
+}
+QMenu::item:selected{
+     color:#fff;
+     background-color: #3F3F46;
+    /* Grey - Blue*/
+     border-top:1px solid #9A9A00;
+     border-bottom:1px solid #9A9A00;
+}
+ QMenu::right-arrow{
+     image: url(./Transparent-Style/arrow-right.png);
+    /* right click main menu top option*/
+     subcontrol-origin: padding;
+     subcontrol-position: center right;
+     width: 18px;
+     height: 18px;
+     border:0px outset #3F3F46;
+    /* Grey - Blue*/
+}
+/* ********************* */
+/* LCD Counter */
+/* ********************* */
+ QLCDNumber{
+     color: #9A9A00;
+     Background: #000;
+     border-color: #3F3F46;
+    /* Grey - Blue*/
+     border-style: solid;
+     border-width: 1px;
+     border-radius: 5px;
+}
+/* **************************************** */
+/* Launch application Drop down Box */
+/* **************************************** */
+ QComboBox{
+     background-color: #333337;
+     padding: 3px 5px 5px 5px;
+     height: 26px;
+     border-radius: 5px;
+     border-top:1px solid #9A9A00;
+     border-bottom:1px solid #9A9A00;
+}
+ QComboBox:on{
+     padding: 3px 5px 5px 5px;
+     color: white;
+     background-color: #3F3F46;
+    /* Grey - Blue*/
+}
+ QComboBox:hover{
+     border-radius: 3px;
+     border-top:3px double #9A9A00;
+     border-bottom:3px double #9A9A00;
+    /* padding: 0px;
+     */
+}
+ QComboBox::drop-down{
+    /* Down arrow in combo box */
+     outline: none;
+     border: none;
+     border-width: 1px;
+}
+ QComboBox::menu-indicator{
+     image: url(./Transparent-Style/arrow-down.png);
+     subcontrol-origin: padding;
+     subcontrol-position: center right;
+     width: 18px;
+     height: 18px;
+     border:1px outset #3F3F46;
+    /* Grey - Blue*/
+}
+/* ************************* */
+/* QComboBox::down-arrow:on, */
+/* ************************* */
+ QComboBox::down-arrow:hover,QComboBox::down-arrow:focus {
+     image: url(./Transparent-Style/arrow-down-hover.png);
+}
+ QComboBox::up-arrow:hover,QComboBox::up-arrow:focus {
+     image: url(./Transparent-Style/arrow-up-hover.png);
+}
+ QComboBox::down-arrow{
+     image:url(./Transparent-Style/arrow-down.png);
+     subcontrol-origin: padding;
+     subcontrol-position: center right;
+     width: 18px;
+     height: 18px;
+}
+ QComboBox::down-arrow:on{
+     image:url(./Transparent-Style/arrow-up.png);
+}
+ QComboBox:editable {
+     background: black;
+    /* color: pink;
+     */
+}
+ QComboBox::item{
+}
+ QComboBox QAbstractItemView{
+     selection-color:#fff;
+     outline: 1px solid #9a9a00;
+     selection-background-color:#3F3F46;
+    /* Grey - Blue*/
+     border-top:1px solid #9a9a00;
+     border-bottom:1px solid #9a9a00;
+     padding: 5px;
+}
+/* **************************************************************** */
+/* Action Buttons */
+/* */
+/* Open list, Restore Backup, Create Backup, RUN, Shortcut Button */
+/* Sort, Load order backup, Load Order Restore */
+/* **************************************************************** */
+ QPushButton{
+     background-color: #333337;
+     min-height:26px;
+     padding:1px 5%;
+     text-align: center;
+     border-radius: 5px;
+     border-top:1px solid #9A9A00;
+     border-bottom:1px solid #9A9A00;
+}
+ QPushButton::menu-indicator{
+     image: url(./Transparent-Style/arrow-down.png);
+     subcontrol-origin: padding;
+     subcontrol-position: center right;
+     width: 18px;
+     height: 18px;
+     border:1px hidden #3F3F46;
+    /* Grey - Blue*/
+}
+ QPushButton::menu-indicator:Hover{
+     image: url(./Transparent-Style/arrow-down-hover.png);
+}
+ QPushButton:focus{
+}
+ QPushButton:on,QPushButton:checked,QPushButton:pressed,QPushButton:checked:hover{
+     background: #3F3F46;
+    /* Grey - Blue*/
+     border-radius: 1px;
+     border: 1px solid #9a9a00;
+}
+ QPushButton:hover{
+     border-radius: 3px;
+     border-top:3px double #9A9A00;
+     border-bottom:3px double #9A9A00;
+}
+ QDialog QPushButton,QSlider::handle:horizontal,QSlider::handle:vertical{
+     color:#fff;
+     border-color:#707070;
+     border-style:solid;
+     border-width:1px;
+}
+ QPushButton:disabled{
+}
+ QPushButton:open{
+}
+ QPushButton:!enabled{
+}
+/* **************************************** */
+/* Filter Button */
+/* **************************************** */
+ QPushButton#displayCategoriesBtn{
+     min-width: 20px;
+     background:transparent;
+     color: transparent;
+     border: 1px hidden #9a9a00;
+}
+ QPushButton#displayCategoriesBtn:checked{
+     image: url(./Transparent-Style/arrow-left.png);
+}
+ QPushButton#displayCategoriesBtn:!checked{
+     image: url(./Transparent-Style/arrow-right.png);
+}
+ QPushButton#displayCategoriesBtn:checked:hover{
+     image: url(./Transparent-Style/arrow-left-hover.png);
+}
+ QPushButton#displayCategoriesBtn:!checked:hover{
+     image: url(./Transparent-Style/arrow-right-hover.png);
+}
+/* **************************************** */
+/* Scroll bar */
+/* **************************************** */
+ QScrollBar{
+     height:20px;
+     width:20px;
+     background-color:transparent;
+}
+ QScrollBar::handle{
+     border: 1px solid #aaa;
+     border-radius: 4px;
+}
+ QScrollBar::handle:vertical{
+     margin: 1px 4px;
+     min-height:20px;
+     min-width: 10px;
+     background-color:qlineargradient(x1: 0, y1: 0, x2: 1, y2: 0, stop:0 #9A9A00, stop:1 #000000);
+}
+ QScrollBar::handle:vertical:hover{
+     background-color:qlineargradient(x1: 0, y1: 0, x2: 1, y2: 0, stop:0 #000000, stop:1 #9A9A00);
+}
+ QScrollBar::handle:horizontal{
+     min-height:10px;
+    min-width:20px;
+    margin:4px 1px;
+     background-color:qlineargradient(x1: 0, y1: 0, x2: 0, y2: 1, stop:0 #9A9A00, stop:1 #000000);
+}
+ QScrollBar::handle:horizontal:hover{
+     background-color:qlineargradient(x1: 0, y1: 0, x2: 0, y2: 1, stop:0 #000000, stop:1 #9A9A00);
+}
+ QScrollBar::add-page:vertical, QScrollBar::sub-page:vertical,QScrollBar::add-page:horizontal, QScrollBar::sub-page:horizontal{
+     background-color: transparent;
+}
+ QScrollBar::add-line:vertical,QScrollBar::sub-line:vertical,QScrollBar::add-line:horizontal,QScrollBar::sub-line:horizontal{
+     height:0;
+     width:0;
+}
+/* ******************************************************** */
+/* Main Tree View Inherited from QAbstractItemView */
+/* ******************************************************** */
+ QTreeView {
+}
+ QTreeView:item{
+     padding: 3px;
+     font-size: 16px;
+     height: 18px;
+    /*Bottom text Box*/
+}
+ QTreeView:item:selected{
+     color:#fff;
+     padding: 0px;
+     background-color: #3F3F46;
+    /* Grey - Blue*/
+     border-top:1px solid #9A9A00;
+     border-bottom:1px solid #9A9A00;
+}
+ QTreeView:item QLineEdit{
+     outline: none;
+     border: none;
+     padding: 0px;
+     margin: 0px;
+}
+ QTreeView::branch:has-siblings:!adjoins-item{
+     background:url(Transparent-Style/vault-101-item-line-v.png) center center no-repeat;
+}
+ QTreeView::branch:has-siblings{
+     background:url(Transparent-Style/vault-101-itemB-line.png) center center no-repeat;
+}
+ QTreeView::branch:!has-children:!has-siblings:adjoins-item{
+     background:url(Transparent-Style/vault-101-itemB-end.png) center center no-repeat;
+}
+ QTreeView::branch:closed:has-children:has-siblings{
+     background:url(Transparent-Style/vault-101-itemB-close.png) center center no-repeat;
+}
+ QTreeView::branch:closed:has-children:!has-siblings{
+     background:url(Transparent-Style/vault-101-itemB-close-last.png) center center no-repeat;
+}
+ QTreeView::branch:open:has-children:has-siblings{
+     background:url(Transparent-Style/vault-101-itemB-open.png) center center no-repeat;
+}
+ QTreeView::branch:open:has-children:!has-siblings{
+     background:url(Transparent-Style/vault-101-itemB-open-last.png) center center no-repeat;
+}
+/* **************************************************************** */
+/* Checkboxes and Radio buttons common #QCheckBox, #QRadioButton */
+/* common */
+/* **************************************************************** */
+ QTreeView::indicator,QCheckBox::indicator{
+     outline: none;
+     border: none;
+     padding: 0px;
+     width: 24px;
+     height: 24px;
+}
+ QGroupBox::indicator:checked,QGroupBox::indicator:indeterminate,QTreeView::indicator:checked,QTreeView::indicator:indeterminate,QCheckBox::indicator:checked,QCheckBox::indicator:indeterminate{
+     image: url(./Transparent-Style/checkbox-checked.png);
+}
+ QGroupBox::indicator:checked:hover,QGroupBox::indicator:indeterminate:hover,QTreeView::indicator:checked:hover,QTreeView::indicator:indeterminate:hover,QCheckBox::indicator:checked:hover,QCheckBox::indicator:indeterminate:hover{
+     image: url(./Transparent-Style/checkbox-hover.png);
+}
+ QGroupBox::indicator:checked:disabled,QGroupBox::indicator:indeterminate:disabled,QTreeView::indicator:checked:disabled,QTreeView::indicator:indeterminate:disabled,QCheckBox::indicator:checked:disabled,QCheckBox::indicator:indeterminate:disabled{
+     image: url(./Transparent-Style/checkbox-checked-disabled.png);
+}
+ QGroupBox::indicator:unchecked,QTreeView::indicator:unchecked,QCheckBox::indicator:unchecked{
+     image: url(./Transparent-Style/checkbox.png);
+}
+ QGroupBox::indicator:unchecked:hover,QTreeView::indicator:unchecked:hover,QCheckBox::indicator:unchecked:hover{
+     image: url(./Transparent-Style/checkbox-checked-hover.png);
+}
+ QGroupBox::indicator:unchecked:disabled,QTreeView::indicator:unchecked:disabled,QCheckBox::indicator:unchecked:disabled{
+     image: url(./Transparent-Style/checkbox-checked-disabled.png);
+}
+ QTreeWidget#categoriesList::item:has-children{
+     background-image: url(./Transparent-Style/arrow-right-small.png);
+}
+ QTreeWidget#categoriesList::item:has-children:open{
+     background-image: url(./Transparent-Style/branch-opened.png);
+}
+/* ******************************** */
+/* Special styles */
+/* increase categories tab width */
+/* ******************************** */
+ QTreeView#modList::item,QTreeWidget#categoriesTree::item,#tabConflicts QTreeWidget::item,QListView::item,QTreeView#espList::item,QTreeView#treeContent::item{
+     padding: .3em 0em;
+}
+ QTreeView#modList::item,QTreeWidget#categoriesTree::item,#tabConflicts QTreeWidget::item,QListView::item,QTreeView#espList::item,QTreeView#treeContent::item{
+     padding: .3em 0em;
+}
+ QTreeWidget#categoriesGroup,QTreeWidget#categoriesList{
+     min-width: 200px;
+}
+ QTreeWidget#categoriesList::item {
+     background-position: center left;
+     background-repeat: no-repeat;
+     padding: 0.35em 4px;
+}
+/* ********************* */
+/* Display Radio Button */
+/* ********************* */
+ QRadioButton::indicator{
+     width: 16px;
+     height: 16px;
+}
+ QRadioButton::indicator::checked{
+     image: url(./Transparent-Style/radio-BOS-checked.png);
+}
+ QRadioButton::indicator::unchecked{
+     image: url(./Transparent-Style/radio-BOS.png);
+}
+ QRadioButton::indicator::unchecked:hover{
+     image: url(./Transparent-Style/radio-BOS-hover.png);
+}
+/* **************************************** */
+/* Spinners #QSpinBox, #QDoubleSpinBox */
+/* **************************************** */
+ QAbstractSpinBox{
+     padding: 5px;
+     background-color: transparent;
+     color: #eff0f1;
+     border-radius: 2px;
+     min-width: Auto;
+}
+ QAbstractSpinBox::up-button,QAbstractSpinBox::down-button{
+     border-style: solid;
+     border-width: 1px;
+     subcontrol-origin: border;
+}
+ QAbstractSpinBox::up-button:hover,QAbstractSpinBox::down-button:hover{
+     background-color: transparent;
+}
+ QAbstractSpinBox::up-button{
+     background-color: transparent;
+     subcontrol-origin: border;
+     subcontrol-position: center right;
+     padding-right: 5px;
+    /* subcontrol-position: top right;
+     */
+}
+ QAbstractSpinBox::down-button{
+     background-color: transparent;
+     subcontrol-origin: border;
+     subcontrol-position: center left;
+     padding-left: 5px;
+    /* subcontrol-position: bottom right;
+     */
+}
+ QAbstractSpinBox::up-arrow{
+     border-image: url(./Transparent-Style/narrow-arrow-right.png);
+}
+QAbstractSpinBox::down-arrow{
+     border-image: url(./Transparent-Style/narrow-arrow-left.png);
+}
+/* QTextEdit,QWebView,QLineEdit,QComboBox{
+     border-color:#3F3F46;
+    /* Grey - Blue*/
+    /*
+}
+*/
+/* **************************************** */
+/* Tooltips #QToolTip, #SaveGameInfoWidget */
+/* **************************************** */
+ QToolTip{
+     background-color:#121212;
+     color:#C0C0C0;
+     padding:0px;
+     border-color:#9A9A00;
+     border-radius: 3px;
+     border-width:1px;
+     border-style:solid;
+}
+ SaveGameInfoWidget{
+     font-size: 16px;
+     background-color:#121212;
+     color:#C0C0C0;
+     padding:0px;
+     border-color:#9A9A00;
+     border-radius: 3px;
+     border-width:1px;
+     border-style:solid;
+}
+/* **************************** */
+/* Handles Web, Nexus info tab */
+/* **************************** */
+ QWebView{
+     background-color: Black;
+}
+ QLineEdit{
+     font-family: Segoe UI;
+     min-height: 20px;
+     font-size: 16px;
+     background-color:#3F3F46;
+     selection-background-color: rgba(154,154,0,0.6);
+    border-color:#9A9A00;
+     border-radius: 3px;
+     border-width:1px;
+     border-style:solid;
+}
+ QTextEdit{
+     color: #cccccc;
+     font-family: Segoe UI;
+     font-size: 16px;
+    /* background-color:#000;
+     */
+     selection-background-color: rgba(154,154,0,0.6);
+     border-color:#9A9A00;
+     border-radius: 3px;
+     border-width:1px;
+     border-style:solid;
+}
+/* Font size */
+ QLabel,QMenu,QPushButton,QAbstractSpinBox,QGroupBox,QCheckBox,QRadioButton{
+     color: #cccccc;
+     font-family: Segoe UI;
+     font-size: 16px;
+    /* was 14px Profile font size */
+}
+ QAbstractItemView{
+     color: #cccccc;
+     font-family: Segoe UI;
+    /* font-family: Source Sans Pro;
+     */
+     font-size: 16px;
+    /* Body font size*/
+}
+ QRadioButton{
+     color: #cccccc;
+     font-family: Segoe UI;
+    /* font-family: Source Sans Pro;
+     */
+     font-size: 16px;
+}
+ QWebView,QComboBox,QComboBox:editable{
+     font-family:Segoe UI;
+     font-style: normal;
+     font-weight: normal;
+     font-size: 16px;
+     background-color:#000;
+    /* border-color:#3F3F46;
+    /* Grey - Blue*/
+     color: #cccccc;
+     font-family: Arial;
+     font-size: 16px;
+    /* Filter Name*/
+}
+ QHeaderView::section{
+    /* font-family: Source Sans Pro;
+     */
+     font-family: Segoe UI;
+     font-size: 16px;
+    /*Top Bar on menus font*/
+}
+ QListView::item{
+     color:#F1F1F1;
+    /* White */
+}
+ QGroupBox {
+}
+ QGroupBox::title {
+     subcontrol-origin: margin;
+     subcontrol-position: top center;
+}
+ QGroupBox::indicator {
+     subcontrol-origin: margin;
+     subcontrol-position: top center;
+}
+ QLabel {
+     color: #cccccc;
+    /* color: #F1F1F1;
+    /* White */
+    /* border: none;
+    outline: none;
+     border-radius: 5px;
+     border-top:1px solid #9A9A00;
+     border-bottom:1px solid #9A9A00;
+    */
+}

--- a/src/stylesheets/dark.qss
+++ b/src/stylesheets/dark.qss
@@ -247,6 +247,11 @@ QMenu::item:selected
   border-color: #3EA0CA;
 }
 
+QMenuBar::item:selected {
+  background-color: #3c4b54;
+  border-color: #3EA0CA;
+}
+
 QProgressBar
 {
   border: 2px solid grey;

--- a/src/stylesheets/skyrim.qss
+++ b/src/stylesheets/skyrim.qss
@@ -488,6 +488,14 @@ QHeaderView {
     image: url(./skyrim/arrow-down.png); }
 
 /* Context menus, toolbar drop-downs #QMenu  */
+QMenuBar {
+	background-color: #000;
+}
+
+QMenuBar::item:selected {
+	background-color: #121212;
+}
+
 QMenu {
   background-color: transparent; }
   QMenu::item,

--- a/src/stylesheets/vs15 Dark-Green.qss
+++ b/src/stylesheets/vs15 Dark-Green.qss
@@ -435,13 +435,13 @@ QScrollBar::sub-line {
   background-color: #3E3E42;
   border: none; }
 
-/*QScrollBar::add-line:horizontal:hover, 
-QScrollBar::sub-line:horizontal:hover, 
-QScrollBar::add-line:vertical:hover, 
+/*QScrollBar::add-line:horizontal:hover,
+QScrollBar::sub-line:horizontal:hover,
+QScrollBar::add-line:vertical:hover,
 QScrollBar::sub-line:vertical:hover,
-QScrollBar::add-line:horizontal:pressed, 
-QScrollBar::sub-line:horizontal:pressed, 
-QScrollBar::add-line:vertical:pressed, 
+QScrollBar::add-line:horizontal:pressed,
+QScrollBar::sub-line:horizontal:pressed,
+QScrollBar::add-line:vertical:pressed,
 QScrollBar::sub-line:vertical:pressed { }*/
 QScrollBar::handle:hover {
   background: #9E9E9E; }
@@ -551,7 +551,7 @@ QMenu::item {
   background: transparent;
   padding: 4px 20px; }
 
-QMenu::item:selected {
+QMenu::item:selected, QMenuBar::item:selected {
   background-color: #333334; }
 
 QMenu::item:disabled {

--- a/src/stylesheets/vs15 Dark-Green.qss
+++ b/src/stylesheets/vs15 Dark-Green.qss
@@ -201,8 +201,7 @@ QToolBar::separator {
   width: 0; }
 
 QToolButton {
-  margin: 0 4px 0 4px;
-  padding: 5px; }
+  padding: 4px; }
   QToolButton:hover, QToolButton:focus {
     background-color: #3E3E40; }
   QToolButton:pressed {

--- a/src/stylesheets/vs15 Dark-Orange.qss
+++ b/src/stylesheets/vs15 Dark-Orange.qss
@@ -436,13 +436,13 @@ QScrollBar::sub-line {
   background-color: #3E3E42;
   border: none; }
 
-/*QScrollBar::add-line:horizontal:hover, 
-QScrollBar::sub-line:horizontal:hover, 
-QScrollBar::add-line:vertical:hover, 
+/*QScrollBar::add-line:horizontal:hover,
+QScrollBar::sub-line:horizontal:hover,
+QScrollBar::add-line:vertical:hover,
 QScrollBar::sub-line:vertical:hover,
-QScrollBar::add-line:horizontal:pressed, 
-QScrollBar::sub-line:horizontal:pressed, 
-QScrollBar::add-line:vertical:pressed, 
+QScrollBar::add-line:horizontal:pressed,
+QScrollBar::sub-line:horizontal:pressed,
+QScrollBar::add-line:vertical:pressed,
 QScrollBar::sub-line:vertical:pressed { }*/
 QScrollBar::handle:hover {
   background: #9E9E9E; }
@@ -552,7 +552,7 @@ QMenu::item {
   background: transparent;
   padding: 4px 20px; }
 
-QMenu::item:selected {
+QMenu::item:selected, QMenuBar::item:selected {
   background-color: #333334; }
 
 QMenu::item:disabled {

--- a/src/stylesheets/vs15 Dark-Orange.qss
+++ b/src/stylesheets/vs15 Dark-Orange.qss
@@ -202,8 +202,7 @@ QToolBar::separator {
   width: 0; }
 
 QToolButton {
-  margin: 0 4px 0 4px;
-  padding: 5px; }
+  padding: 4px; }
   QToolButton:hover, QToolButton:focus {
     background-color: #3E3E40; }
   QToolButton:pressed {

--- a/src/stylesheets/vs15 Dark-Purple.qss
+++ b/src/stylesheets/vs15 Dark-Purple.qss
@@ -436,13 +436,13 @@ QScrollBar::sub-line {
   background-color: #3E3E42;
   border: none; }
 
-/*QScrollBar::add-line:horizontal:hover, 
-QScrollBar::sub-line:horizontal:hover, 
-QScrollBar::add-line:vertical:hover, 
+/*QScrollBar::add-line:horizontal:hover,
+QScrollBar::sub-line:horizontal:hover,
+QScrollBar::add-line:vertical:hover,
 QScrollBar::sub-line:vertical:hover,
-QScrollBar::add-line:horizontal:pressed, 
-QScrollBar::sub-line:horizontal:pressed, 
-QScrollBar::add-line:vertical:pressed, 
+QScrollBar::add-line:horizontal:pressed,
+QScrollBar::sub-line:horizontal:pressed,
+QScrollBar::add-line:vertical:pressed,
 QScrollBar::sub-line:vertical:pressed { }*/
 QScrollBar::handle:hover {
   background: #9E9E9E; }
@@ -552,7 +552,7 @@ QMenu::item {
   background: transparent;
   padding: 4px 20px; }
 
-QMenu::item:selected {
+QMenu::item:selected, QMenuBar::item:selected {
   background-color: #333334; }
 
 QMenu::item:disabled {

--- a/src/stylesheets/vs15 Dark-Purple.qss
+++ b/src/stylesheets/vs15 Dark-Purple.qss
@@ -202,8 +202,7 @@ QToolBar::separator {
   width: 0; }
 
 QToolButton {
-  margin: 0 4px 0 4px;
-  padding: 5px; }
+  padding: 4px; }
   QToolButton:hover, QToolButton:focus {
     background-color: #3E3E40; }
   QToolButton:pressed {

--- a/src/stylesheets/vs15 Dark-Red.qss
+++ b/src/stylesheets/vs15 Dark-Red.qss
@@ -436,13 +436,13 @@ QScrollBar::sub-line {
   background-color: #3E3E42;
   border: none; }
 
-/*QScrollBar::add-line:horizontal:hover, 
-QScrollBar::sub-line:horizontal:hover, 
-QScrollBar::add-line:vertical:hover, 
+/*QScrollBar::add-line:horizontal:hover,
+QScrollBar::sub-line:horizontal:hover,
+QScrollBar::add-line:vertical:hover,
 QScrollBar::sub-line:vertical:hover,
-QScrollBar::add-line:horizontal:pressed, 
-QScrollBar::sub-line:horizontal:pressed, 
-QScrollBar::add-line:vertical:pressed, 
+QScrollBar::add-line:horizontal:pressed,
+QScrollBar::sub-line:horizontal:pressed,
+QScrollBar::add-line:vertical:pressed,
 QScrollBar::sub-line:vertical:pressed { }*/
 QScrollBar::handle:hover {
   background: #9E9E9E; }
@@ -552,7 +552,7 @@ QMenu::item {
   background: transparent;
   padding: 4px 20px; }
 
-QMenu::item:selected {
+QMenu::item:selected, QMenuBar::item:selected {
   background-color: #333334; }
 
 QMenu::item:disabled {

--- a/src/stylesheets/vs15 Dark-Red.qss
+++ b/src/stylesheets/vs15 Dark-Red.qss
@@ -202,8 +202,7 @@ QToolBar::separator {
   width: 0; }
 
 QToolButton {
-  margin: 0 4px 0 4px;
-  padding: 5px; }
+  padding: 4px; }
   QToolButton:hover, QToolButton:focus {
     background-color: #3E3E40; }
   QToolButton:pressed {

--- a/src/stylesheets/vs15 Dark-Yellow.qss
+++ b/src/stylesheets/vs15 Dark-Yellow.qss
@@ -436,13 +436,13 @@ QScrollBar::sub-line {
   background-color: #3E3E42;
   border: none; }
 
-/*QScrollBar::add-line:horizontal:hover, 
-QScrollBar::sub-line:horizontal:hover, 
-QScrollBar::add-line:vertical:hover, 
+/*QScrollBar::add-line:horizontal:hover,
+QScrollBar::sub-line:horizontal:hover,
+QScrollBar::add-line:vertical:hover,
 QScrollBar::sub-line:vertical:hover,
-QScrollBar::add-line:horizontal:pressed, 
-QScrollBar::sub-line:horizontal:pressed, 
-QScrollBar::add-line:vertical:pressed, 
+QScrollBar::add-line:horizontal:pressed,
+QScrollBar::sub-line:horizontal:pressed,
+QScrollBar::add-line:vertical:pressed,
 QScrollBar::sub-line:vertical:pressed { }*/
 QScrollBar::handle:hover {
   background: #9E9E9E; }
@@ -552,7 +552,7 @@ QMenu::item {
   background: transparent;
   padding: 4px 20px; }
 
-QMenu::item:selected {
+QMenu::item:selected, QMenuBar::item:selected {
   background-color: #333334; }
 
 QMenu::item:disabled {

--- a/src/stylesheets/vs15 Dark-Yellow.qss
+++ b/src/stylesheets/vs15 Dark-Yellow.qss
@@ -202,8 +202,7 @@ QToolBar::separator {
   width: 0; }
 
 QToolButton {
-  margin: 0 4px 0 4px;
-  padding: 5px; }
+  padding: 4px; }
   QToolButton:hover, QToolButton:focus {
     background-color: #3E3E40; }
   QToolButton:pressed {

--- a/src/stylesheets/vs15 Dark.qss
+++ b/src/stylesheets/vs15 Dark.qss
@@ -435,13 +435,13 @@ QScrollBar::sub-line {
   background-color: #3E3E42;
   border: none; }
 
-/*QScrollBar::add-line:horizontal:hover, 
-QScrollBar::sub-line:horizontal:hover, 
-QScrollBar::add-line:vertical:hover, 
+/*QScrollBar::add-line:horizontal:hover,
+QScrollBar::sub-line:horizontal:hover,
+QScrollBar::add-line:vertical:hover,
 QScrollBar::sub-line:vertical:hover,
-QScrollBar::add-line:horizontal:pressed, 
-QScrollBar::sub-line:horizontal:pressed, 
-QScrollBar::add-line:vertical:pressed, 
+QScrollBar::add-line:horizontal:pressed,
+QScrollBar::sub-line:horizontal:pressed,
+QScrollBar::add-line:vertical:pressed,
 QScrollBar::sub-line:vertical:pressed { }*/
 QScrollBar::handle:hover {
   background: #9E9E9E; }
@@ -551,7 +551,7 @@ QMenu::item {
   background: transparent;
   padding: 4px 20px; }
 
-QMenu::item:selected {
+QMenu::item:selected, QMenuBar::item:selected {
   background-color: #333334; }
 
 QMenu::item:disabled {

--- a/src/stylesheets/vs15 Dark.qss
+++ b/src/stylesheets/vs15 Dark.qss
@@ -201,8 +201,7 @@ QToolBar::separator {
   width: 0; }
 
 QToolButton {
-  margin: 0 4px 0 4px;
-  padding: 5px; }
+  padding: 4px; }
   QToolButton:hover, QToolButton:focus {
     background-color: #3E3E40; }
   QToolButton:pressed {


### PR DESCRIPTION
Adds a main menu with all the actions from the toolbar. The only visual change should be that all buttons are now in one toolbar, nothing is aligned to the right anymore, and links are in their own toolbar.

- Changed the statusbar to be always visible since it displays help when hovering stuff.
- Changed the notifications button to always be enabled, the dialog will show a dummy "no notifications" in the list when empty. When there were no notifications, the toolbar button was disabled, but at least it had a tooltip saying so. As a menu item however, the reason for being disabled was unclear, so it's now always enabled. The icon still shows the number of notifications, that hasn't changed.
- There was quite a bit of work involved in making the `QAction` reusable in both the toolbar and main menu, especially those that had submenus (help, tools and endorse) because they were actually _replaced_ on the fly with `QToolButton`s. None of that is necessary, `QAction`s support having subactions in them and doing that allowed them to be reused as-is in both the toolbar and menu.
- Also fixed a probable bug where the visibility of the endorsement button (and now also menu item) was not toggled when changing the endorsement integration setting in the options.
- Toolbar links to executables are now in their own toolbar, allowing the user to move them wherever they damn well please instead of shoving them to the right. The toolbar is hidden by default unless there are links in it.
- Added options to the toolbar: icon size, and icon/text/icon+text.
- Went through every .qss we have since most of them did not handle `QMenuBar` correctly (or at all).