### PR TITLE
Validation progress dialog fixes

### DIFF
--- a/src/nxmaccessmanager.h
+++ b/src/nxmaccessmanager.h
@@ -144,6 +144,7 @@ public:
     std::optional<APIUserAccount>);
 
   std::function<FinishedCallback> finished;
+  std::function<void (const ValidationAttempt&)> attemptFinished;
 
   NexusKeyValidator(NXMAccessManager& am);
   ~NexusKeyValidator();
@@ -269,9 +270,12 @@ private:
   States m_validationState;
 
   void startValidationCheck(const QString& key);
+
   void onValidatorFinished(
     ValidationAttempt::Result r, const QString& message,
     std::optional<APIUserAccount>);
+
+  void onValidatorAttemptFinished(const ValidationAttempt& a);
 
   void startProgress();
   void stopProgress();

--- a/src/nxmaccessmanager.h
+++ b/src/nxmaccessmanager.h
@@ -137,7 +137,7 @@ class ValidationProgressDialog : public QDialog
   Q_OBJECT;
 
 public:
-  ValidationProgressDialog(const NexusKeyValidator& v);
+  ValidationProgressDialog(NexusKeyValidator& v);
 
   void setParentWidget(QWidget* w);
 
@@ -150,7 +150,7 @@ protected:
 
 private:
   std::unique_ptr<Ui::ValidationProgressDialog> ui;
-  const NexusKeyValidator& m_validator;
+  NexusKeyValidator& m_validator;
   QTimer* m_updateTimer;
   bool m_first;
 
@@ -169,8 +169,7 @@ class NXMAccessManager : public QNetworkAccessManager
 public:
   static const std::chrono::seconds ValidationTimeout;
 
-  explicit NXMAccessManager(QObject *parent, const QString &moVersion);
-
+  NXMAccessManager(QObject *parent, const QString &moVersion);
 
   void setTopLevelWidget(QWidget* w);
 
@@ -233,6 +232,9 @@ private:
   void startValidationCheck(const QString& key);
   void onValidatorState(NexusKeyValidator::States s, const QString& e);
   void onValidatorFinished(const APIUserAccount& user);
+
+  void startProgress();
+  void stopProgress();
 };
 
 #endif // NXMACCESSMANAGER_H

--- a/src/settingsdialognexus.cpp
+++ b/src/settingsdialognexus.cpp
@@ -112,6 +112,12 @@ NexusSettingsTab::NexusSettingsTab(Settings& s, SettingsDialog& d)
   QObject::connect(ui->clearCacheButton, &QPushButton::clicked, [&]{ on_clearCacheButton_clicked(); });
   QObject::connect(ui->associateButton, &QPushButton::clicked, [&]{ on_associateButton_clicked(); });
 
+  if (settings().nexus().hasApiKey()) {
+    addNexusLog(QObject::tr("Connected."));
+  } else {
+    addNexusLog(QObject::tr("Not connected."));
+  }
+
   updateNexusState();
 }
 

--- a/src/settingsdialognexus.cpp
+++ b/src/settingsdialognexus.cpp
@@ -240,17 +240,13 @@ void NexusSettingsTab::validateKey(const QString& key)
     m_nexusValidator.reset(new NexusKeyValidator(
       *NexusInterface::instance(dialog().pluginContainer())->getAccessManager()));
 
-    m_nexusValidator->stateChanged = [&](auto&& s, auto&& e){
-      onValidatorStateChanged(s, e);
-    };
-
-    m_nexusValidator->finished = [&](auto&& user) {
-      onValidatorFinished(user);
+    m_nexusValidator->finished = [&](auto&& r, auto&& m, auto&& u) {
+      onValidatorFinished(r, m, u);
     };
   }
 
   addNexusLog(QObject::tr("Checking API key..."));
-  m_nexusValidator->start(key);
+  m_nexusValidator->start(key, NexusKeyValidator::OneShot);
 }
 
 void NexusSettingsTab::onSSOKeyChanged(const QString& key)
@@ -277,30 +273,29 @@ void NexusSettingsTab::onSSOStateChanged(NexusSSOLogin::States s, const QString&
   updateNexusState();
 }
 
