### PR TITLE
Reverted changes to the toolbar

### DIFF
--- a/src/mainwindow.cpp
+++ b/src/mainwindow.cpp
@@ -202,6 +202,7 @@ MainWindow::MainWindow(QSettings &initSettings
   , ui(new Ui::MainWindow)
   , m_WasVisible(false)
   , m_menuBarVisible(true)
+  , m_linksSeparator(nullptr)
   , m_Tutorial(this, "MainWindow")
   , m_OldProfileIndex(-1)
   , m_ModListGroupingProxy(nullptr)
@@ -251,15 +252,7 @@ MainWindow::MainWindow(QSettings &initSettings
 
   updateProblemsButton();
 
-  // Setup toolbar
-
-  setupActionMenu(ui->actionTool);
-  setupActionMenu(ui->actionHelp);
-  setupActionMenu(ui->actionEndorseMO);
-
-  createHelpMenu();
-  createEndorseMenu();
-
+  setupToolbar();
   toggleMO2EndorseState();
 
   TaskProgressManager::instance().tryCreateTaskbar();
@@ -400,7 +393,7 @@ MainWindow::MainWindow(QSettings &initSettings
   connect(&TutorialManager::instance(), SIGNAL(windowTutorialFinished(QString)), this, SLOT(windowTutorialFinished(QString)));
   connect(ui->tabWidget, SIGNAL(currentChanged(int)), &TutorialManager::instance(), SIGNAL(tabChanged(int)));
   connect(ui->modList->header(), SIGNAL(sortIndicatorChanged(int,Qt::SortOrder)), this, SLOT(modListSortIndicatorChanged(int,Qt::SortOrder)));
-  connect(ui->linksToolBar, SIGNAL(customContextMenuRequested(QPoint)), this, SLOT(linksToolBar_customContextMenuRequested(QPoint)));
+  connect(ui->toolBar, SIGNAL(customContextMenuRequested(QPoint)), this, SLOT(toolBar_customContextMenuRequested(QPoint)));
   connect(ui->menuToolbars, &QMenu::aboutToShow, [&]{ toolbarMenu_aboutToShow(); });
 
   connect(&m_OrganizerCore, &OrganizerCore::modInstalled, this, &MainWindow::modInstalled);
@@ -601,6 +594,34 @@ static QModelIndex mapToModel(const QAbstractItemModel *targetModel, QModelIndex
   return result;
 }
 
+void MainWindow::setupToolbar()
+{
+  setupActionMenu(ui->actionTool);
+  setupActionMenu(ui->actionHelp);
+  setupActionMenu(ui->actionEndorseMO);
+
+  createHelpMenu();
+  createEndorseMenu();
+
+  // find last separator, add a spacer just before it so the icons are
+  // right-aligned
+  m_linksSeparator = nullptr;
+  for (auto* a : ui->toolBar->actions()) {
+    if (a->isSeparator()) {
+      m_linksSeparator = a;
+    }
+  }
+
+  if (m_linksSeparator) {
+    auto* spacer = new QWidget(ui->toolBar);
+    spacer->setSizePolicy(QSizePolicy::MinimumExpanding, QSizePolicy::Preferred);
+    ui->toolBar->insertWidget(m_linksSeparator, spacer);
+
+  } else {
+    qWarning("no separator found on the toolbar, icons won't be right-aligned");
+  }
+}
+
 void MainWindow::setupActionMenu(QAction* a)
 {
   a->setMenu(new QMenu(this));
@@ -612,9 +633,11 @@ void MainWindow::setupActionMenu(QAction* a)
 
 void MainWindow::updatePinnedExecutables()
 {
-  for (auto* a : ui->linksToolBar->actions()) {
-    ui->linksToolBar->removeAction(a);
-    a->deleteLater();
+  for (auto* a : ui->toolBar->actions()) {
+    if (a->objectName().startsWith("custom__")) {
+      ui->toolBar->removeAction(a);
+      a->deleteLater();
+    }
   }
 
   ui->menuRun->clear();
@@ -637,13 +660,18 @@ void MainWindow::updatePinnedExecutables()
         qDebug("failed to connect trigger?");
       }
 
-      ui->linksToolBar->addAction(exeAction);
+      if (m_linksSeparator) {
+        ui->toolBar->insertAction(m_linksSeparator, exeAction);
+      } else {
+        // separator wasn't found, add it to the end
+        ui->toolBar->addAction(exeAction);
+      }
+
       ui->menuRun->addAction(exeAction);
     }
   }
 
-  // don't show the toolbar or menu if there are no links
-  ui->linksToolBar->setVisible(hasLinks);
+  // don't show the menu if there are no links
   ui->menuRun->menuAction()->setVisible(hasLinks);
 }
 
@@ -660,7 +688,6 @@ void MainWindow::toolbarMenu_aboutToShow()
 
   ui->actionMainMenuToggle->setChecked(ui->menuBar->isVisible());
   ui->actionToolBarMainToggle->setChecked(ui->toolBar->isVisible());
-  ui->actionToolBarLinksToggle->setChecked(ui->linksToolBar->isVisible());
 
   ui->actionToolBarSmallIcons->setChecked(ui->toolBar->iconSize() == SmallToolbarSize);
   ui->actionToolBarMediumIcons->setChecked(ui->toolBar->iconSize() == MediumToolbarSize);
@@ -685,11 +712,6 @@ void MainWindow::on_actionMainMenuToggle_triggered()
 void MainWindow::on_actionToolBarMainToggle_triggered()
 {
   ui->toolBar->setVisible(!ui->toolBar->isVisible());
-}
-
-void MainWindow::on_actionToolBarLinksToggle_triggered()
-{
-  ui->linksToolBar->setVisible(!ui->linksToolBar->isVisible());
 }
 
 void MainWindow::on_actionToolBarSmallIcons_triggered()
@@ -6207,23 +6229,23 @@ void MainWindow::removeFromToolbar()
 }
 
 
-void MainWindow::linksToolBar_customContextMenuRequested(const QPoint &point)
+void MainWindow::toolBar_customContextMenuRequested(const QPoint &point)
 {
-  QAction *action = ui->linksToolBar->actionAt(point);
+  QAction *action = ui->toolBar->actionAt(point);
 
   if (action != nullptr) {
     if (action->objectName().startsWith("custom_")) {
       m_ContextAction = action;
       QMenu menu;
       menu.addAction(tr("Remove '%1' from the toolbar").arg(action->text()), this, SLOT(removeFromToolbar()));
-      menu.exec(ui->linksToolBar->mapToGlobal(point));
+      menu.exec(ui->toolBar->mapToGlobal(point));
       return;
     }
   }
 
   // did not click a link button, show the default context menu
   auto* m = createPopupMenu();
-  m->exec(ui->linksToolBar->mapToGlobal(point));
+  m->exec(ui->toolBar->mapToGlobal(point));
 }
 
 void MainWindow::on_espList_customContextMenuRequested(const QPoint &pos)

--- a/src/mainwindow.cpp
+++ b/src/mainwindow.cpp
@@ -6880,7 +6880,7 @@ void MainWindow::dropEvent(QDropEvent *event)
   event->accept();
 }
 
