### PR TITLE
Automatically fill in the name of new executables

### DIFF
--- a/src/editexecutablesdialog.cpp
+++ b/src/editexecutablesdialog.cpp
@@ -619,8 +619,9 @@ void EditExecutablesDialog::on_browseBinary_clicked()
     ui->binary->setText(QDir::toNativeSeparators(binaryName));
   }
 
-  // setting title if currently empty
-  if (ui->title->text().isEmpty()) {
+  // setting title if currently empty or some variation of "New Executable"
+  if (ui->title->text().isEmpty() || 
+      ui->title->text().startsWith("New Executable", Qt::CaseInsensitive)) {
     const auto prefix = QFileInfo(binaryName).baseName();
     const auto newTitle = m_executablesList.makeNonConflictingTitle(prefix);
 


### PR DESCRIPTION
When the binary browse button is used to select a binary, this
will use the binary name to fill in the executable name if the
previous executable name stated with "New Executable".