### PR TITLE
Menu bar can be hidden, also shows executable shortcuts

### DIFF
--- a/src/mainwindow.cpp
+++ b/src/mainwindow.cpp
@@ -1069,12 +1069,12 @@ void MainWindow::showEvent(QShowEvent *event)
 
 void MainWindow::closeEvent(QCloseEvent* event)
 {
-  if (!exit()) {
+  if (!confirmExit()) {
     event->ignore();
   }
 }
 
-bool MainWindow::exit()
+bool MainWindow::confirmExit()
 {
   m_closing = true;
 
@@ -5518,7 +5518,9 @@ void MainWindow::on_actionUpdate_triggered()
 
 void MainWindow::on_actionExit_triggered()
 {
-  exit();
+  if (confirmExit()) {
+    qApp->exit();
+  }
 }
 
 void MainWindow::actionEndorseMO()

--- a/src/mainwindow.cpp
+++ b/src/mainwindow.cpp
@@ -738,6 +738,10 @@ void MainWindow::setToolbarButtonStyle(Qt::ToolButtonStyle s)
 
 void MainWindow::on_centralWidget_customContextMenuRequested(const QPoint &pos)
 {
+  // this allows for getting the context menu even if both the menubar and all
+  // the toolbars are hidden; an alternative is the Alt key handled in
+  // keyPressEvent() below
+
   // the custom context menu event bubbles up to here if widgets don't actually
   // process this, which would show the menu when right-clicking button, labels,
   // etc.

--- a/src/mainwindow.h
+++ b/src/mainwindow.h
@@ -153,7 +153,7 @@ public:
 
   void displayModInformation(ModInfo::Ptr modInfo, unsigned int index, int tab);
 
-  bool exit();
+  bool confirmExit();
 
   virtual bool closeWindow();
   virtual void setWindowEnabled(bool enabled);

--- a/src/mainwindow.h
+++ b/src/mainwindow.h
@@ -195,6 +195,7 @@ protected:
   virtual void resizeEvent(QResizeEvent *event);
   virtual void dragEnterEvent(QDragEnterEvent *event);
   virtual void dropEvent(QDropEvent *event);
+  void keyPressEvent(QKeyEvent *event) override;
 
 private slots:
   void on_actionChange_Game_triggered();
@@ -633,6 +634,7 @@ private slots: // ui slots
   void on_actionSettings_triggered();
   void on_actionUpdate_triggered();
   void on_actionExit_triggered();
+  void on_actionMainMenuToggle_triggered();
   void on_actionToolBarMainToggle_triggered();
   void on_actionToolBarLinksToggle_triggered();
   void on_actionToolBarSmallIcons_triggered();
@@ -642,7 +644,7 @@ private slots: // ui slots
   void on_actionToolBarTextOnly_triggered();
   void on_actionToolBarIconsAndText_triggered();
 
-
+  void on_centralWidget_customContextMenuRequested(const QPoint &pos);
   void on_bsaList_customContextMenuRequested(const QPoint &pos);
   void on_clearFiltersButton_clicked();
   void on_btnRefreshData_clicked();

--- a/src/mainwindow.h
+++ b/src/mainwindow.h
@@ -211,7 +211,7 @@ private:
   void createHelpMenu();
   void createEndorseMenu();
 
-  void updateToolBar();
+  void updatePinnedExecutables();
   void setToolbarSize(const QSize& s);
   void setToolbarButtonStyle(Qt::ToolButtonStyle s);
   void toolbarMenu_aboutToShow();
@@ -323,6 +323,10 @@ private:
   Ui::MainWindow *ui;
 
   bool m_WasVisible;
+
+  // this has to be remembered because by the time storeSettings() is called,
+  // the window is closed and the menubar is hidden
+  bool m_menuBarVisible;
 
   MOBase::TutorialControl m_Tutorial;
 

--- a/src/mainwindow.ui
+++ b/src/mainwindow.ui
@@ -30,6 +30,9 @@
      <verstretch>0</verstretch>
     </sizepolicy>
    </property>
+   <property name="contextMenuPolicy">
+    <enum>Qt::CustomContextMenu</enum>
+   </property>
    <layout class="QHBoxLayout" name="horizontalLayout_8">
     <property name="leftMargin">
      <number>6</number>
@@ -1432,6 +1435,7 @@ p, li { white-space: pre-wrap; }
      <property name="title">
       <string>&amp;Toolbars</string>
      </property>
+     <addaction name="actionMainMenuToggle"/>
      <addaction name="actionToolBarMainToggle"/>
      <addaction name="actionToolBarLinksToggle"/>
      <addaction name="separator"/>
@@ -1719,22 +1723,12 @@ p, li { white-space: pre-wrap; }
     <string>Exits Mod Organizer</string>
    </property>
   </action>
-  <action name="actionToolbar_Size">
-   <property name="text">
-    <string>Toolbar Size</string>
-   </property>
-  </action>
-  <action name="actionToolbar_style">
-   <property name="text">
-    <string>Toolbar Buttons</string>
-   </property>
-  </action>
   <action name="actionToolBarMainToggle">
    <property name="checkable">
     <bool>true</bool>
    </property>
    <property name="text">
-    <string>&amp;Main</string>
+    <string>M&amp;ain</string>
    </property>
   </action>
   <action name="actionToolBarLinksToggle">
@@ -1791,6 +1785,14 @@ p, li { white-space: pre-wrap; }
    </property>
    <property name="text">
     <string>M&amp;edium Icons</string>
+   </property>
+  </action>
+  <action name="actionMainMenuToggle">
+   <property name="checkable">
+    <bool>true</bool>
+   </property>
+   <property name="text">
+    <string>&amp;Menu</string>
    </property>
   </action>
  </widget>

--- a/src/mainwindow.ui
+++ b/src/mainwindow.ui
@@ -1392,7 +1392,7 @@ p, li { white-space: pre-wrap; }
      <height>21</height>
     </rect>
    </property>
-   <widget class="QMenu" name="menu_File">
+   <widget class="QMenu" name="menuFile">
     <property name="title">
      <string>&amp;File</string>
     </property>
@@ -1402,7 +1402,7 @@ p, li { white-space: pre-wrap; }
     <addaction name="separator"/>
     <addaction name="actionExit"/>
    </widget>
-   <widget class="QMenu" name="menu_Tools">
+   <widget class="QMenu" name="menuTools">
     <property name="title">
      <string>&amp;Tools</string>
     </property>
@@ -1413,7 +1413,7 @@ p, li { white-space: pre-wrap; }
     <addaction name="separator"/>
     <addaction name="actionSettings"/>
    </widget>
-   <widget class="QMenu" name="menu_Help">
+   <widget class="QMenu" name="menuHelp">
     <property name="title">
      <string>&amp;Help</string>
     </property>
@@ -1421,7 +1421,7 @@ p, li { white-space: pre-wrap; }
     <addaction name="actionUpdate"/>
     <addaction name="actionEndorseMO"/>
    </widget>
-   <widget class="QMenu" name="menu_Edit">
+   <widget class="QMenu" name="menuEdit">
     <property name="title">
      <string>&amp;Edit</string>
     </property>
@@ -1450,11 +1450,17 @@ p, li { white-space: pre-wrap; }
     <addaction name="menuToolbars"/>
     <addaction name="actionNotifications"/>
    </widget>
-   <addaction name="menu_File"/>
-   <addaction name="menu_Edit"/>
+   <widget class="QMenu" name="menuRun">
+    <property name="title">
+     <string>&amp;Run</string>
+    </property>
+   </widget>
+   <addaction name="menuFile"/>
+   <addaction name="menuEdit"/>
    <addaction name="menuView"/>
-   <addaction name="menu_Tools"/>
-   <addaction name="menu_Help"/>
+   <addaction name="menuTools"/>
+   <addaction name="menuRun"/>
+   <addaction name="menuHelp"/>
   </widget>
   <widget class="QToolBar" name="linksToolBar">
    <property name="contextMenuPolicy">


### PR DESCRIPTION
- Added a menubar toggle in the context menu
- Added ways to make the menu reappear if you hide everything:
  - show the toolbar popup when right-clicking around the border of the main window
  - intercept the Alt key and make the main menu visible
- Added new _Run_ menu that has the same executable shortcuts that are on the toolbar. Only visible when there are shortcuts available.