### PR TITLE
New dialog to manually enter Nexus API key

### DIFF
--- a/src/nexusmanualkey.ui
+++ b/src/nexusmanualkey.ui
@@ -11,7 +11,7 @@
    </rect>
   </property>
   <property name="windowTitle">
-   <string>Dialog</string>
+   <string>Manual Nexus API Key</string>
   </property>
   <layout class="QVBoxLayout" name="verticalLayout_2" stretch="1,0">
    <item>

--- a/src/nexusmanualkey.ui
+++ b/src/nexusmanualkey.ui
@@ -7,16 +7,16 @@
     <x>0</x>
     <y>0</y>
     <width>452</width>
-    <height>302</height>
+    <height>236</height>
    </rect>
   </property>
   <property name="windowTitle">
    <string>Dialog</string>
   </property>
-  <layout class="QVBoxLayout" name="verticalLayout_2">
+  <layout class="QVBoxLayout" name="verticalLayout_2" stretch="1,0">
    <item>
     <widget class="QWidget" name="widget" native="true">
-     <layout class="QVBoxLayout" name="verticalLayout">
+     <layout class="QVBoxLayout" name="verticalLayout" stretch="0,1,0">
       <property name="leftMargin">
        <number>0</number>
       </property>
@@ -30,10 +30,152 @@
        <number>0</number>
       </property>
       <item>
-       <widget class="QPlainTextEdit" name="key">
-        <property name="placeholderText">
-         <string>Enter API key here</string>
-        </property>
+       <widget class="QWidget" name="widget_2" native="true">
+        <layout class="QVBoxLayout" name="verticalLayout_3">
+         <property name="leftMargin">
+          <number>0</number>
+         </property>
+         <property name="topMargin">
+          <number>0</number>
+         </property>
+         <property name="rightMargin">
+          <number>0</number>
+         </property>
+         <property name="bottomMargin">
+          <number>0</number>
+         </property>
+         <item>
+          <widget class="QLabel" name="label">
+           <property name="text">
+            <string>1. Get your personal API key</string>
+           </property>
+          </widget>
+         </item>
+         <item>
+          <widget class="QPushButton" name="openBrowser">
+           <property name="text">
+            <string>Open Browser</string>
+           </property>
+          </widget>
+         </item>
+        </layout>
+       </widget>
+      </item>
+      <item>
+       <widget class="QWidget" name="widget_3" native="true">
+        <layout class="QVBoxLayout" name="verticalLayout_4" stretch="0,1">
+         <property name="leftMargin">
+          <number>0</number>
+         </property>
+         <property name="topMargin">
+          <number>0</number>
+         </property>
+         <property name="rightMargin">
+          <number>0</number>
+         </property>
+         <property name="bottomMargin">
+          <number>0</number>
+         </property>
+         <item>
+          <widget class="QWidget" name="widget_4" native="true">
+           <layout class="QHBoxLayout" name="horizontalLayout">
+            <property name="leftMargin">
+             <number>0</number>
+            </property>
+            <property name="topMargin">
+             <number>0</number>
+            </property>
+            <property name="rightMargin">
+             <number>0</number>
+            </property>
+            <property name="bottomMargin">
+             <number>0</number>
+            </property>
+            <item>
+             <widget class="QLabel" name="label_2">
+              <property name="text">
+               <string>2. Enter your personal API key</string>
+              </property>
+             </widget>
+            </item>
+            <item>
+             <spacer name="horizontalSpacer">
+              <property name="orientation">
+               <enum>Qt::Horizontal</enum>
+              </property>
+              <property name="sizeHint" stdset="0">
+               <size>
+                <width>115</width>
+                <height>20</height>
+               </size>
+              </property>
+             </spacer>
+            </item>
+            <item>
+             <widget class="QPushButton" name="paste">
+              <property name="text">
+               <string>Paste</string>
+              </property>
+             </widget>
+            </item>
+            <item>
+             <widget class="QPushButton" name="clear">
+              <property name="text">
+               <string>Clear</string>
+              </property>
+             </widget>
+            </item>
+           </layout>
+          </widget>
+         </item>
+         <item>
+          <widget class="QPlainTextEdit" name="key">
+           <property name="sizePolicy">
+            <sizepolicy hsizetype="Ignored" vsizetype="Ignored">
+             <horstretch>0</horstretch>
+             <verstretch>0</verstretch>
+            </sizepolicy>
+           </property>
+           <property name="minimumSize">
+            <size>
+             <width>1</width>
+             <height>1</height>
+            </size>
+           </property>
+           <property name="placeholderText">
+            <string>Enter API key here</string>
+           </property>
+          </widget>
+         </item>
+        </layout>
+       </widget>
+      </item>
+      <item>
+       <widget class="QWidget" name="widget_5" native="true">
+        <layout class="QVBoxLayout" name="verticalLayout_5">
+         <property name="leftMargin">
+          <number>0</number>
+         </property>
+         <property name="topMargin">
+          <number>0</number>
+         </property>
+         <property name="rightMargin">
+          <number>0</number>
+         </property>
+         <property name="bottomMargin">
+          <number>0</number>
+         </property>
+         <item>
+          <widget class="QLabel" name="label_3">
+           <property name="text">
+            <string>&lt;b&gt;Sharing this key with anyone could get your Nexus account banned. You can always revoke this key from your account on the Nexus website.&lt;/b&gt;</string>
+           </property>
+           <property name="wordWrap">
+            <bool>true</bool>
+           </property>
+          </widget>
+         </item>
+        </layout>
        </widget>
       </item>
      </layout>

