### PR TITLE
Proper exit procedure

### DIFF
--- a/src/main.cpp
+++ b/src/main.cpp
@@ -563,10 +563,12 @@ int runApplication(MOApplication &application, SingleInstance &instance,
     if (game == nullptr) {
       InstanceManager &instance = InstanceManager::instance();
       QString instanceName = instance.currentInstance();
+
       if (instanceName.compare("Portable", Qt::CaseInsensitive) != 0) {
         instance.clearCurrentInstance();
-        return INT_MAX;
+        return RestartExitCode;
       }
+
       return 1;
     }
 
@@ -710,6 +712,8 @@ int runApplication(MOApplication &application, SingleInstance &instance,
       splash.finish(&mainWindow);
 
       res = application.exec();
+      mainWindow.onBeforeClose();
+      mainWindow.close();
 
       NexusInterface::instance(&pluginContainer)
         ->getAccessManager()->setTopLevelWidget(nullptr);
@@ -867,6 +871,7 @@ int main(int argc, char *argv[])
 
   do {
     LogModel::instance().clear();
+    ResetExitFlag();
 
     // make sure the log file isn't locked in case MO was restarted and
     // the previous instance gets deleted
@@ -904,10 +909,11 @@ int main(int argc, char *argv[])
       splash = ":/MO/gui/splash";
     }
 
-    int result = runApplication(application, instance, splash);
-    if (result != INT_MAX) {
+    const int result = runApplication(application, instance, splash);
+    if (result != RestartExitCode) {
       return result;
     }
+
     argc = 1;
     moshortcut = MOShortcut("");
   } while (true);

--- a/src/mainwindow.h
+++ b/src/mainwindow.h
@@ -111,7 +111,6 @@ class MainWindow : public QMainWindow, public IUserInterface
   friend class OrganizerProxy;
 
 public:
-
   explicit MainWindow(Settings &settings,
                       OrganizerCore &organizerCore, PluginContainer &pluginContainer,
                       QWidget *parent = 0);
@@ -154,7 +153,8 @@ public:
   void displayModInformation(
     ModInfo::Ptr modInfo, unsigned int modIndex, ModInfoTabIDs tabID) override;
 
-  bool confirmExit();
+  bool canExit();
+  void onBeforeClose();
 
   virtual bool closeWindow();
   virtual void setWindowEnabled(bool enabled);
@@ -383,9 +383,8 @@ private:
   LockedDialogBase *m_LockDialog { nullptr };
   uint64_t m_LockCount { 0 };
 
-  bool m_closing{ false };
-
   bool m_showArchiveData{ true };
+  bool m_exitAfterWait{ false };
 
   MOBase::DelayedFileWriter m_ArchiveListWriter;
 
@@ -672,8 +671,8 @@ private slots: // ui slots
   void on_categoriesOrBtn_toggled(bool checked);
   void on_managedArchiveLabel_linkHovered(const QString &link);
 
-  void storeSettings(Settings& settings);
-  void readSettings(const Settings& settings);
+  void storeSettings();
+  void readSettings();
   void setupModList();
 };
 

--- a/src/settingsdialog.cpp
+++ b/src/settingsdialog.cpp
@@ -33,8 +33,8 @@ SettingsDialog::SettingsDialog(PluginContainer *pluginContainer, Settings& setti
   : TutorableDialog("SettingsDialog", parent)
   , ui(new Ui::SettingsDialog)
   , m_settings(settings)
+  , m_exit(Exit::None)
   , m_pluginContainer(pluginContainer)
-  , m_restartNeeded(false)
 {
   ui->setupUi(this);
 
@@ -61,9 +61,14 @@ QWidget* SettingsDialog::parentWidgetForDialogs()
   }
 }
 
-void SettingsDialog::setRestartNeeded()
+void SettingsDialog::setExitNeeded(ExitFlags e)
 {
-  m_restartNeeded = true;
+  m_exit = e;
+}
+
+ExitFlags SettingsDialog::exitNeeded() const
+{
+  return m_exit;
 }
 
 int SettingsDialog::exec()
@@ -84,16 +89,6 @@ int SettingsDialog::exec()
     // update settings for each tab
     for (std::unique_ptr<SettingsTab> const &tab: m_tabs) {
       tab->update();
-    }
-  }
-
-  if (m_restartNeeded) {
-    if (QMessageBox::question(parentWidgetForDialogs(),
-      tr("Restart Mod Organizer?"),
-      tr("In order to finish configuration changes, MO must be restarted.\n"
-        "Restart it now?"),
-      QMessageBox::Yes | QMessageBox::No) == QMessageBox::Yes) {
-      qApp->exit(INT_MAX);
     }
   }
 

