### PR TITLE
Statusbar

### DIFF
--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -116,6 +116,7 @@ SET(organizer_SRCS
     forcedloaddialog.cpp
     forcedloaddialogwidget.cpp
 	filterwidget.cpp
+	statusbar.cpp
 
     shared/windows_error.cpp
     shared/error_report.cpp
@@ -213,6 +214,7 @@ SET(organizer_HDRS
     forcedloaddialog.h
     forcedloaddialogwidget.h
 	filterwidget.h
+	statusbar.h
 
     shared/windows_error.h
     shared/error_report.h
@@ -277,6 +279,7 @@ set(application
 	moshortcut
 	selfupdater
 	singleinstance
+	statusbar
 )
 
 set(browser

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -117,6 +117,7 @@ SET(organizer_SRCS
     forcedloaddialogwidget.cpp
 	filterwidget.cpp
 	statusbar.cpp
+	apiuseraccount.cpp
 
     shared/windows_error.cpp
     shared/error_report.cpp
@@ -215,6 +216,7 @@ SET(organizer_HDRS
     forcedloaddialogwidget.h
 	filterwidget.h
 	statusbar.h
+	apiuseraccount.h
 
     shared/windows_error.h
     shared/error_report.h
@@ -299,6 +301,7 @@ set(core
 	nxmaccessmanager
 	organizercore
 	organizerproxy
+	apiuseraccount
 )
 
 set(dialogs

--- a/src/apiuseraccount.cpp
+++ b/src/apiuseraccount.cpp
@@ -1,0 +1,67 @@
+#include "apiuseraccount.h"
+
+APIUserAccount::APIUserAccount()
+  : m_type(APIUserAccountTypes::None)
+{
+}
+
+const QString& APIUserAccount::id() const
+{
+  return m_id;
+}
+
+const QString& APIUserAccount::name() const
+{
+  return m_name;
+}
+
+APIUserAccountTypes APIUserAccount::type() const
+{
+  return m_type;
+}
+
+const APILimits& APIUserAccount::limits() const
+{
+  return m_limits;
+}
+
+APIUserAccount& APIUserAccount::id(const QString& id)
+{
+  m_id = id;
+  return *this;
+}
+
+APIUserAccount& APIUserAccount::name(const QString& name)
+{
+  m_name = name;
+  return *this;
+}
+
+APIUserAccount& APIUserAccount::type(APIUserAccountTypes type)
+{
+  m_type = type;
+  return *this;
+}
+
+APIUserAccount& APIUserAccount::limits(const APILimits& limits)
+{
+  m_limits = limits;
+  return *this;
+}
+
+int APIUserAccount::remainingRequests() const
+{
+  return std::max(
+    m_limits.remainingDailyRequests,
+    m_limits.remainingHourlyRequests);
+}
+
+bool APIUserAccount::shouldThrottle() const
+{
+  return (remainingRequests() < ThrottleThreshold);
+}
+
+bool APIUserAccount::exhausted() const
+{
+  return (remainingRequests() <= 0);
+}

--- a/src/apiuseraccount.h
+++ b/src/apiuseraccount.h
@@ -1,0 +1,129 @@
+#ifndef APIUSERACCOUNT_H
+#define APIUSERACCOUNT_H
+
+#include <QString>
+
+/**
+* represents user account types on a mod provider website such as nexus
+*/
+enum class APIUserAccountTypes
+{
+  // not logged in
+  None = 0,
+
+  // regular account
+  Regular,
+
+  // premium account
+  Premium
+};
+
+
+/**
+* current limits imposed on the user account
+**/
+struct APILimits
+{
+  // maximum number of requests per day
+  int maxDailyRequests = 0;
+
+  // remaining number of requests today
+  int remainingDailyRequests = 0;
+
+  // maximum number of requests per hour
+  int maxHourlyRequests = 0;
+
+  // remaining number of requests this hour
+  int remainingHourlyRequests = 0;
+};
+
+
+/**
+* API statistics
+*/
+struct APIStats
+{
+  // number of API requests currently queued
+  int requestsQueued = 0;
+};
+
+
+/**
+* represents a user account on the mod provier website
+*/
+class APIUserAccount
+{
+public:
+  // when the number of remanining requests is under this number, further
+  // requests will be throttled by avoiding non-critical ones
+  static const int ThrottleThreshold = 200;
+
+  APIUserAccount();
+
+  /**
+  * user id
+  */
+  const QString& id() const;
+
+  /**
+  * user name
+  */
+  const QString& name() const;
+
+  /**
+  * account type
+  */
+  APIUserAccountTypes type() const;
+
+  /**
+  * current API limits
+  */
+  const APILimits& limits() const;
+
+
+  /**
+  * sets the user id
+  */
+  APIUserAccount& id(const QString& id);
+
+  /**
+  * sets the user name
+  **/
+  APIUserAccount& name(const QString& name);
+
+  /**
+  * sets the acount type
+  */
+  APIUserAccount& type(APIUserAccountTypes type);
+
+  /**
+  * sets the current limits
+  */
+  APIUserAccount& limits(const APILimits& limits);
+
+
+  /**
+  * returns the number of remaining requests
+  */
+  int remainingRequests() const;
+
+  /**
+  * whether the number of remaining requests is low enough that further
+  * requests should be throttled
+  */
+  bool shouldThrottle() const;
+
+  /**
+  * true if all the remaining requests have been used and the API will refuse
+  * further requests
+  */
+  bool exhausted() const;
+
+private:
+  QString m_id, m_name;
+  APIUserAccountTypes m_type;
+  APILimits m_limits;
+  APIStats m_stats;
+};
+
+#endif // APIUSERACCOUNT_H

--- a/src/mainwindow.cpp
+++ b/src/mainwindow.cpp
@@ -227,13 +227,30 @@ MainWindow::MainWindow(QSettings &initSettings
   QWebEngineProfile::defaultProfile()->setPersistentStoragePath(m_OrganizerCore.settings().getCacheDirectory());
 
   ui->setupUi(this);
+  m_statusBar.reset(new StatusBar(statusBar(), ui));
 
   {
     auto* ni = NexusInterface::instance(&m_PluginContainer);
 
+    // there are two ways to get here:
+    //  1) the user just started MO, and
+    //  2) the user has changed some setting that required a restart
+    //
+    // "restarting" MO doesn't actually re-execute the binary, it just basically
+    // executes most of main() again, so a bunch of things are actually not
+    // reset
+    //
+    // one of these things is the api status, which will have fired its events
+    // long before the execution gets here because stuff is still cached and no
+    // real request to nexus is actually done
+    //
+    // therefore, when the user starts MO normally, the user account and stats
+    // will be empty (which is fine) and populated later on when the api key
+    // check has finished
+    //
+    // in the rare case where the user restarts MO through the settings, this
+    // will correctly pick up the previous values
     updateWindowTitle(ni->getAPIUserAccount());
-
-    m_statusBar.reset(new StatusBar(statusBar(), ui));
     m_statusBar->setAPI(ni->getAPIStats(), ni->getAPIUserAccount());
   }
 

--- a/src/mainwindow.cpp
+++ b/src/mainwindow.cpp
@@ -902,7 +902,7 @@ void MainWindow::updateProblemsButton()
 
   // updating the status bar, may be null very early when MO is starting
   if (m_statusBar) {
-    m_statusBar->setHasNotifications(numProblems > 0);
+    m_statusBar->updateNotifications(numProblems > 0);
   }
 }
 

--- a/src/mainwindow.cpp
+++ b/src/mainwindow.cpp
@@ -225,8 +225,17 @@ MainWindow::MainWindow(QSettings &initSettings
   QWebEngineProfile::defaultProfile()->setHttpCacheMaximumSize(52428800);
   QWebEngineProfile::defaultProfile()->setCachePath(m_OrganizerCore.settings().getCacheDirectory());
   QWebEngineProfile::defaultProfile()->setPersistentStoragePath(m_OrganizerCore.settings().getCacheDirectory());
+
   ui->setupUi(this);
-  updateWindowTitle({});
+
+  {
+    auto* ni = NexusInterface::instance(&m_PluginContainer);
+
+    updateWindowTitle(ni->getAPIUserAccount());
+
+    m_statusBar.reset(new StatusBar(statusBar(), ui));
+    m_statusBar->setAPI(ni->getAPIStats(), ni->getAPIUserAccount());
+  }
 
   languageChange(m_OrganizerCore.settings().language());
 
@@ -243,8 +252,6 @@ MainWindow::MainWindow(QSettings &initSettings
           ui->logList, SLOT(scrollToBottom()));
   connect(ui->logList->model(), SIGNAL(dataChanged(QModelIndex,QModelIndex)),
           ui->logList, SLOT(scrollToBottom()));
-
-  m_statusBar.reset(new StatusBar(statusBar(), ui));
 
   updateProblemsButton();
 

--- a/src/mainwindow.cpp
+++ b/src/mainwindow.cpp
@@ -727,6 +727,7 @@ void MainWindow::updatePinnedExecutables()
         iconForExecutable(iter->m_BinaryInfo.filePath()), iter->m_Title);
 
       exeAction->setObjectName(QString("custom__") + iter->m_Title);
+      exeAction->setStatusTip(iter->m_BinaryInfo.filePath());
 
       if (!connect(exeAction, SIGNAL(triggered()), this, SLOT(startExeAction()))) {
         qDebug("failed to connect trigger?");

--- a/src/mainwindow.cpp
+++ b/src/mainwindow.cpp
@@ -77,6 +77,7 @@ along with Mod Organizer.  If not, see <http://www.gnu.org/licenses/>.
 #include "nxmaccessmanager.h"
 #include "appconfig.h"
 #include "eventfilter.h"
+#include "statusbar.h"
 #include <utility.h>
 #include <dataarchives.h>
 #include <bsainvalidation.h>
@@ -242,13 +243,7 @@ MainWindow::MainWindow(QSettings &initSettings
   connect(ui->logList->model(), SIGNAL(dataChanged(QModelIndex,QModelIndex)),
           ui->logList, SLOT(scrollToBottom()));
 
-  m_RefreshProgress = new QProgressBar(statusBar());
-  m_RefreshProgress->setTextVisible(true);
-  m_RefreshProgress->setRange(0, 100);
-  m_RefreshProgress->setValue(0);
-  m_RefreshProgress->setVisible(false);
-  statusBar()->addWidget(m_RefreshProgress, 1000);
-  statusBar()->clearMessage();
+  m_statusBar.reset(new StatusBar(statusBar()));
 
   updateProblemsButton();
 
@@ -2534,15 +2529,8 @@ void MainWindow::setESPListSorting(int index)
 
 void MainWindow::refresher_progress(int percent)
 {
-  if (percent == 100) {
-    m_RefreshProgress->setVisible(false);
-    this->setEnabled(true);
-  } else if (!m_RefreshProgress->isVisible()) {
-    this->setEnabled(false);
-    m_RefreshProgress->setVisible(true);
-    m_RefreshProgress->setRange(0, 100);
-    m_RefreshProgress->setValue(percent);
-  }
+  setEnabled(percent == 100);
+  m_statusBar->setProgress(percent);
 }
 
 void MainWindow::directory_refreshed()

--- a/src/mainwindow.cpp
+++ b/src/mainwindow.cpp
@@ -934,6 +934,8 @@ void MainWindow::updateProblemsButton()
     final = original;
   }
 
+  ui->actionNotifications->setEnabled(numProblems > 0);
+
   // setting the icon on the action (shown on the menu)
   ui->actionNotifications->setIcon(final);
 

--- a/src/mainwindow.cpp
+++ b/src/mainwindow.cpp
@@ -243,7 +243,7 @@ MainWindow::MainWindow(QSettings &initSettings
   connect(ui->logList->model(), SIGNAL(dataChanged(QModelIndex,QModelIndex)),
           ui->logList, SLOT(scrollToBottom()));
 
-  m_statusBar.reset(new StatusBar(statusBar(), ui->actionNotifications));
+  m_statusBar.reset(new StatusBar(statusBar(), ui));
 
   updateProblemsButton();
 
@@ -571,7 +571,7 @@ void MainWindow::updateWindowTitle(const APIUserAccount& user)
 
 void MainWindow::onRequestsChanged(const APIStats& stats, const APIUserAccount& user)
 {
-  m_statusBar->updateAPI(stats, user);
+  m_statusBar->setAPI(stats, user);
 }
 
 
@@ -902,7 +902,7 @@ void MainWindow::updateProblemsButton()
 
   // updating the status bar, may be null very early when MO is starting
   if (m_statusBar) {
-    m_statusBar->updateNotifications(numProblems > 0);
+    m_statusBar->setNotifications(numProblems > 0);
   }
 }
 
@@ -5593,13 +5593,9 @@ void MainWindow::openDataOriginExplorer_clicked()
 
 void MainWindow::updateAvailable()
 {
-  for (QAction *action : ui->toolBar->actions()) {
-    if (action->text() == tr("Update")) {
-      action->setEnabled(true);
-      action->setToolTip(tr("Update available"));
-      break;
-    }
-  }
+  ui->actionUpdate->setEnabled(true);
+  ui->actionUpdate->setToolTip(tr("Update available"));
+  m_statusBar->setUpdateAvailable(true);
 }
 
 

--- a/src/mainwindow.cpp
+++ b/src/mainwindow.cpp
@@ -243,7 +243,7 @@ MainWindow::MainWindow(QSettings &initSettings
   connect(ui->logList->model(), SIGNAL(dataChanged(QModelIndex,QModelIndex)),
           ui->logList, SLOT(scrollToBottom()));
 
-  m_statusBar.reset(new StatusBar(statusBar()));
+  m_statusBar.reset(new StatusBar(statusBar(), ui->actionNotifications));
 
   updateProblemsButton();
 
@@ -898,6 +898,11 @@ void MainWindow::updateProblemsButton()
     if (auto* button=dynamic_cast<QAbstractButton*>(actionWidget)) {
       button->setIcon(final);
     }
+  }
+
+  // updating the status bar, may be null very early when MO is starting
+  if (m_statusBar) {
+    m_statusBar->setHasNotifications(numProblems > 0);
   }
 }
 

--- a/src/mainwindow.h
+++ b/src/mainwindow.h
@@ -326,8 +326,8 @@ private:
   bool m_WasVisible;
 
   // this has to be remembered because by the time storeSettings() is called,
-  // the window is closed and the menubar is hidden
-  bool m_menuBarVisible;
+  // the window is closed and the all bars are hidden
+  bool m_menuBarVisible, m_statusBarVisible;
 
   std::unique_ptr<StatusBar> m_statusBar;
 
@@ -651,6 +651,7 @@ private slots: // ui slots
   void on_actionExit_triggered();
   void on_actionMainMenuToggle_triggered();
   void on_actionToolBarMainToggle_triggered();
+  void on_actionStatusBarToggle_triggered();
   void on_actionToolBarSmallIcons_triggered();
   void on_actionToolBarMediumIcons_triggered();
   void on_actionToolBarLargeIcons_triggered();
@@ -694,6 +695,9 @@ private slots: // ui slots
   void on_categoriesAndBtn_toggled(bool checked);
   void on_categoriesOrBtn_toggled(bool checked);
   void on_managedArchiveLabel_linkHovered(const QString &link);
+
+  void showMenuBar(bool b);
+  void showStatusBar(bool b);
 };
 
 

--- a/src/mainwindow.h
+++ b/src/mainwindow.h
@@ -416,8 +416,7 @@ private:
 
 private slots:
 
-  void updateWindowTitle(const QString &accountName, int, bool premium);
-
+  void updateWindowTitle(const APIUserAccount& user);
   void showMessage(const QString &message);
   void showError(const QString &message);
 
@@ -544,7 +543,7 @@ private slots:
   void nxmDownloadURLs(QString, int modID, int fileID, QVariant userData, QVariant resultData, int requestID);
   void nxmRequestFailed(QString gameName, int modID, int fileID, QVariant userData, int requestID, QNetworkReply::NetworkError error, const QString &errorString);
 
-  void updateAPICounter(int queueCount, std::tuple<int, int, int, int> limits);
+  void onRequestsChanged(const APIStats& stats, const APIUserAccount& user);
 
   void editCategories();
   void deselectFilters();

--- a/src/mainwindow.h
+++ b/src/mainwindow.h
@@ -37,6 +37,7 @@ struct Executable;
 class CategoryFactory;
 class LockedDialogBase;
 class OrganizerCore;
+class StatusBar;
 #include "plugincontainer.h" //class PluginContainer;
 class PluginListSortProxy;
 namespace BSA { class Archive; }
@@ -75,7 +76,6 @@ class QListWidgetItem;
 class QMenu;
 class QModelIndex;
 class QPoint;
-class QProgressBar;
 class QProgressDialog;
 class QTranslator;
 class QTreeWidgetItem;
@@ -329,6 +329,8 @@ private:
   // the window is closed and the menubar is hidden
   bool m_menuBarVisible;
 
+  std::unique_ptr<StatusBar> m_statusBar;
+
   // last separator on the toolbar, used to add spacer for right-alignment and
   // as an insert point for executables
   QAction* m_linksSeparator;
@@ -338,7 +340,6 @@ private:
   int m_OldProfileIndex;
 
   std::vector<QString> m_ModNameList; // the mod-list to go with the directory structure
-  QProgressBar *m_RefreshProgress;
   bool m_Refreshing;
 
   QStringList m_DefaultArchives;

--- a/src/mainwindow.ui
+++ b/src/mainwindow.ui
@@ -412,7 +412,7 @@ p, li { white-space: pre-wrap; }
              </widget>
             </item>
             <item>
-             <layout class="QHBoxLayout" name="horizontalLayout_4" stretch="0,0,1,1,0,0,1,1,1">
+             <layout class="QHBoxLayout" name="horizontalLayout_4" stretch="0,0,1,1,0,1,1">
               <item>
                <widget class="QPushButton" name="displayCategoriesBtn">
                 <property name="maximumSize">
@@ -471,37 +471,6 @@ p, li { white-space: pre-wrap; }
                 </property>
                </spacer>
               </item>
-              <item>
-               <widget class="QLabel" name="apiRequests">
-                <property name="toolTip">
-                 <string>Nexus API Queued and Remaining Requests</string>
-                </property>
-                <property name="whatsThis">
-                 <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;This tracks the number of queued Nexus API requests on the left (&lt;span style=&quot; font-weight:600;&quot;&gt;Q&lt;/span&gt;) and the remaining daily (&lt;span style=&quot; font-weight:600;&quot;&gt;D&lt;/span&gt;) and hourly (&lt;span style=&quot; font-weight:600;&quot;&gt;H&lt;/span&gt;) requests on the right. The Nexus API limits you to a pool of requests per day and requests per hour. It is dynamically updated every time a request is completed. If you run out of requests, you will be unable to queue downloads, check updates, parse mod info, or even log in. Both pools must be consumed before this happens.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
-                </property>
-                <property name="frameShape">
-                 <enum>QFrame::StyledPanel</enum>
-                </property>
-                <property name="frameShadow">
-                 <enum>QFrame::Sunken</enum>
-                </property>
-                <property name="lineWidth">
-                 <number>2</number>
-                </property>
-                <property name="midLineWidth">
-                 <number>1</number>
-                </property>
-                <property name="text">
-                 <string>API: Q: 0 | D: 0 | H: 0</string>
-                </property>
-                <property name="alignment">
-                 <set>Qt::AlignCenter</set>
-                </property>
-                <property name="margin">
-                 <number>2</number>
-                </property>
-               </widget>
-              </item>
               <item alignment="Qt::AlignLeft">
                <widget class="QPushButton" name="clearFiltersButton">
                 <property name="sizePolicy">
@@ -545,19 +514,6 @@ p, li { white-space: pre-wrap; }
                  </size>
                 </property>
                </widget>
-              </item>
-              <item>
-               <spacer name="horizontalSpacer_4">
-                <property name="orientation">
-                 <enum>Qt::Horizontal</enum>
-                </property>
-                <property name="sizeHint" stdset="0">
-                 <size>
-                  <width>40</width>
-                  <height>20</height>
-                 </size>
-                </property>
-               </spacer>
               </item>
               <item>
                <widget class="QComboBox" name="groupCombo">

--- a/src/mainwindow.ui
+++ b/src/mainwindow.ui
@@ -1397,6 +1397,7 @@ p, li { white-space: pre-wrap; }
      </property>
      <addaction name="actionMainMenuToggle"/>
      <addaction name="actionToolBarMainToggle"/>
+     <addaction name="actionStatusBarToggle"/>
      <addaction name="separator"/>
      <addaction name="actionToolBarSmallIcons"/>
      <addaction name="actionToolBarMediumIcons"/>
@@ -1730,6 +1731,14 @@ p, li { white-space: pre-wrap; }
    </property>
    <property name="text">
     <string>&amp;Menu</string>
+   </property>
+  </action>
+  <action name="actionStatusBarToggle">
+   <property name="checkable">
+    <bool>true</bool>
+   </property>
+   <property name="text">
+    <string>St&amp;atus bar</string>
    </property>
   </action>
  </widget>

--- a/src/nexusinterface.cpp
+++ b/src/nexusinterface.cpp
@@ -38,6 +38,82 @@ using namespace MOBase;
 using namespace MOShared;
 
 
+void throttledWarning(const APIUserAccount& user)
+{
+  qCritical() <<
+    QString(
+      "You have fewer than %1 requests remaining (%2). Only downloads and "
+      "login validation are being allowed.")
+    .arg(APIUserAccount::ThrottleThreshold)
+    .arg(user.remainingRequests());
+}
+
+
+APIUserAccount::APIUserAccount()
+  : m_type(APIUserAccountTypes::None)
+{
+}
+
+const QString& APIUserAccount::id() const
+{
+  return m_id;
+}
+
+const QString& APIUserAccount::name() const
+{
+  return m_name;
+}
+
+APIUserAccountTypes APIUserAccount::type() const
+{
+  return m_type;
+}
+
+const APILimits& APIUserAccount::limits() const
+{
+  return m_limits;
+}
+
+APIUserAccount& APIUserAccount::id(const QString& id)
+{
+  m_id = id;
+  return *this;
+}
+
+APIUserAccount& APIUserAccount::name(const QString& name)
+{
+  m_name = name;
+  return *this;
+}
+
+APIUserAccount& APIUserAccount::type(APIUserAccountTypes type)
+{
+  m_type = type;
+  return *this;
+}
+
+APIUserAccount& APIUserAccount::limits(const APILimits& limits)
+{
+  m_limits = limits;
+  return *this;
+}
+
+int APIUserAccount::remainingRequests() const
+{
+  return m_limits.remainingDailyRequests + m_limits.remainingHourlyRequests;
+}
+
+bool APIUserAccount::shouldThrottle() const
+{
+  return (remainingRequests() < ThrottleThreshold);
+}
+
+bool APIUserAccount::exhausted() const
+{
+  return (remainingRequests() <= 0);
+}
+
+
 NexusBridge::NexusBridge(PluginContainer *pluginContainer, const QString &subModule)
   : m_Interface(NexusInterface::instance(pluginContainer))
   , m_SubModule(subModule)
@@ -179,15 +255,39 @@ void NexusBridge::nxmRequestFailed(QString gameName, int modID, int fileID, QVar
 QAtomicInt NexusInterface::NXMRequestInfo::s_NextID(0);
 
 
+APILimits NexusInterface::defaultAPILimits()
+{
+  // https://app.swaggerhub.com/apis-docs/NexusMods/nexus-mods_public_api_params_in_form_data/1.0#/
+  const int MaxDaily = 2500;
+  const int MaxHourly = 100;
+
+  APILimits limits;
+
+  limits.maxDailyRequests = MaxDaily;
+  limits.remainingDailyRequests = MaxDaily;
+  limits.maxHourlyRequests = MaxHourly;
+  limits.remainingHourlyRequests = MaxHourly;
+
+  return limits;
+}
+
+APILimits NexusInterface::parseLimits(const QNetworkReply* reply)
+{
+  APILimits limits;
+
+  limits.maxDailyRequests = reply->rawHeader("x-rl-daily-limit").toInt();
+  limits.remainingDailyRequests = reply->rawHeader("x-rl-daily-remaining").toInt();
+  limits.maxHourlyRequests = reply->rawHeader("x-rl-hourly-limit").toInt();
+  limits.remainingHourlyRequests = reply->rawHeader("x-rl-hourly-remaining").toInt();
+
+  return limits;
+}
+
+
 NexusInterface::NexusInterface(PluginContainer *pluginContainer)
   : m_PluginContainer(pluginContainer)
-  , m_RemainingDailyRequests(2500)
-  , m_RemainingHourlyRequests(100)
-  , m_MaxDailyRequests(2500)
-  , m_MaxHourlyRequests(100)
-  , m_IsPremium(false)
-  , m_UserID(0)
 {
+  m_User.limits(defaultAPILimits());
   m_MOVersion = createVersionInfo();
 
   m_AccessManager = new NXMAccessManager(this, m_MOVersion.displayString(3));
@@ -222,15 +322,10 @@ void NexusInterface::loginCompleted()
   nextRequest();
 }
 
-void NexusInterface::setRateMax(const QString&, int userId, bool isPremium, std::tuple<int, int, int, int> limits)
+void NexusInterface::setUserAccount(const APIUserAccount& user)
 {
-  m_RemainingDailyRequests = std::get<0>(limits);
-  m_MaxDailyRequests = std::get<1>(limits);
-  m_RemainingHourlyRequests = std::get<2>(limits);
-  m_MaxHourlyRequests = std::get<3>(limits);
-  m_IsPremium = isPremium;
-  m_UserID = userId;
-  emit requestsChanged(m_RequestQueue.size(), limits);
+  m_User = user;
+  emit requestsChanged(stats(), m_User);
 }
 
 void NexusInterface::interpretNexusFileName(const QString &fileName, QString &modName, int &modID, bool query)
@@ -369,70 +464,70 @@ int NexusInterface::requestDescription(QString gameName, int modID, QObject *rec
 int NexusInterface::requestModInfo(QString gameName, int modID, QObject *receiver, QVariant userData,
   const QString &subModule, MOBase::IPluginGame const *game)
 {
-  if (std::max(m_RemainingDailyRequests, m_RemainingHourlyRequests) >= 200) {
-    NXMRequestInfo requestInfo(modID, NXMRequestInfo::TYPE_MODINFO, userData, subModule, game);
-    m_RequestQueue.enqueue(requestInfo);
-
-    connect(this, SIGNAL(nxmModInfoAvailable(QString, int, QVariant, QVariant, int)),
-      receiver, SLOT(nxmModInfoAvailable(QString, int, QVariant, QVariant, int)), Qt::UniqueConnection);
-
-    connect(this, SIGNAL(nxmRequestFailed(QString, int, int, QVariant, int, QNetworkReply::NetworkError, QString)),
-      receiver, SLOT(nxmRequestFailed(QString, int, int, QVariant, int, QNetworkReply::NetworkError, QString)), Qt::UniqueConnection);
-
-    nextRequest();
-    return requestInfo.m_ID;
+  if (m_User.shouldThrottle()) {
+    throttledWarning(m_User);
+    return -1;
   }
-  qCritical() << QString("You have fewer than 200 requests remaining (%1). Only downloads and login validation are being allowed.")
-    .arg(std::max(m_RemainingDailyRequests, m_RemainingHourlyRequests));
-  return -1;
+
+  NXMRequestInfo requestInfo(modID, NXMRequestInfo::TYPE_MODINFO, userData, subModule, game);
+  m_RequestQueue.enqueue(requestInfo);
+
+  connect(this, SIGNAL(nxmModInfoAvailable(QString, int, QVariant, QVariant, int)),
+    receiver, SLOT(nxmModInfoAvailable(QString, int, QVariant, QVariant, int)), Qt::UniqueConnection);
+
+  connect(this, SIGNAL(nxmRequestFailed(QString, int, int, QVariant, int, QNetworkReply::NetworkError, QString)),
+    receiver, SLOT(nxmRequestFailed(QString, int, int, QVariant, int, QNetworkReply::NetworkError, QString)), Qt::UniqueConnection);
+
+  nextRequest();
+  return requestInfo.m_ID;
 }
 
 int NexusInterface::requestUpdateInfo(QString gameName, NexusInterface::UpdatePeriod period, QObject *receiver, QVariant userData,
   const QString &subModule, const MOBase::IPluginGame *game)
 {
-  if (std::max(m_RemainingDailyRequests, m_RemainingHourlyRequests) >= 200) {
-    NXMRequestInfo requestInfo(period, NXMRequestInfo::TYPE_CHECKUPDATES, userData, subModule, game);
-    m_RequestQueue.enqueue(requestInfo);
-
-    connect(this, SIGNAL(nxmUpdateInfoAvailable(QString, QVariant, QVariant, int)),
-      receiver, SLOT(nxmUpdateInfoAvailable(QString, QVariant, QVariant, int)), Qt::UniqueConnection);
-
-    connect(this, SIGNAL(nxmRequestFailed(QString, int, int, QVariant, int, QNetworkReply::NetworkError, QString)),
-      receiver, SLOT(nxmRequestFailed(QString, int, int, QVariant, int, QNetworkReply::NetworkError, QString)), Qt::UniqueConnection);
-
-    nextRequest();
-    return requestInfo.m_ID;
+  if (m_User.shouldThrottle()) {
+    throttledWarning(m_User);
+    return -1;
   }
-  qCritical() << QString("You have fewer than 200 requests remaining (%1). Only downloads and login validation are being allowed.")
-    .arg(std::max(m_RemainingDailyRequests, m_RemainingHourlyRequests));
-  return -1;
+
+  NXMRequestInfo requestInfo(period, NXMRequestInfo::TYPE_CHECKUPDATES, userData, subModule, game);
+  m_RequestQueue.enqueue(requestInfo);
+
+  connect(this, SIGNAL(nxmUpdateInfoAvailable(QString, QVariant, QVariant, int)),
+    receiver, SLOT(nxmUpdateInfoAvailable(QString, QVariant, QVariant, int)), Qt::UniqueConnection);
+
+  connect(this, SIGNAL(nxmRequestFailed(QString, int, int, QVariant, int, QNetworkReply::NetworkError, QString)),
+    receiver, SLOT(nxmRequestFailed(QString, int, int, QVariant, int, QNetworkReply::NetworkError, QString)), Qt::UniqueConnection);
+
+  nextRequest();
+  return requestInfo.m_ID;
 }
 
 int NexusInterface::requestUpdates(const int &modID, QObject *receiver, QVariant userData,
                                    QString gameName, const QString &subModule)
 {
-  if (std::max(m_RemainingDailyRequests, m_RemainingHourlyRequests) >= 200) {
-    IPluginGame *game = getGame(gameName);
-    if (game == nullptr) {
-      qCritical("requestUpdates can't find plugin for %s", qUtf8Printable(gameName));
-      return -1;
-    }
-
-    NXMRequestInfo requestInfo(modID, NXMRequestInfo::TYPE_GETUPDATES, userData, subModule, game);
-    m_RequestQueue.enqueue(requestInfo);
-
-    connect(this, SIGNAL(nxmUpdatesAvailable(QString, int, QVariant, QVariant, int)),
-      receiver, SLOT(nxmUpdatesAvailable(QString, int, QVariant, QVariant, int)), Qt::UniqueConnection);
-
-    connect(this, SIGNAL(nxmRequestFailed(QString, int, int, QVariant, int, QNetworkReply::NetworkError, QString)),
-      receiver, SLOT(nxmRequestFailed(QString, int, int, QVariant, int, QNetworkReply::NetworkError, QString)), Qt::UniqueConnection);
-
-    nextRequest();
-    return requestInfo.m_ID;
+  if (m_User.shouldThrottle()) {
+    throttledWarning(m_User);
+    return -1;
   }
-  qCritical() << QString("You have fewer than 200 requests remaining (%1). Only downloads and login validation are being allowed.")
-    .arg(std::max(m_RemainingDailyRequests, m_RemainingHourlyRequests));
-  return -1;
+
+  IPluginGame *game = getGame(gameName);
+  if (game == nullptr) {
+    qCritical("requestUpdates can't find plugin for %s", qUtf8Printable(gameName));
+    return -1;
+  }
+
+  NXMRequestInfo requestInfo(modID, NXMRequestInfo::TYPE_GETUPDATES, userData, subModule, game);
+  m_RequestQueue.enqueue(requestInfo);
+
+  connect(this, SIGNAL(nxmUpdatesAvailable(QString, int, QVariant, QVariant, int)),
+    receiver, SLOT(nxmUpdatesAvailable(QString, int, QVariant, QVariant, int)), Qt::UniqueConnection);
+
+  connect(this, SIGNAL(nxmRequestFailed(QString, int, int, QVariant, int, QNetworkReply::NetworkError, QString)),
+    receiver, SLOT(nxmRequestFailed(QString, int, int, QVariant, int, QNetworkReply::NetworkError, QString)), Qt::UniqueConnection);
+
+  nextRequest();
+  return requestInfo.m_ID;
 }
 
 
@@ -527,23 +622,23 @@ int NexusInterface::requestEndorsementInfo(QObject *receiver, QVariant userData,
 int NexusInterface::requestToggleEndorsement(QString gameName, int modID, QString modVersion, bool endorse, QObject *receiver, QVariant userData,
                                              const QString &subModule, MOBase::IPluginGame const *game)
 {
-  if (std::max(m_RemainingDailyRequests, m_RemainingHourlyRequests) >= 200) {
-    NXMRequestInfo requestInfo(modID, modVersion, NXMRequestInfo::TYPE_TOGGLEENDORSEMENT, userData, subModule, game);
-    requestInfo.m_Endorse = endorse;
-    m_RequestQueue.enqueue(requestInfo);
-
-    connect(this, SIGNAL(nxmEndorsementToggled(QString, int, QVariant, QVariant, int)),
-      receiver, SLOT(nxmEndorsementToggled(QString, int, QVariant, QVariant, int)), Qt::UniqueConnection);
-
-    connect(this, SIGNAL(nxmRequestFailed(QString, int, int, QVariant, int, QNetworkReply::NetworkError, QString)),
-      receiver, SLOT(nxmRequestFailed(QString, int, int, QVariant, int, QNetworkReply::NetworkError, QString)), Qt::UniqueConnection);
-
-    nextRequest();
-    return requestInfo.m_ID;
+  if (m_User.shouldThrottle()) {
+    throttledWarning(m_User);
+    return -1;
   }
-  qCritical() << QString("You have fewer than 200 requests remaining (%1). Only downloads and login validation are being allowed.")
-    .arg(std::max(m_RemainingDailyRequests, m_RemainingHourlyRequests));
-  return -1;
+
+  NXMRequestInfo requestInfo(modID, modVersion, NXMRequestInfo::TYPE_TOGGLEENDORSEMENT, userData, subModule, game);
+  requestInfo.m_Endorse = endorse;
+  m_RequestQueue.enqueue(requestInfo);
+
+  connect(this, SIGNAL(nxmEndorsementToggled(QString, int, QVariant, QVariant, int)),
+    receiver, SLOT(nxmEndorsementToggled(QString, int, QVariant, QVariant, int)), Qt::UniqueConnection);
+
+  connect(this, SIGNAL(nxmRequestFailed(QString, int, int, QVariant, int, QNetworkReply::NetworkError, QString)),
+    receiver, SLOT(nxmRequestFailed(QString, int, int, QVariant, int, QNetworkReply::NetworkError, QString)), Qt::UniqueConnection);
+
+  nextRequest();
+  return requestInfo.m_ID;
 }
 
 int NexusInterface::requestTrackingInfo(QObject *receiver, QVariant userData, const QString &subModule)
@@ -564,23 +659,23 @@ int NexusInterface::requestTrackingInfo(QObject *receiver, QVariant userData, co
 int NexusInterface::requestToggleTracking(QString gameName, int modID, bool track, QObject *receiver, QVariant userData,
                                           const QString &subModule, MOBase::IPluginGame const *game)
 {
-  if (std::max(m_RemainingDailyRequests, m_RemainingHourlyRequests) >= 200) {
-    NXMRequestInfo requestInfo(modID, NXMRequestInfo::TYPE_TOGGLETRACKING, userData, subModule, game);
-    requestInfo.m_Track = track;
-    m_RequestQueue.enqueue(requestInfo);
-
-    connect(this, SIGNAL(nxmTrackingToggled(QString, int, QVariant, bool, int)),
-      receiver, SLOT(nxmTrackingToggled(QString, int, QVariant, bool, int)), Qt::UniqueConnection);
-
-    connect(this, SIGNAL(nxmRequestFailed(QString, int, int, QVariant, int, QNetworkReply::NetworkError, QString)),
-      receiver, SLOT(nxmRequestFailed(QString, int, int, QVariant, int, QNetworkReply::NetworkError, QString)), Qt::UniqueConnection);
-
-    nextRequest();
-    return requestInfo.m_ID;
+  if (m_User.shouldThrottle()) {
+    throttledWarning(m_User);
+    return -1;
   }
-  qCritical() << QString("You have fewer than 200 requests remaining (%1). Only downloads and login validation are being allowed.")
-    .arg(std::max(m_RemainingDailyRequests, m_RemainingHourlyRequests));
-  return -1;
+
+  NXMRequestInfo requestInfo(modID, NXMRequestInfo::TYPE_TOGGLETRACKING, userData, subModule, game);
+  requestInfo.m_Track = track;
+  m_RequestQueue.enqueue(requestInfo);
+
+  connect(this, SIGNAL(nxmTrackingToggled(QString, int, QVariant, bool, int)),
+    receiver, SLOT(nxmTrackingToggled(QString, int, QVariant, bool, int)), Qt::UniqueConnection);
+
+  connect(this, SIGNAL(nxmRequestFailed(QString, int, int, QVariant, int, QNetworkReply::NetworkError, QString)),
+    receiver, SLOT(nxmRequestFailed(QString, int, int, QVariant, int, QNetworkReply::NetworkError, QString)), Qt::UniqueConnection);
+
+  nextRequest();
+  return requestInfo.m_ID;
 }
 
 int NexusInterface::requestInfoFromMd5(QString gameName, QByteArray &hash, QObject *receiver, QVariant userData,
@@ -645,7 +740,7 @@ void NexusInterface::nextRequest()
     }
   }
 
-  if (std::max(m_RemainingDailyRequests, m_RemainingHourlyRequests) <= 0) {
+  if (m_User.exhausted()) {
     m_RequestQueue.clear();
     QTime time = QTime::currentTime();
     QTime targetTime;
@@ -696,9 +791,9 @@ void NexusInterface::nextRequest()
       } break;
       case NXMRequestInfo::TYPE_DOWNLOADURL: {
         ModRepositoryFileInfo *fileInfo = qobject_cast<ModRepositoryFileInfo*>(qvariant_cast<QObject*>(info.m_UserData));
-        if (m_IsPremium) {
+        if (m_User.type() == APIUserAccountTypes::Premium) {
           url = QString("%1/games/%2/mods/%3/files/%4/download_link").arg(info.m_URL).arg(info.m_GameName).arg(info.m_ModID).arg(info.m_FileID);
-        } else if (!fileInfo->nexusKey.isEmpty() && fileInfo->nexusExpires && fileInfo->nexusDownloadUser == m_UserID) {
+        } else if (!fileInfo->nexusKey.isEmpty() && fileInfo->nexusExpires && fileInfo->nexusDownloadUser == m_User.id().toInt()) {
           url = QString("%1/games/%2/mods/%3/files/%4/download_link?key=%5&expires=%6")
           .arg(info.m_URL).arg(info.m_GameName).arg(info.m_ModID).arg(info.m_FileID).arg(fileInfo->nexusKey).arg(fileInfo->nexusExpires);
         } else {
@@ -780,23 +875,16 @@ void NexusInterface::requestFinished(std::list<NXMRequestInfo>::iterator iter)
     if (iter->m_AllowedErrors.contains(error) && iter->m_AllowedErrors[error].contains(statusCode)) {
       // These errors are allows to silently happen.  They should be handled in nxmRequestFailed below.
     } else if (statusCode == 429) {
-      m_RemainingDailyRequests = reply->rawHeader("x-rl-daily-remaining").toInt();
-      m_MaxDailyRequests = reply->rawHeader("x-rl-daily-limit").toInt();
-      m_RemainingHourlyRequests = reply->rawHeader("x-rl-hourly-remaining").toInt();
-      m_MaxHourlyRequests = reply->rawHeader("x-rl-hourly-limit").toInt();
+      m_User.limits(parseLimits(reply));
 
-      if (m_RemainingDailyRequests || m_RemainingHourlyRequests)
+      if (!m_User.exhausted()) {
         qWarning("You appear to be making requests to the Nexus API too quickly and are being throttled. Please inform the MO2 team.");
-      else
+      }
+      else {
         qWarning("All API requests have been consumed and are now being denied.");
+      }
 
-      emit requestsChanged(m_RequestQueue.size(), std::tuple<int, int, int, int>(std::make_tuple(
-        m_RemainingDailyRequests,
-        m_MaxDailyRequests,
-        m_RemainingHourlyRequests,
-        m_MaxHourlyRequests
-      )));
-
+      emit requestsChanged(stats(), m_User);
       qWarning("Error: %s", reply->errorString().toUtf8().constData());
     } else {
       qWarning("request failed: %s", reply->errorString().toUtf8().constData());
@@ -871,17 +959,8 @@ void NexusInterface::requestFinished(std::list<NXMRequestInfo>::iterator iter)
           } break;
         }
 
-        m_RemainingDailyRequests = reply->rawHeader("x-rl-daily-remaining").toInt();
-        m_MaxDailyRequests = reply->rawHeader("x-rl-daily-limit").toInt();
-        m_RemainingHourlyRequests = reply->rawHeader("x-rl-hourly-remaining").toInt();
-        m_MaxHourlyRequests = reply->rawHeader("x-rl-hourly-limit").toInt();
-
-        emit requestsChanged(m_RequestQueue.size(), std::tuple<int, int, int, int>(std::make_tuple(
-          m_RemainingDailyRequests,
-          m_MaxDailyRequests,
-          m_RemainingHourlyRequests,
-          m_MaxHourlyRequests
-        )));
+        m_User.limits(parseLimits(reply));
+        emit requestsChanged(stats(), m_User);
       } else {
         emit nxmRequestFailed(iter->m_GameName, iter->m_ModID, iter->m_FileID, iter->m_UserData, iter->m_ID, reply->error(), tr("invalid response"));
       }
@@ -937,6 +1016,15 @@ void NexusInterface::requestTimeout()
     }
   }
 }
+
+APIStats NexusInterface::stats() const
+{
+  APIStats stats;
+  stats.requestsQueued = m_RequestQueue.size();
+
+  return stats;
+}
+
 
 namespace {
   QString get_management_url()

--- a/src/nexusinterface.h
+++ b/src/nexusinterface.h
@@ -20,6 +20,8 @@ along with Mod Organizer.  If not, see <http://www.gnu.org/licenses/>.
 #ifndef NEXUSINTERFACE_H
 #define NEXUSINTERFACE_H
 
+#include "apiuseraccount.h"
+
 #include <utility.h>
 #include <versioninfo.h>
 #include <imodrepositorybridge.h>
@@ -38,130 +40,6 @@ namespace MOBase { class IPluginGame; }
 
 class NexusInterface;
 class NXMAccessManager;
-
-
-/**
- * represents user account types on a mod provider website such as nexus
- */
-enum class APIUserAccountTypes
-{
-  // not logged in
-  None = 0,
-
-  // regular account
-  Regular,
-
-  // premium account
-  Premium
-};
-
-
-/**
- * current limits imposed on the user account
- **/
-struct APILimits
-{
-  // maximum number of requests per day
-  int maxDailyRequests = 0;
-
-  // remaining number of requests today
-  int remainingDailyRequests = 0;
-
-  // maximum number of requests per hour
-  int maxHourlyRequests = 0;
-
-  // remaining number of requests this hour
-  int remainingHourlyRequests = 0;
-};
-
-
-/**
- * API statistics
- */
-struct APIStats
-{
-  // number of API requests currently queued
-  int requestsQueued = 0;
-};
-
-
-/**
- * represents a user account on the mod provier website
- */
-class APIUserAccount
-{
-public:
-  // when the number of remanining requests is under this number, further
-  // requests will be throttled by avoiding non-critical ones
-  static const int ThrottleThreshold = 300;
-
-  APIUserAccount();
-
-  /**
-   * user id
-   */
-  const QString& id() const;
-
-  /**
-   * user name
-   */
-  const QString& name() const;
-
-  /**
-   * account type
-   */
-  APIUserAccountTypes type() const;
-
-  /**
-   * current API limits
-   */
-  const APILimits& limits() const;
-
-
-  /**
-   * sets the user id
-   */
-  APIUserAccount& id(const QString& id);
-
-  /**
-   * sets the user name
-   **/
-  APIUserAccount& name(const QString& name);
-
-  /**
-   * sets the acount type
-   */
-  APIUserAccount& type(APIUserAccountTypes type);
-
-  /**
-   * sets the current limits
-   */
-  APIUserAccount& limits(const APILimits& limits);
-
-
-  /**
-   * returns the number of remaining requests
-   */
-  int remainingRequests() const;
-
-  /**
-   * whether the number of remaining requests is low enough that further
-   * requests should be throttled
-   */
-  bool shouldThrottle() const;
-
-  /**
-   * true if all the remaining requests have been used and the API will refuse
-   * further requests
-   */
-  bool exhausted() const;
-
-private:
-  QString m_id, m_name;
-  APIUserAccountTypes m_type;
-  APILimits m_limits;
-  APIStats m_stats;
-};
 
 
 /**
@@ -521,6 +399,9 @@ public:
 
   std::vector<std::pair<QString, QString>> getGameChoices(const MOBase::IPluginGame *game);
 
+  APIUserAccount getAPIUserAccount() const;
+  APIStats getAPIStats() const;
+
 public:
 
   /**
@@ -667,8 +548,6 @@ private:
   MOBase::VersionInfo m_MOVersion;
   PluginContainer *m_PluginContainer;
   APIUserAccount m_User;
-
-  APIStats stats() const;
 };
 
 #endif // NEXUSINTERFACE_H

--- a/src/nxmaccessmanager.cpp
+++ b/src/nxmaccessmanager.cpp
@@ -18,8 +18,8 @@ along with Mod Organizer.  If not, see <http://www.gnu.org/licenses/>.
 */
 
 #include "nxmaccessmanager.h"
-
 #include "iplugingame.h"
+#include "nexusinterface.h"
 #include "nxmurl.h"
 #include "report.h"
 #include "utility.h"
@@ -280,14 +280,11 @@ void NXMAccessManager::validateFinished()
         QString name = credentialsData.value("name").toString();
         bool premium = credentialsData.value("is_premium").toBool();
 
-        std::tuple<int, int, int, int> limits(std::make_tuple(
-          m_ValidateReply->rawHeader("x-rl-daily-remaining").toInt(),
-          m_ValidateReply->rawHeader("x-rl-daily-limit").toInt(),
-          m_ValidateReply->rawHeader("x-rl-hourly-remaining").toInt(),
-          m_ValidateReply->rawHeader("x-rl-hourly-limit").toInt()
-        ));
-
-        emit credentialsReceived(name, id, premium, limits);
+        emit credentialsReceived(APIUserAccount()
+          .id(QString("%1").arg(id))
+          .name(name)
+          .type(premium ? APIUserAccountTypes::Premium : APIUserAccountTypes::Regular)
+          .limits(NexusInterface::parseLimits(m_ValidateReply)));
 
         m_ValidateReply->deleteLater();
         m_ValidateReply = nullptr;

--- a/src/nxmaccessmanager.h
+++ b/src/nxmaccessmanager.h
@@ -20,7 +20,6 @@ along with Mod Organizer.  If not, see <http://www.gnu.org/licenses/>.
 #ifndef NXMACCESSMANAGER_H
 #define NXMACCESSMANAGER_H
 
-
 #include <QNetworkAccessManager>
 #include <QTimer>
 #include <QNetworkReply>
@@ -28,6 +27,8 @@ along with Mod Organizer.  If not, see <http://www.gnu.org/licenses/>.
 #include <set>
 
 namespace MOBase { class IPluginGame; }
+
+class APIUserAccount;
 
 /**
  * @brief access manager extended to handle nxm links
@@ -78,7 +79,7 @@ signals:
 
   void validateFailed(const QString &message);
 
-  void credentialsReceived(const QString &userName, int userId, bool premium, std::tuple<int, int, int, int> limits);
+  void credentialsReceived(const APIUserAccount& user);
 
 private slots:
 

--- a/src/nxmaccessmanager.h
+++ b/src/nxmaccessmanager.h
@@ -20,6 +20,7 @@ along with Mod Organizer.  If not, see <http://www.gnu.org/licenses/>.
 #ifndef NXMACCESSMANAGER_H
 #define NXMACCESSMANAGER_H
 
+#include "apiuseraccount.h"
 #include <QNetworkAccessManager>
 #include <QTimer>
 #include <QNetworkReply>
@@ -27,8 +28,6 @@ along with Mod Organizer.  If not, see <http://www.gnu.org/licenses/>.
 #include <set>
 
 namespace MOBase { class IPluginGame; }
-
-class APIUserAccount;
 
 /**
  * @brief access manager extended to handle nxm links
@@ -56,6 +55,7 @@ public:
   QString userAgent(const QString &subModule = QString()) const;
 
   QString apiKey() const;
+  void clearApiKey();
 
   void startValidationCheck();
 
@@ -94,7 +94,6 @@ protected:
       QIODevice *device);
 
 private:
-
   QTimer m_ValidateTimeout;
   QNetworkReply *m_ValidateReply;
   QProgressDialog *m_ProgressDialog { nullptr };
@@ -103,7 +102,6 @@ private:
 
   QString m_ApiKey;
 
-  bool m_ValidateAttempted;
   enum {
     VALIDATE_NOT_CHECKED,
     VALIDATE_CHECKING,
@@ -112,7 +110,6 @@ private:
     VALIDATE_REFUSED,
     VALIDATE_VALID
   } m_ValidateState = VALIDATE_NOT_CHECKED;
-
 };
 
 #endif // NXMACCESSMANAGER_H

--- a/src/settingsdialog.cpp
+++ b/src/settingsdialog.cpp
@@ -511,6 +511,9 @@ bool SettingsDialog::clearKey()
   m_KeyCleared = true;
   const auto ret = m_settings->clearNexusApiKey();
   updateNexusButtons();
+
+  NexusInterface::instance(m_PluginContainer)->getAccessManager()->clearApiKey();
+
   return ret;
 }
 
@@ -522,8 +525,7 @@ void SettingsDialog::testApiKey()
     return;
   }
 
-  auto* am = NexusInterface::instance(m_PluginContainer)->getAccessManager();
-  am->apiCheck(key, true);
+  NexusInterface::instance(m_PluginContainer)->getAccessManager()->apiCheck(key, true);
 }
 
 void SettingsDialog::updateNexusButtons()

--- a/src/statusbar.cpp
+++ b/src/statusbar.cpp
@@ -2,14 +2,16 @@
 #include "nexusinterface.h"
 #include "settings.h"
 
-StatusBar::StatusBar(QStatusBar* bar)
-  : m_bar(bar), m_api(new QLabel), m_progress(new QProgressBar)
+StatusBar::StatusBar(QStatusBar* bar) :
+  m_bar(bar), m_notifications(new QLabel), m_progress(new QProgressBar),
+  m_api(new QLabel)
 {
+  m_bar->addPermanentWidget(m_notifications);
+  m_bar->addPermanentWidget(m_progress);
+  m_bar->addPermanentWidget(m_api);
+
   m_progress->setTextVisible(true);
   m_progress->setRange(0, 100);
-
-  m_bar->addPermanentWidget(m_api);
-  m_bar->addPermanentWidget(m_progress);
 
   m_api->setObjectName("apistats");
   m_api->setStyleSheet("QLabel{ padding-left: 0.1em; padding-right: 0.1em; }");

--- a/src/statusbar.cpp
+++ b/src/statusbar.cpp
@@ -1,0 +1,27 @@
+#include "statusbar.h"
+
+StatusBar::StatusBar(QStatusBar* bar)
+  : m_bar(bar), m_nexusAPI(new QLabel), m_progress(new QProgressBar)
+{
+  m_progress->setTextVisible(true);
+  m_progress->setRange(0, 100);
+  m_progress->setValue(0);
+  m_progress->setVisible(false);
+
+  m_bar->addPermanentWidget(m_nexusAPI);
+  m_bar->addPermanentWidget(m_progress);
+
+  m_bar->clearMessage();
+}
+
+void StatusBar::setProgress(int percent)
+{
+  qDebug().nospace() << "progress: " << percent;
+
+  if (percent < 0 || percent >= 100) {
+    m_progress->setVisible(false);
+  } else if (!m_progress->isVisible()) {
+    m_progress->setVisible(true);
+    m_progress->setValue(percent);
+  }
+}

--- a/src/statusbar.cpp
+++ b/src/statusbar.cpp
@@ -2,16 +2,20 @@
 #include "nexusinterface.h"
 #include "settings.h"
 
-StatusBar::StatusBar(QStatusBar* bar) :
-  m_bar(bar), m_notifications(new QLabel), m_progress(new QProgressBar),
+StatusBar::StatusBar(QStatusBar* bar, QAction* notifications) :
+  m_bar(bar), m_progress(new QProgressBar), m_notifications(new QToolButton),
   m_api(new QLabel)
 {
-  m_bar->addPermanentWidget(m_notifications);
   m_bar->addPermanentWidget(m_progress);
+  m_bar->addPermanentWidget(m_notifications);
   m_bar->addPermanentWidget(m_api);
 
   m_progress->setTextVisible(true);
   m_progress->setRange(0, 100);
+  m_progress->setMaximumWidth(100);
+
+  m_notifications->setDefaultAction(notifications);
+  m_notifications->setAutoRaise(true);
 
   m_api->setObjectName("apistats");
   m_api->setStyleSheet("QLabel{ padding-left: 0.1em; padding-right: 0.1em; }");
@@ -29,6 +33,11 @@ void StatusBar::setProgress(int percent)
     m_progress->setVisible(true);
     m_progress->setValue(percent);
   }
+}
+
+void StatusBar::setHasNotifications(bool b)
+{
+  m_notifications->setVisible(b);
 }
 
 void StatusBar::updateAPI(const APIStats& stats, const APIUserAccount& user)

--- a/src/statusbar.cpp
+++ b/src/statusbar.cpp
@@ -23,7 +23,6 @@ StatusBar::StatusBar(QStatusBar* bar, Ui::MainWindow* ui) :
   m_notifications->set(false);
 
   m_api->setObjectName("apistats");
-  m_api->setStyleSheet("QLabel{ padding: 0.1em 0 0.1em 0; }");
 
   m_bar->clearMessage();
   setProgress(-1);
@@ -55,28 +54,36 @@ void StatusBar::setAPI(const APIStats& stats, const APIUserAccount& user)
     .arg(user.limits().remainingDailyRequests)
     .arg(user.limits().remainingHourlyRequests));
 
-  QColor textColor;
-  QColor backgroundColor;
+  QString textColor;
+  QString backgroundColor;
 
   if (user.type() == APIUserAccountTypes::None) {
-    backgroundColor = Qt::transparent;
+    backgroundColor = "transparent";
   } else if (user.remainingRequests() > 300) {
     textColor = "white";
-    backgroundColor = Qt::darkGreen;
+    backgroundColor = "darkgreen";
   } else if (user.remainingRequests() < 150) {
     textColor = "white";
-    backgroundColor = Qt::darkRed;
+    backgroundColor = "darkred";
   } else {
     textColor = "black";
-    backgroundColor = Qt::darkYellow;
+    backgroundColor = "rgb(226, 192, 0)";  // yellow
   }
 
-  QPalette palette = m_api->palette();
+  m_api->setStyleSheet(QString(R"(
+    QLabel
+    {
+      padding-left: 0.1em;
+      padding-right: 0.1em;
+      padding-top: 0;
+      padding-bottom: 0;
+      color: %1;
+      background-color: %2;
+    }
+    )")
+    .arg(textColor)
+    .arg(backgroundColor));
 
-  palette.setColor(QPalette::WindowText, textColor);
-  palette.setColor(QPalette::Background, backgroundColor);
-
-  m_api->setPalette(palette);
   m_api->setAutoFillBackground(true);
 }
 

--- a/src/statusbar.cpp
+++ b/src/statusbar.cpp
@@ -29,7 +29,8 @@ void StatusBar::setProgress(int percent)
 {
   if (percent < 0 || percent >= 100) {
     m_progress->setVisible(false);
-  } else if (!m_progress->isVisible()) {
+  } else {
+    m_bar->showMessage(QObject::tr("Loading..."));
     m_progress->setVisible(true);
     m_progress->setValue(percent);
   }

--- a/src/statusbar.cpp
+++ b/src/statusbar.cpp
@@ -23,6 +23,13 @@ StatusBar::StatusBar(QStatusBar* bar, Ui::MainWindow* ui) :
   m_notifications->set(false);
 
   m_api->setObjectName("apistats");
+  m_api->setToolTip(QObject::tr(
+    "This tracks the number of queued Nexus API requests, as well as the "
+    "remaining daily and hourly requests. The Nexus API limits you to a pool "
+    "of requests per day and requests per hour. It is dynamically updated "
+    "every time a request is completed. If you run out of requests, you will "
+    "be unable to queue downloads, check updates, parse mod info, or even log "
+    "in. Both pools must be consumed before this happens."));
 
   m_bar->clearMessage();
   setProgress(-1);

--- a/src/statusbar.cpp
+++ b/src/statusbar.cpp
@@ -54,7 +54,7 @@ void StatusBar::setAPI(const APIStats& stats, const APIUserAccount& user)
 
   if (user.type() == APIUserAccountTypes::None) {
     text = "API: not logged in";
-    textColor = "white";
+    textColor = "initial";
     backgroundColor = "transparent";
   } else {
     text = QString("API: Queued: %1 | Daily: %2 | Hourly: %3")

--- a/src/statusbar.cpp
+++ b/src/statusbar.cpp
@@ -48,27 +48,33 @@ void StatusBar::setNotifications(bool hasNotifications)
 
 void StatusBar::setAPI(const APIStats& stats, const APIUserAccount& user)
 {
-  m_api->setText(
-    QString("API: Q: %1 | D: %2 | H: %3")
-    .arg(stats.requestsQueued)
-    .arg(user.limits().remainingDailyRequests)
-    .arg(user.limits().remainingHourlyRequests));
-
+  QString text;
   QString textColor;
   QString backgroundColor;
 
   if (user.type() == APIUserAccountTypes::None) {
+    text = "API: not logged in";
+    textColor = "white";
     backgroundColor = "transparent";
-  } else if (user.remainingRequests() > 300) {
-    textColor = "white";
-    backgroundColor = "darkgreen";
-  } else if (user.remainingRequests() < 150) {
-    textColor = "white";
-    backgroundColor = "darkred";
   } else {
-    textColor = "black";
-    backgroundColor = "rgb(226, 192, 0)";  // yellow
+    text = QString("API: Queued: %1 | Daily: %2 | Hourly: %3")
+      .arg(stats.requestsQueued)
+      .arg(user.limits().remainingDailyRequests)
+      .arg(user.limits().remainingHourlyRequests);
+
+    if (user.remainingRequests() > 500) {
+      textColor = "white";
+      backgroundColor = "darkgreen";
+    } else if (user.remainingRequests() > 200) {
+      textColor = "black";
+      backgroundColor = "rgb(226, 192, 0)";  // yellow
+    } else {
+      textColor = "white";
+      backgroundColor = "darkred";
+    }
   }
+
+  m_api->setText(text);
 
   m_api->setStyleSheet(QString(R"(
     QLabel

--- a/src/statusbar.cpp
+++ b/src/statusbar.cpp
@@ -1,27 +1,68 @@
 #include "statusbar.h"
+#include "nexusinterface.h"
+#include "settings.h"
 
 StatusBar::StatusBar(QStatusBar* bar)
-  : m_bar(bar), m_nexusAPI(new QLabel), m_progress(new QProgressBar)
+  : m_bar(bar), m_api(new QLabel), m_progress(new QProgressBar)
 {
   m_progress->setTextVisible(true);
   m_progress->setRange(0, 100);
-  m_progress->setValue(0);
-  m_progress->setVisible(false);
 
-  m_bar->addPermanentWidget(m_nexusAPI);
+  m_bar->addPermanentWidget(m_api);
   m_bar->addPermanentWidget(m_progress);
 
+  m_api->setObjectName("apistats");
+  m_api->setStyleSheet("QLabel{ padding-left: 0.1em; padding-right: 0.1em; }");
+
   m_bar->clearMessage();
+  setProgress(-1);
+  updateAPI({}, {});
 }
 
 void StatusBar::setProgress(int percent)
 {
-  qDebug().nospace() << "progress: " << percent;
-
   if (percent < 0 || percent >= 100) {
     m_progress->setVisible(false);
   } else if (!m_progress->isVisible()) {
     m_progress->setVisible(true);
     m_progress->setValue(percent);
   }
+}
+
+void StatusBar::updateAPI(const APIStats& stats, const APIUserAccount& user)
+{
+  m_api->setText(
+    QString("API: Q: %1 | D: %2 | H: %3")
+    .arg(stats.requestsQueued)
+    .arg(user.limits().remainingDailyRequests)
+    .arg(user.limits().remainingHourlyRequests));
+
+  QColor textColor;
+  QColor backgroundColor;
+
+  if (user.type() == APIUserAccountTypes::None) {
+    backgroundColor = Qt::transparent;
+  } else if (user.remainingRequests() > 300) {
+    textColor = "white";
+    backgroundColor = Qt::darkGreen;
+  } else if (user.remainingRequests() < 150) {
+    textColor = "white";
+    backgroundColor = Qt::darkRed;
+  } else {
+    textColor = "black";
+    backgroundColor = Qt::darkYellow;
+  }
+
+  QPalette palette = m_api->palette();
+
+  palette.setColor(QPalette::WindowText, textColor);
+  palette.setColor(QPalette::Background, backgroundColor);
+
+  m_api->setPalette(palette);
+  m_api->setAutoFillBackground(true);
+}
+
+void StatusBar::checkSettings(const Settings& settings)
+{
+  m_api->setVisible(!settings.hideAPICounter());
 }

--- a/src/statusbar.h
+++ b/src/statusbar.h
@@ -11,16 +11,17 @@ class Settings;
 class StatusBar
 {
 public:
-  StatusBar(QStatusBar* bar);
+  StatusBar(QStatusBar* bar, QAction* notifications);
 
   void setProgress(int percent);
+  void setHasNotifications(bool b);
   void updateAPI(const APIStats& stats, const APIUserAccount& user);
   void checkSettings(const Settings& settings);
 
 private:
   QStatusBar* m_bar;
-  QLabel* m_notifications;
   QProgressBar* m_progress;
+  QToolButton* m_notifications;
   QLabel* m_api;
 };
 

--- a/src/statusbar.h
+++ b/src/statusbar.h
@@ -1,0 +1,20 @@
+#ifndef MO_STATUSBAR_H
+#define MO_STATUSBAR_H
+
+#include <QStatusBar>
+#include <QProgressBar>
+
+class StatusBar
+{
+public:
+  StatusBar(QStatusBar* bar);
+
+  void setProgress(int percent);
+
+private:
+  QStatusBar* m_bar;
+  QLabel* m_api;
+  QProgressBar* m_progress;
+};
+
+#endif // MO_STATUSBAR_H

--- a/src/statusbar.h
+++ b/src/statusbar.h
@@ -7,14 +7,15 @@
 struct APIStats;
 class APIUserAccount;
 class Settings;
+namespace Ui { class MainWindow; }
 
 
-class StatusBarNotifications : public QWidget
+class StatusBarAction : public QWidget
 {
 public:
-  StatusBarNotifications(QAction* action);
+  StatusBarAction(QAction* action);
 
-  void update(bool hasNotifications);
+  void set(bool visible);
 
 protected:
   void mouseDoubleClickEvent(QMouseEvent* e) override;
@@ -23,23 +24,27 @@ private:
   QAction* m_action;
   QLabel* m_icon;
   QLabel* m_text;
+
+  QString cleanupActionText(const QString& s) const;
 };
 
 
 class StatusBar
 {
 public:
-  StatusBar(QStatusBar* bar, QAction* actionNotifications);
+  StatusBar(QStatusBar* bar, Ui::MainWindow* ui);
 
   void setProgress(int percent);
-  void updateNotifications(bool hasNotifications);
-  void updateAPI(const APIStats& stats, const APIUserAccount& user);
+  void setNotifications(bool hasNotifications);
+  void setAPI(const APIStats& stats, const APIUserAccount& user);
+  void setUpdateAvailable(bool b);
   void checkSettings(const Settings& settings);
 
 private:
   QStatusBar* m_bar;
-  StatusBarNotifications* m_notifications;
   QProgressBar* m_progress;
+  StatusBarAction* m_notifications;
+  StatusBarAction* m_update;
   QLabel* m_api;
 };
 

--- a/src/statusbar.h
+++ b/src/statusbar.h
@@ -19,8 +19,9 @@ public:
 
 private:
   QStatusBar* m_bar;
-  QLabel* m_api;
+  QLabel* m_notifications;
   QProgressBar* m_progress;
+  QLabel* m_api;
 };
 
 #endif // MO_STATUSBAR_H

--- a/src/statusbar.h
+++ b/src/statusbar.h
@@ -8,20 +8,38 @@ struct APIStats;
 class APIUserAccount;
 class Settings;
 
+
+class StatusBarNotifications : public QWidget
+{
+public:
+  StatusBarNotifications(QAction* action);
+
+  void update(bool hasNotifications);
+
+protected:
+  void mouseDoubleClickEvent(QMouseEvent* e) override;
+
+private:
+  QAction* m_action;
+  QLabel* m_icon;
+  QLabel* m_text;
+};
+
+
 class StatusBar
 {
 public:
-  StatusBar(QStatusBar* bar, QAction* notifications);
+  StatusBar(QStatusBar* bar, QAction* actionNotifications);
 
   void setProgress(int percent);
-  void setHasNotifications(bool b);
+  void updateNotifications(bool hasNotifications);
   void updateAPI(const APIStats& stats, const APIUserAccount& user);
   void checkSettings(const Settings& settings);
 
 private:
   QStatusBar* m_bar;
+  StatusBarNotifications* m_notifications;
   QProgressBar* m_progress;
-  QToolButton* m_notifications;
   QLabel* m_api;
 };
 

--- a/src/statusbar.h
+++ b/src/statusbar.h
@@ -4,12 +4,18 @@
 #include <QStatusBar>
 #include <QProgressBar>
 
+struct APIStats;
+class APIUserAccount;
+class Settings;
+
 class StatusBar
 {
 public:
   StatusBar(QStatusBar* bar);
 
   void setProgress(int percent);
+  void updateAPI(const APIStats& stats, const APIUserAccount& user);
+  void checkSettings(const Settings& settings);
 
 private:
   QStatusBar* m_bar;


### PR DESCRIPTION
- The main focus of this PR is to add stuff to the status bar: the progress bar, notifications, a new update notice and the API stats. The main change I did along the way was a refactoring of the API data, which used to be spread out in a bunch of variables and even a tuple of four ints. I've moved all of that into an `APIUserAccount`, which is much easier to pass around.

- I've also cleaned up a lot of copy/pasted code in `NexusInterface` that used to repeat an `if` and a magic number for throttling, as well as a log message. I've moved the check to `APIUserAccount::shouldThrottle()` and the logging to `throttledWarning()`. The parsing of the limits (`"x-rl-daily-limit"`, etc.) has also been moved to a static function `parseLimits()`.

- The progress bar had been broken for a while (forever?) and stayed at 1%. This is fixed.

- There's an option to hide the status bar entirely.

- I did some work that was unrelated to the status bar itself, but that I found was behaving incorrectly while testing the API stats. The main problem was that clearing the API key removed it from the settings and credentials manager, but it was still in `NXMAccessManager`, which allowed the user to do requests even after clearing the key. I've also fixed the title bar not updating properly when restarting MO after changing the nexus settings. So for now, clearing the key or adding a key manually updates the UI live and correctly. The only thing that's still broken is adding the key from the website, but the reload fixes it.