### PR TITLE
Reset m_closing to false when the user cancels closing

### DIFF
--- a/src/mainwindow.cpp
+++ b/src/mainwindow.cpp
@@ -983,6 +983,7 @@ void MainWindow::closeEvent(QCloseEvent* event)
                           tr("There are still downloads in progress, do you really want to quit?"),
                           QMessageBox::Yes | QMessageBox::Cancel) == QMessageBox::Cancel) {
       event->ignore();
+      m_closing = false;
       return;
     } else {
       m_OrganizerCore.downloadManager()->pauseAll();


### PR DESCRIPTION
Without the fix:

- Start a download
- While the download is running, attempt to close MO, you get a warning that downloads are running
- Cancel
- Run a virtualized executable, you'll get the `WaitingOnCloseDialog()` instead of the regular `LockedDialog`.

Resetting `m_closing` fixes that.