### PR TITLE
Display the splash screen on the same monitor as the main window

### DIFF
--- a/src/main.cpp
+++ b/src/main.cpp
@@ -597,6 +597,17 @@ int runApplication(MOApplication &application, SingleInstance &instance,
 
     QPixmap pixmap(splashPath);
     QSplashScreen splash(pixmap);
+
+    if (settings.contains("window_monitor")) {
+      const int monitor = settings.value("window_monitor").toInt();
+
+      if (monitor != -1) {
+        QDesktopWidget* desktop = QApplication::desktop();
+        const QPoint center = desktop->availableGeometry(monitor).center();
+        splash.move(center - splash.rect().center());
+      }
+    }
+
     splash.show();
     splash.activateWindow();
 

--- a/src/mainwindow.cpp
+++ b/src/mainwindow.cpp
@@ -1930,6 +1930,7 @@ void MainWindow::storeSettings(QSettings &settings) {
   if (settings.value("reset_geometry", false).toBool()) {
     settings.remove("window_geometry");
     settings.remove("window_split");
+    settings.remove("window_monitor");
     settings.remove("log_split");
     settings.remove("filters_visible");
     settings.remove("browser_geometry");
@@ -1938,6 +1939,7 @@ void MainWindow::storeSettings(QSettings &settings) {
   } else {
     settings.setValue("window_geometry", saveGeometry());
     settings.setValue("window_split", ui->splitter->saveState());
+    settings.setValue("window_monitor", QApplication::desktop()->screenNumber(this));
     settings.setValue("log_split", ui->topLevelSplitter->saveState());
     settings.setValue("browser_geometry", m_IntegratedBrowser.saveGeometry());
     settings.setValue("filters_visible", ui->displayCategoriesBtn->isChecked());


### PR DESCRIPTION
- Remember where the window was, save it in `window_monitor`.
- Use that to position the splash screen next time

I couldn't reuse the window geometry itself, because it's a blob that's parsed by `restoreGeometry()` and that happens way after the splash screen is shown.