### PR TITLE
Reset m_closing to false when the user cancels closing

### DIFF
--- a/src/mainwindow.cpp
+++ b/src/mainwindow.cpp
@@ -1049,6 +1049,7 @@ bool MainWindow::exit()
     if (QMessageBox::question(this, tr("Downloads in progress"),
                           tr("There are still downloads in progress, do you really want to quit?"),
                           QMessageBox::Yes | QMessageBox::Cancel) == QMessageBox::Cancel) {
+      m_closing = false;
       return false;
     } else {
       m_OrganizerCore.downloadManager()->pauseAll();


### PR DESCRIPTION
Without the fix:

- Start a download
- While the download is running, attempt to close MO, you get a warning that downloads are running
- Cancel
- Run a virtualized executable, you'll get the `WaitingOnCloseDialog()` instead of the regular `LockedDialog`.

Resetting `m_closing` fixes that.