### PR TITLE
Nexus login progress dialog and Nexus settings

### DIFF
--- a/src/apiuseraccount.cpp
+++ b/src/apiuseraccount.cpp
@@ -1,8 +1,30 @@
 #include "apiuseraccount.h"
 
+QString localizedUserAccountType(APIUserAccountTypes t)
+{
+  switch (t)
+  {
+    case APIUserAccountTypes::Regular:
+      return QObject::tr("Regular");
+
+    case APIUserAccountTypes::Premium:
+      return QObject::tr("Premium");
+
+    case APIUserAccountTypes::None:  // fall-through
+    default:
+      return QObject::tr("None");
+  }
+}
+
+
 APIUserAccount::APIUserAccount()
   : m_type(APIUserAccountTypes::None)
 {
+}
+
+bool APIUserAccount::isValid() const
+{
+  return !m_key.isEmpty();
 }
 
 const QString& APIUserAccount::apiKey() const

--- a/src/apiuseraccount.cpp
+++ b/src/apiuseraccount.cpp
@@ -5,6 +5,11 @@ APIUserAccount::APIUserAccount()
 {
 }
 
+const QString& APIUserAccount::apiKey() const
+{
+  return m_key;
+}
+
 const QString& APIUserAccount::id() const
 {
   return m_id;
@@ -23,6 +28,12 @@ APIUserAccountTypes APIUserAccount::type() const
 const APILimits& APIUserAccount::limits() const
 {
   return m_limits;
+}
+
+APIUserAccount& APIUserAccount::apiKey(const QString& key)
+{
+  m_key = key;
+  return *this;
 }
 
 APIUserAccount& APIUserAccount::id(const QString& id)

--- a/src/apiuseraccount.h
+++ b/src/apiuseraccount.h
@@ -60,6 +60,12 @@ public:
 
   APIUserAccount();
 
+
+  /**
+  * api key
+  */
+  const QString& apiKey() const;
+
   /**
   * user id
   */
@@ -80,6 +86,11 @@ public:
   */
   const APILimits& limits() const;
 
+
+  /**
+   * sets the api key
+   */
+  APIUserAccount& apiKey(const QString& key);
 
   /**
   * sets the user id
@@ -120,7 +131,7 @@ public:
   bool exhausted() const;
 
 private:
-  QString m_id, m_name;
+  QString m_key, m_id, m_name;
   APIUserAccountTypes m_type;
   APILimits m_limits;
   APIStats m_stats;

--- a/src/apiuseraccount.h
+++ b/src/apiuseraccount.h
@@ -18,6 +18,8 @@ enum class APIUserAccountTypes
   Premium
 };
 
+QString localizedUserAccountType(APIUserAccountTypes t);
+
 
 /**
 * current limits imposed on the user account
@@ -60,6 +62,11 @@ public:
 
   APIUserAccount();
 
+
+  /**
+   * whether the user is logged in
+   */
+  bool isValid() const;
 
   /**
   * api key
@@ -134,7 +141,6 @@ private:
   QString m_key, m_id, m_name;
   APIUserAccountTypes m_type;
   APILimits m_limits;
-  APIStats m_stats;
 };
 
 #endif // APIUSERACCOUNT_H

--- a/src/downloadlistwidget.cpp
+++ b/src/downloadlistwidget.cpp
@@ -201,40 +201,49 @@ void DownloadListWidget::onCustomContextMenu(const QPoint &point)
   QModelIndex index = indexAt(point);
   bool hidden = false;
 
-  if (index.row() >= 0) {
-    m_ContextRow = qobject_cast<QSortFilterProxyModel*>(model())->mapToSource(index).row();
-    DownloadManager::DownloadState state = m_Manager->getState(m_ContextRow);
-    hidden = m_Manager->isHidden(m_ContextRow);
+  try
+  {
+    if (index.row() >= 0) {
+      m_ContextRow = qobject_cast<QSortFilterProxyModel*>(model())->mapToSource(index).row();
+      DownloadManager::DownloadState state = m_Manager->getState(m_ContextRow);
 
-    if (state >= DownloadManager::STATE_READY) {
-      menu.addAction(tr("Install"), this, SLOT(issueInstall()));
-      if (m_Manager->isInfoIncomplete(m_ContextRow))
-        menu.addAction(tr("Query Info"), this, SLOT(issueQueryInfoMd5()));
-      else
-        menu.addAction(tr("Visit on Nexus"), this, SLOT(issueVisitOnNexus()));
-      menu.addAction(tr("Open File"), this, SLOT(issueOpenFile()));
-      menu.addAction(tr("Show in Folder"), this, SLOT(issueOpenInDownloadsFolder()));
+      hidden = m_Manager->isHidden(m_ContextRow);
+
+      if (state >= DownloadManager::STATE_READY) {
+        menu.addAction(tr("Install"), this, SLOT(issueInstall()));
+        if (m_Manager->isInfoIncomplete(m_ContextRow))
+          menu.addAction(tr("Query Info"), this, SLOT(issueQueryInfoMd5()));
+        else
+          menu.addAction(tr("Visit on Nexus"), this, SLOT(issueVisitOnNexus()));
+        menu.addAction(tr("Open File"), this, SLOT(issueOpenFile()));
+        menu.addAction(tr("Show in Folder"), this, SLOT(issueOpenInDownloadsFolder()));
+
+        menu.addSeparator();
+
+        menu.addAction(tr("Delete"), this, SLOT(issueDelete()));
+        if (hidden)
+          menu.addAction(tr("Un-Hide"), this, SLOT(issueRestoreToView()));
+        else
+          menu.addAction(tr("Hide"), this, SLOT(issueRemoveFromView()));
+      } else if (state == DownloadManager::STATE_DOWNLOADING) {
+        menu.addAction(tr("Cancel"), this, SLOT(issueCancel()));
+        menu.addAction(tr("Pause"), this, SLOT(issuePause()));
+        menu.addAction(tr("Show in Folder"), this, SLOT(issueOpenInDownloadsFolder()));
+      } else if ((state == DownloadManager::STATE_PAUSED) || (state == DownloadManager::STATE_ERROR)
+                || (state == DownloadManager::STATE_PAUSING)) {
+        menu.addAction(tr("Delete"), this, SLOT(issueDelete()));
+        menu.addAction(tr("Resume"), this, SLOT(issueResume()));
+        menu.addAction(tr("Show in Folder"), this, SLOT(issueOpenInDownloadsFolder()));
+      }
 
       menu.addSeparator();
-
-      menu.addAction(tr("Delete"), this, SLOT(issueDelete()));
-      if (hidden)
-        menu.addAction(tr("Un-Hide"), this, SLOT(issueRestoreToView()));
-      else
-        menu.addAction(tr("Hide"), this, SLOT(issueRemoveFromView()));
-    } else if (state == DownloadManager::STATE_DOWNLOADING) {
-      menu.addAction(tr("Cancel"), this, SLOT(issueCancel()));
-      menu.addAction(tr("Pause"), this, SLOT(issuePause()));
-      menu.addAction(tr("Show in Folder"), this, SLOT(issueOpenInDownloadsFolder()));
-    } else if ((state == DownloadManager::STATE_PAUSED) || (state == DownloadManager::STATE_ERROR)
-              || (state == DownloadManager::STATE_PAUSING)) {
-      menu.addAction(tr("Delete"), this, SLOT(issueDelete()));
-      menu.addAction(tr("Resume"), this, SLOT(issueResume()));
-      menu.addAction(tr("Show in Folder"), this, SLOT(issueOpenInDownloadsFolder()));
     }
-
-    menu.addSeparator();
+  } catch(std::exception&)
+  {
+    // this happens when the download index is not found, ignore it and don't
+    // display download-specific actions
   }
+
   menu.addAction(tr("Delete Installed Downloads..."), this, SLOT(issueDeleteCompleted()));
   menu.addAction(tr("Delete Uninstalled Downloads..."), this, SLOT(issueDeleteUninstalled()));
   menu.addAction(tr("Delete All Downloads..."), this, SLOT(issueDeleteAll()));

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -713,7 +713,13 @@ int runApplication(MOApplication &application, SingleInstance &instance,
       mainWindow.activateWindow();
 
       splash.finish(&mainWindow);
-      return application.exec();
+
+      const auto ret = application.exec();
+
+      NexusInterface::instance(&pluginContainer)
+        ->getAccessManager()->setTopLevelWidget(nullptr);
+
+      return ret;
     }
   } catch (const std::exception &e) {
     reportError(e.what());

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -697,6 +697,9 @@ int runApplication(MOApplication &application, SingleInstance &instance,
       // set up main window and its data structures
       MainWindow mainWindow(settings, organizer, pluginContainer);
 
+      NexusInterface::instance(&pluginContainer)
+        ->getAccessManager()->setTopLevelWidget(&mainWindow);
+
       QObject::connect(&mainWindow, SIGNAL(styleChanged(QString)), &application,
                        SLOT(setStyleFile(QString)));
       QObject::connect(&instance, SIGNAL(messageSent(QString)), &organizer,

--- a/src/mainwindow.cpp
+++ b/src/mainwindow.cpp
@@ -399,7 +399,6 @@ MainWindow::MainWindow(QSettings &initSettings
   connect(NexusInterface::instance(&pluginContainer), SIGNAL(requestNXMDownload(QString)), &m_OrganizerCore, SLOT(downloadRequestedNXM(QString)));
   connect(NexusInterface::instance(&pluginContainer), SIGNAL(nxmDownloadURLsAvailable(QString,int,int,QVariant,QVariant,int)), this, SLOT(nxmDownloadURLs(QString,int,int,QVariant,QVariant,int)));
   connect(NexusInterface::instance(&pluginContainer), SIGNAL(needLogin()), &m_OrganizerCore, SLOT(nexusApi()));
-  connect(NexusInterface::instance(&pluginContainer)->getAccessManager(), SIGNAL(validateFailed(QString)), this, SLOT(validationFailed(QString)));
 
   connect(
     NexusInterface::instance(&pluginContainer)->getAccessManager(),
@@ -3093,11 +3092,6 @@ void MainWindow::untrack_clicked()
       ModInfo::getByIndex(idx.data(Qt::UserRole + 1).toInt())->track(false);
     }
   });
-}
-
-void MainWindow::validationFailed(const QString &error)
-{
-  qDebug("Nexus API validation failed: %s", qUtf8Printable(error));
 }
 
 void MainWindow::windowTutorialFinished(const QString &windowName)

--- a/src/mainwindow.h
+++ b/src/mainwindow.h
@@ -510,8 +510,6 @@ private slots:
   // nexus related
   void checkModsForUpdates();
 
-  void validationFailed(const QString &message);
-
   void linkClicked(const QString &url);
 
   void updateAvailable();

--- a/src/nexusinterface.h
+++ b/src/nexusinterface.h
@@ -151,6 +151,7 @@ public:
 public:
   static APILimits defaultAPILimits();
   static APILimits parseLimits(const QNetworkReply* reply);
+  static APILimits parseLimits(const QList<QNetworkReply::RawHeaderPair>& headers);
 
   ~NexusInterface();
 

--- a/src/nxmaccessmanager.cpp
+++ b/src/nxmaccessmanager.cpp
@@ -618,14 +618,11 @@ void NXMAccessManager::clearCookies()
   }
 }
 
-void NXMAccessManager::startValidationCheck(const QString& key, bool showProgress)
+void NXMAccessManager::startValidationCheck(const QString& key)
 {
   m_validationState = NotChecked;
   m_validator.start(key);
-
-  if (showProgress) {
-    m_ProgressDialog->start();
-  }
+  m_ProgressDialog->start();
 }
 
 void NXMAccessManager::onValidatorState(
@@ -674,13 +671,13 @@ bool NXMAccessManager::validateWaiting() const
   return m_validator.isActive();
 }
 
-void NXMAccessManager::apiCheck(const QString &apiKey, ApiCheckFlags flags)
+void NXMAccessManager::apiCheck(const QString &apiKey, bool force)
 {
   if (m_validator.isActive()) {
     return;
   }
 
-  if (flags & Force) {
+  if (force) {
     m_validationState = NotChecked;
   }
 
@@ -689,7 +686,7 @@ void NXMAccessManager::apiCheck(const QString &apiKey, ApiCheckFlags flags)
     return;
   }
 
-  startValidationCheck(apiKey, (flags & HideProgress) == 0);
+  startValidationCheck(apiKey);
 }
 
 const QString& NXMAccessManager::MOVersion() const

--- a/src/nxmaccessmanager.cpp
+++ b/src/nxmaccessmanager.cpp
@@ -313,7 +313,7 @@ void NexusKeyValidator::start(const QString& key)
     return;
   }
 
-  qDebug("Checking Nexus API Key...");
+  m_active = true;
   setState(Connecting);
 
   const QString requestUrl(NexusBaseUrl + "/users/validate");
@@ -328,11 +328,11 @@ void NexusKeyValidator::start(const QString& key)
 
   m_reply = m_manager.get(request);
   if (!m_reply) {
+    close();
     setState(Error, QObject::tr("Failed to request %1").arg(requestUrl));
     return;
   }
 
-  m_active = true;
   m_timeout.start(NXMAccessManager::ValidationTimeout);
 
   QObject::connect(

--- a/src/nxmaccessmanager.cpp
+++ b/src/nxmaccessmanager.cpp
@@ -167,7 +167,7 @@ QString NexusSSOLogin::stateToString(States s, const QString& e)
       return QObject::tr("Opened browser, waiting for user...");
 
     case Finished:
-      return QObject::tr("Connected.");
+      return QObject::tr("Finished.");
 
     case Timeout:
       return QObject::tr(

--- a/src/nxmaccessmanager.cpp
+++ b/src/nxmaccessmanager.cpp
@@ -164,7 +164,9 @@ QString NexusSSOLogin::stateToString(States s, const QString& e)
       return QObject::tr("Waiting for Nexus...");
 
     case WaitingForBrowser:
-      return QObject::tr("Opened browser, waiting for user...");
+      return QObject::tr(
+        "Opened Nexus in browser.\n"
+        "Switch to your browser and accept the request.");
 
     case Finished:
       return QObject::tr("Finished.");

--- a/src/nxmaccessmanager.cpp
+++ b/src/nxmaccessmanager.cpp
@@ -43,7 +43,7 @@ using namespace MOBase;
 using namespace std::chrono_literals;
 
 const QString NexusBaseUrl("https://api.nexusmods.com/v1");
-const auto ValidationTimeout = 10s;
+const std::chrono::seconds NXMAccessManager::ValidationTimeout = 10s;
 
 
 ValidationProgressDialog::ValidationProgressDialog(std::chrono::seconds t)

--- a/src/nxmaccessmanager.cpp
+++ b/src/nxmaccessmanager.cpp
@@ -242,15 +242,12 @@ void NexusSSOLogin::onConnected()
 
   m_keyReceived = false;
 
-  //if (m_guid.isEmpty()) {
   boost::uuids::random_generator generator;
   boost::uuids::uuid sessionId = generator();
   m_guid = boost::uuids::to_string(sessionId).c_str();
-  //}
 
   QJsonObject data;
   data.insert(QString("id"), QJsonValue(m_guid));
-  //data.insert(QString("token"), QJsonValue(m_token));
   data.insert(QString("protocol"), 2);
 
   const QString message = QJsonDocument(data).toJson();
@@ -275,7 +272,6 @@ void NexusSSOLogin::onMessage(const QString& s)
 
   if (data.contains("connection_token")) {
     // first answer
-    m_token = data["connection_token"].toString();
 
     // open browser
     const auto url = NexusSSOPage.arg(m_guid);

--- a/src/nxmaccessmanager.h
+++ b/src/nxmaccessmanager.h
@@ -41,6 +41,8 @@ public:
 
   ~NXMAccessManager();
 
+  void setTopLevelWidget(QWidget* w);
+
   bool validated() const;
 
   bool validateAttempted() const;
@@ -94,9 +96,10 @@ protected:
       QIODevice *device);
 
 private:
+  QWidget* m_TopLevel;
   QTimer m_ValidateTimeout;
   QNetworkReply *m_ValidateReply;
-  QProgressDialog *m_ProgressDialog { nullptr };
+  mutable QProgressDialog* m_ProgressDialog;
 
   QString m_MOVersion;
 

--- a/src/nxmaccessmanager.h
+++ b/src/nxmaccessmanager.h
@@ -67,6 +67,7 @@ class NXMAccessManager : public QNetworkAccessManager
 {
   Q_OBJECT
 public:
+  static const std::chrono::seconds ValidationTimeout;
 
   explicit NXMAccessManager(QObject *parent, const QString &moVersion);
 

--- a/src/nxmaccessmanager.h
+++ b/src/nxmaccessmanager.h
@@ -93,7 +93,6 @@ private:
   QWebSocket m_socket;
   QString m_guid;
   bool m_keyReceived;
-  QString m_token;
   bool m_active;
   QTimer m_timeout;
 

--- a/src/nxmaccessmanager.h
+++ b/src/nxmaccessmanager.h
@@ -26,11 +26,12 @@ along with Mod Organizer.  If not, see <http://www.gnu.org/licenses/>.
 #include <QNetworkReply>
 #include <QProgressDialog>
 #include <QElapsedTimer>
+#include <QDialogButtonBox>
 #include <set>
 
 namespace MOBase { class IPluginGame; }
 
-class ValidationProgressDialog : QObject
+class ValidationProgressDialog : private QDialog
 {
   Q_OBJECT;
 
@@ -38,14 +39,19 @@ public:
   ValidationProgressDialog(std::chrono::seconds timeout);
 
   void setParentWidget(QWidget* w);
+
   void start();
   void stop();
 
+  using QDialog::show;
+
+protected:
+  void closeEvent(QCloseEvent* e) override;
+
 private:
   std::chrono::seconds m_timeout;
-  std::unique_ptr<QDialog> m_dialogHolder;
-  QDialog* m_dialog;
   QProgressBar* m_bar;
+  QDialogButtonBox* m_buttons;
   QTimer* m_timer;
   QElapsedTimer m_elapsed;
 

--- a/src/nxmaccessmanager.h
+++ b/src/nxmaccessmanager.h
@@ -165,15 +165,6 @@ class NXMAccessManager : public QNetworkAccessManager
 {
   Q_OBJECT
 public:
-  enum ApiCheckFlagsEnum
-  {
-    NoFlags = 0,
-    Force,
-    HideProgress
-  };
-
-  Q_DECLARE_FLAGS(ApiCheckFlags, ApiCheckFlagsEnum)
-
   static const std::chrono::seconds ValidationTimeout;
 
   explicit NXMAccessManager(QObject *parent, const QString &moVersion);
@@ -186,7 +177,7 @@ public:
   bool validateAttempted() const;
   bool validateWaiting() const;
 
-  void apiCheck(const QString &apiKey, ApiCheckFlags flags=NoFlags);
+  void apiCheck(const QString &apiKey, bool force=false);
 
   void showCookies() const;
 
@@ -237,11 +228,9 @@ private:
   NexusKeyValidator m_validator;
   States m_validationState;
 
-  void startValidationCheck(const QString& key, bool showProgress);
+  void startValidationCheck(const QString& key);
   void onValidatorState(NexusKeyValidator::States s, const QString& e);
   void onValidatorFinished(const APIUserAccount& user);
 };
-
-Q_DECLARE_OPERATORS_FOR_FLAGS(NXMAccessManager::ApiCheckFlags);
 
 #endif // NXMACCESSMANAGER_H

--- a/src/nxmaccessmanager.h
+++ b/src/nxmaccessmanager.h
@@ -29,6 +29,26 @@ along with Mod Organizer.  If not, see <http://www.gnu.org/licenses/>.
 
 namespace MOBase { class IPluginGame; }
 
+class ValidationProgressDialog : QObject
+{
+  Q_OBJECT;
+
+public:
+  ValidationProgressDialog();
+
+  void setParentWidget(QWidget* w);
+  void show();
+  void hide();
+
+private:
+  std::unique_ptr<QDialog> m_dialogHolder;
+  QDialog* m_dialog;
+  QProgressBar* m_bar;
+
+  void onButton(QAbstractButton* b);
+};
+
+
 /**
  * @brief access manager extended to handle nxm links
  **/
@@ -99,7 +119,7 @@ private:
   QWidget* m_TopLevel;
   QTimer m_ValidateTimeout;
   QNetworkReply *m_ValidateReply;
-  mutable QProgressDialog* m_ProgressDialog;
+  mutable ValidationProgressDialog m_ProgressDialog;
 
   QString m_MOVersion;
 

--- a/src/nxmaccessmanager.h
+++ b/src/nxmaccessmanager.h
@@ -80,6 +80,8 @@ public:
   std::function<void (QString)> keyChanged;
   std::function<void (States, QString)> stateChanged;
 
+  static QString stateToString(States s, const QString& e);
+
   NexusSSOLogin();
 
   void start();
@@ -125,6 +127,8 @@ public:
 
   std::function<void (APIUserAccount)> finished;
   std::function<void (States, QString)> stateChanged;
+
+  static QString stateToString(States s, const QString& e);
 
   NexusKeyValidator(NXMAccessManager& am);
   ~NexusKeyValidator();
@@ -236,7 +240,6 @@ private:
   void startValidationCheck(const QString& key, bool showProgress);
   void onValidatorState(NexusKeyValidator::States s, const QString& e);
   void onValidatorFinished(const APIUserAccount& user);
-  void onValidatorError(const QString& e);
 };
 
 Q_DECLARE_OPERATORS_FOR_FLAGS(NXMAccessManager::ApiCheckFlags);

