### PR TITLE
Removed 'L' from the language code in version.rc

### DIFF
--- a/src/version.rc
+++ b/src/version.rc
@@ -32,6 +32,6 @@ BEGIN
 
     BLOCK "VarFileInfo"
     BEGIN
-      VALUE "Translation", 0x0409L, 1200
+      VALUE "Translation", 0x0409, 1200
     END
 END


### PR DESCRIPTION
 - It's incorrect, since language codes are unsigned shorts, and
 - It actually breaks the translation section and makes retrieving it through standard Windows API fail