### PR TITLE
Fixing the icons on the toolbar and menus

### DIFF
--- a/src/mainwindow.cpp
+++ b/src/mainwindow.cpp
@@ -849,7 +849,7 @@ void MainWindow::updateProblemsButton()
 
   const std::size_t numProblems = checkForProblems();
 
-  // starting icon
+  // original icon without a count painted on it
   const QIcon original = m_originalNotificationIcon.isNull() ?
     QIcon(DefaultIconName) : m_originalNotificationIcon;
 
@@ -860,8 +860,8 @@ void MainWindow::updateProblemsButton()
     ui->actionNotifications->setToolTip(tr("There are notifications to read"));
 
     // will contain the original icon, plus a notification count; this also
-    // makes sure the pixmap is exactly 64x64 by 1) requesting the icon that's
-    // as close to 64x64 as possible, then scaling it up if it's too small
+    // makes sure the pixmap is exactly 64x64 by requesting the icon that's
+    // as close to 64x64 as possible, and then scaling it up if it's too small
     QPixmap merged = original.pixmap(64, 64).scaled(64, 64);
 
     {

--- a/src/mainwindow.cpp
+++ b/src/mainwindow.cpp
@@ -401,8 +401,6 @@ MainWindow::MainWindow(QSettings &initSettings
 
   connect(&m_IntegratedBrowser, SIGNAL(requestDownload(QUrl,QNetworkReply*)), &m_OrganizerCore, SLOT(requestDownload(QUrl,QNetworkReply*)));
 
-  connect(this, SIGNAL(styleChanged(QString)), this, SLOT(updateStyle(QString)));
-
   m_CheckBSATimer.setSingleShot(true);
   connect(&m_CheckBSATimer, SIGNAL(timeout()), this, SLOT(checkBSAList()));
 
@@ -465,17 +463,63 @@ MainWindow::MainWindow(QSettings &initSettings
 
   refreshExecutablesList();
   updatePinnedExecutables();
-
-  for (QAction *action : ui->toolBar->actions()) {
-    // set the name of the widget to the name of the action to allow styling
-    QWidget *actionWidget = ui->toolBar->widgetForAction(action);
-    actionWidget->setObjectName(action->objectName());
-    actionWidget->style()->unpolish(actionWidget);
-    actionWidget->style()->polish(actionWidget);
-  }
-
+  resetActionIcons();
   updatePluginCount();
   updateModCount();
+}
+
+void MainWindow::resetActionIcons()
+{
+  // this is a bit of a hack
+  //
+  // the .qss files have historically set qproperty-icon by id and these ids
+  // correspond to the QActions created in the .ui file
+  //
+  // the problem is that QActions do not support having their icon property
+  // set from a .qss because they're not widgets (they don't inherit from
+  // QWidget), and styling only works on widget
+  //
+  // a QAction _does_ have an associated icon, it just can't be set from a .qss
+  // file
+  //
+  // so here, a dummy QToolButton widget is created for each QAction and is
+  // given the same name as the action, which makes it pick up the icon
+  // specified in the .qss file
+  //
+  // that icon is then given to the widget used by the QAction (if it's some
+  // sort of button, which typically happens on the toolbar) _and_ to the
+  // QAction itself, which is used in the menu bar
+
+  // QActions created from the .ui file are children of the main window
+  for (QAction* action : findChildren<QAction*>()) {
+    // creating a dummy button
+    auto dummy = std::make_unique<QToolButton>();
+
+    // reusing the action name
+    dummy->setObjectName(action->objectName());
+
+    // styling the button, this has to be done manually because the button is
+    // never added anywhere
+    style()->polish(dummy.get());
+
+    // the button's icon may be null if it wasn't specified in the .qss file,
+    // which can happen if the stylesheet just doesn't override icons, or for
+    // other actions like the pinned custom executables
+    const auto icon = dummy->icon();
+    if (icon.isNull()) {
+      continue;
+    }
+
+    // button associated with the action on the toolbar
+    QWidget* actionWidget = ui->toolBar->widgetForAction(action);
+
+    if (auto* actionButton=dynamic_cast<QAbstractButton*>(actionWidget)) {
+      actionButton->setIcon(icon);
+    }
+
+    // the action's icon is used by the menu bar
+    action->setIcon(icon);
+  }
 }
 
 
@@ -565,8 +609,7 @@ void MainWindow::allowListResize()
 
 void MainWindow::updateStyle(const QString&)
 {
-  // no effect?
-  ensurePolished();
+  resetActionIcons();
 }
 
 void MainWindow::resizeEvent(QResizeEvent *event)
@@ -1049,6 +1092,16 @@ void MainWindow::showEvent(QShowEvent *event)
   QMainWindow::showEvent(event);
 
   if (!m_WasVisible) {
+    // this needs to be connected here instead of in the constructor because the
+    // actual changing of the stylesheet is done by MOApplication, which
+    // connects its signal in runApplication() (in main.cpp), and that happens
+    // _after_ the MainWindow is constructed, but _before_ it is shown
+    //
+    // by connecting the event here, changing the style setting will first be
+    // handled by MOApplication, and then in updateStyle(), at which point the
+    // stylesheet has already been set correctly
+    connect(this, SIGNAL(styleChanged(QString)), this, SLOT(updateStyle(QString)));
+
     // only the first time the window becomes visible
     m_Tutorial.registerControl();
 

--- a/src/mainwindow.h
+++ b/src/mainwindow.h
@@ -631,6 +631,7 @@ private slots:
   void search_activated();
   void searchClear_activated();
 
+  void resetActionIcons();
   void updateModCount();
   void updatePluginCount();
 

--- a/src/mainwindow.h
+++ b/src/mainwindow.h
@@ -398,6 +398,10 @@ private:
 
   MOBase::DelayedFileWriter m_ArchiveListWriter;
 
+  // icon set by the stylesheet, used to remember its original appearance
+  // when painting the count
+  QIcon m_originalNotificationIcon;
+
   enum class ShortcutType {
     Toolbar,
     Desktop,


### PR DESCRIPTION
Neither the menu icons nor the toolbar items that had dropdown menus were styled correctly. The underlying problem is that we're using .qss files to try to style them, but they're `QAction`s, and those cannot be styled from .qss files, because they're not widgets (`QAction` is not derived from `QWidget`).

Historically, this was made to work by duplicating the `QAction` ID and also assigning it to the `QToolButton` that was on the toolbar. This would never have worked for the menus, and it also broke for a variety of reason when I put the `QAction`s directly in the toolbar instead of manually creating `QToolButton`s for them. In any case, the solution will always be a bit of a hack, because Qt doesn't allow styling `QAction`s from .qss files.

This change brings back some of the hacks, but avoids permanently changing object names, and also handles menu items correctly. It creates a dummy `QToolButton` per action, styles it properly, gets its icon, and assigns it to both the `QAction` and the `QAbstractButton` that's on the toolbar. This happens on startup and when the theme is changed from the settings.

I also fixed a long-standing bug where the notifications icon wasn't styled properly because it was hardcoded to use Qt's default warning icon. I now remember the original icon from the theme (or use the default warning icon if the theme didn't specify any) and draw the notification count on that.