-void MainWindow::keyPressEvent(QKeyEvent *event)
+void MainWindow::keyReleaseEvent(QKeyEvent *event)
 {
   // if the menubar is hidden, pressing Alt will make it visible
   if (event->key() == Qt::Key_Alt) {
@@ -6890,7 +6890,7 @@ void MainWindow::keyPressEvent(QKeyEvent *event)
     }
   }
 
-  QMainWindow::keyPressEvent(event);
+  QMainWindow::keyReleaseEvent(event);
 }
 
 void MainWindow::on_clickBlankButton_clicked()

--- a/src/mainwindow.h
+++ b/src/mainwindow.h
@@ -207,6 +207,7 @@ private:
 
   void cleanup();
 
+  void setupToolbar();
   void setupActionMenu(QAction* a);
   void createHelpMenu();
   void createEndorseMenu();
@@ -327,6 +328,10 @@ private:
   // this has to be remembered because by the time storeSettings() is called,
   // the window is closed and the menubar is hidden
   bool m_menuBarVisible;
+
+  // last separator on the toolbar, used to add spacer for right-alignment and
+  // as an insert point for executables
+  QAction* m_linksSeparator;
 
   MOBase::TutorialControl m_Tutorial;
 
@@ -602,7 +607,7 @@ private slots:
    */
   void allowListResize();
 
-  void linksToolBar_customContextMenuRequested(const QPoint &point);
+  void toolBar_customContextMenuRequested(const QPoint &point);
   void removeFromToolbar();
   void overwriteClosed(int);
 
