### PR TITLE
Symlinks warning

### DIFF
--- a/src/instancemanager.cpp
+++ b/src/instancemanager.cpp
@@ -263,6 +263,11 @@ QStringList InstanceManager::instances() const
 }
 
 
+bool InstanceManager::isPortablePath(const QString& dataPath)
+{
+  return (dataPath == qApp->applicationDirPath());
+}
+
 bool InstanceManager::portableInstall() const
 {
   return QFile::exists(qApp->applicationDirPath() + "/" +
@@ -303,7 +308,7 @@ void InstanceManager::createDataPath(const QString &dataPath) const
 QString InstanceManager::determineDataPath()
 {
   QString instanceId = currentInstance();
-  if (portableInstallIsLocked()) 
+  if (portableInstallIsLocked())
   {
     instanceId.clear();
   }

--- a/src/instancemanager.h
+++ b/src/instancemanager.h
@@ -39,6 +39,7 @@ public:
   QString currentInstance() const;
 
   bool allowedToChangeInstance() const;
+  static bool isPortablePath(const QString& dataPath);
 
 private:
 

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -515,6 +515,10 @@ int runApplication(MOApplication &application, SingleInstance &instance,
   const QString dataPath = application.property("dataPath").toString();
   log::info("data path: {}", dataPath);
 
+  if (InstanceManager::isPortablePath(dataPath)) {
+    log::debug("this is a portable instance");
+  }
+
   if (!bootstrap()) {
     reportError("failed to set up data paths");
     return 1;
@@ -530,6 +534,8 @@ int runApplication(MOApplication &application, SingleInstance &instance,
 
     Settings settings(dataPath + "/" + QString::fromStdWString(AppConfig::iniFileName()));
     log::getDefault().setLevel(settings.diagnostics().logLevel());
+
+    log::debug("using ini at '{}'", settings.filename());
 
     // global crashDumpType sits in OrganizerCore to make a bit less ugly to
     // update it when the settings are changed during runtime
@@ -860,6 +866,8 @@ int main(int argc, char *argv[])
   } // we continue for the primary instance OR if MO was called with parameters
 
   do {
+    LogModel::instance().clear();
+
     // make sure the log file isn't locked in case MO was restarted and
     // the previous instance gets deleted
     log::getDefault().setFile({});


### PR DESCRIPTION
- Only log a warning for symlinks instead of exiting MO
- Added logs: when dmp files are present, for portable instances, and the ini path
- Clear the log widget when switching instances