### PR TITLE
Dialog settings

### DIFF
--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -141,6 +141,7 @@ SET(organizer_SRCS
 	envsecurity.cpp
 	envshortcut.cpp
 	envwindows.cpp
+	colortable.cpp
 
     shared/windows_error.cpp
     shared/error_report.cpp
@@ -263,6 +264,7 @@ SET(organizer_HDRS
 	envsecurity.h
 	envshortcut.h
 	envwindows.h
+	colortable.h
 
     shared/windows_error.h
     shared/error_report.h
@@ -473,6 +475,7 @@ set(utilities
 )
 
 set(widgets
+	colortable
 	genericicondelegate
 	filerenamer
 	filterwidget

--- a/src/colortable.cpp
+++ b/src/colortable.cpp
@@ -1,0 +1,278 @@
+#include "colortable.h"
+#include "modflagicondelegate.h"
+#include "settings.h"
+
+class ColorItem;
+ColorItem* colorItemForRow(QTableWidget* table, int row);
+
+void paintBackground(
+  QTableWidget* table, QPainter* p, const QStyleOptionViewItem& option,
+  const QModelIndex& index);
+
+
+class ColoredBackgroundDelegate : public QStyledItemDelegate
+{
+public:
+  ColoredBackgroundDelegate(QTableWidget* table)
+    : m_table(table)
+  {
+  }
+
+  void paint(
+    QPainter* p, const QStyleOptionViewItem& option,
+    const QModelIndex& index) const override
+  {
+    paintBackground(m_table, p, option, index);
+
+    QStyleOptionViewItem itemOption(option);
+    initStyleOption(&itemOption, index);
+    itemOption.state = QStyle::State_Enabled;
+
+    QStyledItemDelegate::paint(p, itemOption, index);
+  }
+
+private:
+  QTableWidget* m_table;
+};
+
+
+class FakeModFlagIconDelegate : public ModFlagIconDelegate
+{
+public:
+  explicit FakeModFlagIconDelegate(QTableWidget* table)
+    : m_table(table)
+  {
+  }
+
+  void paint(
+    QPainter *painter, const QStyleOptionViewItem &option,
+    const QModelIndex &index) const override
+  {
+    paintBackground(m_table, painter, option, index);
+    ModFlagIconDelegate::paintIcons(painter, option, index, getIcons(index));
+  }
+
+protected:
+  QList<QString> getIcons(const QModelIndex &index) const override
+  {
+    const auto flags = {
+      ModInfo::FLAG_CONFLICT_MIXED,
+      ModInfo::FLAG_ARCHIVE_LOOSE_CONFLICT_OVERWRITE,
+      ModInfo::FLAG_ARCHIVE_LOOSE_CONFLICT_OVERWRITTEN,
+      ModInfo::FLAG_ARCHIVE_CONFLICT_MIXED,
+      ModInfo::FLAG_BACKUP,
+      ModInfo::FLAG_NOTENDORSED,
+      ModInfo::FLAG_NOTES,
+      ModInfo::FLAG_ALTERNATE_GAME
+    };
+
+    return getIconsForFlags(flags, false);
+  }
+
+  size_t getNumIcons(const QModelIndex &index) const override
+  {
+    return getIcons(index).size();
+  }
+
+private:
+  QTableWidget* m_table;
+};
+
+
+class ColorItem : public QTableWidgetItem
+{
+public:
+  ColorItem(
+    QString caption, QColor defaultColor,
+    std::function<QColor ()> get,
+    std::function<void (const QColor&)> commit) :
+      m_caption(std::move(caption)), m_default(defaultColor),
+      m_get(get), m_commit(commit)
+  {
+    setText(m_caption);
+    set(get());
+  }
+
+  const QString& caption() const
+  {
+    return m_caption;
+  }
+
+  QColor get() const
+  {
+    return m_temp;
+  }
+
+  bool set(const QColor& c)
+  {
+    if (m_temp != c) {
+      m_temp = c;
+      return true;
+    }
+
+    return false;
+  }
+
+  void commit()
+  {
+    m_commit(m_temp);
+  }
+
+  bool reset()
+  {
+    return set(m_default);
+  }
+
+private:
+  const QString m_caption;
+  const QColor m_default;
+  std::function<QColor ()> m_get;
+  std::function<void (const QColor&)> m_commit;
+  QColor m_temp;
+};
+
+
+ColorItem* colorItemForRow(QTableWidget* table, int row)
+{
+  return dynamic_cast<ColorItem*>(table->item(row, 0));
+}
+
+template <class F>
+void forEachColorItem(QTableWidget* table, F&& f)
+{
+  const auto rowCount = table->rowCount();
+
+  for (int i=0; i<rowCount; ++i) {
+    if (auto* ci=colorItemForRow(table, i)) {
+      f(ci);
+    }
+  }
+}
+
+void paintBackground(
+  QTableWidget* table, QPainter* p, const QStyleOptionViewItem& option,
+  const QModelIndex& index)
+{
+  if (auto* ci=colorItemForRow(table, index.row())) {
+    p->save();
+    p->fillRect(option.rect, ci->get());
+    p->restore();
+  }
+}
+
+
+ColorTable::ColorTable(QWidget* parent)
+  : QTableWidget(parent), m_settings(nullptr)
+{
+  setColumnCount(3);
+  setHorizontalHeaderLabels({"", "", ""});
+
+  setItemDelegateForColumn(1, new ColoredBackgroundDelegate(this));
+  setItemDelegateForColumn(2, new FakeModFlagIconDelegate(this));
+
+  connect(
+    this, &QTableWidget::cellActivated,
+    [&]{ onColorActivated(); });
+}
+
+void ColorTable::load(Settings& s)
+{
+  m_settings = &s;
+
+  addColor(
+    QObject::tr("Is overwritten (loose files)"),
+    QColor(0, 255, 0, 64),
+    [this]{ return m_settings->colors().modlistOverwrittenLoose(); },
+    [this](auto&& v){ m_settings->colors().setModlistOverwrittenLoose(v); });
+
+  addColor(
+    QObject::tr("Is overwriting (loose files)"),
+    QColor(255, 0, 0, 64),
+    [this]{ return m_settings->colors().modlistOverwritingLoose(); },
+    [this](auto&& v){ m_settings->colors().setModlistOverwritingLoose(v); });
+
+  addColor(
+    QObject::tr("Is overwritten (archives)"),
+    QColor(0, 255, 255, 64),
+    [this]{ return m_settings->colors().modlistOverwrittenArchive(); },
+    [this](auto&& v){ m_settings->colors().setModlistOverwrittenArchive(v); });
+
+  addColor(
+    QObject::tr("Is overwriting (archives)"),
+    QColor(255, 0, 255, 64),
+    [this]{ return m_settings->colors().modlistOverwritingArchive(); },
+    [this](auto&& v){ m_settings->colors().setModlistOverwritingArchive(v); });
+
+  addColor(
+    QObject::tr("Mod contains selected plugin"),
+    QColor(0, 0, 255, 64),
+    [this]{ return m_settings->colors().modlistContainsPlugin(); },
+    [this](auto&& v){ m_settings->colors().setModlistContainsPlugin(v); });
+
+  addColor(
+    QObject::tr("Plugin is contained in selected mod"),
+    QColor(0, 0, 255, 64),
+    [this]{ return m_settings->colors().pluginListContained(); },
+    [this](auto&& v){ m_settings->colors().setPluginListContained(v); });
+}
+
+void ColorTable::resetColors()
+{
+  bool changed = false;
+
+  forEachColorItem(this, [&](auto* item) {
+    if (item->reset()) {
+      changed = true;
+    }
+  });
+
+  if (changed) {
+    update();
+  }
+}
+
+void ColorTable::commitColors()
+{
+  forEachColorItem(this, [](auto* item) {
+    item->commit();
+  });
+}
+
+void ColorTable::addColor(
+  const QString& text, const QColor& defaultColor,
+  std::function<QColor ()> get,
+  std::function<void (const QColor&)> commit)
+{
+  const auto r = rowCount();
+  setRowCount(r + 1);
+
+  auto* item = new ColorItem(text, defaultColor, get, commit);
+
+  setItem(r, 0, item);
+  setItem(r, 1, new QTableWidgetItem("Text"));
+  setItem(r, 2, new QTableWidgetItem);
+
+  resizeColumnsToContents();
+}
+
+void ColorTable::onColorActivated()
+{
+  const auto rows = selectionModel()->selectedRows();
+  if (rows.isEmpty()) {
+    return;
+  }
+
+  const auto row = rows[0].row();
+  auto* ci = colorItemForRow(this, row);
+  if (!ci) {
+    return;
+  }
+
+  const QColor result = QColorDialog::getColor(
+    ci->get(), topLevelWidget(), ci->caption(), QColorDialog::ShowAlphaChannel);
+
+  if (result.isValid()) {
+    ci->set(result);
+    update(model()->index(row, 1));
+  }
+}

--- a/src/colortable.cpp
+++ b/src/colortable.cpp
@@ -10,6 +10,8 @@ void paintBackground(
   const QModelIndex& index);
 
 
+// delegate for the sample text column; paints the background color
+//
 class ColoredBackgroundDelegate : public QStyledItemDelegate
 {
 public:
@@ -26,6 +28,9 @@ public:
 
     QStyleOptionViewItem itemOption(option);
     initStyleOption(&itemOption, index);
+
+    // paint the default stuff like text, but override the state to avoid
+    // destroying the background for selected items, etc.
     itemOption.state = QStyle::State_Enabled;
 
     QStyledItemDelegate::paint(p, itemOption, index);
@@ -36,6 +41,8 @@ private:
 };
 
 
+// delegate for the icons column; paints the background and icons
+//
 class FakeModFlagIconDelegate : public ModFlagIconDelegate
 {
 public:
@@ -79,6 +86,8 @@ private:
 };
 
 
+// item used in the first column of the table
+//
 class ColorItem : public QTableWidgetItem
 {
 public:
@@ -93,16 +102,22 @@ public:
     set(get());
   }
 
+  // color caption
+  //
   const QString& caption() const
   {
     return m_caption;
   }
 
+  // the current color
+  //
   QColor get() const
   {
     return m_temp;
   }
 
+  // sets the current color, commit() must be called to save it
+  //
   bool set(const QColor& c)
   {
     if (m_temp != c) {
@@ -113,14 +128,18 @@ public:
     return false;
   }
 
-  void commit()
-  {
-    m_commit(m_temp);
-  }
-
+  // resets the current color, commit() must be called to save it
+  //
   bool reset()
   {
     return set(m_default);
+  }
+
+  // saves the current color
+  //
+  void commit()
+  {
+    m_commit(m_temp);
   }
 
 private:
@@ -246,9 +265,7 @@ void ColorTable::addColor(
   const auto r = rowCount();
   setRowCount(r + 1);
 
-  auto* item = new ColorItem(text, defaultColor, get, commit);
-
-  setItem(r, 0, item);
+  setItem(r, 0, new ColorItem(text, defaultColor, get, commit));
   setItem(r, 1, new QTableWidgetItem("Text"));
   setItem(r, 2, new QTableWidgetItem);
 

--- a/src/colortable.h
+++ b/src/colortable.h
@@ -1,0 +1,28 @@
+#ifndef COLORTABLE_H
+#define COLORTABLE_H
+
+#include <QTableWidget>
+
+class Settings;
+
+class ColorTable : public QTableWidget
+{
+public:
+  ColorTable(QWidget* parent=nullptr);
+
+  void load(Settings& s);
+  void resetColors();
+  void commitColors();
+
+private:
+  Settings* m_settings;
+
+  void addColor(
+    const QString& text, const QColor& defaultColor,
+    std::function<QColor ()> get,
+    std::function<void (const QColor&)> commit);
+
+  void onColorActivated();
+};
+
+#endif // COLORTABLE_H

--- a/src/colortable.h
+++ b/src/colortable.h
@@ -5,13 +5,24 @@
 
 class Settings;
 
+// a QTableWidget to view and modify color settings
+//
 class ColorTable : public QTableWidget
 {
 public:
   ColorTable(QWidget* parent=nullptr);
 
+  // adds colors to the table from the settings
+  //
   void load(Settings& s);
+
+  // resets the colors to their default values; commitColors() must be called
+  // to save them
+  //
   void resetColors();
+
+  // commits any changes
+  //
   void commitColors();
 
 private:

--- a/src/icondelegate.cpp
+++ b/src/icondelegate.cpp
@@ -32,13 +32,10 @@ IconDelegate::IconDelegate(QObject *parent)
 {
 }
 
-
-void IconDelegate::paint(QPainter *painter, const QStyleOptionViewItem &option, const QModelIndex &index) const
+void IconDelegate::paintIcons(
+  QPainter *painter, const QStyleOptionViewItem &option,
+  const QModelIndex &index, const QList<QString>& icons)
 {
-  QStyledItemDelegate::paint(painter, option, index);
-
-  QList<QString> icons = getIcons(index);
-
   int x = 4;
   painter->save();
 
@@ -65,5 +62,11 @@ void IconDelegate::paint(QPainter *painter, const QStyleOptionViewItem &option, 
   }
 
   painter->restore();
+}
+
+void IconDelegate::paint(QPainter *painter, const QStyleOptionViewItem &option, const QModelIndex &index) const
+{
+  QStyledItemDelegate::paint(painter, option, index);
+  paintIcons(painter, option, index, getIcons(index));
 }
 

--- a/src/icondelegate.h
+++ b/src/icondelegate.h
@@ -27,25 +27,19 @@ along with Mod Organizer.  If not, see <http://www.gnu.org/licenses/>.
 
 class IconDelegate : public QStyledItemDelegate
 {
-  Q_OBJECT
+  Q_OBJECT;
+
 public:
-
   explicit IconDelegate(QObject *parent = 0);
-
   virtual void paint(QPainter *painter, const QStyleOptionViewItem &option, const QModelIndex &index) const;
 
-signals:
-  
-public slots:
+  static void paintIcons(
+    QPainter *painter, const QStyleOptionViewItem &option,
+    const QModelIndex &index, const QList<QString>& icons);
 
-private:
-
+protected:
   virtual QList<QString> getIcons(const QModelIndex &index) const = 0;
   virtual size_t getNumIcons(const QModelIndex &index) const = 0;
-
-
-private:
-
 };
 
 #endif // ICONDELEGATE_H

--- a/src/mainwindow.cpp
+++ b/src/mainwindow.cpp
@@ -263,6 +263,7 @@ MainWindow::MainWindow(Settings &settings
 
   setupToolbar();
   toggleMO2EndorseState();
+  toggleUpdateAction();
 
   TaskProgressManager::instance().tryCreateTaskbar();
 
@@ -5007,6 +5008,7 @@ void MainWindow::on_actionSettings_triggered()
   bool oldDisplayForeign(settings.interface().displayForeign());
   bool proxy = settings.network().useProxy();
   DownloadManager *dlManager = m_OrganizerCore.downloadManager();
+  const bool oldCheckForUpdates = settings.checkForUpdates();
 
 
   SettingsDialog dialog(&m_PluginContainer, settings, this);
@@ -5084,6 +5086,14 @@ void MainWindow::on_actionSettings_triggered()
   m_OrganizerCore.cycleDiagnostics();
 
   toggleMO2EndorseState();
+
+  if (oldCheckForUpdates != settings.checkForUpdates()) {
+    toggleUpdateAction();
+
+    if (settings.checkForUpdates()) {
+      m_OrganizerCore.checkForUpdates();
+    }
+  }
 }
 
 void MainWindow::on_actionNexus_triggered()
@@ -5594,6 +5604,12 @@ void MainWindow::toggleMO2EndorseState()
   ui->actionEndorseMO->menu()->setEnabled(enabled);
   ui->actionEndorseMO->setToolTip(text);
   ui->actionEndorseMO->setStatusTip(text);
+}
+
+void MainWindow::toggleUpdateAction()
+{
+  const auto& s = m_OrganizerCore.settings();
+  ui->actionUpdate->setVisible(s.checkForUpdates());
 }
 
 void MainWindow::nxmEndorsementsAvailable(QVariant userData, QVariant resultData, int)

--- a/src/mainwindow.h
+++ b/src/mainwindow.h
@@ -313,6 +313,7 @@ private:
   void sendSelectedPluginsToPriority(int newPriority);
 
   void toggleMO2EndorseState();
+  void toggleUpdateAction();
 
 private:
 

--- a/src/moapplication.cpp
+++ b/src/moapplication.cpp
@@ -132,8 +132,8 @@ bool MOApplication::notify(QObject *receiver, QEvent *event)
 
 void MOApplication::updateStyle(const QString &fileName)
 {
-  if (fileName == "Fusion") {
-    setStyle(QStyleFactory::create("fusion"));
+  if (QStyleFactory::keys().contains(fileName)) {
+    setStyle(QStyleFactory::create(fileName));
     setStyleSheet("");
   } else {
     setStyle(new ProxyStyle(QStyleFactory::create(m_DefaultStyle)));

--- a/src/modflagicondelegate.cpp
+++ b/src/modflagicondelegate.cpp
@@ -31,72 +31,82 @@ void ModFlagIconDelegate::columnResized(int logicalIndex, int, int newSize)
   }
 }
 
-QList<QString> ModFlagIconDelegate::getIcons(const QModelIndex &index) const {
+QList<QString> ModFlagIconDelegate::getIconsForFlags(
+  std::vector<ModInfo::EFlag> flags, bool compact)
+{
   QList<QString> result;
-  QVariant modid = index.data(Qt::UserRole + 1);
-  if (modid.isValid()) {
-    ModInfo::Ptr info = ModInfo::getByIndex(modid.toInt());
-    std::vector<ModInfo::EFlag> flags = info->getFlags();
 
-    // Don't do flags for overwrite
-    if (std::find(flags.begin(), flags.end(),ModInfo::FLAG_OVERWRITE) != flags.end())
-      return result;
+  // Don't do flags for overwrite
+  if (std::find(flags.begin(), flags.end(),ModInfo::FLAG_OVERWRITE) != flags.end())
+    return result;
 
-    // insert conflict icons to provide nicer alignment
-    { // insert loose file conflicts first
-      auto iter = std::find_first_of(flags.begin(), flags.end(),
-                                     m_ConflictFlags, m_ConflictFlags + 4);
-      if (iter != flags.end()) {
-        result.append(getFlagIcon(*iter));
-        flags.erase(iter);
-      } else if (!m_Compact) {
-        result.append(QString());
-      }
-    }
-
-    { // insert loose vs archive overwrite second
-      auto iter = std::find(flags.begin(), flags.end(),
-        ModInfo::FLAG_ARCHIVE_LOOSE_CONFLICT_OVERWRITE);
-      if (iter != flags.end()) {
-        result.append(getFlagIcon(*iter));
-        flags.erase(iter);
-      } else if (!m_Compact) {
-        result.append(QString());
-      }
-    }
-
-    { // insert loose vs archive overwritten third
-      auto iter = std::find_first_of(flags.begin(), flags.end(),
-        m_ArchiveLooseConflictFlags + 1, m_ArchiveLooseConflictFlags + 2);
-      if (iter != flags.end()) {
-        result.append(getFlagIcon(*iter));
-        flags.erase(iter);
-      } else if (!m_Compact) {
-        result.append(QString());
-      }
-    }
-
-    { // insert archive conflicts last
-      auto iter = std::find_first_of(flags.begin(), flags.end(),
-        m_ArchiveConflictFlags, m_ArchiveConflictFlags + 3);
-      if (iter != flags.end()) {
-        result.append(getFlagIcon(*iter));
-        flags.erase(iter);
-      } else if (!m_Compact) {
-        result.append(QString());
-      }
-    }
-
-    for (auto iter = flags.begin(); iter != flags.end(); ++iter) {
-      auto iconPath = getFlagIcon(*iter);
-      if (!iconPath.isEmpty())
-        result.append(iconPath);
+  // insert conflict icons to provide nicer alignment
+  { // insert loose file conflicts first
+    auto iter = std::find_first_of(flags.begin(), flags.end(),
+                                    m_ConflictFlags, m_ConflictFlags + 4);
+    if (iter != flags.end()) {
+      result.append(getFlagIcon(*iter));
+      flags.erase(iter);
+    } else if (!compact) {
+      result.append(QString());
     }
   }
+
+  { // insert loose vs archive overwrite second
+    auto iter = std::find(flags.begin(), flags.end(),
+      ModInfo::FLAG_ARCHIVE_LOOSE_CONFLICT_OVERWRITE);
+    if (iter != flags.end()) {
+      result.append(getFlagIcon(*iter));
+      flags.erase(iter);
+    } else if (!compact) {
+      result.append(QString());
+    }
+  }
+
+  { // insert loose vs archive overwritten third
+    auto iter = std::find_first_of(flags.begin(), flags.end(),
+      m_ArchiveLooseConflictFlags + 1, m_ArchiveLooseConflictFlags + 2);
+    if (iter != flags.end()) {
+      result.append(getFlagIcon(*iter));
+      flags.erase(iter);
+    } else if (!compact) {
+      result.append(QString());
+    }
+  }
+
+  { // insert archive conflicts last
+    auto iter = std::find_first_of(flags.begin(), flags.end(),
+      m_ArchiveConflictFlags, m_ArchiveConflictFlags + 3);
+    if (iter != flags.end()) {
+      result.append(getFlagIcon(*iter));
+      flags.erase(iter);
+    } else if (!compact) {
+      result.append(QString());
+    }
+  }
+
+  for (auto iter = flags.begin(); iter != flags.end(); ++iter) {
+    auto iconPath = getFlagIcon(*iter);
+    if (!iconPath.isEmpty())
+      result.append(iconPath);
+  }
+
   return result;
 }
 
-QString ModFlagIconDelegate::getFlagIcon(ModInfo::EFlag flag) const
+QList<QString> ModFlagIconDelegate::getIcons(const QModelIndex &index) const
+{
+  QVariant modid = index.data(Qt::UserRole + 1);
+
+  if (modid.isValid()) {
+    ModInfo::Ptr info = ModInfo::getByIndex(modid.toInt());
+    return getIconsForFlags(info->getFlags(), m_Compact);
+  }
+
+  return {};
+}
+
+QString ModFlagIconDelegate::getFlagIcon(ModInfo::EFlag flag)
 {
   switch (flag) {
     case ModInfo::FLAG_BACKUP: return QStringLiteral(":/MO/gui/emblem_backup");

--- a/src/modflagicondelegate.h
+++ b/src/modflagicondelegate.h
@@ -5,20 +5,23 @@
 
 class ModFlagIconDelegate : public IconDelegate
 {
-Q_OBJECT
+  Q_OBJECT;
 
 public:
   explicit ModFlagIconDelegate(QObject *parent = 0, int logicalIndex = -1, int compactSize = 120);
   virtual QSize sizeHint(const QStyleOptionViewItem &option, const QModelIndex &index) const;
 
+  static QList<QString> getIconsForFlags(
+    std::vector<ModInfo::EFlag> flags, bool compact);
+
+  static QString getFlagIcon(ModInfo::EFlag flag);
+
 public slots:
   void columnResized(int logicalIndex, int oldSize, int newSize);
 
-private:
+protected:
   virtual QList<QString> getIcons(const QModelIndex &index) const;
   virtual size_t getNumIcons(const QModelIndex &index) const;
-
-  QString getFlagIcon(ModInfo::EFlag flag) const;
 
 private:
   static ModInfo::EFlag m_ConflictFlags[4];

--- a/src/organizercore.cpp
+++ b/src/organizercore.cpp
@@ -74,25 +74,6 @@ using namespace MOBase;
 //static
 CrashDumpsType OrganizerCore::m_globalCrashDumpsType = CrashDumpsType::None;
 
-static bool isOnline()
-{
-  const auto runningFlags =
-    QNetworkInterface::IsUp | QNetworkInterface::IsRunning;
-
-  for (auto&& i : QNetworkInterface::allInterfaces()) {
-    if (!(i.flags() & QNetworkInterface::IsLoopBack)) {
-      if (i.flags() & runningFlags) {
-        auto addresses = i.addressEntries();
-        if (!addresses.empty()) {
-          return true;
-        }
-      }
-    }
-  }
-
-  return false;
-}
-
 static std::wstring getProcessName(HANDLE process)
 {
   wchar_t buffer[MAX_PATH];
@@ -307,14 +288,15 @@ void OrganizerCore::setUserInterface(IUserInterface *userInterface,
   m_InstallationManager.setParentWidget(widget);
   m_Updater.setUserInterface(widget);
 
-  if (userInterface != nullptr) {
-    // this currently wouldn't work reliably if the ui isn't initialized yet to
-    // display the result
-    if (isOnline() && !m_Settings.network().offlineMode()) {
-      m_Updater.testForUpdate();
-    } else {
-      log::debug("user doesn't seem to be connected to the internet");
-    }
+  checkForUpdates();
+}
+
+void OrganizerCore::checkForUpdates()
+{
+  // this currently wouldn't work reliably if the ui isn't initialized yet to
+  // display the result
+  if (m_UserInterface != nullptr) {
+    m_Updater.testForUpdate(m_Settings);
   }
 }
 

--- a/src/organizercore.h
+++ b/src/organizercore.h
@@ -109,6 +109,7 @@ public:
 
   void updateExecutablesList();
 
+  void checkForUpdates();
   void startMOUpdate();
 
   Settings &settings();

--- a/src/selfupdater.cpp
+++ b/src/selfupdater.cpp
@@ -122,8 +122,18 @@ void SelfUpdater::setPluginContainer(PluginContainer *pluginContainer)
   m_Interface->setPluginContainer(pluginContainer);
 }
 
-void SelfUpdater::testForUpdate()
+void SelfUpdater::testForUpdate(const Settings& settings)
 {
+  if (settings.network().offlineMode()) {
+    log::debug("not checking for updates, in offline mode");
+    return;
+  }
+
+  if (!settings.checkForUpdates()) {
+    log::debug("not checking for updates, disabled");
+    return;
+  }
+
   // TODO: if prereleases are disabled we could just request the latest release
   // directly
   try {

--- a/src/selfupdater.h
+++ b/src/selfupdater.h
@@ -37,7 +37,7 @@ namespace MOBase { class IPluginGame; }
 
 class QNetworkReply;
 class QProgressDialog;
-
+class Settings;
 
 /**
  * @brief manages updates for Mod Organizer itself
@@ -81,6 +81,11 @@ public:
   void setPluginContainer(PluginContainer *pluginContainer);
 
   /**
+  * @brief request information about the current version
+  **/
+  void testForUpdate(const Settings& settings);
+
+  /**
    * @brief start the update process
    * @note this should not be called if there is no update available
    **/
@@ -90,13 +95,6 @@ public:
    * @return current version of Mod Organizer
    **/
   MOBase::VersionInfo getVersion() const { return m_MOVersion; }
-
-public slots:
-
-  /**
-   * @brief request information about the current version
-   **/
-  void testForUpdate();
 
 signals:
 

--- a/src/settings.cpp
+++ b/src/settings.cpp
@@ -178,6 +178,16 @@ QString Settings::filename() const
   return m_Settings.fileName();
 }
 
+bool Settings::checkForUpdates() const
+{
+  return get<bool>(m_Settings, "Settings", "check_for_updates", true);
+}
+
+void Settings::setCheckForUpdates(bool b)
+{
+  set(m_Settings, "Settings", "check_for_updates", b);
+}
+
 bool Settings::usePrereleases() const
 {
   return get<bool>(m_Settings, "Settings", "use_prereleases", false);

--- a/src/settings.cpp
+++ b/src/settings.cpp
@@ -623,7 +623,13 @@ void GeometrySettings::saveGeometry(const QDialog* d)
 
 bool GeometrySettings::restoreGeometry(QDialog* d) const
 {
-  return restoreWindowGeometry(d);
+  const auto r = restoreWindowGeometry(d);
+
+  if (centerDialogs()) {
+    centerOnParent(d);
+  }
+
+  return r;
 }
 
 void GeometrySettings::saveWindowGeometry(const QWidget* w)
@@ -829,6 +835,16 @@ void GeometrySettings::setModInfoTabOrder(const QString& names)
   set(m_Settings, "Widgets", "ModInfoTabOrder", names);
 }
 
+bool GeometrySettings::centerDialogs() const
+{
+  return get<bool>(m_Settings, "Settings", "center_dialogs", false);
+}
+
+void GeometrySettings::setCenterDialogs(bool b)
+{
+  set(m_Settings, "Settings", "center_dialogs", b);
+}
+
 void GeometrySettings::centerOnMainWindowMonitor(QWidget* w)
 {
   const auto monitor = getOptional<int>(
@@ -848,6 +864,22 @@ void GeometrySettings::centerOnMonitor(QWidget* w, int monitor)
   }
 
   w->move(center - w->rect().center());
+}
+
+void GeometrySettings::centerOnParent(QWidget* w, QWidget* parent)
+{
+  if (!parent) {
+    parent = w->parentWidget();
+
+    if (!parent) {
+      parent = qApp->activeWindow();
+    }
+  }
+
+  if (parent && parent->isVisible()) {
+    const auto pr = parent->geometry();
+    w->move(pr.center() - w->rect().center());
+  }
 }
 
 void GeometrySettings::saveMainWindowMonitor(const QMainWindow* w)

--- a/src/settings.cpp
+++ b/src/settings.cpp
@@ -22,7 +22,9 @@ along with Mod Organizer.  If not, see <http://www.gnu.org/licenses/>.
 #include "serverinfo.h"
 #include "executableslist.h"
 #include "appconfig.h"
-#include "expanderwidget.h"
+#include "env.h"
+#include "envmetrics.h"
+#include <expanderwidget.h>
 #include <utility.h>
 #include <iplugingame.h>
 
@@ -604,19 +606,78 @@ void GeometrySettings::resetIfNeeded()
   removeSection(m_Settings, "Geometry");
 }
 
-void GeometrySettings::saveGeometry(const QWidget* w)
+void GeometrySettings::saveGeometry(const QMainWindow* w)
+{
+  saveWindowGeometry(w);
+}
+
+bool GeometrySettings::restoreGeometry(QMainWindow* w) const
+{
+  return restoreWindowGeometry(w);
+}
+
+void GeometrySettings::saveGeometry(const QDialog* d)
+{
+  saveWindowGeometry(d);
+}
+
+bool GeometrySettings::restoreGeometry(QDialog* d) const
+{
+  return restoreWindowGeometry(d);
+}
+
+void GeometrySettings::saveWindowGeometry(const QWidget* w)
 {
   set(m_Settings, "Geometry", geoSettingName(w), w->saveGeometry());
 }
 
-bool GeometrySettings::restoreGeometry(QWidget* w) const
+bool GeometrySettings::restoreWindowGeometry(QWidget* w) const
 {
   if (auto v=getOptional<QByteArray>(m_Settings, "Geometry", geoSettingName(w))) {
     w->restoreGeometry(*v);
+    ensureWindowOnScreen(w);
     return true;
   }
 
   return false;
+}
+
+void GeometrySettings::ensureWindowOnScreen(QWidget* w) const
+{
+  // users report that the main window and/or dialogs are displayed off-screen;
+  // the usual workaround is keyboard navigation to move it
+  //
+  // qt should have code that deals with multiple monitors and off-screen
+  // geometries, but there seems to be bugs or inconsistencies that can't be
+  // reproduced
+  //
+  // the closest would probably be https://bugreports.qt.io/browse/QTBUG-64498,
+  // which is about multiple monitors and high dpi, but it seems fixed as of
+  // 5.12.4, which is shipped with 2.2.1
+  //
+  // without being to reproduce the problem, some simple checks are made in a
+  // timer, which may mitigate the issues
+
+  QTimer::singleShot(100, w, [w] {
+    const auto borders = 20;
+
+    // desktop geometry, made smaller to make sure there isn't just a few pixels
+    const auto originalDg = env::Environment().metrics().desktopGeometry();
+    const auto dg = originalDg.adjusted(borders, borders, -borders, -borders);
+
+    const auto g = w->geometry();
+
+    if (!dg.intersects(g)) {
+      log::warn(
+        "window '{}' is offscreen, moving to main monitor; geo={}, desktop={}",
+        w->objectName(), g, originalDg);
+
+      // widget is off-screen, center it on main monitor
+      centerOnMonitor(w, -1);
+
+      log::warn("window '{}' now at {}", w->objectName(), w->geometry());
+    }
+  });
 }
 
 void GeometrySettings::saveState(const QMainWindow* w)
@@ -771,12 +832,17 @@ void GeometrySettings::setModInfoTabOrder(const QString& names)
 void GeometrySettings::centerOnMainWindowMonitor(QWidget* w)
 {
   const auto monitor = getOptional<int>(
-    m_Settings, "Geometry", "MainWindow_monitor");
+    m_Settings, "Geometry", "MainWindow_monitor").value_or(-1);
 
+  centerOnMonitor(w, monitor);
+}
+
+void GeometrySettings::centerOnMonitor(QWidget* w, int monitor)
+{
   QPoint center;
 
-  if (monitor && QGuiApplication::screens().size() > *monitor) {
-    center = QGuiApplication::screens().at(*monitor)->geometry().center();
+  if (monitor >= 0 && monitor < QGuiApplication::screens().size()) {
+    center = QGuiApplication::screens().at(monitor)->geometry().center();
   } else {
     center = QGuiApplication::primaryScreen()->geometry().center();
   }
@@ -1886,16 +1952,4 @@ int DiagnosticsSettings::crashDumpsMax() const
 void DiagnosticsSettings::setCrashDumpsMax(int n)
 {
   set(m_Settings, "Settings", "crash_dumps_max", n);
-}
-
-
-GeometrySaver::GeometrySaver(Settings& s, QDialog* dialog)
-  : m_settings(s), m_dialog(dialog)
-{
-  m_settings.geometry().restoreGeometry(m_dialog);
-}
-
-GeometrySaver::~GeometrySaver()
-{
-  m_settings.geometry().saveGeometry(m_dialog);
 }

--- a/src/settings.h
+++ b/src/settings.h
@@ -692,6 +692,11 @@ public:
   bool archiveParsing() const;
   void setArchiveParsing(bool b);
 
+  // whether the user wants to check for updates
+  //
+  bool checkForUpdates() const;
+  void setCheckForUpdates(bool b);
+
   // whether the user wants to upgrade to pre-releases
   //
   bool usePrereleases() const;

--- a/src/settings.h
+++ b/src/settings.h
@@ -41,20 +41,6 @@ class ServerList;
 class Settings;
 
 
-// helper class that calls restoreGeometry() in the constructor and
-// saveGeometry() in the destructor
-//
-class GeometrySaver
-{
-public:
-  GeometrySaver(Settings& s, QDialog* dialog);
-  ~GeometrySaver();
-
-private:
-  Settings& m_settings;
-  QDialog* m_dialog;
-};
-
 
 // setting for the currently managed game
 //
@@ -141,8 +127,11 @@ public:
   void resetIfNeeded();
 
 
-  void saveGeometry(const QWidget* w);
-  bool restoreGeometry(QWidget* w) const;
+  void saveGeometry(const QMainWindow* w);
+  bool restoreGeometry(QMainWindow* w) const;
+
+  void saveGeometry(const QDialog* d);
+  bool restoreGeometry(QDialog* d) const;
 
   void saveState(const QMainWindow* window);
   bool restoreState(QMainWindow* window) const;
@@ -182,6 +171,12 @@ public:
 private:
   QSettings& m_Settings;
   bool m_Reset;
+
+  void saveWindowGeometry(const QWidget* w);
+  bool restoreWindowGeometry(QWidget* w) const;
+
+  void ensureWindowOnScreen(QWidget* w) const;
+  static void centerOnMonitor(QWidget* w, int monitor);
 };
 
 
@@ -762,6 +757,30 @@ private:
   SteamSettings m_Steam;
   InterfaceSettings m_Interface;
   DiagnosticsSettings m_Diagnostics;
+};
+
+
+// helper class that calls restoreGeometry() in the constructor and
+// saveGeometry() in the destructor
+//
+template <class W>
+class GeometrySaver
+{
+public:
+  GeometrySaver(Settings& s, W* w)
+    : m_settings(s), m_widget(w)
+  {
+    m_settings.geometry().restoreGeometry(m_widget);
+  }
+
+  ~GeometrySaver()
+  {
+    m_settings.geometry().saveGeometry(m_widget);
+  }
+
+private:
+  Settings& m_settings;
+  W* m_widget;
 };
 
 #endif // SETTINGS_H

--- a/src/settings.h
+++ b/src/settings.h
@@ -160,6 +160,11 @@ public:
   QStringList modInfoTabOrder() const;
   void setModInfoTabOrder(const QString& names);
 
+  // whether dialogs should be centered on their parent
+  //
+  bool centerDialogs() const;
+  void setCenterDialogs(bool b);
+
   // assumes the given widget is a top-level
   //
   void centerOnMainWindowMonitor(QWidget* w);
@@ -177,6 +182,7 @@ private:
 
   void ensureWindowOnScreen(QWidget* w) const;
   static void centerOnMonitor(QWidget* w, int monitor);
+  static void centerOnParent(QWidget* w, QWidget* parent=nullptr);
 };
 
 

--- a/src/settingsdialog.ui
+++ b/src/settingsdialog.ui
@@ -42,46 +42,64 @@
          <property name="title">
           <string>User Interface</string>
          </property>
-         <layout class="QGridLayout" name="gridLayout_7">
-          <item row="2" column="0">
-           <widget class="QLabel" name="label_10">
-            <property name="text">
-             <string>Style</string>
-            </property>
-           </widget>
-          </item>
-          <item row="0" column="0">
-           <widget class="QLabel" name="label_5">
-            <property name="text">
-             <string>Language</string>
-            </property>
-           </widget>
-          </item>
-          <item row="0" column="1">
-           <widget class="QComboBox" name="languageBox">
-            <property name="toolTip">
-             <string>The display language</string>
-            </property>
-            <property name="whatsThis">
-             <string>&lt;!DOCTYPE HTML PUBLIC &quot;-//W3C//DTD HTML 4.0//EN&quot; &quot;http://www.w3.org/TR/REC-html40/strict.dtd&quot;&gt;
+         <layout class="QVBoxLayout" name="verticalLayout_14">
+          <item>
+           <widget class="QWidget" name="widget_6" native="true">
+            <layout class="QFormLayout" name="formLayout_4">
+             <property name="leftMargin">
+              <number>0</number>
+             </property>
+             <property name="topMargin">
+              <number>0</number>
+             </property>
+             <property name="rightMargin">
+              <number>0</number>
+             </property>
+             <property name="bottomMargin">
+              <number>0</number>
+             </property>
+             <item row="0" column="0">
+              <widget class="QLabel" name="label_5">
+               <property name="text">
+                <string>Language</string>
+               </property>
+              </widget>
+             </item>
+             <item row="0" column="1">
+              <widget class="QComboBox" name="languageBox">
+               <property name="toolTip">
+                <string>The display language</string>
+               </property>
+               <property name="whatsThis">
+                <string>&lt;!DOCTYPE HTML PUBLIC &quot;-//W3C//DTD HTML 4.0//EN&quot; &quot;http://www.w3.org/TR/REC-html40/strict.dtd&quot;&gt;
 &lt;html&gt;&lt;head&gt;&lt;meta name=&quot;qrichtext&quot; content=&quot;1&quot; /&gt;&lt;style type=&quot;text/css&quot;&gt;
 p, li { white-space: pre-wrap; }
 &lt;/style&gt;&lt;/head&gt;&lt;body style=&quot; font-family:'MS Shell Dlg 2'; font-size:8.25pt; font-weight:400; font-style:normal;&quot;&gt;
 &lt;p style=&quot; margin-top:0px; margin-bottom:0px; margin-left:0px; margin-right:0px; -qt-block-indent:0; text-indent:0px;&quot;&gt;&lt;span style=&quot; font-size:8pt;&quot;&gt;The display language. This will only displaye languages for which you have a translation installed.&lt;/span&gt;&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
-            </property>
+               </property>
+              </widget>
+             </item>
+             <item row="1" column="0">
+              <widget class="QLabel" name="label_10">
+               <property name="text">
+                <string>Style</string>
+               </property>
+              </widget>
+             </item>
+             <item row="1" column="1">
+              <widget class="QComboBox" name="styleBox">
+               <property name="toolTip">
+                <string>graphical style</string>
+               </property>
+               <property name="whatsThis">
+                <string>graphical style of the MO user interface</string>
+               </property>
+              </widget>
+             </item>
+            </layout>
            </widget>
           </item>
-          <item row="2" column="1">
-           <widget class="QComboBox" name="styleBox">
-            <property name="toolTip">
-             <string>graphical style</string>
-            </property>
-            <property name="whatsThis">
-             <string>graphical style of the MO user interface</string>
-            </property>
-           </widget>
-          </item>
-          <item row="4" column="0" colspan="2">
+          <item>
            <widget class="QCheckBox" name="centerDialogs">
             <property name="toolTip">
              <string>Dialogs will always be centered on the main window, but will remember their size.</string>
@@ -94,7 +112,7 @@ p, li { white-space: pre-wrap; }
             </property>
            </widget>
           </item>
-          <item row="5" column="0" colspan="2">
+          <item>
            <widget class="QPushButton" name="resetDialogsButton">
             <property name="maximumSize">
              <size>
@@ -113,7 +131,7 @@ p, li { white-space: pre-wrap; }
             </property>
            </widget>
           </item>
-          <item row="6" column="0" colspan="2">
+          <item>
            <widget class="QPushButton" name="categoriesBtn">
             <property name="toolTip">
              <string>Modify the categories available to arrange your mods.</string>
@@ -125,6 +143,19 @@ p, li { white-space: pre-wrap; }
              <string>Configure Mod Categories</string>
             </property>
            </widget>
+          </item>
+          <item>
+           <spacer name="verticalSpacer_11">
+            <property name="orientation">
+             <enum>Qt::Vertical</enum>
+            </property>
+            <property name="sizeHint" stdset="0">
+             <size>
+              <width>0</width>
+              <height>0</height>
+             </size>
+            </property>
+           </spacer>
           </item>
          </layout>
         </widget>
@@ -176,70 +207,90 @@ p, li { white-space: pre-wrap; }
          <property name="title">
           <string>Colors</string>
          </property>
-         <layout class="QGridLayout" name="gridLayout_5">
-          <item row="6" column="0">
-           <widget class="QCheckBox" name="colorSeparatorsBox">
-            <property name="toolTip">
-             <string>When this is enabled, the color defined for a separator will be shown on the mod list scrollbar at the location of the separator.  This can be useful for quick navigation between separator sections or to a specific separator section.</string>
+         <layout class="QVBoxLayout" name="verticalLayout_13">
+          <item>
+           <widget class="QTableWidget" name="colorTable">
+            <property name="editTriggers">
+             <set>QAbstractItemView::NoEditTriggers</set>
             </property>
-            <property name="whatsThis">
-             <string>When this is enabled, the color defined for a separator will be shown on the mod list scrollbar at the location of the separator.  This can be useful for quick navigation between separator sections or to a specific separator section.</string>
+            <property name="selectionMode">
+             <enum>QAbstractItemView::SingleSelection</enum>
             </property>
-            <property name="text">
-             <string>Show mod list separator colors on the scrollbar</string>
+            <property name="selectionBehavior">
+             <enum>QAbstractItemView::SelectRows</enum>
             </property>
-            <property name="checked">
+            <property name="verticalScrollMode">
+             <enum>QAbstractItemView::ScrollPerPixel</enum>
+            </property>
+            <property name="cornerButtonEnabled">
+             <bool>false</bool>
+            </property>
+            <attribute name="horizontalHeaderVisible">
+             <bool>false</bool>
+            </attribute>
+            <attribute name="horizontalHeaderHighlightSections">
+             <bool>false</bool>
+            </attribute>
+            <attribute name="horizontalHeaderStretchLastSection">
              <bool>true</bool>
-            </property>
+            </attribute>
+            <attribute name="verticalHeaderVisible">
+             <bool>false</bool>
+            </attribute>
            </widget>
           </item>
-          <item row="4" column="0" colspan="2">
-           <widget class="QPushButton" name="containedBtn">
-            <property name="text">
-             <string>Plugin is Contained in selected Mod</string>
-            </property>
-           </widget>
-          </item>
-          <item row="1" column="0">
-           <widget class="QPushButton" name="overwrittenBtn">
-            <property name="text">
-             <string>Is overwritten (loose files)</string>
-            </property>
-           </widget>
-          </item>
-          <item row="1" column="1">
-           <widget class="QPushButton" name="overwritingBtn">
-            <property name="text">
-             <string>Is overwriting (loose files)</string>
-            </property>
-           </widget>
-          </item>
-          <item row="5" column="0" colspan="2">
-           <widget class="QPushButton" name="resetColorsBtn">
-            <property name="text">
-             <string>Reset Colors</string>
-            </property>
-           </widget>
-          </item>
-          <item row="3" column="0" colspan="2">
-           <widget class="QPushButton" name="containsBtn">
-            <property name="text">
-             <string>Mod Contains selected Plugin</string>
-            </property>
-           </widget>
-          </item>
-          <item row="2" column="0">
-           <widget class="QPushButton" name="overwrittenArchiveBtn">
-            <property name="text">
-             <string>Is overwritten (archive files)</string>
-            </property>
-           </widget>
-          </item>
-          <item row="2" column="1">
-           <widget class="QPushButton" name="overwritingArchiveBtn">
-            <property name="text">
-             <string>Is overwriting (archive files)</string>
-            </property>
+          <item>
+           <widget class="QWidget" name="widget_5" native="true">
+            <layout class="QHBoxLayout" name="horizontalLayout_3">
+             <property name="leftMargin">
+              <number>0</number>
+             </property>
+             <property name="topMargin">
+              <number>0</number>
+             </property>
+             <property name="rightMargin">
+              <number>0</number>
+             </property>
+             <property name="bottomMargin">
+              <number>0</number>
+             </property>
+             <item>
+              <widget class="QCheckBox" name="colorSeparatorsBox">
+               <property name="toolTip">
+                <string>When this is enabled, the color defined for a separator will be shown on the mod list scrollbar at the location of the separator.  This can be useful for quick navigation between separator sections or to a specific separator section.</string>
+               </property>
+               <property name="whatsThis">
+                <string>When this is enabled, the color defined for a separator will be shown on the mod list scrollbar at the location of the separator.  This can be useful for quick navigation between separator sections or to a specific separator section.</string>
+               </property>
+               <property name="text">
+                <string>Show mod list separator colors on the scrollbar</string>
+               </property>
+               <property name="checked">
+                <bool>true</bool>
+               </property>
+              </widget>
+             </item>
+             <item>
+              <spacer name="horizontalSpacer_2">
+               <property name="orientation">
+                <enum>Qt::Horizontal</enum>
+               </property>
+               <property name="sizeHint" stdset="0">
+                <size>
+                 <width>40</width>
+                 <height>20</height>
+                </size>
+               </property>
+              </spacer>
+             </item>
+             <item>
+              <widget class="QPushButton" name="resetColorsBtn">
+               <property name="text">
+                <string>Reset Colors</string>
+               </property>
+              </widget>
+             </item>
+            </layout>
            </widget>
           </item>
          </layout>

--- a/src/settingsdialog.ui
+++ b/src/settingsdialog.ui
@@ -68,14 +68,10 @@
              <item row="0" column="1">
               <widget class="QComboBox" name="languageBox">
                <property name="toolTip">
-                <string>The display language</string>
+                <string>The language of the user interface.</string>
                </property>
                <property name="whatsThis">
-                <string>&lt;!DOCTYPE HTML PUBLIC &quot;-//W3C//DTD HTML 4.0//EN&quot; &quot;http://www.w3.org/TR/REC-html40/strict.dtd&quot;&gt;
-&lt;html&gt;&lt;head&gt;&lt;meta name=&quot;qrichtext&quot; content=&quot;1&quot; /&gt;&lt;style type=&quot;text/css&quot;&gt;
-p, li { white-space: pre-wrap; }
-&lt;/style&gt;&lt;/head&gt;&lt;body style=&quot; font-family:'MS Shell Dlg 2'; font-size:8.25pt; font-weight:400; font-style:normal;&quot;&gt;
-&lt;p style=&quot; margin-top:0px; margin-bottom:0px; margin-left:0px; margin-right:0px; -qt-block-indent:0; text-indent:0px;&quot;&gt;&lt;span style=&quot; font-size:8pt;&quot;&gt;The display language. This will only displaye languages for which you have a translation installed.&lt;/span&gt;&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
+                <string>The language of the user interface.</string>
                </property>
               </widget>
              </item>
@@ -89,10 +85,10 @@ p, li { white-space: pre-wrap; }
              <item row="1" column="1">
               <widget class="QComboBox" name="styleBox">
                <property name="toolTip">
-                <string>graphical style</string>
+                <string>Visual theme of the user interface.</string>
                </property>
                <property name="whatsThis">
-                <string>graphical style of the MO user interface</string>
+                <string>Visual theme of the user interface.</string>
                </property>
               </widget>
              </item>
@@ -121,10 +117,10 @@ p, li { white-space: pre-wrap; }
              </size>
             </property>
             <property name="toolTip">
-             <string>Reset stored information from dialogs.</string>
+             <string>Reset all choices made in dialogs.</string>
             </property>
             <property name="whatsThis">
-             <string>This will make all dialogs show up again where you checked the &quot;Remember selection&quot;-box.</string>
+             <string>Reset all choices made in dialogs.</string>
             </property>
             <property name="text">
              <string>Reset Dialog Choices</string>
@@ -169,7 +165,10 @@ p, li { white-space: pre-wrap; }
           <item>
            <widget class="QCheckBox" name="showMetaBox">
             <property name="toolTip">
-             <string>If checked, the download list will display meta information instead of file names.</string>
+             <string>Show meta information instead of file names in the download list.</string>
+            </property>
+            <property name="whatsThis">
+             <string>Show meta information instead of file names in the download list.</string>
             </property>
             <property name="text">
              <string>Show Meta Information</string>
@@ -179,7 +178,10 @@ p, li { white-space: pre-wrap; }
           <item>
            <widget class="QCheckBox" name="compactBox">
             <property name="toolTip">
-             <string>If checked, the download interface will be more compact.</string>
+             <string>Make the download list more compact.</string>
+            </property>
+            <property name="whatsThis">
+             <string>Make the download list more compact.</string>
             </property>
             <property name="text">
              <string>Compact List</string>
@@ -257,10 +259,10 @@ p, li { white-space: pre-wrap; }
              <item>
               <widget class="QCheckBox" name="colorSeparatorsBox">
                <property name="toolTip">
-                <string>When this is enabled, the color defined for a separator will be shown on the mod list scrollbar at the location of the separator.  This can be useful for quick navigation between separator sections or to a specific separator section.</string>
+                <string>Colors set on separators will also be shown in the mod list scrollbar at the location of the separator. This can be useful for quickly navigating to a specific separator.</string>
                </property>
                <property name="whatsThis">
-                <string>When this is enabled, the color defined for a separator will be shown on the mod list scrollbar at the location of the separator.  This can be useful for quick navigation between separator sections or to a specific separator section.</string>
+                <string>Colors set on separators will also be shown in the mod list scrollbar at the location of the separator. This can be useful for quickly navigating to a specific separator.</string>
                </property>
                <property name="text">
                 <string>Show mod list separator colors on the scrollbar</string>
@@ -285,6 +287,12 @@ p, li { white-space: pre-wrap; }
              </item>
              <item>
               <widget class="QPushButton" name="resetColorsBtn">
+               <property name="toolTip">
+                <string>Reset all colors to their default value.</string>
+               </property>
+               <property name="whatsThis">
+                <string>Reset all colors to their default value.</string>
+               </property>
                <property name="text">
                 <string>Reset Colors</string>
                </property>
@@ -305,10 +313,10 @@ p, li { white-space: pre-wrap; }
           <item>
            <widget class="QCheckBox" name="checkForUpdates">
             <property name="toolTip">
-             <string>Mod Organizer checks for updates on Github on startup.</string>
+             <string>Check for Mod Organizer updates on Github on startup.</string>
             </property>
             <property name="whatsThis">
-             <string>Mod Organizer checks for updates on Github on startup.</string>
+             <string>Check for Mod Organizer updates on Github on startup.</string>
             </property>
             <property name="text">
              <string>Check for updates</string>
@@ -321,7 +329,7 @@ p, li { white-space: pre-wrap; }
              <string>Update to non-stable releases.</string>
             </property>
             <property name="whatsThis">
-             <string>If this is enabled, the integrated update mechanism will notify of all releases, including pre-releases (alphas, betas). Please use this only if you're sufficiently tech-savvy to investigate issues, look for known problems in the issue tracker and create meaningful reports.</string>
+             <string>Update to non-stable releases.</string>
             </property>
             <property name="text">
              <string>Install Pre-releases (Betas)</string>

--- a/src/settingsdialog.ui
+++ b/src/settingsdialog.ui
@@ -1535,7 +1535,19 @@ programs you are intentionally running.</string>
   </customwidget>
  </customwidgets>
  <tabstops>
-  <tabstop>logLevelBox</tabstop>
+  <tabstop>tabWidget</tabstop>
+  <tabstop>languageBox</tabstop>
+  <tabstop>styleBox</tabstop>
+  <tabstop>centerDialogs</tabstop>
+  <tabstop>resetDialogsButton</tabstop>
+  <tabstop>categoriesBtn</tabstop>
+  <tabstop>showMetaBox</tabstop>
+  <tabstop>compactBox</tabstop>
+  <tabstop>checkForUpdates</tabstop>
+  <tabstop>usePrereleaseBox</tabstop>
+  <tabstop>colorTable</tabstop>
+  <tabstop>colorSeparatorsBox</tabstop>
+  <tabstop>resetColorsBtn</tabstop>
   <tabstop>baseDirEdit</tabstop>
   <tabstop>browseBaseDirBtn</tabstop>
   <tabstop>downloadDirEdit</tabstop>
@@ -1548,7 +1560,18 @@ programs you are intentionally running.</string>
   <tabstop>browseProfilesDirBtn</tabstop>
   <tabstop>overwriteDirEdit</tabstop>
   <tabstop>browseOverwriteDirBtn</tabstop>
+  <tabstop>managedGameDirEdit</tabstop>
+  <tabstop>browseGameDirBtn</tabstop>
+  <tabstop>nexusConnect</tabstop>
+  <tabstop>nexusManualKey</tabstop>
+  <tabstop>nexusDisconnect</tabstop>
+  <tabstop>nexusLog</tabstop>
+  <tabstop>offlineBox</tabstop>
+  <tabstop>endorsementBox</tabstop>
+  <tabstop>proxyBox</tabstop>
+  <tabstop>hideAPICounterBox</tabstop>
   <tabstop>associateButton</tabstop>
+  <tabstop>clearCacheButton</tabstop>
   <tabstop>knownServersList</tabstop>
   <tabstop>preferredServersList</tabstop>
   <tabstop>steamUserEdit</tabstop>
@@ -1558,8 +1581,17 @@ programs you are intentionally running.</string>
   <tabstop>pluginBlacklist</tabstop>
   <tabstop>appIDEdit</tabstop>
   <tabstop>mechanismBox</tabstop>
+  <tabstop>hideUncheckedBox</tabstop>
+  <tabstop>forceEnableBox</tabstop>
+  <tabstop>lockGUIBox</tabstop>
+  <tabstop>displayForeignBox</tabstop>
+  <tabstop>enableArchiveParsingBox</tabstop>
   <tabstop>bsaDateBtn</tabstop>
-  <tabstop>tabWidget</tabstop>
+  <tabstop>execBlacklistBtn</tabstop>
+  <tabstop>resetGeometryBtn</tabstop>
+  <tabstop>logLevelBox</tabstop>
+  <tabstop>dumpsTypeBox</tabstop>
+  <tabstop>dumpsMaxEdit</tabstop>
  </tabstops>
  <resources>
   <include location="resources.qrc"/>

--- a/src/settingsdialog.ui
+++ b/src/settingsdialog.ui
@@ -211,7 +211,7 @@
          </property>
          <layout class="QVBoxLayout" name="verticalLayout_13">
           <item>
-           <widget class="QTableWidget" name="colorTable">
+           <widget class="ColorTable" name="colorTable">
             <property name="editTriggers">
              <set>QAbstractItemView::NoEditTriggers</set>
             </property>
@@ -1527,6 +1527,13 @@ programs you are intentionally running.</string>
    </item>
   </layout>
  </widget>
+ <customwidgets>
+  <customwidget>
+   <class>ColorTable</class>
+   <extends>QTableWidget</extends>
+   <header>colortable.h</header>
+  </customwidget>
+ </customwidgets>
  <tabstops>
   <tabstop>logLevelBox</tabstop>
   <tabstop>baseDirEdit</tabstop>

--- a/src/settingsdialog.ui
+++ b/src/settingsdialog.ui
@@ -86,97 +86,23 @@ p, li { white-space: pre-wrap; }
        <item>
         <widget class="QGroupBox" name="groupBox">
          <property name="title">
-          <string>User interface</string>
+          <string>User Interface</string>
          </property>
-         <layout class="QGridLayout" name="gridLayout">
-          <item row="2" column="0" colspan="2">
-           <widget class="QGroupBox" name="ModlistGroupBox">
-            <property name="title">
-             <string>Colors</string>
-            </property>
-            <layout class="QGridLayout" name="gridLayout_5">
-             <item row="6" column="0">
-              <widget class="QCheckBox" name="colorSeparatorsBox">
-               <property name="toolTip">
-                <string>When this is enabled, the color defined for a separator will be shown on the mod list scrollbar at the location of the separator.  This can be useful for quick navigation between separator sections or to a specific separator section.</string>
-               </property>
-               <property name="whatsThis">
-                <string>When this is enabled, the color defined for a separator will be shown on the mod list scrollbar at the location of the separator.  This can be useful for quick navigation between separator sections or to a specific separator section.</string>
-               </property>
-               <property name="text">
-                <string>Show mod list separator colors on the scrollbar</string>
-               </property>
-               <property name="checked">
-                <bool>true</bool>
-               </property>
-              </widget>
-             </item>
-             <item row="4" column="0" colspan="2">
-              <widget class="QPushButton" name="containedBtn">
-               <property name="text">
-                <string>Plugin is Contained in selected Mod</string>
-               </property>
-              </widget>
-             </item>
-             <item row="1" column="0">
-              <widget class="QPushButton" name="overwrittenBtn">
-               <property name="text">
-                <string>Is overwritten (loose files)</string>
-               </property>
-              </widget>
-             </item>
-             <item row="1" column="1">
-              <widget class="QPushButton" name="overwritingBtn">
-               <property name="text">
-                <string>Is overwriting (loose files)</string>
-               </property>
-              </widget>
-             </item>
-             <item row="5" column="0" colspan="2">
-              <widget class="QPushButton" name="resetColorsBtn">
-               <property name="text">
-                <string>Reset Colors</string>
-               </property>
-              </widget>
-             </item>
-             <item row="3" column="0" colspan="2">
-              <widget class="QPushButton" name="containsBtn">
-               <property name="text">
-                <string>Mod Contains selected Plugin</string>
-               </property>
-              </widget>
-             </item>
-             <item row="2" column="0">
-              <widget class="QPushButton" name="overwrittenArchiveBtn">
-               <property name="text">
-                <string>Is overwritten (archive files)</string>
-               </property>
-              </widget>
-             </item>
-             <item row="2" column="1">
-              <widget class="QPushButton" name="overwritingArchiveBtn">
-               <property name="text">
-                <string>Is overwriting (archive files)</string>
-               </property>
-              </widget>
-             </item>
-            </layout>
-           </widget>
-          </item>
-          <item row="6" column="0" colspan="2">
-           <widget class="QPushButton" name="categoriesBtn">
-            <property name="toolTip">
-             <string>Modify the categories available to arrange your mods.</string>
+         <layout class="QVBoxLayout" name="verticalLayout_2">
+          <item>
+           <widget class="QCheckBox" name="centerDialogs">
+            <property name="statusTip">
+             <string>Dialogs will always be centered on the main window, but will remember their size.</string>
             </property>
             <property name="whatsThis">
-             <string>Modify the categories available to arrange your mods.</string>
+             <string>Dialogs will always be centered on the main window, but will remember their size.</string>
             </property>
             <property name="text">
-             <string>Configure Mod Categories</string>
+             <string>Always center dialogs</string>
             </property>
            </widget>
           </item>
-          <item row="5" column="0" colspan="2">
+          <item>
            <widget class="QPushButton" name="resetDialogsButton">
             <property name="maximumSize">
              <size>
@@ -195,36 +121,119 @@ p, li { white-space: pre-wrap; }
             </property>
            </widget>
           </item>
-          <item row="0" column="0">
+          <item>
+           <widget class="QPushButton" name="categoriesBtn">
+            <property name="toolTip">
+             <string>Modify the categories available to arrange your mods.</string>
+            </property>
+            <property name="whatsThis">
+             <string>Modify the categories available to arrange your mods.</string>
+            </property>
+            <property name="text">
+             <string>Configure Mod Categories</string>
+            </property>
+           </widget>
+          </item>
+         </layout>
+        </widget>
+       </item>
+       <item>
+        <widget class="QGroupBox" name="groupBox_5">
+         <property name="title">
+          <string>Download List</string>
+         </property>
+         <layout class="QHBoxLayout" name="horizontalLayout_11">
+          <item>
            <widget class="QCheckBox" name="compactBox">
             <property name="toolTip">
              <string>If checked, the download interface will be more compact.</string>
             </property>
             <property name="text">
-             <string>Compact Download Interface</string>
+             <string>Compact List</string>
             </property>
            </widget>
           </item>
-          <item row="4" column="0" colspan="2">
-           <spacer name="verticalSpacer">
-            <property name="orientation">
-             <enum>Qt::Vertical</enum>
-            </property>
-            <property name="sizeHint" stdset="0">
-             <size>
-              <width>20</width>
-              <height>40</height>
-             </size>
-            </property>
-           </spacer>
-          </item>
-          <item row="0" column="1">
+          <item>
            <widget class="QCheckBox" name="showMetaBox">
             <property name="toolTip">
              <string>If checked, the download list will display meta information instead of file names.</string>
             </property>
             <property name="text">
-             <string>Download Meta Information</string>
+             <string>Show Meta Information</string>
+            </property>
+           </widget>
+          </item>
+         </layout>
+        </widget>
+       </item>
+       <item>
+        <widget class="QGroupBox" name="ModlistGroupBox">
+         <property name="title">
+          <string>Colors</string>
+         </property>
+         <layout class="QGridLayout" name="gridLayout_5">
+          <item row="6" column="0">
+           <widget class="QCheckBox" name="colorSeparatorsBox">
+            <property name="toolTip">
+             <string>When this is enabled, the color defined for a separator will be shown on the mod list scrollbar at the location of the separator.  This can be useful for quick navigation between separator sections or to a specific separator section.</string>
+            </property>
+            <property name="whatsThis">
+             <string>When this is enabled, the color defined for a separator will be shown on the mod list scrollbar at the location of the separator.  This can be useful for quick navigation between separator sections or to a specific separator section.</string>
+            </property>
+            <property name="text">
+             <string>Show mod list separator colors on the scrollbar</string>
+            </property>
+            <property name="checked">
+             <bool>true</bool>
+            </property>
+           </widget>
+          </item>
+          <item row="4" column="0" colspan="2">
+           <widget class="QPushButton" name="containedBtn">
+            <property name="text">
+             <string>Plugin is Contained in selected Mod</string>
+            </property>
+           </widget>
+          </item>
+          <item row="1" column="0">
+           <widget class="QPushButton" name="overwrittenBtn">
+            <property name="text">
+             <string>Is overwritten (loose files)</string>
+            </property>
+           </widget>
+          </item>
+          <item row="1" column="1">
+           <widget class="QPushButton" name="overwritingBtn">
+            <property name="text">
+             <string>Is overwriting (loose files)</string>
+            </property>
+           </widget>
+          </item>
+          <item row="5" column="0" colspan="2">
+           <widget class="QPushButton" name="resetColorsBtn">
+            <property name="text">
+             <string>Reset Colors</string>
+            </property>
+           </widget>
+          </item>
+          <item row="3" column="0" colspan="2">
+           <widget class="QPushButton" name="containsBtn">
+            <property name="text">
+             <string>Mod Contains selected Plugin</string>
+            </property>
+           </widget>
+          </item>
+          <item row="2" column="0">
+           <widget class="QPushButton" name="overwrittenArchiveBtn">
+            <property name="text">
+             <string>Is overwritten (archive files)</string>
+            </property>
+           </widget>
+          </item>
+          <item row="2" column="1">
+           <widget class="QPushButton" name="overwritingArchiveBtn">
+            <property name="text">
+             <string>Is overwriting (archive files)</string>
             </property>
            </widget>
           </item>
@@ -1411,7 +1420,6 @@ programs you are intentionally running.</string>
   <tabstop>styleBox</tabstop>
   <tabstop>logLevelBox</tabstop>
   <tabstop>usePrereleaseBox</tabstop>
-  <tabstop>compactBox</tabstop>
   <tabstop>categoriesBtn</tabstop>
   <tabstop>baseDirEdit</tabstop>
   <tabstop>browseBaseDirBtn</tabstop>

--- a/src/settingsdialog.ui
+++ b/src/settingsdialog.ui
@@ -7,7 +7,7 @@
     <x>0</x>
     <y>0</y>
     <width>586</width>
-    <height>486</height>
+    <height>491</height>
    </rect>
   </property>
   <property name="windowTitle">
@@ -23,75 +23,67 @@
       <attribute name="title">
        <string>General</string>
       </attribute>
-      <layout class="QVBoxLayout" name="verticalLayout_3">
-       <item>
-        <layout class="QHBoxLayout" name="horizontalLayout_3">
-         <item>
-          <widget class="QLabel" name="label_5">
-           <property name="text">
-            <string>Language</string>
-           </property>
-          </widget>
-         </item>
-         <item>
-          <widget class="QComboBox" name="languageBox">
-           <property name="toolTip">
-            <string>The display language</string>
-           </property>
-           <property name="whatsThis">
-            <string>&lt;!DOCTYPE HTML PUBLIC &quot;-//W3C//DTD HTML 4.0//EN&quot; &quot;http://www.w3.org/TR/REC-html40/strict.dtd&quot;&gt;
-&lt;html&gt;&lt;head&gt;&lt;meta name=&quot;qrichtext&quot; content=&quot;1&quot; /&gt;&lt;style type=&quot;text/css&quot;&gt;
-p, li { white-space: pre-wrap; }
-&lt;/style&gt;&lt;/head&gt;&lt;body style=&quot; font-family:'MS Shell Dlg 2'; font-size:8.25pt; font-weight:400; font-style:normal;&quot;&gt;
-&lt;p style=&quot; margin-top:0px; margin-bottom:0px; margin-left:0px; margin-right:0px; -qt-block-indent:0; text-indent:0px;&quot;&gt;&lt;span style=&quot; font-size:8pt;&quot;&gt;The display language. This will only displaye languages for which you have a translation installed.&lt;/span&gt;&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
-           </property>
-          </widget>
-         </item>
-        </layout>
-       </item>
-       <item>
-        <layout class="QHBoxLayout" name="horizontalLayout_4">
-         <item>
-          <widget class="QLabel" name="label_10">
-           <property name="text">
-            <string>Style</string>
-           </property>
-          </widget>
-         </item>
-         <item>
-          <widget class="QComboBox" name="styleBox">
-           <property name="toolTip">
-            <string>graphical style</string>
-           </property>
-           <property name="whatsThis">
-            <string>graphical style of the MO user interface</string>
-           </property>
-          </widget>
-         </item>
-        </layout>
-       </item>
-       <item>
-        <widget class="QCheckBox" name="usePrereleaseBox">
-         <property name="toolTip">
-          <string>Update to non-stable releases.</string>
+      <layout class="QGridLayout" name="gridLayout" rowstretch="0,0,0,0,0,1">
+       <item row="5" column="0" colspan="2">
+        <spacer name="verticalSpacer">
+         <property name="orientation">
+          <enum>Qt::Vertical</enum>
          </property>
-         <property name="whatsThis">
-          <string>If this is enabled, the integrated update mechanism will notify of all releases, including pre-releases (alphas, betas). Please use this only if you're sufficiently tech-savvy to investigate issues, look for known problems in the issue tracker and create meaningful reports.</string>
+         <property name="sizeHint" stdset="0">
+          <size>
+           <width>0</width>
+           <height>0</height>
+          </size>
          </property>
-         <property name="text">
-          <string>Install Pre-releases (Betas)</string>
-         </property>
-        </widget>
+        </spacer>
        </item>
-       <item>
+       <item row="0" column="0" rowspan="2">
         <widget class="QGroupBox" name="groupBox">
          <property name="title">
           <string>User Interface</string>
          </property>
-         <layout class="QVBoxLayout" name="verticalLayout_2">
-          <item>
+         <layout class="QGridLayout" name="gridLayout_7">
+          <item row="2" column="0">
+           <widget class="QLabel" name="label_10">
+            <property name="text">
+             <string>Style</string>
+            </property>
+           </widget>
+          </item>
+          <item row="0" column="0">
+           <widget class="QLabel" name="label_5">
+            <property name="text">
+             <string>Language</string>
+            </property>
+           </widget>
+          </item>
+          <item row="0" column="1">
+           <widget class="QComboBox" name="languageBox">
+            <property name="toolTip">
+             <string>The display language</string>
+            </property>
+            <property name="whatsThis">
+             <string>&lt;!DOCTYPE HTML PUBLIC &quot;-//W3C//DTD HTML 4.0//EN&quot; &quot;http://www.w3.org/TR/REC-html40/strict.dtd&quot;&gt;
+&lt;html&gt;&lt;head&gt;&lt;meta name=&quot;qrichtext&quot; content=&quot;1&quot; /&gt;&lt;style type=&quot;text/css&quot;&gt;
+p, li { white-space: pre-wrap; }
+&lt;/style&gt;&lt;/head&gt;&lt;body style=&quot; font-family:'MS Shell Dlg 2'; font-size:8.25pt; font-weight:400; font-style:normal;&quot;&gt;
+&lt;p style=&quot; margin-top:0px; margin-bottom:0px; margin-left:0px; margin-right:0px; -qt-block-indent:0; text-indent:0px;&quot;&gt;&lt;span style=&quot; font-size:8pt;&quot;&gt;The display language. This will only displaye languages for which you have a translation installed.&lt;/span&gt;&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
+            </property>
+           </widget>
+          </item>
+          <item row="2" column="1">
+           <widget class="QComboBox" name="styleBox">
+            <property name="toolTip">
+             <string>graphical style</string>
+            </property>
+            <property name="whatsThis">
+             <string>graphical style of the MO user interface</string>
+            </property>
+           </widget>
+          </item>
+          <item row="4" column="0" colspan="2">
            <widget class="QCheckBox" name="centerDialogs">
-            <property name="statusTip">
+            <property name="toolTip">
              <string>Dialogs will always be centered on the main window, but will remember their size.</string>
             </property>
             <property name="whatsThis">
@@ -102,7 +94,7 @@ p, li { white-space: pre-wrap; }
             </property>
            </widget>
           </item>
-          <item>
+          <item row="5" column="0" colspan="2">
            <widget class="QPushButton" name="resetDialogsButton">
             <property name="maximumSize">
              <size>
@@ -121,7 +113,7 @@ p, li { white-space: pre-wrap; }
             </property>
            </widget>
           </item>
-          <item>
+          <item row="6" column="0" colspan="2">
            <widget class="QPushButton" name="categoriesBtn">
             <property name="toolTip">
              <string>Modify the categories available to arrange your mods.</string>
@@ -137,12 +129,22 @@ p, li { white-space: pre-wrap; }
          </layout>
         </widget>
        </item>
-       <item>
+       <item row="0" column="1">
         <widget class="QGroupBox" name="groupBox_5">
          <property name="title">
           <string>Download List</string>
          </property>
-         <layout class="QHBoxLayout" name="horizontalLayout_11">
+         <layout class="QVBoxLayout" name="verticalLayout_2">
+          <item>
+           <widget class="QCheckBox" name="showMetaBox">
+            <property name="toolTip">
+             <string>If checked, the download list will display meta information instead of file names.</string>
+            </property>
+            <property name="text">
+             <string>Show Meta Information</string>
+            </property>
+           </widget>
+          </item>
           <item>
            <widget class="QCheckBox" name="compactBox">
             <property name="toolTip">
@@ -154,19 +156,22 @@ p, li { white-space: pre-wrap; }
            </widget>
           </item>
           <item>
-           <widget class="QCheckBox" name="showMetaBox">
-            <property name="toolTip">
-             <string>If checked, the download list will display meta information instead of file names.</string>
+           <spacer name="verticalSpacer_5">
+            <property name="orientation">
+             <enum>Qt::Vertical</enum>
             </property>
-            <property name="text">
-             <string>Show Meta Information</string>
+            <property name="sizeHint" stdset="0">
+             <size>
+              <width>0</width>
+              <height>0</height>
+             </size>
             </property>
-           </widget>
+           </spacer>
           </item>
          </layout>
         </widget>
        </item>
-       <item>
+       <item row="3" column="0" colspan="2">
         <widget class="QGroupBox" name="ModlistGroupBox">
          <property name="title">
           <string>Colors</string>
@@ -236,6 +241,54 @@ p, li { white-space: pre-wrap; }
              <string>Is overwriting (archive files)</string>
             </property>
            </widget>
+          </item>
+         </layout>
+        </widget>
+       </item>
+       <item row="1" column="1">
+        <widget class="QGroupBox" name="groupBox_6">
+         <property name="title">
+          <string>Updates</string>
+         </property>
+         <layout class="QVBoxLayout" name="verticalLayout_3">
+          <item>
+           <widget class="QCheckBox" name="checkForUpdates">
+            <property name="toolTip">
+             <string>Mod Organizer checks for updates on Github on startup.</string>
+            </property>
+            <property name="whatsThis">
+             <string>Mod Organizer checks for updates on Github on startup.</string>
+            </property>
+            <property name="text">
+             <string>Check for updates</string>
+            </property>
+           </widget>
+          </item>
+          <item>
+           <widget class="QCheckBox" name="usePrereleaseBox">
+            <property name="toolTip">
+             <string>Update to non-stable releases.</string>
+            </property>
+            <property name="whatsThis">
+             <string>If this is enabled, the integrated update mechanism will notify of all releases, including pre-releases (alphas, betas). Please use this only if you're sufficiently tech-savvy to investigate issues, look for known problems in the issue tracker and create meaningful reports.</string>
+            </property>
+            <property name="text">
+             <string>Install Pre-releases (Betas)</string>
+            </property>
+           </widget>
+          </item>
+          <item>
+           <spacer name="verticalSpacer_9">
+            <property name="orientation">
+             <enum>Qt::Vertical</enum>
+            </property>
+            <property name="sizeHint" stdset="0">
+             <size>
+              <width>0</width>
+              <height>0</height>
+             </size>
+            </property>
+           </spacer>
           </item>
          </layout>
         </widget>
@@ -1416,11 +1469,7 @@ programs you are intentionally running.</string>
   </layout>
  </widget>
  <tabstops>
-  <tabstop>languageBox</tabstop>
-  <tabstop>styleBox</tabstop>
   <tabstop>logLevelBox</tabstop>
-  <tabstop>usePrereleaseBox</tabstop>
-  <tabstop>categoriesBtn</tabstop>
   <tabstop>baseDirEdit</tabstop>
   <tabstop>browseBaseDirBtn</tabstop>
   <tabstop>downloadDirEdit</tabstop>

--- a/src/settingsdialoggeneral.cpp
+++ b/src/settingsdialoggeneral.cpp
@@ -208,13 +208,24 @@ void GeneralSettingsTab::selectLanguage()
 void GeneralSettingsTab::addStyles()
 {
   ui->styleBox->addItem("None", "");
-  ui->styleBox->addItem("Fusion", "Fusion");
+  for (auto&& key : QStyleFactory::keys()) {
+    ui->styleBox->addItem(key, key);
+  }
 
-  QDirIterator langIter(QCoreApplication::applicationDirPath() + "/" + QString::fromStdWString(AppConfig::stylesheetsPath()), QStringList("*.qss"), QDir::Files);
-  while (langIter.hasNext()) {
-    langIter.next();
-    QString style = langIter.fileName();
-    ui->styleBox->addItem(style, style);
+  ui->styleBox->insertSeparator(ui->styleBox->count());
+
+  QDirIterator iter(
+    QCoreApplication::applicationDirPath() + "/" +
+      QString::fromStdWString(AppConfig::stylesheetsPath()),
+        QStringList("*.qss"),
+    QDir::Files);
+
+  while (iter.hasNext()) {
+    iter.next();
+
+    ui->styleBox->addItem(
+      iter.fileInfo().completeBaseName(),
+      iter.fileName());
   }
 }
 

--- a/src/settingsdialoggeneral.cpp
+++ b/src/settingsdialoggeneral.cpp
@@ -51,6 +51,7 @@ GeneralSettingsTab::GeneralSettingsTab(Settings& s, SettingsDialog& d)
   setContainsColor(settings().colors().modlistContainsPlugin());
   setContainedColor(settings().colors().pluginListContained());
 
+  ui->centerDialogs->setChecked(settings().geometry().centerDialogs());
   ui->compactBox->setChecked(settings().interface().compactDownloads());
   ui->showMetaBox->setChecked(settings().interface().metaDownloads());
   ui->usePrereleaseBox->setChecked(settings().usePrereleases());
@@ -91,6 +92,7 @@ void GeneralSettingsTab::update()
   settings().colors().setModlistContainsPlugin(getContainsColor());
   settings().colors().setPluginListContained(getContainedColor());
 
+  settings().geometry().setCenterDialogs(ui->centerDialogs->isChecked());
   settings().interface().setCompactDownloads(ui->compactBox->isChecked());
   settings().interface().setMetaDownloads(ui->showMetaBox->isChecked());
   settings().setUsePrereleases(ui->usePrereleaseBox->isChecked());

--- a/src/settingsdialoggeneral.cpp
+++ b/src/settingsdialoggeneral.cpp
@@ -6,64 +6,121 @@
 
 using MOBase::QuestionBoxMemory;
 
+
+class ColorItem : public QTableWidgetItem
+{
+public:
+  ColorItem(
+    const QColor& defaultColor,
+    std::function<QColor ()> get,
+    std::function<void (const QColor&)> commit)
+     : m_default(defaultColor), m_get(get), m_commit(commit)
+  {
+    set(get());
+  }
+
+  QColor get() const
+  {
+    return m_temp;
+  }
+
+  bool set(const QColor& c)
+  {
+    if (m_temp != c) {
+      m_temp = c;
+      return true;
+    }
+
+    return false;
+  }
+
+  void commit()
+  {
+    m_commit(m_temp);
+  }
+
+  bool reset()
+  {
+    return set(m_default);
+  }
+
+private:
+  const QColor m_default;
+  std::function<QColor ()> m_get;
+  std::function<void (const QColor&)> m_commit;
+  QColor m_temp;
+};
+
+
+class ColorDelegate : public QStyledItemDelegate
+{
+public:
+  ColorDelegate(QTableWidget* table)
+    : m_table(table)
+  {
+  }
+
+protected:
+  void paint(
+    QPainter* p, const QStyleOptionViewItem& option,
+    const QModelIndex& index) const override
+  {
+    if (!paintColor(p, option, index)) {
+      QStyledItemDelegate::paint(p, option, index);
+    }
+  }
+
+private:
+  QTableWidget* m_table;
+
+  bool paintColor(
+    QPainter* p, const QStyleOptionViewItem& option,
+    const QModelIndex& index) const
+  {
+    if (index.column() != 1) {
+      return false;
+    }
+
+    const auto* item = dynamic_cast<ColorItem*>(
+      m_table->item(index.row(), index.column()));
+
+    if (!item) {
+      return false;
+    }
+
+    p->save();
+    p->fillRect(option.rect, item->get());
+    p->restore();
+
+    return true;
+  }
+};
+
+
+template <class F>
+void forEachColorItem(QTableWidget* table, F&& f)
+{
+  const auto rowCount = table->rowCount();
+
+  for (int i=0; i<rowCount; ++i) {
+    if (auto* item=dynamic_cast<ColorItem*>(table->item(i, 1))) {
+      f(item);
+    }
+  }
+}
+
+
 GeneralSettingsTab::GeneralSettingsTab(Settings& s, SettingsDialog& d)
   : SettingsTab(s, d)
 {
   addLanguages();
-  {
-    QString languageCode = settings().interface().language();
-    int currentID        = ui->languageBox->findData(languageCode);
-    // I made a mess. :( Most languages are stored with only the iso country
-    // code (2 characters like "de") but chinese
-    // with the exact language variant (zh_TW) so I have to search for both
-    // variants
-    if (currentID == -1) {
-      currentID = ui->languageBox->findData(languageCode.mid(0, 2));
-    }
-    if (currentID != -1) {
-      ui->languageBox->setCurrentIndex(currentID);
-    }
-  }
+  selectLanguage();
 
   addStyles();
+  selectStyle();
 
-  {
-    const int currentID = ui->styleBox->findData(
-      settings().interface().styleName().value_or(""));
+  setColorTable();
 
-    if (currentID != -1) {
-      ui->styleBox->setCurrentIndex(currentID);
-    }
-  }
-
-  //version with stylesheet
-  setButtonColor(ui->overwritingBtn, settings().colors().modlistOverwritingLoose());
-  setButtonColor(ui->overwrittenBtn, settings().colors().modlistOverwrittenLoose());
-  setButtonColor(ui->overwritingArchiveBtn, settings().colors().modlistOverwritingArchive());
-  setButtonColor(ui->overwrittenArchiveBtn, settings().colors().modlistOverwrittenArchive());
-  setButtonColor(ui->containsBtn, settings().colors().modlistContainsPlugin());
-  setButtonColor(ui->containedBtn, settings().colors().pluginListContained());
-
-  setOverwritingColor(settings().colors().modlistOverwritingLoose());
-  setOverwrittenColor(settings().colors().modlistOverwrittenLoose());
-  setOverwritingArchiveColor(settings().colors().modlistOverwritingArchive());
-  setOverwrittenArchiveColor(settings().colors().modlistOverwrittenArchive());
-  setContainsColor(settings().colors().modlistContainsPlugin());
-  setContainedColor(settings().colors().pluginListContained());
-
-  ui->centerDialogs->setChecked(settings().geometry().centerDialogs());
-  ui->compactBox->setChecked(settings().interface().compactDownloads());
-  ui->showMetaBox->setChecked(settings().interface().metaDownloads());
-  ui->checkForUpdates->setChecked(settings().checkForUpdates());
-  ui->usePrereleaseBox->setChecked(settings().usePrereleases());
-  ui->colorSeparatorsBox->setChecked(settings().colors().colorSeparatorScrollbar());
-
-  QObject::connect(ui->overwritingArchiveBtn, &QPushButton::clicked, [&]{ on_overwritingArchiveBtn_clicked(); });
-  QObject::connect(ui->overwritingBtn, &QPushButton::clicked, [&]{ on_overwritingBtn_clicked(); });
-  QObject::connect(ui->overwrittenArchiveBtn, &QPushButton::clicked, [&]{ on_overwrittenArchiveBtn_clicked(); });
-  QObject::connect(ui->overwrittenBtn, &QPushButton::clicked, [&]{ on_overwrittenBtn_clicked(); });
-  QObject::connect(ui->containedBtn, &QPushButton::clicked, [&]{ on_containedBtn_clicked(); });
-  QObject::connect(ui->containsBtn, &QPushButton::clicked, [&]{ on_containsBtn_clicked(); });
   QObject::connect(ui->categoriesBtn, &QPushButton::clicked, [&]{ on_categoriesBtn_clicked(); });
   QObject::connect(ui->resetColorsBtn, &QPushButton::clicked, [&]{ on_resetColorsBtn_clicked(); });
   QObject::connect(ui->resetDialogsButton, &QPushButton::clicked, [&]{ on_resetDialogsButton_clicked(); });
@@ -86,18 +143,16 @@ void GeneralSettingsTab::update()
     emit settings().styleChanged(newStyle);
   }
 
-  settings().colors().setModlistOverwritingLoose(getOverwritingColor());
-  settings().colors().setModlistOverwrittenLoose(getOverwrittenColor());
-  settings().colors().setModlistOverwritingArchive(getOverwritingArchiveColor());
-  settings().colors().setModlistOverwrittenArchive(getOverwrittenArchiveColor());
-  settings().colors().setModlistContainsPlugin(getContainsColor());
-  settings().colors().setPluginListContained(getContainedColor());
-
   settings().geometry().setCenterDialogs(ui->centerDialogs->isChecked());
   settings().interface().setCompactDownloads(ui->compactBox->isChecked());
   settings().interface().setMetaDownloads(ui->showMetaBox->isChecked());
   settings().setCheckForUpdates(ui->checkForUpdates->isChecked());
   settings().setUsePrereleases(ui->usePrereleaseBox->isChecked());
+
+  forEachColorItem(ui->colorTable, [](auto* item) {
+    item->commit();
+  });
+
   settings().colors().setColorSeparatorScrollbar(ui->colorSeparatorsBox->isChecked());
 }
 
@@ -134,6 +189,22 @@ void GeneralSettingsTab::addLanguages()
   }
 }
 
+void GeneralSettingsTab::selectLanguage()
+{
+  QString languageCode = settings().interface().language();
+  int currentID        = ui->languageBox->findData(languageCode);
+  // I made a mess. :( Most languages are stored with only the iso country
+  // code (2 characters like "de") but chinese
+  // with the exact language variant (zh_TW) so I have to search for both
+  // variants
+  if (currentID == -1) {
+    currentID = ui->languageBox->findData(languageCode.mid(0, 2));
+  }
+  if (currentID != -1) {
+    ui->languageBox->setCurrentIndex(currentID);
+  }
+}
+
 void GeneralSettingsTab::addStyles()
 {
   ui->styleBox->addItem("None", "");
@@ -147,107 +218,136 @@ void GeneralSettingsTab::addStyles()
   }
 }
 
+void GeneralSettingsTab::selectStyle()
+{
+  const int currentID = ui->styleBox->findData(
+    settings().interface().styleName().value_or(""));
+
+  if (currentID != -1) {
+    ui->styleBox->setCurrentIndex(currentID);
+  }
+}
+
+void GeneralSettingsTab::setColorTable()
+{
+  ui->colorTable->setColumnCount(2);
+  ui->colorTable->setHorizontalHeaderLabels({
+    QObject::tr("Item"), QObject::tr("Color")
+    });
+
+  ui->colorTable->setItemDelegate(new ColorDelegate(ui->colorTable));
+
+  addColor(
+    QObject::tr("Is overwritten (loose files)"),
+    QColor(0, 255, 0, 64),
+    [this]{ return settings().colors().modlistOverwrittenLoose(); },
+    [this](auto&& v){ settings().colors().setModlistOverwrittenLoose(v); });
+
+  addColor(
+    QObject::tr("Is overwriting (loose files)"),
+    QColor(255, 0, 0, 64),
+    [this]{ return settings().colors().modlistOverwritingLoose(); },
+    [this](auto&& v){ settings().colors().setModlistOverwritingLoose(v); });
+
+  addColor(
+    QObject::tr("Is overwritten (archives)"),
+    QColor(0, 255, 255, 64),
+    [this]{ return settings().colors().modlistOverwrittenArchive(); },
+    [this](auto&& v){ settings().colors().setModlistOverwrittenArchive(v); });
+
+  addColor(
+    QObject::tr("Is overwriting (archives)"),
+    QColor(255, 0, 255, 64),
+    [this]{ return settings().colors().modlistOverwritingArchive(); },
+    [this](auto&& v){ settings().colors().setModlistOverwritingArchive(v); });
+
+  addColor(
+    QObject::tr("Mod contains selected plugin"),
+    QColor(0, 0, 255, 64),
+    [this]{ return settings().colors().modlistContainsPlugin(); },
+    [this](auto&& v){ settings().colors().setModlistContainsPlugin(v); });
+
+  addColor(
+    QObject::tr("Plugin is contained in selected mod"),
+    QColor(0, 0, 255, 64),
+    [this]{ return settings().colors().pluginListContained(); },
+    [this](auto&& v){ settings().colors().setPluginListContained(v); });
+
+  QObject::connect(
+    ui->colorTable, &QTableWidget::cellActivated,
+    [&]{ onColorActivated(); });
+}
+
+void GeneralSettingsTab::addColor(
+  const QString& text, const QColor& defaultColor,
+  std::function<QColor ()> get,
+  std::function<void (const QColor&)> commit)
+{
+  const auto r = ui->colorTable->rowCount();
+  ui->colorTable->setRowCount(r + 1);
+
+  ui->colorTable->setItem(r, 0, new QTableWidgetItem(text));
+  ui->colorTable->setItem(r, 1, new ColorItem(defaultColor, get, commit));
+
+  ui->colorTable->resizeColumnsToContents();
+}
+
 void GeneralSettingsTab::resetDialogs()
 {
   settings().widgets().resetQuestionButtons();
 }
 
-void GeneralSettingsTab::setButtonColor(QPushButton *button, const QColor &color)
+void GeneralSettingsTab::onColorActivated()
 {
-  button->setStyleSheet(
-    QString("QPushButton {"
-      "background-color: rgba(%1, %2, %3, %4);"
-      "color: %5;"
-      "border: 1px solid;"
-      "padding: 3px;"
-      "}")
-    .arg(color.red())
-    .arg(color.green())
-    .arg(color.blue())
-    .arg(color.alpha())
-    .arg(ColorSettings::idealTextColor(color).name())
-  );
-};
-
-void GeneralSettingsTab::on_containsBtn_clicked()
-{
-  QColor result = QColorDialog::getColor(m_ContainsColor, &dialog(), "Color Picker: Mod contains selected plugin", QColorDialog::ShowAlphaChannel);
-  if (result.isValid()) {
-    m_ContainsColor = result;
-    setButtonColor(ui->containsBtn, result);
+  const auto rows = ui->colorTable->selectionModel()->selectedRows();
+  if (rows.isEmpty()) {
+    return;
   }
-}
 
-void GeneralSettingsTab::on_containedBtn_clicked()
-{
-  QColor result = QColorDialog::getColor(m_ContainedColor, &dialog(), "ColorPicker: Plugin is Contained in selected Mod", QColorDialog::ShowAlphaChannel);
-  if (result.isValid()) {
-    m_ContainedColor = result;
-    setButtonColor(ui->containedBtn, result);
+  const auto row = rows[0].row();
+
+  const auto text = ui->colorTable->item(row, 0)->text();
+  auto* item = dynamic_cast<ColorItem*>(ui->colorTable->item(row, 1));
+
+  if (!item) {
+    return;
   }
-}
 
-void GeneralSettingsTab::on_overwrittenBtn_clicked()
-{
-  QColor result = QColorDialog::getColor(m_OverwrittenColor, &dialog(), "ColorPicker: Is overwritten (loose files)", QColorDialog::ShowAlphaChannel);
-  if (result.isValid()) {
-    m_OverwrittenColor = result;
-    setButtonColor(ui->overwrittenBtn, result);
-  }
-}
+  const QColor result = QColorDialog::getColor(
+    item->get(), &dialog(), text, QColorDialog::ShowAlphaChannel);
 
-void GeneralSettingsTab::on_overwritingBtn_clicked()
-{
-  QColor result = QColorDialog::getColor(m_OverwritingColor, &dialog(), "ColorPicker: Is overwriting (loose files)", QColorDialog::ShowAlphaChannel);
   if (result.isValid()) {
-    m_OverwritingColor = result;
-    setButtonColor(ui->overwritingBtn, result);
-  }
-}
-
-void GeneralSettingsTab::on_overwrittenArchiveBtn_clicked()
-{
-  QColor result = QColorDialog::getColor(m_OverwrittenArchiveColor, &dialog(), "ColorPicker: Is overwritten (archive files)", QColorDialog::ShowAlphaChannel);
-  if (result.isValid()) {
-    m_OverwrittenArchiveColor = result;
-    setButtonColor(ui->overwrittenArchiveBtn, result);
-  }
-}
-
-void GeneralSettingsTab::on_overwritingArchiveBtn_clicked()
-{
-  QColor result = QColorDialog::getColor(m_OverwritingArchiveColor, &dialog(), "ColorPicker: Is overwriting (archive files)", QColorDialog::ShowAlphaChannel);
-  if (result.isValid()) {
-    m_OverwritingArchiveColor = result;
-    setButtonColor(ui->overwritingArchiveBtn, result);
+    item->set(result);
+    ui->colorTable->update(ui->colorTable->model()->index(row, 1));
   }
 }
 
 void GeneralSettingsTab::on_resetColorsBtn_clicked()
 {
-  m_OverwritingColor = QColor(255, 0, 0, 64);
-  m_OverwrittenColor = QColor(0, 255, 0, 64);
-  m_OverwritingArchiveColor = QColor(255, 0, 255, 64);
-  m_OverwrittenArchiveColor = QColor(0, 255, 255, 64);
-  m_ContainsColor = QColor(0, 0, 255, 64);
-  m_ContainedColor = QColor(0, 0, 255, 64);
+  bool changed = false;
 
-  setButtonColor(ui->overwritingBtn, m_OverwritingColor);
-  setButtonColor(ui->overwrittenBtn, m_OverwrittenColor);
-  setButtonColor(ui->overwritingArchiveBtn, m_OverwritingArchiveColor);
-  setButtonColor(ui->overwrittenArchiveBtn, m_OverwrittenArchiveColor);
-  setButtonColor(ui->containsBtn, m_ContainsColor);
-  setButtonColor(ui->containedBtn, m_ContainedColor);
+  forEachColorItem(ui->colorTable, [&](auto* item) {
+    if (item->reset()) {
+      changed = true;
+    }
+  });
+
+  if (changed) {
+    ui->colorTable->update();
+  }
 }
 
 void GeneralSettingsTab::on_resetDialogsButton_clicked()
 {
-  if (QMessageBox::question(
-    parentWidget(), QObject::tr("Confirm?"),
+  const auto r = QMessageBox::question(
+    parentWidget(),
+    QObject::tr("Confirm?"),
     QObject::tr(
       "This will reset all the choices you made to dialogs and make them all "
       "visible again. Continue?"),
-    QMessageBox::Yes | QMessageBox::No) == QMessageBox::Yes) {
+    QMessageBox::Yes | QMessageBox::No);
+
+  if (r == QMessageBox::Yes) {
     resetDialogs();
   }
 }
@@ -255,6 +355,7 @@ void GeneralSettingsTab::on_resetDialogsButton_clicked()
 void GeneralSettingsTab::on_categoriesBtn_clicked()
 {
   CategoriesDialog dialog(&dialog());
+
   if (dialog.exec() == QDialog::Accepted) {
     dialog.commitChanges();
   }

--- a/src/settingsdialoggeneral.cpp
+++ b/src/settingsdialoggeneral.cpp
@@ -16,6 +16,13 @@ GeneralSettingsTab::GeneralSettingsTab(Settings& s, SettingsDialog& d)
 
   ui->colorTable->load(s);
 
+  ui->centerDialogs->setChecked(settings().geometry().centerDialogs());
+  ui->compactBox->setChecked(settings().interface().compactDownloads());
+  ui->showMetaBox->setChecked(settings().interface().metaDownloads());
+  ui->checkForUpdates->setChecked(settings().checkForUpdates());
+  ui->usePrereleaseBox->setChecked(settings().usePrereleases());
+  ui->colorSeparatorsBox->setChecked(settings().colors().colorSeparatorScrollbar());
+
   QObject::connect(
     ui->categoriesBtn, &QPushButton::clicked,
     [&]{ on_categoriesBtn_clicked(); });
@@ -49,14 +56,13 @@ void GeneralSettingsTab::update()
     emit settings().styleChanged(newStyle);
   }
 
+  ui->colorTable->commitColors();
+
   settings().geometry().setCenterDialogs(ui->centerDialogs->isChecked());
   settings().interface().setCompactDownloads(ui->compactBox->isChecked());
   settings().interface().setMetaDownloads(ui->showMetaBox->isChecked());
   settings().setCheckForUpdates(ui->checkForUpdates->isChecked());
   settings().setUsePrereleases(ui->usePrereleaseBox->isChecked());
-
-  ui->colorTable->commitColors();
-
   settings().colors().setColorSeparatorScrollbar(ui->colorSeparatorsBox->isChecked());
 }
 

--- a/src/settingsdialoggeneral.cpp
+++ b/src/settingsdialoggeneral.cpp
@@ -2,113 +2,8 @@
 #include "ui_settingsdialog.h"
 #include "appconfig.h"
 #include "categoriesdialog.h"
+#include "colortable.h"
 #include <questionboxmemory.h>
-
-using MOBase::QuestionBoxMemory;
-
-
-class ColorItem : public QTableWidgetItem
-{
-public:
-  ColorItem(
-    const QColor& defaultColor,
-    std::function<QColor ()> get,
-    std::function<void (const QColor&)> commit)
-     : m_default(defaultColor), m_get(get), m_commit(commit)
-  {
-    set(get());
-  }
-
-  QColor get() const
-  {
-    return m_temp;
-  }
-
-  bool set(const QColor& c)
-  {
-    if (m_temp != c) {
-      m_temp = c;
-      return true;
-    }
-
-    return false;
-  }
-
-  void commit()
-  {
-    m_commit(m_temp);
-  }
-
-  bool reset()
-  {
-    return set(m_default);
-  }
-
-private:
-  const QColor m_default;
-  std::function<QColor ()> m_get;
-  std::function<void (const QColor&)> m_commit;
-  QColor m_temp;
-};
-
-
-class ColorDelegate : public QStyledItemDelegate
-{
-public:
-  ColorDelegate(QTableWidget* table)
-    : m_table(table)
-  {
-  }
-
-protected:
-  void paint(
-    QPainter* p, const QStyleOptionViewItem& option,
-    const QModelIndex& index) const override
-  {
-    if (!paintColor(p, option, index)) {
-      QStyledItemDelegate::paint(p, option, index);
-    }
-  }
-
-private:
-  QTableWidget* m_table;
-
-  bool paintColor(
-    QPainter* p, const QStyleOptionViewItem& option,
-    const QModelIndex& index) const
-  {
-    if (index.column() != 1) {
-      return false;
-    }
-
-    const auto* item = dynamic_cast<ColorItem*>(
-      m_table->item(index.row(), index.column()));
-
-    if (!item) {
-      return false;
-    }
-
-    p->save();
-    p->fillRect(option.rect, item->get());
-    p->restore();
-
-    return true;
-  }
-};
-
-
-template <class F>
-void forEachColorItem(QTableWidget* table, F&& f)
-{
-  const auto rowCount = table->rowCount();
-
-  for (int i=0; i<rowCount; ++i) {
-    if (auto* item=dynamic_cast<ColorItem*>(table->item(i, 1))) {
-      f(item);
-    }
-  }
-}
-
 
 GeneralSettingsTab::GeneralSettingsTab(Settings& s, SettingsDialog& d)
   : SettingsTab(s, d)
@@ -119,17 +14,26 @@ GeneralSettingsTab::GeneralSettingsTab(Settings& s, SettingsDialog& d)
   addStyles();
   selectStyle();
 
-  setColorTable();
+  ui->colorTable->load(s);
 
-  QObject::connect(ui->categoriesBtn, &QPushButton::clicked, [&]{ on_categoriesBtn_clicked(); });
-  QObject::connect(ui->resetColorsBtn, &QPushButton::clicked, [&]{ on_resetColorsBtn_clicked(); });
-  QObject::connect(ui->resetDialogsButton, &QPushButton::clicked, [&]{ on_resetDialogsButton_clicked(); });
+  QObject::connect(
+    ui->categoriesBtn, &QPushButton::clicked,
+    [&]{ on_categoriesBtn_clicked(); });
+
+  QObject::connect(
+    ui->resetColorsBtn, &QPushButton::clicked,
+    [&]{ on_resetColorsBtn_clicked(); });
+
+  QObject::connect(
+    ui->resetDialogsButton, &QPushButton::clicked,
+    [&]{ on_resetDialogsButton_clicked(); });
 }
 
 void GeneralSettingsTab::update()
 {
   const QString oldLanguage = settings().interface().language();
-  const QString newLanguage = ui->languageBox->itemData(ui->languageBox->currentIndex()).toString();
+  const QString newLanguage = ui->languageBox->itemData(
+    ui->languageBox->currentIndex()).toString();
 
   if (newLanguage != oldLanguage) {
     settings().interface().setLanguage(newLanguage);
@@ -137,7 +41,9 @@ void GeneralSettingsTab::update()
   }
 
   const QString oldStyle = settings().interface().styleName().value_or("");
-  const QString newStyle = ui->styleBox->itemData(ui->styleBox->currentIndex()).toString();
+  const QString newStyle = ui->styleBox->itemData(
+    ui->styleBox->currentIndex()).toString();
+
   if (oldStyle != newStyle) {
     settings().interface().setStyleName(newStyle);
     emit settings().styleChanged(newStyle);
@@ -149,9 +55,7 @@ void GeneralSettingsTab::update()
   settings().setCheckForUpdates(ui->checkForUpdates->isChecked());
   settings().setUsePrereleases(ui->usePrereleaseBox->isChecked());
 
-  forEachColorItem(ui->colorTable, [](auto* item) {
-    item->commit();
-  });
+  ui->colorTable->commitColors();
 
   settings().colors().setColorSeparatorScrollbar(ui->colorSeparatorsBox->isChecked());
 }
@@ -258,113 +162,14 @@ void GeneralSettingsTab::selectStyle()
   }
 }
 
-void GeneralSettingsTab::setColorTable()
-{
-  ui->colorTable->setColumnCount(2);
-  ui->colorTable->setHorizontalHeaderLabels({
-    QObject::tr("Item"), QObject::tr("Color")
-    });
-
-  ui->colorTable->setItemDelegate(new ColorDelegate(ui->colorTable));
-
-  addColor(
-    QObject::tr("Is overwritten (loose files)"),
-    QColor(0, 255, 0, 64),
-    [this]{ return settings().colors().modlistOverwrittenLoose(); },
-    [this](auto&& v){ settings().colors().setModlistOverwrittenLoose(v); });
-
-  addColor(
-    QObject::tr("Is overwriting (loose files)"),
-    QColor(255, 0, 0, 64),
-    [this]{ return settings().colors().modlistOverwritingLoose(); },
-    [this](auto&& v){ settings().colors().setModlistOverwritingLoose(v); });
-
-  addColor(
-    QObject::tr("Is overwritten (archives)"),
-    QColor(0, 255, 255, 64),
-    [this]{ return settings().colors().modlistOverwrittenArchive(); },
-    [this](auto&& v){ settings().colors().setModlistOverwrittenArchive(v); });
-
-  addColor(
-    QObject::tr("Is overwriting (archives)"),
-    QColor(255, 0, 255, 64),
-    [this]{ return settings().colors().modlistOverwritingArchive(); },
-    [this](auto&& v){ settings().colors().setModlistOverwritingArchive(v); });
-
-  addColor(
-    QObject::tr("Mod contains selected plugin"),
-    QColor(0, 0, 255, 64),
-    [this]{ return settings().colors().modlistContainsPlugin(); },
-    [this](auto&& v){ settings().colors().setModlistContainsPlugin(v); });
-
-  addColor(
-    QObject::tr("Plugin is contained in selected mod"),
-    QColor(0, 0, 255, 64),
-    [this]{ return settings().colors().pluginListContained(); },
-    [this](auto&& v){ settings().colors().setPluginListContained(v); });
-
-  QObject::connect(
-    ui->colorTable, &QTableWidget::cellActivated,
-    [&]{ onColorActivated(); });
-}
-
-void GeneralSettingsTab::addColor(
-  const QString& text, const QColor& defaultColor,
-  std::function<QColor ()> get,
-  std::function<void (const QColor&)> commit)
-{
-  const auto r = ui->colorTable->rowCount();
-  ui->colorTable->setRowCount(r + 1);
-
-  ui->colorTable->setItem(r, 0, new QTableWidgetItem(text));
-  ui->colorTable->setItem(r, 1, new ColorItem(defaultColor, get, commit));
-
-  ui->colorTable->resizeColumnsToContents();
-}
-
 void GeneralSettingsTab::resetDialogs()
 {
   settings().widgets().resetQuestionButtons();
 }
 
-void GeneralSettingsTab::onColorActivated()
-{
-  const auto rows = ui->colorTable->selectionModel()->selectedRows();
-  if (rows.isEmpty()) {
-    return;
-  }
-
-  const auto row = rows[0].row();
-
-  const auto text = ui->colorTable->item(row, 0)->text();
-  auto* item = dynamic_cast<ColorItem*>(ui->colorTable->item(row, 1));
-
-  if (!item) {
-    return;
-  }
-
-  const QColor result = QColorDialog::getColor(
-    item->get(), &dialog(), text, QColorDialog::ShowAlphaChannel);
-
-  if (result.isValid()) {
-    item->set(result);
-    ui->colorTable->update(ui->colorTable->model()->index(row, 1));
-  }
-}
-
 void GeneralSettingsTab::on_resetColorsBtn_clicked()
 {
-  bool changed = false;
-
-  forEachColorItem(ui->colorTable, [&](auto* item) {
-    if (item->reset()) {
-      changed = true;
-    }
-  });
-
-  if (changed) {
-    ui->colorTable->update();
-  }
+  ui->colorTable->resetColors();
 }
 
 void GeneralSettingsTab::on_resetDialogsButton_clicked()

--- a/src/settingsdialoggeneral.cpp
+++ b/src/settingsdialoggeneral.cpp
@@ -54,6 +54,7 @@ GeneralSettingsTab::GeneralSettingsTab(Settings& s, SettingsDialog& d)
   ui->centerDialogs->setChecked(settings().geometry().centerDialogs());
   ui->compactBox->setChecked(settings().interface().compactDownloads());
   ui->showMetaBox->setChecked(settings().interface().metaDownloads());
+  ui->checkForUpdates->setChecked(settings().checkForUpdates());
   ui->usePrereleaseBox->setChecked(settings().usePrereleases());
   ui->colorSeparatorsBox->setChecked(settings().colors().colorSeparatorScrollbar());
 
@@ -95,6 +96,7 @@ void GeneralSettingsTab::update()
   settings().geometry().setCenterDialogs(ui->centerDialogs->isChecked());
   settings().interface().setCompactDownloads(ui->compactBox->isChecked());
   settings().interface().setMetaDownloads(ui->showMetaBox->isChecked());
+  settings().setCheckForUpdates(ui->checkForUpdates->isChecked());
   settings().setUsePrereleases(ui->usePrereleaseBox->isChecked());
   settings().colors().setColorSeparatorScrollbar(ui->colorSeparatorsBox->isChecked());
 }

--- a/src/settingsdialoggeneral.h
+++ b/src/settingsdialoggeneral.h
@@ -12,38 +12,22 @@ public:
   void update();
 
 private:
-  QColor m_OverwritingColor;
-  QColor m_OverwrittenColor;
-  QColor m_OverwritingArchiveColor;
-  QColor m_OverwrittenArchiveColor;
-  QColor m_ContainsColor;
-  QColor m_ContainedColor;
-
   void addLanguages();
+  void selectLanguage();
+
   void addStyles();
+  void selectStyle();
+
+  void setColorTable();
+
   void resetDialogs();
-  void setButtonColor(QPushButton *button, const QColor &color);
 
-  QColor getOverwritingColor() { return m_OverwritingColor; }
-  QColor getOverwrittenColor() { return m_OverwrittenColor; }
-  QColor getOverwritingArchiveColor() { return m_OverwritingArchiveColor; }
-  QColor getOverwrittenArchiveColor() { return m_OverwrittenArchiveColor; }
-  QColor getContainsColor() { return m_ContainsColor; }
-  QColor getContainedColor() { return m_ContainedColor; }
+  void addColor(
+    const QString& text, const QColor& defaultColor,
+    std::function<QColor ()> get,
+    std::function<void (const QColor&)> commit);
 
-  void setOverwritingColor(QColor col) { m_OverwritingColor = col; }
-  void setOverwrittenColor(QColor col) { m_OverwrittenColor = col; }
-  void setOverwritingArchiveColor(QColor col) { m_OverwritingArchiveColor = col; }
-  void setOverwrittenArchiveColor(QColor col) { m_OverwrittenArchiveColor = col; }
-  void setContainsColor(QColor col) { m_ContainsColor = col; }
-  void setContainedColor(QColor col) { m_ContainedColor = col; }
-
-  void on_overwritingArchiveBtn_clicked();
-  void on_overwritingBtn_clicked();
-  void on_overwrittenArchiveBtn_clicked();
-  void on_overwrittenBtn_clicked();
-  void on_containedBtn_clicked();
-  void on_containsBtn_clicked();
+  void onColorActivated();
 
   void on_categoriesBtn_clicked();
   void on_resetColorsBtn_clicked();

--- a/src/settingsdialoggeneral.h
+++ b/src/settingsdialoggeneral.h
@@ -18,16 +18,7 @@ private:
   void addStyles();
   void selectStyle();
 
-  void setColorTable();
-
   void resetDialogs();
-
-  void addColor(
-    const QString& text, const QColor& defaultColor,
-    std::function<QColor ()> get,
-    std::function<void (const QColor&)> commit);
-
-  void onColorActivated();
 
   void on_categoriesBtn_clicked();
   void on_resetColorsBtn_clicked();


### PR DESCRIPTION
Dialog and window settings:
- Make sure windows and dialogs are on screen
- Added option to keep dialogs centered over the main window

Settings:
- Visual rework of the General settings tab
- Added toggle for checking for updates, removed dubious online check, just try checking and see what happens
- Now using `ColorTable` for colors instead of buttons
- Query Qt for its default styles instead of hardcoding `"Fusion"`
