### PR TITLE
Categories panel collapsing

### DIFF
--- a/src/mainwindow.cpp
+++ b/src/mainwindow.cpp
@@ -1208,13 +1208,12 @@ void MainWindow::hookUpWindowTutorials()
 
 void MainWindow::showEvent(QShowEvent *event)
 {
-  readSettings(m_OrganizerCore.settings());
-
-  refreshFilters();
-
   QMainWindow::showEvent(event);
 
   if (!m_WasVisible) {
+    readSettings(m_OrganizerCore.settings());
+    refreshFilters();
+
     // this needs to be connected here instead of in the constructor because the
     // actual changing of the stylesheet is done by MOApplication, which
     // connects its signal in runApplication() (in main.cpp), and that happens


### PR DESCRIPTION
The categories panel reverts to being collapsed after minimizing and restoring the window. That's because `showEvent()` is supposed to restore geometry on startup, but it actually does it on _every_ show even, which includes restoring after minimizing.