@@ -640,7 +645,6 @@ private slots: // ui slots
   void on_actionExit_triggered();
   void on_actionMainMenuToggle_triggered();
   void on_actionToolBarMainToggle_triggered();
-  void on_actionToolBarLinksToggle_triggered();
   void on_actionToolBarSmallIcons_triggered();
   void on_actionToolBarMediumIcons_triggered();
   void on_actionToolBarLargeIcons_triggered();

--- a/src/mainwindow.h
+++ b/src/mainwindow.h
@@ -195,7 +195,7 @@ protected:
   virtual void resizeEvent(QResizeEvent *event);
   virtual void dragEnterEvent(QDragEnterEvent *event);
   virtual void dropEvent(QDropEvent *event);
-  void keyPressEvent(QKeyEvent *event) override;
+  void keyReleaseEvent(QKeyEvent *event) override;
 
 private slots:
   void on_actionChange_Game_triggered();

--- a/src/mainwindow.ui
+++ b/src/mainwindow.ui
@@ -1352,8 +1352,14 @@ p, li { white-space: pre-wrap; }
    </layout>
   </widget>
   <widget class="QToolBar" name="toolBar">
+   <property name="contextMenuPolicy">
+    <enum>Qt::CustomContextMenu</enum>
+   </property>
    <property name="windowTitle">
     <string>Main ToolBar</string>
+   </property>
+   <property name="movable">
+    <bool>false</bool>
    </property>
    <property name="iconSize">
     <size>
@@ -1368,11 +1374,9 @@ p, li { white-space: pre-wrap; }
     <bool>false</bool>
    </attribute>
    <addaction name="actionChange_Game"/>
-   <addaction name="actionAdd_Profile"/>
-   <addaction name="separator"/>
-   <addaction name="actionNexus"/>
    <addaction name="actionInstallMod"/>
-   <addaction name="separator"/>
+   <addaction name="actionNexus"/>
+   <addaction name="actionAdd_Profile"/>
    <addaction name="actionModify_Executables"/>
    <addaction name="actionTool"/>
    <addaction name="actionSettings"/>
@@ -1437,7 +1441,6 @@ p, li { white-space: pre-wrap; }
      </property>
      <addaction name="actionMainMenuToggle"/>
      <addaction name="actionToolBarMainToggle"/>
-     <addaction name="actionToolBarLinksToggle"/>
      <addaction name="separator"/>
      <addaction name="actionToolBarSmallIcons"/>
      <addaction name="actionToolBarMediumIcons"/>
@@ -1461,26 +1464,6 @@ p, li { white-space: pre-wrap; }
    <addaction name="menuTools"/>
    <addaction name="menuRun"/>
    <addaction name="menuHelp"/>
-  </widget>
-  <widget class="QToolBar" name="linksToolBar">
-   <property name="contextMenuPolicy">
-    <enum>Qt::CustomContextMenu</enum>
-   </property>
-   <property name="windowTitle">
-    <string>Links ToolBar</string>
-   </property>
-   <property name="iconSize">
-    <size>
-     <width>42</width>
-     <height>36</height>
-    </size>
-   </property>
-   <attribute name="toolBarArea">
-    <enum>TopToolBarArea</enum>
-   </attribute>
-   <attribute name="toolBarBreak">
-    <bool>false</bool>
-   </attribute>
   </widget>
   <action name="actionInstallMod">
    <property name="icon">
@@ -1734,15 +1717,7 @@ p, li { white-space: pre-wrap; }
     <bool>true</bool>
    </property>
    <property name="text">
-    <string>M&amp;ain</string>
-   </property>
-  </action>
-  <action name="actionToolBarLinksToggle">
-   <property name="checkable">
-    <bool>true</bool>
-   </property>
-   <property name="text">
-    <string>&amp;Links</string>
+    <string>M&amp;ain Toolbar</string>
    </property>
   </action>
   <action name="actionToolBarSmallIcons">


### PR DESCRIPTION
 - Swapped back "add profile" and "install mod" icons
 - Removed links toolbar, icons are added to the main one
 - Locked the toolbar because there's only one now
 - Right align everything after the last separator, including executable shortcuts
 - Show the main menu when releasing alt instead of pressing, less annoying to take screenshots with alt+printscreen without having the menu pop up