### PR TITLE
Improved Nexus Description display and BBCode support.

### DIFF
--- a/src/bbcode.cpp
+++ b/src/bbcode.cpp
@@ -183,7 +183,7 @@ private:
     m_TagMap["email="]  = std::make_pair(QRegExp("\\[email=\"?([^\\]]*)\"?\\](.*)\\[/email\\]"),
                                          "<a href=\"mailto:\\1\">\\2</a>");
     m_TagMap["youtube"] = std::make_pair(QRegExp("\\[youtube\\](.*)\\[/youtube\\]"),
-                                         "<a href=\"https://youtu.be./\\1\">https://youtu.be/\\1</a>");
+                                         "<a href=\"https://www.youtube.com/watch?v=\\1\">https://www.youtube.com/watch?v=\\1</a>");
 
 
     // make all patterns non-greedy and case-insensitive

--- a/src/bbcode.cpp
+++ b/src/bbcode.cpp
@@ -183,7 +183,7 @@ private:
     m_TagMap["email="]  = std::make_pair(QRegExp("\\[email=\"?([^\\]]*)\"?\\](.*)\\[/email\\]"),
                                          "<a href=\"mailto:\\1\">\\2</a>");
     m_TagMap["youtube"] = std::make_pair(QRegExp("\\[youtube\\](.*)\\[/youtube\\]"),
-                                         "<a href=\"http://www.youtube.com/v/\\1\">http://www.youtube.com/v/\\1</a>");
+                                         "<a href=\"https://youtu.be./\\1\">https://youtu.be/\\1</a>");
 
 
     // make all patterns non-greedy and case-insensitive

--- a/src/bbcode.cpp
+++ b/src/bbcode.cpp
@@ -140,6 +140,8 @@ private:
                                         "<figure class=\"quote\"><blockquote>\\1</blockquote></figure>");
     m_TagMap["quote="] = std::make_pair(QRegExp("\\[quote=([^\\]]*)\\](.*)\\[/quote\\]"),
                                         "<figure class=\"quote\"><blockquote>\\2</blockquote></figure>");
