### PR TITLE
Added "Open Origin in Explorer" to the data tab

### DIFF
--- a/src/mainwindow.cpp
+++ b/src/mainwindow.cpp
@@ -3377,7 +3377,7 @@ void MainWindow::openExplorer_clicked()
   }
 }
 
-void MainWindow::openOriginExplorer_clicked()
+void MainWindow::openPluginOriginExplorer_clicked()
 {
   QItemSelectionModel *selection = ui->espList->selectionModel();
   if (selection->hasSelection() && selection->selectedRows().count() > 0) {
@@ -4721,7 +4721,7 @@ void MainWindow::on_modList_customContextMenuRequested(const QPoint &pos)
       // no selection
       QMenu menu(this);
       initModListContextMenu(&menu);
-      menu.exec(modList->mapToGlobal(pos));
+      menu.exec(modList->viewport()->mapToGlobal(pos));
     } else {
       QMenu menu(this);
 
@@ -4866,7 +4866,7 @@ void MainWindow::on_modList_customContextMenuRequested(const QPoint &pos)
         menu.setDefaultAction(infoAction);
       }
 
-      menu.exec(modList->mapToGlobal(pos));
+      menu.exec(modList->viewport()->mapToGlobal(pos));
     }
   } catch (const std::exception &e) {
     reportError(tr("Exception: ").arg(e.what()));
@@ -5005,7 +5005,7 @@ void MainWindow::on_savegameList_customContextMenuRequested(const QPoint &pos)
 
   menu.addAction(deleteMenuLabel, this, SLOT(deleteSavegame_clicked()));
 
-  menu.exec(ui->savegameList->mapToGlobal(pos));
+  menu.exec(ui->savegameList->viewport()->mapToGlobal(pos));
 }
 
 void MainWindow::linkToolbar()
@@ -5447,6 +5447,24 @@ void MainWindow::openDataFile()
   m_OrganizerCore.executeFileVirtualized(this, targetInfo);
 }
 
+void MainWindow::openDataOriginExplorer_clicked()
+{
+  if (m_ContextItem == nullptr) {
+    return;
+  }
+
+  const auto isArchive = m_ContextItem->data(0, Qt::UserRole + 1).toBool();
+  const auto isDirectory = m_ContextItem->data(0, Qt::UserRole + 3).toBool();
+
+  if (isArchive || isDirectory) {
+    return;
+  }
+
+  const auto fullPath = m_ContextItem->data(0, Qt::UserRole).toString();
+
+  qDebug().nospace() << "opening in explorer: " << fullPath;
+  shell::ExploreFile(fullPath);
+}
 
 void MainWindow::updateAvailable()
 {
@@ -5490,8 +5508,15 @@ void MainWindow::on_dataTree_customContextMenuRequested(const QPoint &pos)
       menu.addAction(tr("Preview"), this, SLOT(previewDataFile()));
     }
 
+    const auto isArchive = m_ContextItem->data(0, Qt::UserRole + 1).toBool();
+    const auto isDirectory = m_ContextItem->data(0, Qt::UserRole + 3).toBool();
+
+    if (!isArchive && !isDirectory) {
+      menu.addAction("Open Origin in Explorer", this, SLOT(openDataOriginExplorer_clicked()));
+    }
+
     // offer to hide/unhide file, but not for files from archives
-    if (!m_ContextItem->data(0, Qt::UserRole + 1).toBool()) {
+    if (!isArchive) {
       if (m_ContextItem->text(0).endsWith(ModInfo::s_HiddenExt)) {
         menu.addAction(tr("Un-Hide"), this, SLOT(unhideFile()));
       } else {
@@ -5504,7 +5529,7 @@ void MainWindow::on_dataTree_customContextMenuRequested(const QPoint &pos)
   menu.addAction(tr("Write To File..."), this, SLOT(writeDataToFile()));
   menu.addAction(tr("Refresh"), this, SLOT(on_btnRefreshData_clicked()));
 
-  menu.exec(dataTree->mapToGlobal(pos));
+  menu.exec(dataTree->viewport()->mapToGlobal(pos));
 }
 
 void MainWindow::on_conflictsCheckBox_toggled(bool)
@@ -6086,7 +6111,7 @@ void MainWindow::on_bsaList_customContextMenuRequested(const QPoint &pos)
   QMenu menu;
   menu.addAction(tr("Extract..."), this, SLOT(extractBSATriggered()));
 
-  menu.exec(ui->bsaList->mapToGlobal(pos));
+  menu.exec(ui->bsaList->viewport()->mapToGlobal(pos));
 }
 
 void MainWindow::on_bsaList_itemChanged(QTreeWidgetItem*, int)
@@ -6163,7 +6188,7 @@ void MainWindow::on_categoriesList_customContextMenuRequested(const QPoint &pos)
   menu.addAction(tr("Edit Categories..."), this, SLOT(editCategories()));
   menu.addAction(tr("Deselect filter"), this, SLOT(deselectFilters()));
 
-  menu.exec(ui->categoriesList->mapToGlobal(pos));
+  menu.exec(ui->categoriesList->viewport()->mapToGlobal(pos));
 }
 
 
@@ -6271,7 +6296,7 @@ void MainWindow::on_espList_customContextMenuRequested(const QPoint &pos)
   unsigned int modInfoIndex = ModInfo::getIndex(m_OrganizerCore.pluginList()->origin(idx.data().toString()));
   //this is to avoid showing the option on game files like skyrim.esm
   if (modInfoIndex != UINT_MAX) {
-    menu.addAction(tr("Open Origin in Explorer"), this, SLOT(openOriginExplorer_clicked()));
+    menu.addAction(tr("Open Origin in Explorer"), this, SLOT(openPluginOriginExplorer_clicked()));
     ModInfo::Ptr modInfo = ModInfo::getByIndex(modInfoIndex);
     std::vector<ModInfo::EFlag> flags = modInfo->getFlags();
 
@@ -6282,7 +6307,7 @@ void MainWindow::on_espList_customContextMenuRequested(const QPoint &pos)
   }
 
   try {
-    menu.exec(ui->espList->mapToGlobal(pos));
+    menu.exec(ui->espList->viewport()->mapToGlobal(pos));
   } catch (const std::exception &e) {
     reportError(tr("Exception: ").arg(e.what()));
   } catch (...) {

--- a/src/mainwindow.h
+++ b/src/mainwindow.h
@@ -445,7 +445,7 @@ private slots:
   void visitOnNexus_clicked();
   void visitWebPage_clicked();
   void openExplorer_clicked();
-  void openOriginExplorer_clicked();
+  void openPluginOriginExplorer_clicked();
   void openOriginInformation_clicked();
   void information_clicked();
   void enableSelectedMods_clicked();
@@ -464,6 +464,7 @@ private slots:
   void previewDataFile();
   void hideFile();
   void unhideFile();
+  void openDataOriginExplorer_clicked();
 
   // pluginlist context menu
   void enableSelectedPlugins_clicked();


### PR DESCRIPTION
- Add the "Open Origin in Explorer" item only on items that are not in an archive and not a directory.
- Renamed `openOriginExplorer_clicked()` to `openPluginOriginExplorer_clicked()` to make it clearer
- Also fixed context menus having a vertical offset from the mouse cursor on pretty much every list on the main window. They were using `mapToGlobal()` on the list itself instead of on the viewport, which accounts for the header size.