### PR TITLE
Removed some ambiguous overloads for settings

### DIFF
--- a/src/profile.h
+++ b/src/profile.h
@@ -315,15 +315,12 @@ public:
 
   QVariant setting(
     const QString &section, const QString &name,
-    const QVariant &fallback) const;
+    const QVariant &fallback={}) const;
 
-  QVariant setting(const QString &name, const QVariant &fallback={}) const;
+  void storeSetting(
+    const QString &section, const QString &name, const QVariant &value={});
 
-  void storeSetting(const QString &section, const QString &name,
-                    const QVariant &value);
-  void storeSetting(const QString &name, const QVariant &value);
-  void removeSetting(const QString &section, const QString &name = QString());
-  void removeSetting(const QString &name);
+  void removeSetting(const QString &section, const QString &name);
 
   QVariantMap settingsByGroup(const QString &section) const;
   void storeSettingsByGroup(const QString &section, const QVariantMap &values);


### PR DESCRIPTION
My commit 897d315359718712a8e6b160c279f563f7436367 broke some of the profile settings by silently changing some calls from `(section, name)` to `(name, fallback)` because of ambiguities caused by the introduction of additional overloads.

I've removed all the overloads for `setting()`, `storeSetting()` and `removeSetting()`. The consequence is that the section name must be provided, even if it's empty, but it makes all the calls explicit.