+    m_TagMap["spoiler"] = std::make_pair(QRegExp("\\[spoiler\\](.*)\\[/spoiler\\]"),
+      "<details><summary>Spoiler:  <div class=\"bbc_spoiler_show\">Show</div></summary><div class=\"spoiler_content\">\\1</div></details>");
     m_TagMap["code"]   = std::make_pair(QRegExp("\\[code\\](.*)\\[/code\\]"),
                                         "<code>\\1</code>");
     m_TagMap["heading"]= std::make_pair(QRegExp("\\[heading\\](.*)\\[/heading\\]"),

--- a/src/bbcode.cpp
+++ b/src/bbcode.cpp
@@ -137,11 +137,11 @@ private:
     m_TagMap["center"] = std::make_pair(QRegExp("\\[center\\](.*)\\[/center\\]"),
                                         "<div align=\"center\">\\1</div>");
     m_TagMap["quote"]  = std::make_pair(QRegExp("\\[quote\\](.*)\\[/quote\\]"),
-                                        "<blockquote>\"\\1\"</blockquote>");
+                                        "<figure class=\"quote\"><blockquote>\\1</blockquote></figure>");
     m_TagMap["quote="] = std::make_pair(QRegExp("\\[quote=([^\\]]*)\\](.*)\\[/quote\\]"),
-                                        "<blockquote>\"\\2\"<br/><span>--\\1</span></blockquote></p>");
+                                        "<figure class=\"quote\"><blockquote>\\2</blockquote></figure>");
     m_TagMap["code"]   = std::make_pair(QRegExp("\\[code\\](.*)\\[/code\\]"),
-                                        "<pre>\\1</pre>");
+                                        "<code>\\1</code>");
     m_TagMap["heading"]= std::make_pair(QRegExp("\\[heading\\](.*)\\[/heading\\]"),
                                         "<h2><strong>\\1</strong></h2>");
     m_TagMap["line"]   = std::make_pair(QRegExp("\\[line\\]"),

--- a/src/logbuffer.cpp
+++ b/src/logbuffer.cpp
@@ -191,7 +191,7 @@ QVariant LogBuffer::data(const QModelIndex &index, int role) const
   switch (role) {
     case Qt::DisplayRole: {
       if (index.column() == 0) {
-        return m_Messages[msgIndex].time;
+        return m_Messages[msgIndex].time.toString("H: mm: ss");
       } else if (index.column() == 1) {
         const QString &msg = m_Messages[msgIndex].message;
         if (msg.length() < 200) {

--- a/src/modinfodialognexus.cpp
+++ b/src/modinfodialognexus.cpp
@@ -219,9 +219,31 @@ void NexusTab::onModChanged()
     img {
       max-width: 100%;
     }
+  
+    figure.quote {
+      position: relative;
+      padding: 24px;
+      margin: 10px 20px 10px 10px;
+      color: #e1e1e1;
+      line-height: 1.5;
+      font-style: italic;
+      border-left: 6px solid #57a5cc;
+      border-left-color: rgb(87, 165, 204);
+      background: #383838 url(data:image/svg+xml;base64,PHN2ZyBjbGFzcz0iaWNvbi1xdW90ZSIgdmVyc2lvbj0iMS4xIiB4bWxucz0iaHR0cDovL3d3dy53My5vcmcvMjAwMC9zdmciIHN0eWxlPSJmaWxsOnJnYig2OSwgNjksIDcwKTtoZWlnaHQ6MjlweDtsZWZ0OjE1cHg7cG9zaXRpb246YWJzb2x1dGU7dG9wOjE1cHg7d2lkdGg6MzhweDsiPjxwYXRoIGNsYXNzPSJwYXRoMSIgZD0iTTAgMjAuNjc0YzAgNy4yMjUgNC42NjggMTEuMzM3IDkuODkyIDExLjMzNyA0LjgyNC0wLjA2MiA4LjcxOS0zLjk1NiA4Ljc4MS04Ljc3NSAwLTQuNzg1LTMuMzM0LTguMDA5LTcuNTU4LTguMDA5LTAuMDc4LTAuMDA0LTAuMTctMC4wMDYtMC4yNjItMC4wMDYtMC43MDMgMC0xLjM3NyAwLjEyNC0yLjAwMSAwLjM1MiAxLjA0MS00LjAxNCA1LjE1My04LjY4MyA4LjcxLTEwLjU3MmwtNi4xMTMtNS4wMDJjLTYuODkxIDQuODkxLTExLjQ0OCAxMi4zMzgtMTEuNDQ4IDIwLjY3NHpNMjIuNjc1IDIwLjY3NGMwIDcuMjI1IDQuNjY4IDExLjMzNyA5Ljg5MiAxMS4zMzcgNC44LTAuMDU2IDguNjctMy45NjEgOC42Ny04Ljc2OSAwLTAuMDA0IDAtMC4wMDggMC0wLjAxMiAwLTQuNzc5LTMuMjIzLTguMDAyLTcuNDQ3LTguMDAyLTAuMDk1LTAuMDA2LTAuMjA2LTAuMDA5LTAuMzE4LTAuMDA5LTAuNjg0IDAtMS4zMzkgMC4xMjYtMS45NDMgMC4zNTUgMC45MjctNC4wMTQgNS4xNS04LjY4MiA4LjcwNy0xMC41NzJsLTYuMTI0LTUuMDAyYy02Ljg5MSA0Ljg5MS0xMS40MzcgMTIuMzM4LTExLjQzNyAyMC42NzR6IiBzdHlsZT0iZmlsbDpyZ2IoNjksIDY5LCA3MCk7aGVpZ2h0OmF1dG87d2lkdGg6YXV0bzsiLz48L3N2Zz4=) no-repeat;
+    }
+
+    figure.quote blockquote {
+      position: relative;
+      margin: 0;
+      padding: 0;
+    }
 
     a
     {
+      /*should avoid overflow with long links forcing wordwrap regardless of spaces*/  
+      overflow-wrap: break-word;
+      word-wrap: break-word;
+
       color: #8197ec;
       text-decoration: none;
     }

--- a/src/modinfodialognexus.cpp
+++ b/src/modinfodialognexus.cpp
@@ -210,6 +210,14 @@ void NexusTab::onModChanged()
       max-width: 1060px;
       margin-left: auto;
       margin-right: auto;
+      padding-right: 7px;
+      padding-left: 7px;
+      padding-top: 20px;
+      padding-bottom: 20px;
+    }
+    
+    img {
+      max-width: 100%;
     }
 
     a

--- a/src/modinfodialognexus.cpp
+++ b/src/modinfodialognexus.cpp
@@ -238,6 +238,32 @@ void NexusTab::onModChanged()
       padding: 0;
     }
 
+    div.spoiler_content {
+      background: #262626;
+      border: 1px dashed #3b3b3b;
+      padding: 5px;
+      margin: 5px;
+    }
+
+    div.bbc_spoiler_show{
+      border: 1px solid black;
+      background-color: #454545;
+      font-size: 11px;
+      padding: 3px;
+      color: #E6E6E6;
+      border-radius: 3px;
+      display: inline-block;
+      cursor: pointer;
+    }
+  
+    details summary::-webkit-details-marker {
+      display:none;
+    }
+
+    summary:focus {
+      outline: 0;
+    }
+
     a
     {
       /*should avoid overflow with long links forcing wordwrap regardless of spaces*/  


### PR DESCRIPTION
* Added some padding on the entire body for easier reading.
* Fixed images going out of bounds, they will now use the correct dimensions or 100% width if they would be bigger.
* Fixed urls overflowing horizontally by adding break-word to allow word  wrap even with no spaces.
* Added full [quote] tag support: 
![image](https://user-images.githubusercontent.com/26797547/61177705-cf8c2580-a5db-11e9-86e1-cdf6d0bf0e4b.png)
* Added fully functional Spoiler tab support:
![image](https://user-images.githubusercontent.com/26797547/61177723-f5192f00-a5db-11e9-9d7f-d9b870a37bb2.png)

Not related to Nexus, added seconds to the Log list.

Edit: added fix for youtube links not working with old url scheme.


