### PR TITLE
Some warnings on authentication

### DIFF
--- a/src/apiuseraccount.cpp
+++ b/src/apiuseraccount.cpp
@@ -96,5 +96,5 @@ bool APIUserAccount::shouldThrottle() const
 
 bool APIUserAccount::exhausted() const
 {
-  return (remainingRequests() <= 0);
+  return isValid() && (remainingRequests() <= 0);
 }

--- a/src/apiuseraccount.h
+++ b/src/apiuseraccount.h
@@ -51,12 +51,12 @@ struct APIStats
 
 
 /**
-* represents a user account on the mod provier website
+* represents a user account on the mod provider website
 */
 class APIUserAccount
 {
 public:
-  // when the number of remanining requests is under this number, further
+  // when the number of remaining requests is under this number, further
   // requests will be throttled by avoiding non-critical ones
   static const int ThrottleThreshold = 200;
 
@@ -110,7 +110,7 @@ public:
   APIUserAccount& name(const QString& name);
 
   /**
-  * sets the acount type
+  * sets the account type
   */
   APIUserAccount& type(APIUserAccountTypes type);
 

--- a/src/nxmaccessmanager.cpp
+++ b/src/nxmaccessmanager.cpp
@@ -886,11 +886,15 @@ void NXMAccessManager::onValidatorAttemptFinished(const ValidationAttempt& a)
 
 bool NXMAccessManager::validated() const
 {
+  if (m_validationState == Valid) {
+    return true;
+  }
+
   if (m_validator.isActive()) {
     const_cast<NXMAccessManager*>(this)->startProgress();
   }
 
-  return (m_validationState == Valid);
+  return false;
 }
 
 void NXMAccessManager::refuseValidation()


### PR DESCRIPTION
- Disconnecting from Nexus without restarting would show incorrect throttling message instead of disconnected error.
- Validation dialog could pop even if logged in
- Typos in comments