### PR TITLE
Add portable lock feature

### DIFF
--- a/src/instancemanager.cpp
+++ b/src/instancemanager.cpp
@@ -186,6 +186,10 @@ QString InstanceManager::queryInstanceName(const QStringList &instanceList) cons
 
 QString InstanceManager::chooseInstance(const QStringList &instanceList) const
 {
+  if (portableInstallIsLocked()) {
+    return QString();
+  }
+
   enum class Special : uint8_t {
     NewInstance,
     Portable,
@@ -266,6 +270,19 @@ bool InstanceManager::portableInstall() const
 }
 
 
+bool InstanceManager::portableInstallIsLocked() const
+{
+  return QFile::exists(qApp->applicationDirPath() + "/" +
+                       QString::fromStdWString(AppConfig::portableLockFileName()));
+}
+
+
+bool InstanceManager::allowedToChangeInstance() const
+{
+  return !portableInstallIsLocked();
+}
+
+
 void InstanceManager::createDataPath(const QString &dataPath) const
 {
   if (!QDir(dataPath).exists()) {
@@ -286,6 +303,10 @@ void InstanceManager::createDataPath(const QString &dataPath) const
 QString InstanceManager::determineDataPath()
 {
   QString instanceId = currentInstance();
+  if (portableInstallIsLocked()) 
+  {
+    instanceId.clear();
+  }
   if (instanceId.isEmpty() && !m_Reset && (m_overrideInstance || portableInstall()))
   {
     // startup, apparently using portable mode before

--- a/src/instancemanager.h
+++ b/src/instancemanager.h
@@ -38,6 +38,8 @@ public:
 
   QString currentInstance() const;
 
+  bool allowedToChangeInstance() const;
+
 private:
 
   InstanceManager();
@@ -58,6 +60,7 @@ private:
 
   void createDataPath(const QString &dataPath) const;
   bool portableInstall() const;
+  bool portableInstallIsLocked() const;
 
 private:
 

--- a/src/mainwindow.cpp
+++ b/src/mainwindow.cpp
@@ -727,6 +727,10 @@ void MainWindow::setupToolbar()
   } else {
     log::warn("no separator found on the toolbar, icons won't be right-aligned");
   }
+
+  if (!InstanceManager::instance().allowedToChangeInstance()) {
+    ui->actionChange_Game->setVisible(false);
+  }
 }
 
 void MainWindow::setupActionMenu(QAction* a)

--- a/src/shared/appconfig.inc
+++ b/src/shared/appconfig.inc
@@ -17,6 +17,7 @@ APPPARAM(std::wstring, proxyDLLOrig, L"steam_api_orig.dll") // needs to be ident
 APPPARAM(std::wstring, proxyDLLSource, L"proxy.dll")
 APPPARAM(std::wstring, vfs32DLLName, L"usvfs_x86.dll")
 APPPARAM(std::wstring, vfs64DLLName, L"usvfs_x64.dll")
+APPPARAM(std::wstring, portableLockFileName, L"portable.txt")
 APPPARAM(const wchar_t*, localSavePlaceholder, L"__MOProfileSave__\\")
 
 APPPARAM(std::wstring, firstStepsTutorial, L"tutorial_firststeps_main.js")


### PR DESCRIPTION
If the file "portable.txt" is present in the application directory, MO will force itself to be launched as a portable instance.  The change game button and menu item are hidden to prevent the user
from changing out of the portable instance.

This feature is primarily intended for programs like Automaton and Wabbajack that set up a portable install of MO2 with no user interaction.  