### PR TITLE
Small fixes

### DIFF
--- a/src/filedialogmemory.cpp
+++ b/src/filedialogmemory.cpp
@@ -66,7 +66,7 @@ QString FileDialogMemory::getOpenFileName(
   if (currentDir.isEmpty()) {
     auto itor = instance().m_Cache.find(dirID);
     if (itor != instance().m_Cache.end()) {
-      currentDir = itor->first;
+      currentDir = itor->second;
     }
   }
 
@@ -90,7 +90,7 @@ QString FileDialogMemory::getExistingDirectory(
   if (currentDir.isEmpty()) {
     auto itor = instance().m_Cache.find(dirID);
     if (itor != instance().m_Cache.end()) {
-      currentDir = itor->first;
+      currentDir = itor->second;
     }
   }
 

--- a/src/mainwindow.ui
+++ b/src/mainwindow.ui
@@ -1733,7 +1733,7 @@ p, li { white-space: pre-wrap; }
     <bool>true</bool>
    </property>
    <property name="text">
-    <string>St&amp;atus bar</string>
+    <string>Status &amp;bar</string>
    </property>
   </action>
  </widget>

--- a/src/overwriteinfodialog.cpp
+++ b/src/overwriteinfodialog.cpp
@@ -290,5 +290,6 @@ void OverwriteInfoDialog::on_filesView_customContextMenuRequested(const QPoint &
     m_FileSelection.clear();
     m_FileSelection.append(m_FileSystemModel->index(m_FileSystemModel->rootPath(), 0));
   }
-  menu.exec(ui->filesView->mapToGlobal(pos));
+
+  menu.exec(ui->filesView->viewport()->mapToGlobal(pos));
 }

--- a/src/statusbar.cpp
+++ b/src/statusbar.cpp
@@ -23,7 +23,7 @@ StatusBar::StatusBar(QStatusBar* bar, Ui::MainWindow* ui) :
   m_bar->addPermanentWidget(m_notifications);
   m_bar->addPermanentWidget(m_update);
   m_bar->addPermanentWidget(m_api);
-  
+
 
   m_progress->setTextVisible(true);
   m_progress->setRange(0, 100);
@@ -72,8 +72,8 @@ void StatusBar::setAPI(const APIStats& stats, const APIUserAccount& user)
 
   if (user.type() == APIUserAccountTypes::None) {
     text = "API: not logged in";
-    textColor = "initial";
-    backgroundColor = "transparent";
+    textColor = "";
+    backgroundColor = "";
   } else {
     text = QString("API: Queued: %1 | Daily: %2 | Hourly: %3")
       .arg(stats.requestsQueued)
@@ -94,20 +94,25 @@ void StatusBar::setAPI(const APIStats& stats, const APIUserAccount& user)
 
   m_api->setText(text);
 
-  m_api->setStyleSheet(QString(R"(
+  QString ss(R"(
     QLabel
     {
       padding-left: 0.1em;
       padding-right: 0.1em;
       padding-top: 0;
-      padding-bottom: 0;
-      color: %1;
-      background-color: %2;
-    }
-    )")
-    .arg(textColor)
-    .arg(backgroundColor));
+      padding-bottom: 0;)");
 
+  if (!textColor.isEmpty()) {
+    ss += QString("\ncolor: %1;").arg(textColor);
+  }
+
+  if (!backgroundColor.isEmpty()) {
+    ss += QString("\nbackground-color: %2;").arg(backgroundColor);
+  }
+
+  ss += "\n}";
+
+  m_api->setStyleSheet(ss);
   m_api->setAutoFillBackground(true);
 }
 


### PR DESCRIPTION
- "Not logged in" text colour in status bar would not respect theme
- Context menu in overwrite dialog was offset vertically
- Duplicate mnemonic "Status bar" in the view menu
- `FileDialogMemory` didn't actually remember anything