### PR TITLE
New Shortcut class to manage desktop/start menu shortcuts

### DIFF
--- a/src/mainwindow.h
+++ b/src/mainwindow.h
@@ -403,17 +403,13 @@ private:
 
   MOBase::DelayedFileWriter m_ArchiveListWriter;
 
+  QAction* m_LinkToolbar;
+  QAction* m_LinkDesktop;
+  QAction* m_LinkStartMenu;
+
   // icon set by the stylesheet, used to remember its original appearance
   // when painting the count
   QIcon m_originalNotificationIcon;
-
-  enum class ShortcutType {
-    Toolbar,
-    Desktop,
-    StartMenu
-  };
-
-  void addWindowsLink(ShortcutType const);
 
   Executable const &getSelectedExecutable() const;
   Executable &getSelectedExecutable();

--- a/src/shared/util.h
+++ b/src/shared/util.h
@@ -29,6 +29,8 @@ along with Mod Organizer.  If not, see <http://www.gnu.org/licenses/>.
 
 #include <versioninfo.h>
 
+class Executable;
+
 namespace MOShared {
 
 /// Test if a file (or directory) by the specified name exists
@@ -51,6 +53,100 @@ bool CaseInsensitiveEqual(const std::wstring &lhs, const std::wstring &rhs);
 
 namespace env
 {
+
+// an application shortcut that can be either on the desktop or the start menu
+//
+class Shortcut
+{
+public:
+  // location of a shortcut
+  //
+  enum Locations
+  {
+    None = 0,
+
+    // on the desktop
+    Desktop,
+
+    // in the start menu
+    StartMenu
+  };
+
+
+  // empty shortcut
+  //
+  Shortcut();
+
+  // shortcut from an executable
+  //
+  explicit Shortcut(const Executable& exe);
+
+  // sets the name of the shortcut, shown on icons and start menu entries
+  //
+  Shortcut& name(const QString& s);
+
+  // the program to start
+  //
+  Shortcut& target(const QString& s);
+
+  // arguments to pass
+  //
+  Shortcut& arguments(const QString& s);
+
+  // shows in the status bar of explorer, for example
+  //
+  Shortcut& description(const QString& s);
+
+  // path to a binary that contains the icon and its index
+  //
+  Shortcut& icon(const QString& s, int index=0);
+
+  // "start in" option for this shortcut
+  //
+  Shortcut& workingDirectory(const QString& s);
+
+
+  // returns whether this shortcut already exists at the given location; this
+  // does not check whether the shortcut parameters are different, it merely if
+  // the .lnk file exists
+  //
+  bool exists(Locations loc) const;
+
+  // calls remove() if exists(), or add()
+  //
+  bool toggle(Locations loc);
+
+  // adds the shortcut to the given location
+  //
+  bool add(Locations loc);
+
+  // removes the shortcut from the given location
+  //
+  bool remove(Locations loc);
+
+private:
+  QString m_name;
+  QString m_target;
+  QString m_arguments;
+  QString m_description;
+  QString m_icon;
+  int m_iconIndex;
+  QString m_workingDirectory;
+
+
+  // returns the path where the shortcut file should be saved
+  //
+  QString shortcutPath(Locations loc) const;
+
+  // returns the directory where the shortcut file should be saved
+  //
+  QString shortcutDirectory(Locations loc) const;
+
+  // returns the filename of the shortcut file that should be used when saving
+  //
+  QString shortcutFilename() const;
+};
+
 
 // represents one module
 //

--- a/src/shared/util.h
+++ b/src/shared/util.h
@@ -133,6 +133,14 @@ private:
   int m_iconIndex;
   QString m_workingDirectory;
 
+  // returns a qCritical() logger with a prefix already logged
+  //
+  QDebug critical() const;
+
+  // returns a qDebug() logger with a prefix already logged
+  //
+  QDebug debug() const;
+
 
   // returns the path where the shortcut file should be saved
   //
@@ -146,6 +154,11 @@ private:
   //
   QString shortcutFilename() const;
 };
+
+
+// returns a string representation of the given location
+//
+QString toString(Shortcut::Locations loc);
 
 
 // represents one module


### PR DESCRIPTION
A user reported a problem with adding desktop shortcuts and fell into a rare case where the underlying system error was not logged, so I made sure every possible error is now logged properly.

* Added `QAction`s for the link menu instead of using the enum as indexes.
* Moved `CreateShortcut()` and associated stuff into a new `Shortcut` class in utils.h/cpp
* Separated the shell stuff into a `ShellLinkWrapper` class that throws on errors