--- a/src/nexusmanualkey.ui
+++ b/src/nexusmanualkey.ui
@@ -1,0 +1,89 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<ui version="4.0">
+ <class>NexusManualKeyDialog</class>
+ <widget class="QDialog" name="NexusManualKeyDialog">
+  <property name="geometry">
+   <rect>
+    <x>0</x>
+    <y>0</y>
+    <width>452</width>
+    <height>302</height>
+   </rect>
+  </property>
+  <property name="windowTitle">
+   <string>Dialog</string>
+  </property>
+  <layout class="QVBoxLayout" name="verticalLayout_2">
+   <item>
+    <widget class="QWidget" name="widget" native="true">
+     <layout class="QVBoxLayout" name="verticalLayout">
+      <property name="leftMargin">
+       <number>0</number>
+      </property>
+      <property name="topMargin">
+       <number>0</number>
+      </property>
+      <property name="rightMargin">
+       <number>0</number>
+      </property>
+      <property name="bottomMargin">
+       <number>0</number>
+      </property>
+      <item>
+       <widget class="QPlainTextEdit" name="key">
+        <property name="placeholderText">
+         <string>Enter API key here</string>
+        </property>
+       </widget>
+      </item>
+     </layout>
+    </widget>
+   </item>
+   <item>
+    <widget class="QDialogButtonBox" name="buttonBox">
+     <property name="orientation">
+      <enum>Qt::Horizontal</enum>
+     </property>
+     <property name="standardButtons">
+      <set>QDialogButtonBox::Cancel|QDialogButtonBox::Ok</set>
+     </property>
+    </widget>
+   </item>
+  </layout>
+ </widget>
+ <resources/>
+ <connections>
+  <connection>
+   <sender>buttonBox</sender>
+   <signal>accepted()</signal>
+   <receiver>NexusManualKeyDialog</receiver>
+   <slot>accept()</slot>
+   <hints>
+    <hint type="sourcelabel">
+     <x>248</x>
+     <y>254</y>
+    </hint>
+    <hint type="destinationlabel">
+     <x>157</x>
+     <y>274</y>
+    </hint>
+   </hints>
+  </connection>
+  <connection>
+   <sender>buttonBox</sender>
+   <signal>rejected()</signal>
+   <receiver>NexusManualKeyDialog</receiver>
+   <slot>reject()</slot>
+   <hints>
+    <hint type="sourcelabel">
+     <x>316</x>
+     <y>260</y>
+    </hint>
+    <hint type="destinationlabel">
+     <x>286</x>
+     <y>274</y>
+    </hint>
+   </hints>
+  </connection>
+ </connections>
+</ui>

--- a/src/nxmaccessmanager.cpp
+++ b/src/nxmaccessmanager.cpp
@@ -176,10 +176,14 @@ bool NXMAccessManager::validateWaiting() const
 }
 
 