--- a/src/settingsdialog.h
+++ b/src/settingsdialog.h
@@ -21,6 +21,7 @@ along with Mod Organizer.  If not, see <http://www.gnu.org/licenses/>.
 #define SETTINGSDIALOG_H
 
 #include "tutorabledialog.h"
+#include "util.h"
 
 class PluginContainer;
 class Settings;
@@ -74,7 +75,9 @@ public:
 
   PluginContainer* pluginContainer();
   QWidget* parentWidgetForDialogs();
-  void setRestartNeeded();
+
+  void setExitNeeded(ExitFlags e);
+  ExitFlags exitNeeded() const;
 
   int exec() override;
 
@@ -82,10 +85,10 @@ public slots:
   virtual void accept();
 
 private:
+  Ui::SettingsDialog* ui;
   Settings& m_settings;
   std::vector<std::unique_ptr<SettingsTab>> m_tabs;
-  Ui::SettingsDialog* ui;
-  bool m_restartNeeded;
+  ExitFlags m_exit;
   PluginContainer* m_pluginContainer;
 };
 

--- a/src/settingsdialognexus.cpp
+++ b/src/settingsdialognexus.cpp
@@ -312,7 +312,7 @@ void NexusSettingsTab::addNexusLog(const QString& s)
 
 bool NexusSettingsTab::setKey(const QString& key)
 {
-  dialog().setRestartNeeded();
+  dialog().setExitNeeded(Exit::Restart);
   const bool ret = settings().nexus().setApiKey(key);
   updateNexusState();
   return ret;
@@ -320,7 +320,7 @@ bool NexusSettingsTab::setKey(const QString& key)
 
 bool NexusSettingsTab::clearKey()
 {
-  dialog().setRestartNeeded();
+  dialog().setExitNeeded(Exit::Restart);
   const auto ret = settings().nexus().clearApiKey();
 
   NexusInterface::instance(dialog().pluginContainer())->getAccessManager()->clearApiKey();

--- a/src/settingsdialogworkarounds.cpp
+++ b/src/settingsdialogworkarounds.cpp
@@ -2,6 +2,7 @@
 #include "ui_settingsdialog.h"
 #include "spawn.h"
 #include "settings.h"
+#include <report.h>
 #include <iplugingame.h>
 
 WorkaroundsSettingsTab::WorkaroundsSettingsTab(Settings& s, SettingsDialog& d)
@@ -118,16 +119,18 @@ void WorkaroundsSettingsTab::on_bsaDateBtn_clicked()
 
 void WorkaroundsSettingsTab::on_resetGeometryBtn_clicked()
 {
-  const auto caption = QObject::tr("Restart Mod Organizer?");
-  const auto text = QObject::tr(
-    "In order to reset the geometry, Mod Organizer must be restarted.\n"
-    "Restart now?");
+  const auto r = MOBase::TaskDialog(parentWidget())
+    .title(QObject::tr("Restart Mod Organizer"))
+    .main(QObject::tr("Restart Mod Organizer"))
+    .content(QObject::tr("Geometries will be reset to their default values."))
+    .icon(QMessageBox::Question)
+    .button({QObject::tr("Restart Mod Organizer"), QMessageBox::Ok})
+    .button({QObject::tr("Cancel"), QMessageBox::Cancel})
+    .exec();
 
-  const auto res = QMessageBox::question(
-    parentWidget(), caption, text, QMessageBox::Yes | QMessageBox::Cancel);
-
-  if (res == QMessageBox::Yes) {
+  if (r == QMessageBox::Ok) {
     settings().geometry().requestReset();
-    qApp->exit(INT_MAX);
+    ExitModOrganizer(Exit::Restart);
+    dialog().close();
   }
 }

--- a/src/shared/util.cpp
+++ b/src/shared/util.cpp
@@ -19,6 +19,7 @@ along with Mod Organizer.  If not, see <http://www.gnu.org/licenses/>.
 
 #include "util.h"
 #include "windows_error.h"
+#include "mainwindow.h"
 
 namespace MOShared
 {
@@ -244,3 +245,49 @@ MOBase::VersionInfo createVersionInfo()
 }
 
 } // namespace MOShared
+
+
+static bool g_exiting = false;
+
+MainWindow* findMainWindow()
+{
+  for (auto* tl : qApp->topLevelWidgets()) {
+    if (auto* mw=dynamic_cast<MainWindow*>(tl)) {
+      return mw;
+    }
+  }
+
+  return nullptr;
+}
+
+bool ExitModOrganizer(ExitFlags e)
+{
+  if (g_exiting) {
+    return true;
+  }
+
+  if (!e.testFlag(Exit::Force)) {
+    if (auto* mw=findMainWindow()) {
+      if (!mw->canExit()) {
+        return false;
+      }
+    }
+  }
+
+  g_exiting = true;
+
+  const int code = (e.testFlag(Exit::Restart) ? RestartExitCode : 0);
+  qApp->exit(code);
+
+  return true;
+}
+
+bool ModOrganizerExiting()
+{
+  return g_exiting;
+}
+
+void ResetExitFlag()
+{
+  g_exiting = false;
+}

--- a/src/shared/util.h
+++ b/src/shared/util.h
@@ -48,4 +48,22 @@ MOBase::VersionInfo createVersionInfo();
 
 } // namespace MOShared
 
+
+enum class Exit
+{
+  None    = 0x00,
+  Normal  = 0x01,
+  Restart = 0x02,
+  Force   = 0x04
+};
+
+const int RestartExitCode = INT_MAX;
+
+using ExitFlags = QFlags<Exit>;
+Q_DECLARE_OPERATORS_FOR_FLAGS(ExitFlags);
+
+bool ExitModOrganizer(ExitFlags e=Exit::Normal);
+bool ModOrganizerExiting();
+void ResetExitFlag();
+
 #endif // UTIL_H

--- a/src/spawn.cpp
+++ b/src/spawn.cpp
@@ -186,12 +186,12 @@ QMessageBox::StandardButton badSteamReg(
     .details(details)
     .icon(QMessageBox::Critical)
     .button({
-    QObject::tr("Continue without starting Steam"),
-    QObject::tr("The program may fail to launch."),
-    QMessageBox::Yes})
+      QObject::tr("Continue without starting Steam"),
+      QObject::tr("The program may fail to launch."),
+      QMessageBox::Yes})
     .button({
-    QObject::tr("Cancel"),
-    QMessageBox::Cancel})
+      QObject::tr("Cancel"),
+      QMessageBox::Cancel})
     .exec();
 }
 
@@ -517,7 +517,7 @@ bool restartAsAdmin(QWidget* parent)
   }
 
   log::debug("exiting MO");
-  qApp->exit(0);
+  ExitModOrganizer(Exit::Force);
 
   return true;
 }


### PR DESCRIPTION
The main problem was that geometry settings were not saved when restarting from the settings dialog, for example by changing nexus information. That's because `storeSettings()` was called from `closeEvent()` only, which isn't fired when closing the window programmatically.

- Added `ExitModOrganizer()`, used instead of `qApp->exit()`
- Main window settings are always saved, after `exec()` returns

A few more things along the way:
- Reset geometry confirmation uses `TaskDialog`
- Moved restart code for the settings dialog to `MainWindow`, removed separate warning about the game path having changed, now uses `TaskDialog`
- Don't log "crash dumps present" every time the settings dialog is closed by not cycling files if the crash dump number hasn't changed.