--- a/src/nxmaccessmanager.h
+++ b/src/nxmaccessmanager.h
@@ -130,7 +130,7 @@ private:
   QWidget* m_TopLevel;
   QTimer m_ValidateTimeout;
   QNetworkReply *m_ValidateReply;
-  mutable ValidationProgressDialog m_ProgressDialog;
+  mutable ValidationProgressDialog* m_ProgressDialog;
 
   QString m_MOVersion;
 

--- a/src/nxmaccessmanager.h
+++ b/src/nxmaccessmanager.h
@@ -25,6 +25,7 @@ along with Mod Organizer.  If not, see <http://www.gnu.org/licenses/>.
 #include <QTimer>
 #include <QNetworkReply>
 #include <QProgressDialog>
+#include <QElapsedTimer>
 #include <set>
 
 namespace MOBase { class IPluginGame; }
@@ -34,18 +35,22 @@ class ValidationProgressDialog : QObject
   Q_OBJECT;
 
 public:
-  ValidationProgressDialog();
+  ValidationProgressDialog(std::chrono::seconds timeout);
 
   void setParentWidget(QWidget* w);
-  void show();
-  void hide();
+  void start();
+  void stop();
 
 private:
+  std::chrono::seconds m_timeout;
   std::unique_ptr<QDialog> m_dialogHolder;
   QDialog* m_dialog;
   QProgressBar* m_bar;