-void NexusSettingsTab::onValidatorStateChanged(
-  NexusKeyValidator::States s, const QString& e)
+void NexusSettingsTab::onValidatorFinished(
+  ValidationAttempt::Result r, const QString& message,
+  std::optional<APIUserAccount> user)
 {
-  if (s != NexusKeyValidator::Finished) {
-    // finished state is handled in onValidatorFinished()
-    const auto log = NexusKeyValidator::stateToString(s, e);
+  if (user) {
+    NexusInterface::instance(dialog().pluginContainer())->setUserAccount(*user);
+    addNexusLog(QObject::tr("Received user acount information"));
 
-    for (auto&& line : log.split("\n")) {
-      addNexusLog(line);
+    if (setKey(user->apiKey())) {
+      addNexusLog(QObject::tr("Linked with Nexus successfully."));
+    } else {
+      addNexusLog(QObject::tr("Failed to set API key"));
+    }
+  } else {
+    if (message.isEmpty()) {
+      // shouldn't happen
+      addNexusLog("Unknown error");
+    } else {
+      addNexusLog(message);
     }
   }
 
   updateNexusState();
-}
-
-void NexusSettingsTab::onValidatorFinished(const APIUserAccount& user)
-{
-  NexusInterface::instance(dialog().pluginContainer())->setUserAccount(user);
-
-  if (!user.apiKey().isEmpty()) {
-    if (setKey(user.apiKey())) {
-      addNexusLog(QObject::tr("Linked with Nexus successfully."));
-    }
-  }
 }
 
 void NexusSettingsTab::addNexusLog(const QString& s)

--- a/src/settingsdialognexus.h
+++ b/src/settingsdialognexus.h
@@ -32,8 +32,9 @@ private:
   void onSSOKeyChanged(const QString& key);
   void onSSOStateChanged(NexusSSOLogin::States s, const QString& e);
 
-  void onValidatorStateChanged(NexusKeyValidator::States s, const QString& e);
-  void onValidatorFinished(const APIUserAccount& user);
+  void onValidatorFinished(
+    ValidationAttempt::Result r, const QString& message,
+    std::optional<APIUserAccount> useR);
 
   void addNexusLog(const QString& s);
 };

--- a/src/validationprogressdialog.ui
+++ b/src/validationprogressdialog.ui
@@ -1,0 +1,117 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<ui version="4.0">
+ <class>ValidationProgressDialog</class>
+ <widget class="QDialog" name="ValidationProgressDialog">
+  <property name="geometry">
+   <rect>
+    <x>0</x>
+    <y>0</y>
+    <width>305</width>
+    <height>93</height>
+   </rect>
+  </property>
+  <property name="windowTitle">
+   <string>Validating Nexus Connection</string>
+  </property>
+  <layout class="QVBoxLayout" name="verticalLayout_2">
+   <item>
+    <widget class="QWidget" name="widget" native="true">
+     <layout class="QVBoxLayout" name="verticalLayout">
+      <property name="leftMargin">
+       <number>0</number>
+      </property>
+      <property name="topMargin">
+       <number>0</number>
+      </property>
+      <property name="rightMargin">
+       <number>0</number>
+      </property>
+      <property name="bottomMargin">
+       <number>0</number>
+      </property>
+      <item>
+       <widget class="QLabel" name="label">
+        <property name="text">
+         <string>Connecting to Nexus...</string>
+        </property>
+       </widget>
+      </item>
+      <item>
+       <widget class="QProgressBar" name="progress">
+        <property name="value">
+         <number>24</number>
+        </property>
+        <property name="textVisible">
+         <bool>false</bool>
+        </property>
+       </widget>
+      </item>
+      <item>
+       <spacer name="verticalSpacer">
+        <property name="orientation">
+         <enum>Qt::Vertical</enum>
+        </property>
+        <property name="sizeHint" stdset="0">
+         <size>
+          <width>20</width>
+          <height>40</height>
+         </size>
+        </property>
+       </spacer>
+      </item>
+     </layout>
+    </widget>
+   </item>
+   <item>
+    <widget class="QWidget" name="widget_2" native="true">
+     <layout class="QHBoxLayout" name="horizontalLayout">
+      <property name="leftMargin">
+       <number>0</number>
+      </property>
+      <property name="topMargin">
+       <number>0</number>
+      </property>
+      <property name="rightMargin">
+       <number>0</number>
+      </property>
+      <property name="bottomMargin">
+       <number>0</number>
+      </property>
+      <item>
+       <widget class="QPushButton" name="cancel">
+        <property name="text">
+         <string>Cancel</string>
+        </property>
+       </widget>
+      </item>
+      <item>
+       <spacer name="horizontalSpacer">
+        <property name="orientation">
+         <enum>Qt::Horizontal</enum>
+        </property>
+        <property name="sizeHint" stdset="0">
+         <size>
+          <width>122</width>
+          <height>20</height>
+         </size>
+        </property>
+       </spacer>
+      </item>
+      <item>
+       <widget class="QPushButton" name="hide">
+        <property name="text">
+         <string>Hide</string>
+        </property>
+        <property name="default">
+         <bool>true</bool>
+        </property>
+       </widget>
+      </item>
+     </layout>
+    </widget>
+   </item>
+  </layout>
+ </widget>
+ <resources/>
+ <connections/>
+</ui>


### PR DESCRIPTION
- Added .ui file for the validation progress dialog
- Fixes theme errors when switching instances. Apparently, once a dialog has a parent, it will spam theme errors if it gets detached later on.
- Validation will automatically try connecting three times before popping up the "try again" dialog.
- The dialog won't be shown at all until the first attempt fails, eliminates the dialog briefly flickering on startup when connection is successful.