-void NXMAccessManager::apiCheck(const QString &apiKey)
+void NXMAccessManager::apiCheck(const QString &apiKey, bool force)
 {
   if (m_ValidateReply != nullptr) {
     return;
+  }
+
+  if (force) {
+    m_ValidateState = VALIDATE_NOT_CHECKED;
   }
 
   if (m_ValidateState == VALIDATE_VALID) {

--- a/src/nxmaccessmanager.h
+++ b/src/nxmaccessmanager.h
@@ -46,7 +46,7 @@ public:
   bool validateAttempted() const;
   bool validateWaiting() const;
 
-  void apiCheck(const QString &apiKey);
+  void apiCheck(const QString &apiKey, bool force=false);
 
   void showCookies() const;
 

--- a/src/settings.h
+++ b/src/settings.h
@@ -188,6 +188,24 @@ public:
   bool getNexusApiKey(QString &apiKey) const;
 
   /**
+  * @brief set the nexus login information
+  *
+  * @param username username
+  * @param password password
+  */
+  bool setNexusApiKey(const QString& apiKey);
+
+  /**
+  * @brief clears the nexus login information
+  */
+  bool clearNexusApiKey();
+
+  /**
+   * @brief returns whether an API key is currently stored
+   */
+  bool hasNexusApiKey() const;
+
+  /**
    * @brief retrieve the login information for steam
    *
    * @param username (out) receives the user name for nexus
@@ -239,14 +257,6 @@ public:
   QColor pluginListContainedColor() const;
 
   QString executablesBlacklist() const;
-
-  /**
-   * @brief set the nexus login information
-   *
-   * @param username username
-   * @param password password
-   */
-  void setNexusApiKey(QString apiKey);
 
   /**
    * @brief set the steam login information
@@ -481,7 +491,6 @@ private:
     void update();
 
   private:
-    QPushButton *m_nexusConnect;
     QCheckBox *m_offlineBox;
     QCheckBox *m_proxyBox;
     QListWidget *m_knownServersList;
@@ -538,9 +547,6 @@ private:
 private slots:
 
   void resetDialogs();
-  void processApiKey(const QString &);
-  void clearApiKey(QPushButton *nexusButton);
-  void checkApiKey(QPushButton *nexusButton);
 
 signals:
 

--- a/src/settingsdialog.cpp
+++ b/src/settingsdialog.cpp
@@ -532,6 +532,8 @@ void SettingsDialog::updateNexusButtons()
     // api key is in the process of being retrieved
     ui->nexusConnect->setText("Connecting the API. Please login within the browser and accept the request. This will time out after 30 minutes.");
     ui->nexusConnect->setEnabled(false);
+    ui->nexusDisconnect->setEnabled(false);
+    ui->nexusManualKey->setEnabled(false);
   }
   else if (m_settings->hasNexusApiKey()) {
     // api key is present

--- a/src/settingsdialog.h
+++ b/src/settingsdialog.h
@@ -156,6 +156,8 @@ private slots:
 
   void on_nexusConnect_clicked();
 
+  void on_nexusManualKey_clicked();
+
   void dispatchLogin();
 
   void loginPing();

--- a/src/settingsdialog.h
+++ b/src/settingsdialog.h
@@ -29,6 +29,7 @@ along with Mod Organizer.  If not, see <http://www.gnu.org/licenses/>.
 #include <QTimer>
 
 class PluginContainer;
+class Settings;
 
 namespace Ui {
     class SettingsDialog;
@@ -44,7 +45,9 @@ class SettingsDialog : public MOBase::TutorableDialog
     Q_OBJECT
 
 public:
-  explicit SettingsDialog(PluginContainer *pluginContainer, QWidget *parent = 0);
+  explicit SettingsDialog(
+    PluginContainer *pluginContainer, Settings* settings, QWidget *parent = 0);
+
   ~SettingsDialog();
 
   /**
@@ -62,9 +65,6 @@ public slots:
 signals:
 
   void resetDialogs();
-  void processApiKey(const QString &);
-  void closeApiConnection(QPushButton *);
-  void revokeApiKey(QPushButton *);
   void retryApiConnection();
 
 private:
@@ -94,105 +94,74 @@ public:
 
 
 private slots:
-  //void on_loginCheckBox_toggled(bool checked);
-
   void on_categoriesBtn_clicked();
-
   void on_execBlacklistBtn_clicked();
-
   void on_bsaDateBtn_clicked();
-
   void on_browseDownloadDirBtn_clicked();
-
   void on_browseModDirBtn_clicked();
-
   void on_browseCacheDirBtn_clicked();
-
   void on_resetDialogsButton_clicked();
-
   void on_pluginsList_currentItemChanged(QListWidgetItem *current, QListWidgetItem *previous);
-
-  void deleteBlacklistItem();
-
   void on_associateButton_clicked();
-
   void on_clearCacheButton_clicked();
-
-  void on_revokeNexusAuthButton_clicked();
-
+  void on_nexusDisconnect_clicked();
   void on_browseBaseDirBtn_clicked();
-
   void on_browseOverwriteDirBtn_clicked();
-
   void on_browseProfilesDirBtn_clicked();
-
   void on_browseGameDirBtn_clicked();
-
   void on_overwritingBtn_clicked();
-
   void on_overwrittenBtn_clicked();
-
   void on_overwritingArchiveBtn_clicked();
-
   void on_overwrittenArchiveBtn_clicked();
-
   void on_containsBtn_clicked();
-
   void on_containedBtn_clicked();
-
   void on_resetColorsBtn_clicked();
-
   void on_baseDirEdit_editingFinished();
-
   void on_downloadDirEdit_editingFinished();
-
   void on_modDirEdit_editingFinished();
-
   void on_cacheDirEdit_editingFinished();
-
   void on_profilesDirEdit_editingFinished();
-
   void on_overwriteDirEdit_editingFinished();
-
   void on_nexusConnect_clicked();
-
   void on_nexusManualKey_clicked();
-
-  void dispatchLogin();
-
-  void loginPing();
-
-  void authError(QAbstractSocket::SocketError error);
-
-  void receiveApiKey(const QString &apiKey);
-
-  void completeApiConnection();
-
   void on_resetGeometryBtn_clicked();
 
+  void deleteBlacklistItem();
+  void dispatchLogin();
+  void loginPing();
+  void authError(QAbstractSocket::SocketError error);
+  void receiveApiKey(const QString &apiKey);
+  void completeApiConnection();
+
 private:
-    Ui::SettingsDialog *ui;
-    PluginContainer *m_PluginContainer;
+  Ui::SettingsDialog *ui;
+  Settings* m_settings;
+  PluginContainer *m_PluginContainer;
 
-    QColor m_OverwritingColor;
-    QColor m_OverwrittenColor;
-    QColor m_OverwritingArchiveColor;
-    QColor m_OverwrittenArchiveColor;
-    QColor m_ContainsColor;
-    QColor m_ContainedColor;
+  QColor m_OverwritingColor;
+  QColor m_OverwrittenColor;
+  QColor m_OverwritingArchiveColor;
+  QColor m_OverwrittenArchiveColor;
+  QColor m_ContainsColor;
+  QColor m_ContainedColor;
 
-    bool m_KeyReceived;
-    bool m_KeyCleared;
-    bool m_GeometriesReset;
-    QString m_UUID;
-    QString m_AuthToken;
+  bool m_KeyReceived;
+  bool m_KeyCleared;
+  bool m_GeometriesReset;
+  QString m_UUID;
+  QString m_AuthToken;
 
-    QString m_ExecutableBlacklist;
-    QWebSocket *m_nexusLogin;
-    QTimer m_loginTimer;
-    int m_totalPings = 0;
+  QString m_ExecutableBlacklist;
+  QWebSocket *m_nexusLogin;
+  QTimer m_loginTimer;
+  int m_totalPings = 0;
+
+  bool setKey(const QString& key);
+  bool clearKey();
+  void updateNexusButtons();
+
+  void fetchNexusApiKey();
+  void testApiKey();
 };
-
-
 
 #endif // SETTINGSDIALOG_H

--- a/src/settingsdialog.ui
+++ b/src/settingsdialog.ui
@@ -511,12 +511,12 @@ p, li { white-space: pre-wrap; }
              </widget>
             </item>
             <item>
-             <widget class="QPushButton" name="revokeNexusAuthButton">
+             <widget class="QPushButton" name="nexusDisconnect">
               <property name="toolTip">
                <string>Clear the stored Nexus API key and force reauthorization.</string>
               </property>
               <property name="text">
-               <string>Revoke Nexus Authorization</string>
+               <string>Disconnect from Nexus</string>
               </property>
               <property name="icon">
                <iconset resource="resources.qrc">

--- a/src/settingsdialog.ui
+++ b/src/settingsdialog.ui
@@ -495,6 +495,22 @@ p, li { white-space: pre-wrap; }
              </spacer>
             </item>
             <item>
+             <widget class="QPushButton" name="nexusManualKey">
+              <property name="sizePolicy">
+               <sizepolicy hsizetype="Minimum" vsizetype="Preferred">
+                <horstretch>0</horstretch>
+                <verstretch>0</verstretch>
+               </sizepolicy>
+              </property>
+              <property name="toolTip">
+               <string>Manually enter the API key and try to login</string>
+              </property>
+              <property name="text">
+               <string>Enter API Key Manually</string>
+              </property>
+             </widget>
+            </item>
+            <item>
              <widget class="QPushButton" name="revokeNexusAuthButton">
               <property name="toolTip">
                <string>Clear the stored Nexus API key and force reauthorization.</string>


### PR DESCRIPTION
- Added a button in nexus settings to open the dialog
- Added new nexusmanualkey.ui for the dialog
- Changing the key manually will force an api check, which required changing `apiCheck()` to have a `force` flag so it will do a check with the new key even if the login was successful before.