+  QTimer* m_timer;
+  QElapsedTimer m_elapsed;
 
   void onButton(QAbstractButton* b);
+  void onTimer();
 };
 
 

--- a/src/organizercore.cpp
+++ b/src/organizercore.cpp
@@ -2484,7 +2484,8 @@ void OrganizerCore::loginSuccessfulUpdate(bool necessary)
 
 void OrganizerCore::loginFailed(const QString &message)
 {
-  qDebug("Nexus API validation failed: %s", qUtf8Printable(message));
+  qDebug().nospace().noquote()
+    << "Nexus API validation failed: " << message;
 
   if (QMessageBox::question(qApp->activeWindow(), tr("Login failed"),
                             tr("Login failed, try again?"))

--- a/src/organizercore.cpp
+++ b/src/organizercore.cpp
@@ -2484,6 +2484,8 @@ void OrganizerCore::loginSuccessfulUpdate(bool necessary)
 
 void OrganizerCore::loginFailed(const QString &message)
 {
+  qDebug("Nexus API validation failed: %s", qUtf8Printable(message));
+
   if (QMessageBox::question(qApp->activeWindow(), tr("Login failed"),
                             tr("Login failed, try again?"))
       == QMessageBox::Yes) {

--- a/src/organizercore.cpp
+++ b/src/organizercore.cpp
@@ -2484,7 +2484,7 @@ void OrganizerCore::loginSuccessfulUpdate(bool necessary)
 
 void OrganizerCore::loginFailed(const QString &message)
 {
-  qDebug().nospace().noquote()
+  qCritical().nospace().noquote()
     << "Nexus API validation failed: " << message;
 
   if (QMessageBox::question(qApp->activeWindow(), tr("Login failed"),

--- a/src/pch.h
+++ b/src/pch.h
@@ -98,6 +98,7 @@
 #include <QDirIterator>
 #include <QDragEnterEvent>
 #include <QDropEvent>
+#include <QElapsedTimer>
 #include <QEvent>
 #include <QFile>
 #include <QFileDialog>

--- a/src/selfupdater.cpp
+++ b/src/selfupdater.cpp
@@ -130,7 +130,7 @@ void SelfUpdater::testForUpdate()
     m_GitHub.releases(GitHub::Repository("Modorganizer2", "modorganizer"),
                       [this](const QJsonArray &releases) {
       if (releases.isEmpty()) {
-        qDebug("Unable to connect to github.com to check version");
+        // error message already logged
         return;
       }
 

--- a/src/settingsdialog.cpp
+++ b/src/settingsdialog.cpp
@@ -450,66 +450,10 @@ void SettingsDialog::onSSOKeyChanged(const QString& key)
 
 void SettingsDialog::onSSOStateChanged(NexusSSOLogin::States s, const QString& e)
 {
-  QString log;
+  const auto log = NexusSSOLogin::stateToString(s, e);
 
-  switch (s)
-  {
-    case NexusSSOLogin::ConnectingToSSO:
-    {
-      log = tr("Connecting to Nexus...");
-      break;
-    }
-
-    case NexusSSOLogin::WaitingForToken:
-    {
-      log = tr("Waiting for Nexus...");
-      break;
-    }
-
-    case NexusSSOLogin::WaitingForBrowser:
-    {
-      log = tr("Opened browser, waiting for user...");
-      break;
-    }
-
-    case NexusSSOLogin::Finished:
-    {
-      log = tr("Connected.");
-      break;
-    }
-
-    case NexusSSOLogin::Timeout:
-    {
-      log = QObject::tr(
-        "No answer from Nexus.\n"
-        "A firewall might be blocking Mod Organizer.");
-
-      break;
-    }
-
-    case NexusSSOLogin::ClosedByRemote:
-    {
-      log = QObject::tr("Nexus closed the connection.");
-      break;
-    }
-
-    case NexusSSOLogin::Cancelled:
-    {
-      log = QObject::tr("Cancelled.");
-      break;
-    }
-
-    case NexusSSOLogin::Error:
-    {
-      log = tr("Error: %1.").arg(e);
-      break;
-    }
-  }
-
-  if (!log.isEmpty()) {
-    for (auto&& line : log.split("\n")) {
-      ui->nexusLog->addItem(line);
-    }
+  for (auto&& line : log.split("\n")) {
+    ui->nexusLog->addItem(line);
   }
 
   updateNexusButtons();
@@ -518,60 +462,10 @@ void SettingsDialog::onSSOStateChanged(NexusSSOLogin::States s, const QString& e
 void SettingsDialog::onValidatorStateChanged(
   NexusKeyValidator::States s, const QString& e)
 {
-  QString log;
+  const auto log = NexusKeyValidator::stateToString(s, e);
 
-  switch (s)
-  {
-    case NexusKeyValidator::Connecting:
-    {
-      log = tr("Connecting to Nexus...");
-      break;
-    }
-
-    case NexusKeyValidator::Finished:
-    {
-      log = tr("Connected.");
-      break;
-    }
-
-    case NexusKeyValidator::InvalidJson:
-    {
-      log = tr("Invalid JSON");
-      break;
-    }
-
-    case NexusKeyValidator::BadResponse:
-    {
-      log = tr("Bad response");
-      break;
-    }
-
-    case NexusKeyValidator::Timeout:
-    {
-      log = QObject::tr(
-        "No answer from Nexus.\n"
-        "A firewall might be blocking Mod Organizer.");
-
-      break;
-    }
-
-    case NexusKeyValidator::Cancelled:
-    {
-      log = QObject::tr("Cancelled.");
-      break;
-    }
-
-    case NexusKeyValidator::Error:
-    {
-      log = tr("Error: %1.").arg(e);
-      break;
-    }
-  }
-
-  if (!log.isEmpty()) {
-    for (auto&& line : log.split("\n")) {
-      ui->nexusLog->addItem(line);
-    }
+  for (auto&& line : log.split("\n")) {
+    ui->nexusLog->addItem(line);
   }
 
   updateNexusButtons();

--- a/src/settingsdialog.h
+++ b/src/settingsdialog.h
@@ -145,15 +145,21 @@ private:
   std::unique_ptr<NexusSSOLogin> m_nexusLogin;
   std::unique_ptr<NexusKeyValidator> m_nexusValidator;
 
+  void validateKey(const QString& key);
   bool setKey(const QString& key);
   bool clearKey();
+
+  void updateNexusState();
   void updateNexusButtons();
+  void updateNexusData();
 
   void onSSOKeyChanged(const QString& key);
   void onSSOStateChanged(NexusSSOLogin::States s, const QString& e);
 
   void onValidatorStateChanged(NexusKeyValidator::States s, const QString& e);
   void onValidatorFinished(const APIUserAccount& user);
+
+  void addNexusLog(const QString& s);
 };
 
 #endif // SETTINGSDIALOG_H

--- a/src/settingsdialog.h
+++ b/src/settingsdialog.h
@@ -21,12 +21,9 @@ along with Mod Organizer.  If not, see <http://www.gnu.org/licenses/>.
 #define SETTINGSDIALOG_H
 
 #include "tutorabledialog.h"
+#include "nxmaccessmanager.h"
 #include <iplugin.h>
-#include <QComboBox>
-#include <QDialog>
-#include <QWebSocket>
 #include <QListWidgetItem>
-#include <QTimer>
 
 class PluginContainer;
 class Settings;
@@ -35,51 +32,6 @@ namespace Ui {
     class SettingsDialog;
 }
 
-class NexusSSOLogin
-{
-public:
-  enum States
-  {
-    Idle,
-    ConnectingToSSO,
-    WaitingForToken,
-    WaitingForBrowser,
-    Finished,
-    Timeout,
-    ClosedByRemote,
-    Cancelled,
-    Error
-  };
-
-  std::function<void (QString)> keyChanged;
-  std::function<void (States, QString)> stateChanged;
-
-  NexusSSOLogin();
-
-  void start();
-  void cancel();
-
-  bool isActive() const;
-
-private:
-  QWebSocket m_socket;
-  QString m_guid;
-  bool m_keyReceived;
-  QString m_token;
-  bool m_active;
-  QTimer m_timeout;
-
-  void setState(States s, const QString& error={});
-
-  void close();
-  void abort();
-
-  void onConnected();
-  void onMessage(const QString& s);
-  void onDisconnected();
-  void onError(QAbstractSocket::SocketError e);
-  void onTimeout();
-};
 
 /**
  * dialog used to change settings for Mod Organizer. On top of the
@@ -197,9 +149,9 @@ private:
   void updateNexusButtons();
 
   void fetchNexusApiKey();
-  void testApiKey();
   void onKeyChanged(const QString& key);
   void onStateChanged(NexusSSOLogin::States s, const QString& e);
+  void onManualKeyValidation(bool success, const QString& e);
 };
 
 #endif // SETTINGSDIALOG_H

--- a/src/settingsdialog.h
+++ b/src/settingsdialog.h
@@ -142,16 +142,18 @@ private:
   bool m_keyChanged;
 
   QString m_ExecutableBlacklist;
-  NexusSSOLogin m_nexusLogin;
+  std::unique_ptr<NexusSSOLogin> m_nexusLogin;
+  std::unique_ptr<NexusKeyValidator> m_nexusValidator;
 
   bool setKey(const QString& key);
   bool clearKey();
   void updateNexusButtons();
 
-  void fetchNexusApiKey();
-  void onKeyChanged(const QString& key);
-  void onStateChanged(NexusSSOLogin::States s, const QString& e);
-  void onManualKeyValidation(bool success, const QString& e);
+  void onSSOKeyChanged(const QString& key);
+  void onSSOStateChanged(NexusSSOLogin::States s, const QString& e);
+
+  void onValidatorStateChanged(NexusKeyValidator::States s, const QString& e);
+  void onValidatorFinished(const APIUserAccount& user);
 };
 
 #endif // SETTINGSDIALOG_H

--- a/src/settingsdialog.ui
+++ b/src/settingsdialog.ui
@@ -451,7 +451,122 @@ If you use pre-releases, never contact me directly by e-mail or via private mess
       <attribute name="title">
        <string>Nexus</string>
       </attribute>
-      <layout class="QVBoxLayout" name="verticalLayout_4" stretch="1,0,0,0,0,1">
+      <layout class="QVBoxLayout" name="verticalLayout_4" stretch="0,1,0,0,0,1">
+       <item>
+        <widget class="QWidget" name="widget" native="true">
+         <layout class="QHBoxLayout" name="horizontalLayout_5">
+          <property name="leftMargin">
+           <number>0</number>
+          </property>
+          <property name="topMargin">
+           <number>0</number>
+          </property>
+          <property name="rightMargin">
+           <number>0</number>
+          </property>
+          <property name="bottomMargin">
+           <number>0</number>
+          </property>
+          <item>
+           <widget class="QGroupBox" name="groupBox_2">
+            <property name="title">
+             <string>Nexus Account</string>
+            </property>
+            <layout class="QFormLayout" name="formLayout">
+             <property name="horizontalSpacing">
+              <number>10</number>
+             </property>
+             <item row="0" column="0">
+              <widget class="QLabel" name="label_2">
+               <property name="text">
+                <string>User ID:</string>
+               </property>
+               <property name="textInteractionFlags">
+                <set>Qt::LinksAccessibleByMouse|Qt::TextSelectableByKeyboard|Qt::TextSelectableByMouse</set>
+               </property>
+              </widget>
+             </item>
+             <item row="0" column="1">
+              <widget class="QLabel" name="nexusUserID">
+               <property name="text">
+                <string>id</string>
+               </property>
+              </widget>
+             </item>
+             <item row="1" column="0">
+              <widget class="QLabel" name="label_3">
+               <property name="text">
+                <string>Name:</string>
+               </property>
+              </widget>
+             </item>
+             <item row="1" column="1">
+              <widget class="QLabel" name="nexusName">
+               <property name="text">
+                <string>name</string>
+               </property>
+              </widget>
+             </item>
+             <item row="2" column="0">
+              <widget class="QLabel" name="label_11">
+               <property name="text">
+                <string>Account:</string>
+               </property>
+              </widget>
+             </item>
+             <item row="2" column="1">
+              <widget class="QLabel" name="nexusAccount">
+               <property name="text">
+                <string>account</string>
+               </property>
+              </widget>
+             </item>
+            </layout>
+           </widget>
+          </item>
+          <item>
+           <widget class="QGroupBox" name="groupBox_3">
+            <property name="title">
+             <string>Statistics</string>
+            </property>
+            <layout class="QFormLayout" name="formLayout_3">
+             <property name="horizontalSpacing">
+              <number>10</number>
+             </property>
+             <item row="0" column="0">
+              <widget class="QLabel" name="label_30">
+               <property name="text">
+                <string>Daily requests:</string>
+               </property>
+              </widget>
+             </item>
+             <item row="0" column="1">
+              <widget class="QLabel" name="nexusDailyRequests">
+               <property name="text">
+                <string>daily requests</string>
+               </property>
+              </widget>
+             </item>
+             <item row="1" column="0">
+              <widget class="QLabel" name="label_31">
+               <property name="text">
+                <string>Hourly requests:</string>
+               </property>
+              </widget>
+             </item>
+             <item row="1" column="1">
+              <widget class="QLabel" name="nexusHourlyRequests">
+               <property name="text">
+                <string>hourly requests</string>
+               </property>
+              </widget>
+             </item>
+            </layout>
+           </widget>
+          </item>
+         </layout>
+        </widget>
+       </item>
        <item>
         <widget class="QGroupBox" name="groupBox_4">
          <property name="title">
@@ -539,129 +654,6 @@ If you use pre-releases, never contact me directly by e-mail or via private mess
               <widget class="QListWidget" name="nexusLog">
                <property name="sizeAdjustPolicy">
                 <enum>QAbstractScrollArea::AdjustToContents</enum>
-               </property>
-              </widget>
-             </item>
-            </layout>
-           </widget>
-          </item>
-         </layout>
-        </widget>
-       </item>
-       <item>
-        <widget class="QWidget" name="widget" native="true">
-         <layout class="QHBoxLayout" name="horizontalLayout_5">
-          <property name="leftMargin">
-           <number>0</number>
-          </property>
-          <property name="topMargin">
-           <number>0</number>
-          </property>
-          <property name="rightMargin">
-           <number>0</number>
-          </property>
-          <property name="bottomMargin">
-           <number>0</number>
-          </property>
-          <item>
-           <widget class="QGroupBox" name="groupBox_2">
-            <property name="title">
-             <string>Nexus Account</string>
-            </property>
-            <layout class="QFormLayout" name="formLayout">
-             <item row="0" column="0">
-              <widget class="QLabel" name="label_2">
-               <property name="text">
-                <string>User ID</string>
-               </property>
-               <property name="textInteractionFlags">
-                <set>Qt::LinksAccessibleByMouse|Qt::TextSelectableByKeyboard|Qt::TextSelectableByMouse</set>
-               </property>
-              </widget>
-             </item>
-             <item row="0" column="1">
-              <widget class="QLabel" name="nexusUserID">
-               <property name="text">
-                <string>id</string>
-               </property>
-              </widget>
-             </item>
-             <item row="1" column="0">
-              <widget class="QLabel" name="label_3">
-               <property name="text">
-                <string>Username</string>
-               </property>
-              </widget>
-             </item>
-             <item row="1" column="1">
-              <widget class="QLabel" name="nexusUsername">
-               <property name="text">
-                <string>username</string>
-               </property>
-              </widget>
-             </item>
-             <item row="2" column="0">
-              <widget class="QLabel" name="label_11">
-               <property name="text">
-                <string>Account</string>
-               </property>
-              </widget>
-             </item>
-             <item row="2" column="1">
-              <widget class="QLabel" name="nexusAccount">
-               <property name="text">
-                <string>account</string>
-               </property>
-              </widget>
-             </item>
-            </layout>
-           </widget>
-          </item>
-          <item>
-           <widget class="QGroupBox" name="groupBox_3">
-            <property name="title">
-             <string>Statistics</string>
-            </property>
-            <layout class="QFormLayout" name="formLayout_3">
-             <item row="0" column="0">
-              <widget class="QLabel" name="label_30">
-               <property name="text">
-                <string>Daily requests</string>
-               </property>
-              </widget>
-             </item>
-             <item row="1" column="0">
-              <widget class="QLabel" name="label_31">
-               <property name="text">
-                <string>Hourly requests</string>
-               </property>
-              </widget>
-             </item>
-             <item row="1" column="1">
-              <widget class="QLabel" name="nexusHourlyRequests">
-               <property name="text">
-                <string>hourly requests</string>
-               </property>
-              </widget>
-             </item>
-             <item row="2" column="0">
-              <widget class="QLabel" name="label_32">
-               <property name="text">
-                <string>Requests queued</string>
-               </property>
-              </widget>
-             </item>
-             <item row="2" column="1">
-              <widget class="QLabel" name="nexusRequestsQueued">
-               <property name="text">
-                <string>queued</string>
-               </property>
-              </widget>
-             </item>
-             <item row="0" column="1">
-              <widget class="QLabel" name="nexusDailyRequests">
-               <property name="text">
-                <string>daily requests</string>
                </property>
               </widget>
              </item>

--- a/src/settingsdialog.ui
+++ b/src/settingsdialog.ui
@@ -451,108 +451,241 @@ If you use pre-releases, never contact me directly by e-mail or via private mess
       <attribute name="title">
        <string>Nexus</string>
       </attribute>
-      <layout class="QVBoxLayout" name="verticalLayout_4">
+      <layout class="QVBoxLayout" name="verticalLayout_4" stretch="1,0,0,0,0,1">
        <item>
-        <widget class="QGroupBox" name="nexusBox">
-         <property name="toolTip">
-          <string>Allows Mod Organizer to connect to the Nexus for downloading mods, checking for updates, and other such things.</string>
-         </property>
-         <property name="whatsThis">
-          <string>&lt;!DOCTYPE HTML PUBLIC &quot;-//W3C//DTD HTML 4.0//EN&quot; &quot;http://www.w3.org/TR/REC-html40/strict.dtd&quot;&gt;
-&lt;html&gt;&lt;head&gt;&lt;meta name=&quot;qrichtext&quot; content=&quot;1&quot; /&gt;&lt;style type=&quot;text/css&quot;&gt;
-p, li { white-space: pre-wrap; }
-&lt;/style&gt;&lt;/head&gt;&lt;body style=&quot; font-family:'MS Shell Dlg 2'; font-size:8pt; font-weight:400; font-style:normal;&quot;&gt;
-&lt;p style=&quot; margin-top:0px; margin-bottom:0px; margin-left:0px; margin-right:0px; -qt-block-indent:0; text-indent:0px;&quot;&gt;Allows Mod Organizer to connect to the Nexus for downloading mods, checking for updates, and other such things.  Clicking &amp;quot;Connect to Nexus&amp;quot; will open a Nexus webpage to authorise Mod Organizer.  You will need to be logged into your Nexus account.  The authorisation is stored in the Windows Credential Manager.  Your Nexus username and password are not required or stored by Mod Organizer.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
-         </property>
+        <widget class="QGroupBox" name="groupBox_4">
          <property name="title">
-          <string>Nexus</string>
+          <string>Nexus Connection</string>
          </property>
-         <layout class="QVBoxLayout" name="verticalLayout_2">
+         <layout class="QHBoxLayout" name="horizontalLayout_14">
           <item>
-           <layout class="QHBoxLayout" name="horizontalLayout_10">
-            <item>
-             <widget class="QPushButton" name="nexusConnect">
-              <property name="text">
-               <string>Connect to Nexus</string>
-              </property>
-             </widget>
-            </item>
-           </layout>
+           <widget class="QWidget" name="widget_2" native="true">
+            <layout class="QVBoxLayout" name="verticalLayout_11">
+             <property name="leftMargin">
+              <number>0</number>
+             </property>
+             <property name="topMargin">
+              <number>0</number>
+             </property>
+             <property name="rightMargin">
+              <number>0</number>
+             </property>
+             <property name="bottomMargin">
+              <number>0</number>
+             </property>
+             <item>
+              <widget class="QPushButton" name="nexusConnect">
+               <property name="text">
+                <string>Connect to Nexus</string>
+               </property>
+              </widget>
+             </item>
+             <item>
+              <widget class="QPushButton" name="nexusManualKey">
+               <property name="toolTip">
+                <string>Manually enter the API key and try to login</string>
+               </property>
+               <property name="text">
+                <string>Enter API Key Manually</string>
+               </property>
+              </widget>
+             </item>
+             <item>
+              <widget class="QPushButton" name="nexusDisconnect">
+               <property name="toolTip">
+                <string>Clear the stored Nexus API key and force reauthorization.</string>
+               </property>
+               <property name="text">
+                <string>Disconnect from Nexus</string>
+               </property>
+               <property name="icon">
+                <iconset resource="resources.qrc">
+                 <normaloff>:/MO/gui/edit_clear</normaloff>:/MO/gui/edit_clear</iconset>
+               </property>
+              </widget>
+             </item>
+             <item>
+              <spacer name="verticalSpacer_3">
+               <property name="orientation">
+                <enum>Qt::Vertical</enum>
+               </property>
+               <property name="sizeHint" stdset="0">
+                <size>
+                 <width>0</width>
+                 <height>0</height>
+                </size>
+               </property>
+              </spacer>
+             </item>
+            </layout>
+           </widget>
           </item>
           <item>
-           <layout class="QHBoxLayout" name="horizontalLayout_11">
-            <item>
-             <spacer name="horizontalSpacer_7">
-              <property name="orientation">
-               <enum>Qt::Horizontal</enum>
-              </property>
-              <property name="sizeHint" stdset="0">
-               <size>
-                <width>40</width>
-                <height>20</height>
-               </size>
-              </property>
-             </spacer>
-            </item>
-            <item>
-             <widget class="QPushButton" name="nexusManualKey">
-              <property name="sizePolicy">
-               <sizepolicy hsizetype="Minimum" vsizetype="Preferred">
-                <horstretch>0</horstretch>
-                <verstretch>0</verstretch>
-               </sizepolicy>
-              </property>
-              <property name="toolTip">
-               <string>Manually enter the API key and try to login</string>
-              </property>
-              <property name="text">
-               <string>Enter API Key Manually</string>
-              </property>
-             </widget>
-            </item>
-            <item>
-             <widget class="QPushButton" name="nexusDisconnect">
-              <property name="toolTip">
-               <string>Clear the stored Nexus API key and force reauthorization.</string>
-              </property>
-              <property name="text">
-               <string>Disconnect from Nexus</string>
-              </property>
-              <property name="icon">
-               <iconset resource="resources.qrc">
-                <normaloff>:/MO/gui/edit_clear</normaloff>:/MO/gui/edit_clear</iconset>
-              </property>
-             </widget>
-            </item>
-            <item>
-             <widget class="QPushButton" name="clearCacheButton">
-              <property name="toolTip">
-               <string>Remove cache and cookies.</string>
-              </property>
-              <property name="text">
-               <string>Clear Cache</string>
-              </property>
-              <property name="icon">
-               <iconset resource="resources.qrc">
-                <normaloff>:/MO/gui/edit_clear</normaloff>:/MO/gui/edit_clear</iconset>
-              </property>
-             </widget>
-            </item>
-            <item>
-             <spacer name="horizontalSpacer_5">
-              <property name="orientation">
-               <enum>Qt::Horizontal</enum>
-              </property>
-              <property name="sizeHint" stdset="0">
-               <size>
-                <width>40</width>
-                <height>20</height>
-               </size>
-              </property>
-             </spacer>
-            </item>
-           </layout>
+           <widget class="QWidget" name="widget_3" native="true">
+            <layout class="QVBoxLayout" name="verticalLayout_12">
+             <property name="leftMargin">
+              <number>0</number>
+             </property>
+             <property name="topMargin">
+              <number>0</number>
+             </property>
+             <property name="rightMargin">
+              <number>0</number>
+             </property>
+             <property name="bottomMargin">
+              <number>0</number>
+             </property>
+             <item>
+              <widget class="QListWidget" name="nexusLog">
+               <property name="sizeAdjustPolicy">
+                <enum>QAbstractScrollArea::AdjustToContents</enum>
+               </property>
+              </widget>
+             </item>
+            </layout>
+           </widget>
           </item>
+         </layout>
+        </widget>
+       </item>
+       <item>
+        <widget class="QWidget" name="widget" native="true">
+         <layout class="QHBoxLayout" name="horizontalLayout_5">
+          <property name="leftMargin">
+           <number>0</number>
+          </property>
+          <property name="topMargin">
+           <number>0</number>
+          </property>
+          <property name="rightMargin">
+           <number>0</number>
+          </property>
+          <property name="bottomMargin">
+           <number>0</number>
+          </property>
+          <item>
+           <widget class="QGroupBox" name="groupBox_2">
+            <property name="title">
+             <string>Nexus Account</string>
+            </property>
+            <layout class="QFormLayout" name="formLayout">
+             <item row="0" column="0">
+              <widget class="QLabel" name="label_2">
+               <property name="text">
+                <string>User ID</string>
+               </property>
+               <property name="textInteractionFlags">
+                <set>Qt::LinksAccessibleByMouse|Qt::TextSelectableByKeyboard|Qt::TextSelectableByMouse</set>
+               </property>
+              </widget>
+             </item>
+             <item row="0" column="1">
+              <widget class="QLabel" name="nexusUserID">
+               <property name="text">
+                <string>id</string>
+               </property>
+              </widget>
+             </item>
+             <item row="1" column="0">
+              <widget class="QLabel" name="label_3">
+               <property name="text">
+                <string>Username</string>
+               </property>
+              </widget>
+             </item>
+             <item row="1" column="1">
+              <widget class="QLabel" name="nexusUsername">
+               <property name="text">
+                <string>username</string>
+               </property>
+              </widget>
+             </item>
+             <item row="2" column="0">
+              <widget class="QLabel" name="label_11">
+               <property name="text">
+                <string>Account</string>
+               </property>
+              </widget>
+             </item>
+             <item row="2" column="1">
+              <widget class="QLabel" name="nexusAccount">
+               <property name="text">
+                <string>account</string>
+               </property>
+              </widget>
+             </item>
+            </layout>
+           </widget>
+          </item>
+          <item>
+           <widget class="QGroupBox" name="groupBox_3">
+            <property name="title">
+             <string>Statistics</string>
+            </property>
+            <layout class="QFormLayout" name="formLayout_3">
+             <item row="0" column="0">
+              <widget class="QLabel" name="label_30">
+               <property name="text">
+                <string>Daily requests</string>
+               </property>
+              </widget>
+             </item>
+             <item row="1" column="0">
+              <widget class="QLabel" name="label_31">
+               <property name="text">
+                <string>Hourly requests</string>
+               </property>
+              </widget>
+             </item>
+             <item row="1" column="1">
+              <widget class="QLabel" name="nexusHourlyRequests">
+               <property name="text">
+                <string>hourly requests</string>
+               </property>
+              </widget>
+             </item>
+             <item row="2" column="0">
+              <widget class="QLabel" name="label_32">
+               <property name="text">
+                <string>Requests queued</string>
+               </property>
+              </widget>
+             </item>
+             <item row="2" column="1">
+              <widget class="QLabel" name="nexusRequestsQueued">
+               <property name="text">
+                <string>queued</string>
+               </property>
+              </widget>
+             </item>
+             <item row="0" column="1">
+              <widget class="QLabel" name="nexusDailyRequests">
+               <property name="text">
+                <string>daily requests</string>
+               </property>
+              </widget>
+             </item>
+            </layout>
+           </widget>
+          </item>
+         </layout>
+        </widget>
+       </item>
+       <item>
+        <widget class="QWidget" name="widget_4" native="true">
+         <layout class="QHBoxLayout" name="horizontalLayout_10">
+          <property name="leftMargin">
+           <number>0</number>
+          </property>
+          <property name="topMargin">
+           <number>0</number>
+          </property>
+          <property name="rightMargin">
+           <number>0</number>
+          </property>
+          <property name="bottomMargin">
+           <number>0</number>
+          </property>
          </layout>
         </widget>
        </item>
@@ -619,6 +752,20 @@ p, li { white-space: pre-wrap; }
           </widget>
          </item>
          <item>
+          <widget class="QPushButton" name="clearCacheButton">
+           <property name="toolTip">
+            <string>Remove cache and cookies.</string>
+           </property>
+           <property name="text">
+            <string>Clear Cache</string>
+           </property>
+           <property name="icon">
+            <iconset resource="resources.qrc">
+             <normaloff>:/MO/gui/edit_clear</normaloff>:/MO/gui/edit_clear</iconset>
+           </property>
+          </widget>
+         </item>
+         <item>
           <spacer name="horizontalSpacer_4">
            <property name="orientation">
             <enum>Qt::Horizontal</enum>
@@ -681,19 +828,6 @@ p, li { white-space: pre-wrap; }
           </layout>
          </item>
         </layout>
-       </item>
-       <item>
-        <spacer name="verticalSpacer_3">
-         <property name="orientation">
-          <enum>Qt::Vertical</enum>
-         </property>
-         <property name="sizeHint" stdset="0">
-          <size>
-           <width>20</width>
-           <height>40</height>
-          </size>
-         </property>
-        </spacer>
        </item>
       </layout>
      </widget>
@@ -1359,7 +1493,6 @@ programs you are intentionally running.</string>
   <tabstop>browseProfilesDirBtn</tabstop>
   <tabstop>overwriteDirEdit</tabstop>
   <tabstop>browseOverwriteDirBtn</tabstop>
-  <tabstop>clearCacheButton</tabstop>
   <tabstop>associateButton</tabstop>
   <tabstop>knownServersList</tabstop>
   <tabstop>preferredServersList</tabstop>


### PR DESCRIPTION
I've had problems with how MO behaves when network connections are refused, especially on startup. The progress dialog isn't in front of the main window, it doesn't show any progress, the "try again" dialog pops up on top of it, etc. This often happens to me when I test releases because my firewall blocks them.

I've also used this opportunity to rework parts of the settings dialog to have some information about what's going on. It looks like this now:

![nexus-settings](https://user-images.githubusercontent.com/14251494/61109630-5cf03e00-a453-11e9-95b6-bd828db064ab.png)

I've extracted a bunch of stuff from `NXMAccessManager` and the settings dialog:
  1) The progress dialog
  2) Retrieving the API key through the browser
  3) Retrieving user info from Nexus using API key

The progress dialog is now a `ValidationProgressDialog` and will use the progress bar to show the timeout. It can also be hidden.

Retrieving the API key from the browser is now done through a `NexusSSOLogin` class. This is used in the settings dialog. Retrieving user info is done from `NexusKeyValidator`. This is used in `NXMAccessManager` so its behaviour is the same when starting up MO, but also in the settings dialog. The advantage is that it's now decoupled from the progress dialog, so I'm logging operations in a small list instead.

When logging in through SSO by opening a browser in the settings dialog, the only thing that's returned is the API key. I added a second step where the user account is retrieved, as if the key had been entered manually. This allows for immediately updating the user account information on the dialog.

I've also added the API key as a member in `APIUserAccount` and removed it from `NXMAccessManager`. The key used to be stored in various places, now it's only the `APIUserAccount` object.

I fixed an annoying error when a download is added but MO is blocked by a firewall. In that case, it takes time for the download to time out and it stays visible in the download list, but it's a "pending" download. Right-clicking it would throw and it was caught in a generic `...` handler. Right-clicking pending downloads now still show the context menu, but without the items related to the selected download.

![pending-download](https://user-images.githubusercontent.com/14251494/61111044-9e361d00-a456-11e9-9600-fa643e79e3ae.png)