### PR TITLE
Executables fixes

### DIFF
--- a/src/editexecutablesdialog.cpp
+++ b/src/editexecutablesdialog.cpp
@@ -55,7 +55,7 @@ private:
 };
 
 
-EditExecutablesDialog::EditExecutablesDialog(OrganizerCore& oc, QWidget* parent)
+EditExecutablesDialog::EditExecutablesDialog(OrganizerCore& oc, int sel, QWidget* parent)
   : TutorableDialog("EditExecutables", parent)
   , ui(new Ui::EditExecutablesDialog)
   , m_organizerCore(oc)
@@ -74,6 +74,10 @@ EditExecutablesDialog::EditExecutablesDialog(OrganizerCore& oc, QWidget* parent)
   ui->mods->addItems(m_organizerCore.modList()->allMods());
   fillList();
   setDirty(false);
+
+  if (sel >= 0 && sel < ui->list->count()) {
+    ui->list->item(sel)->setSelected(true);
+  }
 
   auto* m = new QMenu;
   m->addAction(tr("Add from file..."), [&]{ addFromFile(); });

--- a/src/editexecutablesdialog.cpp
+++ b/src/editexecutablesdialog.cpp
@@ -97,6 +97,7 @@ EditExecutablesDialog::EditExecutablesDialog(OrganizerCore& oc, int sel, QWidget
   connect(ui->steamAppID, &QLineEdit::textChanged, [&]{ save(); });
   connect(ui->mods, &QComboBox::currentTextChanged, [&]{ save(); });
   connect(ui->useApplicationIcon, &QCheckBox::toggled, [&]{ save(); });
+  connect(ui->hide, &QCheckBox::toggled, [&]{ save(); });
   connect(ui->list->model(), &QAbstractItemModel::rowsMoved, [&]{ saveOrder(); });
 }
 
@@ -316,6 +317,8 @@ void EditExecutablesDialog::clearEdits()
   ui->configureLibraries->setEnabled(false);
   ui->useApplicationIcon->setEnabled(false);
   ui->useApplicationIcon->setChecked(false);
+  ui->hide->setEnabled(false);
+  ui->hide->setChecked(false);
 
   m_lastGoodTitle = "";
 }
@@ -330,6 +333,7 @@ void EditExecutablesDialog::setEdits(const Executable& e)
   ui->steamAppID->setEnabled(!e.steamAppID().isEmpty());
   ui->steamAppID->setText(e.steamAppID());
   ui->useApplicationIcon->setChecked(e.usesOwnIcon());
+  ui->hide->setChecked(e.hide());
 
   m_lastGoodTitle = e.title();
 
@@ -375,6 +379,7 @@ void EditExecutablesDialog::setEdits(const Executable& e)
   ui->useApplicationIcon->setEnabled(true);
   ui->createFilesInMod->setEnabled(true);
   ui->forceLoadLibraries->setEnabled(true);
+  ui->hide->setEnabled(true);
 }
 
 void EditExecutablesDialog::save()
@@ -432,6 +437,12 @@ void EditExecutablesDialog::save()
     e->flags(e->flags() | Executable::UseApplicationIcon);
   } else {
     e->flags(e->flags() & (~Executable::UseApplicationIcon));
+  }
+
+  if (ui->hide->isChecked()) {
+    e->flags(e->flags() | Executable::Hide);
+  } else {
+    e->flags(e->flags() & (~Executable::Hide));
   }
 
   setDirty(true);

--- a/src/editexecutablesdialog.cpp
+++ b/src/editexecutablesdialog.cpp
@@ -81,7 +81,7 @@ EditExecutablesDialog::EditExecutablesDialog(OrganizerCore& oc, int sel, QWidget
   setDirty(false);
 
   if (sel >= 0 && sel < ui->list->count()) {
-    ui->list->item(sel)->setSelected(true);
+    selectIndex(sel);
   }
 
   auto* m = new QMenu;
@@ -205,6 +205,14 @@ void EditExecutablesDialog::setDirty(bool b)
   }
 }
 
+void EditExecutablesDialog::selectIndex(int i)
+{
+  if (i >= 0 && i < ui->list->count()) {
+    ui->list->selectionModel()->setCurrentIndex(
+      ui->list->model()->index(i, 0), QItemSelectionModel::ClearAndSelect);
+  }
+}
+
 QListWidgetItem* EditExecutablesDialog::selectedItem()
 {
   const auto selection = ui->list->selectedItems();
@@ -243,7 +251,7 @@ void EditExecutablesDialog::fillList()
 
   // select the first one in the list, if any
   if (ui->list->count() > 0) {
-    ui->list->item(0)->setSelected(true);
+    selectIndex(0);
   } else {
     updateUI(nullptr, nullptr);
   }
@@ -459,13 +467,14 @@ void EditExecutablesDialog::move(QListWidgetItem* item, int direction)
     return;
   }
 
-  const auto row = ui->list->row(item);
+  const auto oldRow = ui->list->row(item);
+  const auto newRow = oldRow + (direction > 0 ? 1 : -1);
 
   // removing item
-  ui->list->takeItem(row);
-  ui->list->insertItem(row + (direction > 0 ? 1 : -1), item);
-  item->setSelected(true);
+  ui->list->takeItem(oldRow);
+  ui->list->insertItem(newRow, item);
 
+  selectIndex(newRow);
   setDirty(true);
 }
 
@@ -530,10 +539,10 @@ void EditExecutablesDialog::on_remove_clicked()
   if (currentRow >= ui->list->count()) {
     // that was the last item, select the new list item, if any
     if (ui->list->count() > 0) {
-      ui->list->item(ui->list->count() - 1)->setSelected(true);
+      selectIndex(ui->list->count() - 1);
     }
   } else {
-    ui->list->item(currentRow)->setSelected(true);
+    selectIndex(currentRow);
   }
 
   setDirty(true);
@@ -689,8 +698,8 @@ void EditExecutablesDialog::addNew(Executable e)
 
   auto* item = createListItem(e);
   ui->list->addItem(item);
-  item->setSelected(true);
 
+  selectIndex(ui->list->count() - 1);
   setDirty(true);
 }
 

--- a/src/editexecutablesdialog.cpp
+++ b/src/editexecutablesdialog.cpp
@@ -71,7 +71,12 @@ EditExecutablesDialog::EditExecutablesDialog(OrganizerCore& oc, int sel, QWidget
   loadCustomOverwrites();
   loadForcedLibraries();
 
-  ui->mods->addItems(m_organizerCore.modList()->allMods());
+  for (auto&& m : m_organizerCore.modList()->allMods()) {
+    if (ModInfo::isRegularName(m)) {
+      ui->mods->addItem(m);
+    }
+  }
+
   fillList();
   setDirty(false);
 

--- a/src/editexecutablesdialog.h
+++ b/src/editexecutablesdialog.h
@@ -148,7 +148,8 @@ public:
   using CustomOverwrites = ToggableMap<QString>;
   using ForcedLibraries = ToggableMap<QList<MOBase::ExecutableForcedLoadSetting>>;
 
-  explicit EditExecutablesDialog(OrganizerCore& oc, QWidget* parent=nullptr);
+  explicit EditExecutablesDialog(
+    OrganizerCore& oc, int selection=-1, QWidget* parent=nullptr);
 
   ~EditExecutablesDialog();
 

--- a/src/editexecutablesdialog.h
+++ b/src/editexecutablesdialog.h
@@ -169,6 +169,7 @@ private slots:
   void on_down_clicked();
 
   void on_title_textChanged(const QString& s);
+  void on_title_editingFinished();
   void on_overwriteSteamAppID_toggled(bool checked);
   void on_createFilesInMod_toggled(bool checked);
   void on_forceLoadLibraries_toggled(bool checked);
@@ -195,6 +196,10 @@ private:
 
   // forced libraries set in the dialog
   ForcedLibraries m_forcedLibraries;
+
+  // remembers the last executable title that made sense, reverts to this when
+  // the widget loses focus if it's empty
+  QString m_lastGoodTitle;
 
   // true when the change events being triggered are in response to loading
   // the executable's data into the UI, not from a user change

--- a/src/editexecutablesdialog.h
+++ b/src/editexecutablesdialog.h
@@ -227,6 +227,7 @@ private:
   bool isTitleConflicting(const QString& s);
   void commitChanges();
   void setDirty(bool b);
+  void selectIndex(int i);
 
   void addFromFile();
   void addEmpty();

--- a/src/editexecutablesdialog.h
+++ b/src/editexecutablesdialog.h
@@ -141,7 +141,8 @@ private:
  **/
 class EditExecutablesDialog : public MOBase::TutorableDialog
 {
-    Q_OBJECT
+    Q_OBJECT;
+    friend class IgnoreChanges;
 
 public:
   using CustomOverwrites = ToggableMap<QString>;
@@ -222,10 +223,18 @@ private:
   void saveOrder();
   bool canMove(const QListWidgetItem* item, int direction);
   void move(QListWidgetItem* item, int direction);
-  void setJarBinary(const QString& binaryName);
   bool isTitleConflicting(const QString& s);
   void commitChanges();
   void setDirty(bool b);
+
+  void addFromFile();
+  void addEmpty();
+  void clone();
+  void addNew(Executable e);
+
+  QFileInfo browseBinary(const QString& initial);
+  void setBinary(const QFileInfo& binary);
+  void setJarBinary(const QFileInfo& binary);
 };
 
 #endif // EDITEXECUTABLESDIALOG_H

--- a/src/editexecutablesdialog.ui
+++ b/src/editexecutablesdialog.ui
@@ -106,6 +106,9 @@
                <iconset resource="resources.qrc">
                 <normaloff>:/MO/gui/add</normaloff>:/MO/gui/add</iconset>
               </property>
+              <property name="popupMode">
+               <enum>QToolButton::InstantPopup</enum>
+              </property>
              </widget>
             </item>
             <item>
@@ -140,7 +143,7 @@
                <string>Move the executable up in the list</string>
               </property>
               <property name="text">
-               <string>Move the executable up in the list</string>
+               <string>Up</string>
               </property>
               <property name="icon">
                <iconset resource="resources.qrc">
@@ -160,7 +163,7 @@
                <string>Move the executable down in the list</string>
               </property>
               <property name="text">
-               <string>Move the executable down in the list</string>
+               <string>Down</string>
               </property>
               <property name="icon">
                <iconset resource="resources.qrc">

--- a/src/editexecutablesdialog.ui
+++ b/src/editexecutablesdialog.ui
@@ -378,7 +378,7 @@ Right now the only case I know of where this needs to be overwritten is for the 
                   <string>If this is enabled, new files are created in the specified mod instead of the &quot;Overwrite&quot; mod.</string>
                  </property>
                  <property name="text">
-                  <string>Create Files in Mod instead of Overwrite (*)</string>
+                  <string>Create files in mod instead of overwrite (*)</string>
                  </property>
                 </widget>
                </item>
@@ -399,7 +399,7 @@ Right now the only case I know of where this needs to be overwritten is for the 
                   <string>If this is enabled, the configured libraries will be automatically loaded when this executable is launched.</string>
                  </property>
                  <property name="text">
-                  <string>Force Load Libraries (*)</string>
+                  <string>Force load libraries (*)</string>
                  </property>
                 </widget>
                </item>
@@ -431,14 +431,27 @@ Right now the only case I know of where this needs to be overwritten is for the 
              <item>
               <widget class="QCheckBox" name="useApplicationIcon">
                <property name="text">
-                <string>Use Application's Icon for desktop shortcuts</string>
+                <string>Use application's icon for desktop shortcuts</string>
+               </property>
+              </widget>
+             </item>
+             <item>
+              <widget class="QCheckBox" name="hide">
+               <property name="toolTip">
+                <string>This executable will not appear in the list, on the toolbar or in the menu. It will still be visible in this dialog.</string>
+               </property>
+               <property name="whatsThis">
+                <string>This executable will not appear in the list, on the toolbar or in the menu. It will still be visible in this dialog.</string>
+               </property>
+               <property name="text">
+                <string>Hide in user interface</string>
                </property>
               </widget>
              </item>
              <item>
               <widget class="QLabel" name="label_5">
                <property name="text">
-                <string>(*) Profile Specific</string>
+                <string>(*) Profile specific</string>
                </property>
                <property name="margin">
                 <number>5</number>

--- a/src/editexecutablesdialog.ui
+++ b/src/editexecutablesdialog.ui
@@ -478,14 +478,25 @@ Right now the only case I know of where this needs to be overwritten is for the 
   </layout>
  </widget>
  <tabstops>
+  <tabstop>add</tabstop>
+  <tabstop>remove</tabstop>
+  <tabstop>up</tabstop>
+  <tabstop>down</tabstop>
+  <tabstop>reset</tabstop>
+  <tabstop>list</tabstop>
+  <tabstop>title</tabstop>
   <tabstop>binary</tabstop>
   <tabstop>browseBinary</tabstop>
   <tabstop>workingDirectory</tabstop>
   <tabstop>browseWorkingDirectory</tabstop>
+  <tabstop>arguments</tabstop>
   <tabstop>overwriteSteamAppID</tabstop>
   <tabstop>steamAppID</tabstop>
   <tabstop>createFilesInMod</tabstop>
   <tabstop>mods</tabstop>
+  <tabstop>forceLoadLibraries</tabstop>
+  <tabstop>configureLibraries</tabstop>
+  <tabstop>useApplicationIcon</tabstop>
  </tabstops>
  <resources>
   <include location="resources.qrc"/>

--- a/src/executableslist.cpp
+++ b/src/executableslist.cpp
@@ -84,6 +84,9 @@ void ExecutablesList::load(const MOBase::IPluginGame* game, const Settings& s)
     if (map["ownicon"].toBool())
       flags |= Executable::UseApplicationIcon;
 
+    if (map["hide"].toBool())
+      flags |= Executable::Hide;
+
     if (map.contains("custom")) {
       // the "custom" setting only exists in older versions
       needsUpgrade = true;
@@ -116,6 +119,7 @@ void ExecutablesList::store(Settings& s)
     map["title"] = item.title();
     map["toolbar"] = item.isShownOnToolbar();
     map["ownicon"] = item.usesOwnIcon();
+    map["hide"] = item.hide();
     map["binary"] = item.binaryInfo().absoluteFilePath();
     map["arguments"] = item.arguments();
     map["workingDirectory"] = item.workingDirectory();
@@ -343,6 +347,10 @@ void ExecutablesList::dump() const
       flags.push_back("icon");
     }
 
+    if (e.flags() & Executable::Hide) {
+      flags.push_back("hide");
+    }
+
     log::debug(
       " . executable '{}'\n"
       "    binary: {}\n"
@@ -456,11 +464,13 @@ bool Executable::usesOwnIcon() const
   return m_flags.testFlag(UseApplicationIcon);
 }
 
+bool Executable::hide() const
+{
+  return m_flags.testFlag(Hide);
+}
+
 void Executable::mergeFrom(const Executable& other)
 {
-  // flags on plugin executables that the user is allowed to change
-  const auto allow = ShowInToolbar;
-
   // this happens after executables are loaded from settings and plugin
   // executables are being added, or when users are modifying executables
 

--- a/src/executableslist.h
+++ b/src/executableslist.h
@@ -39,8 +39,9 @@ class Executable
 public:
   enum Flag
   {
-    ShowInToolbar = 0x02,
-    UseApplicationIcon = 0x04
+    ShowInToolbar      = 0x02,
+    UseApplicationIcon = 0x04,
+    Hide               = 0x08
   };
 
   Q_DECLARE_FLAGS(Flags, Flag);
@@ -69,6 +70,7 @@ public:
   bool isShownOnToolbar() const;
   void setShownOnToolbar(bool state);
   bool usesOwnIcon() const;
+  bool hide() const;
 
   void mergeFrom(const Executable& other);
 

--- a/src/mainwindow.cpp
+++ b/src/mainwindow.cpp
@@ -757,7 +757,7 @@ void MainWindow::updatePinnedExecutables()
   bool hasLinks = false;
 
   for (const auto& exe : *m_OrganizerCore.executablesList()) {
-    if (exe.isShownOnToolbar()) {
+    if (!exe.hide() && exe.isShownOnToolbar()) {
       hasLinks = true;
 
       QAction *exeAction = new QAction(
@@ -1792,23 +1792,44 @@ bool MainWindow::refreshProfiles(bool selectProfile)
 
 void MainWindow::refreshExecutablesList()
 {
-  QComboBox* executablesList = findChild<QComboBox*>("executablesListBox");
-  executablesList->setEnabled(false);
-  executablesList->clear();
-  executablesList->addItem(tr("<Edit...>"));
+  QAbstractItemModel *model = ui->executablesListBox->model();
 
-  QAbstractItemModel *model = executablesList->model();
+  auto add = [&](const QString& title, const QFileInfo& binary) {
+    QIcon icon;
+    if (!binary.fileName().isEmpty()) {
+      icon = iconForExecutable(binary.filePath());
+    }
 
-  int i = 0;
+    ui->executablesListBox->addItem(icon, title);
+
+    const auto i = ui->executablesListBox->count() - 1;
+
+    model->setData(
+      model->index(i, 0),
+      QSize(0, ui->executablesListBox->iconSize().height() + 4),
+      Qt::SizeHintRole);
+  };
+
+
+  ui->executablesListBox->setEnabled(false);
+  ui->executablesListBox->clear();
+
+  add(tr("<Edit...>"), {});
+
   for (const auto& exe : *m_OrganizerCore.executablesList()) {
-    QIcon icon = iconForExecutable(exe.binaryInfo().filePath());
-    executablesList->addItem(icon, exe.title());
-    model->setData(model->index(i, 0), QSize(0, executablesList->iconSize().height() + 4), Qt::SizeHintRole);
-    ++i;
+    if (!exe.hide()) {
+      add(exe.title(), exe.binaryInfo());
+    }
+  }
+
+  if (ui->executablesListBox->count() == 1) {
+    // all executables are hidden, add an empty one to at least be able to
+    // switch to edit
+    add(tr("(no executables)"), QFileInfo(":badfile"));
   }
 
   ui->executablesListBox->setCurrentIndex(1);
-  executablesList->setEnabled(true);
+  ui->executablesListBox->setEnabled(true);
 }
 
 
@@ -2321,27 +2342,42 @@ void MainWindow::installMod(QString fileName)
   }
 }
 
-void MainWindow::on_startButton_clicked() {
-  ui->startButton->setEnabled(false);
+void MainWindow::on_startButton_clicked()
+{
   try {
-    const Executable &selectedExecutable(getSelectedExecutable());
-    QString customOverwrite = m_OrganizerCore.currentProfile()->setting("custom_overwrites", selectedExecutable.title()).toString();
-    auto forcedLibraries = m_OrganizerCore.currentProfile()->determineForcedLibraries(selectedExecutable.title());
-    if (!m_OrganizerCore.currentProfile()->forcedLibrariesEnabled(selectedExecutable.title())) {
+    const Executable* selectedExecutable = getSelectedExecutable();
+    if (!selectedExecutable) {
+      return;
+    }
+
+    ui->startButton->setEnabled(false);
+
+    auto* profile = m_OrganizerCore.currentProfile();
+
+    const QString customOverwrite = profile->setting(
+      "custom_overwrites", selectedExecutable->title()).toString();
+
+    auto forcedLibraries = profile->determineForcedLibraries(
+      selectedExecutable->title());
+
+    if (!profile->forcedLibrariesEnabled(selectedExecutable->title())) {
       forcedLibraries.clear();
     }
+
     m_OrganizerCore.spawnBinary(
-        selectedExecutable.binaryInfo(), selectedExecutable.arguments(),
-        selectedExecutable.workingDirectory().length() != 0
-            ? selectedExecutable.workingDirectory()
-            : selectedExecutable.binaryInfo().absolutePath(),
-        selectedExecutable.steamAppID(),
-        customOverwrite,
-        forcedLibraries);
+      selectedExecutable->binaryInfo(),
+      selectedExecutable->arguments(),
+      selectedExecutable->workingDirectory().length() != 0 ?
+        selectedExecutable->workingDirectory() :
+        selectedExecutable->binaryInfo().absolutePath(),
+      selectedExecutable->steamAppID(),
+      customOverwrite,
+      forcedLibraries);
   } catch (...) {
     ui->startButton->setEnabled(true);
     throw;
   }
+
   ui->startButton->setEnabled(true);
 }
 
@@ -2376,7 +2412,13 @@ void MainWindow::on_executablesListBox_currentIndexChanged(int index)
 
   if (index == 0) {
     modifyExecutablesDialog(previousIndex - 1);
-    ui->executablesListBox->setCurrentIndex(previousIndex);
+    const auto newCount = ui->executablesListBox->count();
+
+    if (previousIndex >= 0 && previousIndex < newCount) {
+      ui->executablesListBox->setCurrentIndex(previousIndex);
+    } else {
+      ui->executablesListBox->setCurrentIndex(newCount - 1);
+    }
   }
 }
 
@@ -2452,8 +2494,14 @@ void MainWindow::on_actionAdd_Profile_triggered()
 void MainWindow::on_actionModify_Executables_triggered()
 {
   const auto sel = (m_OldExecutableIndex > 0 ?  m_OldExecutableIndex - 1 : 0);
+
   if (modifyExecutablesDialog(sel)) {
-    ui->executablesListBox->setCurrentIndex(m_OldExecutableIndex);
+    const auto newCount = ui->executablesListBox->count();
+    if (m_OldExecutableIndex >= 0 && m_OldExecutableIndex < newCount) {
+      ui->executablesListBox->setCurrentIndex(m_OldExecutableIndex);
+    } else {
+      ui->executablesListBox->setCurrentIndex(newCount - 1);
+    }
   }
 }
 
@@ -4972,33 +5020,43 @@ void MainWindow::on_savegameList_customContextMenuRequested(const QPoint &pos)
 
 void MainWindow::linkToolbar()
 {
-  Executable& exe = getSelectedExecutable();
+  Executable* exe = getSelectedExecutable();
+  if (!exe) {
+    return;
+  }
 
-  exe.setShownOnToolbar(!exe.isShownOnToolbar());
+  exe->setShownOnToolbar(!exe->isShownOnToolbar());
   updatePinnedExecutables();
 }
 
 void MainWindow::linkDesktop()
 {
-  env::Shortcut(getSelectedExecutable()).toggle(env::Shortcut::Desktop);
+  if (auto* exe=getSelectedExecutable()) {
+    env::Shortcut(*exe).toggle(env::Shortcut::Desktop);
+  }
 }
 
 void MainWindow::linkMenu()
 {
-  env::Shortcut(getSelectedExecutable()).toggle(env::Shortcut::StartMenu);
+  if (auto* exe=getSelectedExecutable()) {
+    env::Shortcut(*exe).toggle(env::Shortcut::StartMenu);
+  }
 }
 
 void MainWindow::on_linkButton_pressed()
 {
-  const Executable& exe = getSelectedExecutable();
+  const Executable* exe = getSelectedExecutable();
+  if (!exe) {
+    return;
+  }
 
   const QIcon addIcon(":/MO/gui/link");
   const QIcon removeIcon(":/MO/gui/remove");
 
-  env::Shortcut shortcut(exe);
+  env::Shortcut shortcut(*exe);
 
   m_LinkToolbar->setIcon(
-    exe.isShownOnToolbar() ? removeIcon : addIcon);
+    exe->isShownOnToolbar() ? removeIcon : addIcon);
 
   m_LinkDesktop->setIcon(
     shortcut.exists(env::Shortcut::Desktop) ? removeIcon : addIcon);
@@ -6327,16 +6385,19 @@ void MainWindow::on_groupCombo_currentIndexChanged(int index)
   modFilterActive(m_ModListSortProxy->isFilterActive());
 }
 
-const Executable &MainWindow::getSelectedExecutable() const
+Executable* MainWindow::getSelectedExecutable()
 {
-  const QString name = ui->executablesListBox->itemText(ui->executablesListBox->currentIndex());
-  return m_OrganizerCore.executablesList()->get(name);
-}
+  const QString name = ui->executablesListBox->itemText(
+    ui->executablesListBox->currentIndex());
 
-Executable &MainWindow::getSelectedExecutable()
-{
-  const QString name = ui->executablesListBox->itemText(ui->executablesListBox->currentIndex());
-  return m_OrganizerCore.executablesList()->get(name);
+  try
+  {
+    return &m_OrganizerCore.executablesList()->get(name);
+  }
+  catch(std::runtime_error&)
+  {
+    return nullptr;
+  }
 }
 
 void MainWindow::on_showHiddenBox_toggled(bool checked)

--- a/src/mainwindow.cpp
+++ b/src/mainwindow.cpp
@@ -2345,12 +2345,12 @@ void MainWindow::on_startButton_clicked() {
   ui->startButton->setEnabled(true);
 }
 
-bool MainWindow::modifyExecutablesDialog()
+bool MainWindow::modifyExecutablesDialog(int selection)
 {
   bool result = false;
 
   try {
-    EditExecutablesDialog dialog(m_OrganizerCore, this);
+    EditExecutablesDialog dialog(m_OrganizerCore, selection, this);
 
     result = (dialog.exec() == QDialog::Accepted);
 
@@ -2375,7 +2375,7 @@ void MainWindow::on_executablesListBox_currentIndexChanged(int index)
   m_OldExecutableIndex = index;
 
   if (index == 0) {
-    modifyExecutablesDialog();
+    modifyExecutablesDialog(previousIndex - 1);
     ui->executablesListBox->setCurrentIndex(previousIndex);
   }
 }
@@ -2451,7 +2451,8 @@ void MainWindow::on_actionAdd_Profile_triggered()
 
 void MainWindow::on_actionModify_Executables_triggered()
 {
-  if (modifyExecutablesDialog()) {
+  const auto sel = (m_OldExecutableIndex > 0 ?  m_OldExecutableIndex - 1 : 0);
+  if (modifyExecutablesDialog(sel)) {
     ui->executablesListBox->setCurrentIndex(m_OldExecutableIndex);
   }
 }

--- a/src/mainwindow.h
+++ b/src/mainwindow.h
@@ -235,7 +235,7 @@ private:
 
   QList<MOBase::IOrganizer::FileInfo> findFileInfos(const QString &path, const std::function<bool (const MOBase::IOrganizer::FileInfo &)> &filter) const;
 
-  bool modifyExecutablesDialog();
+  bool modifyExecutablesDialog(int selection);
   void displayModInformation(int row, ModInfoTabIDs tab=ModInfoTabIDs::None);
   void testExtractBSA(int modIndex);
 

--- a/src/mainwindow.h
+++ b/src/mainwindow.h
@@ -397,8 +397,7 @@ private:
   // when painting the count
   QIcon m_originalNotificationIcon;
 
-  Executable const &getSelectedExecutable() const;
-  Executable &getSelectedExecutable();
+  Executable* getSelectedExecutable();
 
 private slots:
 

--- a/src/modinfo.cpp
+++ b/src/modinfo.cpp
@@ -61,17 +61,32 @@ bool ModInfo::ByName(const ModInfo::Ptr &LHS, const ModInfo::Ptr &RHS)
   return QString::compare(LHS->name(), RHS->name(), Qt::CaseInsensitive) < 0;
 }
 
+bool ModInfo::isSeparatorName(const QString& name)
+{
+  static QRegExp separatorExp(".*_separator");
+  return separatorExp.exactMatch(name);
+}
+
+bool ModInfo::isBackupName(const QString& name)
+{
+  static QRegExp backupExp(".*backup[0-9]*");
+  return backupExp.exactMatch(name);
+}
+
+bool ModInfo::isRegularName(const QString& name)
+{
+  return !isSeparatorName(name) && !isBackupName(name);
+}
+
 
 ModInfo::Ptr ModInfo::createFrom(PluginContainer *pluginContainer, const MOBase::IPluginGame *game, const QDir &dir, DirectoryEntry **directoryStructure)
 {
   QMutexLocker locker(&s_Mutex);
-  //  int id = s_NextID++;
-  static QRegExp backupExp(".*backup[0-9]*");
-  static QRegExp separatorExp(".*_separator");
   ModInfo::Ptr result;
-  if (backupExp.exactMatch(dir.dirName())) {
+
+  if (isBackupName(dir.dirName())) {
     result = ModInfo::Ptr(new ModInfoBackup(pluginContainer, game, dir, directoryStructure));
-  } else if(separatorExp.exactMatch(dir.dirName())){
+  } else if (isSeparatorName(dir.dirName())) {
     result = Ptr(new ModInfoSeparator(pluginContainer, game, dir, directoryStructure));
   } else {
     result = ModInfo::Ptr(new ModInfoRegular(pluginContainer, game, dir, directoryStructure));

--- a/src/modinfo.h
+++ b/src/modinfo.h
@@ -229,6 +229,18 @@ public:
    */
   static ModInfo::Ptr createFromPlugin(const QString &modName, const QString &espName, const QStringList &bsaNames, ModInfo::EModType modType, MOShared::DirectoryEntry **directoryStructure, PluginContainer *pluginContainer);
 
+  // whether the given name is used for separators
+  //
+  static bool isSeparatorName(const QString& name);
+
+  // whether the given name is used for backups
+  //
+  static bool isBackupName(const QString& name);
+
+  // whether the given name is used for regular mods
+  //
+  static bool isRegularName(const QString& name);
+
   /**
    * @brief retieve a name for one of the CONTENT_ enums
    * @param contentType the content value

--- a/src/stylesheets/Night Eyes.qss
+++ b/src/stylesheets/Night Eyes.qss
@@ -80,6 +80,11 @@ QToolButton:pressed
 	background: #181818;
 }
 
+QToolButton::menu-indicator
+{
+  width: 8px;
+}
+
 
 /* Left Pane & File Trees ----------------------------------------------------- */
 

--- a/src/stylesheets/vs15 Dark-Green.qss
+++ b/src/stylesheets/vs15 Dark-Green.qss
@@ -209,6 +209,13 @@ QToolButton {
   QToolButton:pressed {
     background-color: #009933; }
 
+QToolButton::menu-indicator {
+  image: url(./vs15/combobox-down.png);
+  subcontrol-origin: padding;
+  subcontrol-position: center right;
+  padding-top: 10%;
+  padding-right: 5%; }
+
 /* Group Boxes #QGroupBox */
 QGroupBox {
   border-color: #3F3F46;

--- a/src/stylesheets/vs15 Dark-Orange.qss
+++ b/src/stylesheets/vs15 Dark-Orange.qss
@@ -210,6 +210,13 @@ QToolButton {
   QToolButton:pressed {
     background-color: #CC6600; }
 
+QToolButton::menu-indicator {
+  image: url(./vs15/combobox-down.png);
+  subcontrol-origin: padding;
+  subcontrol-position: center right;
+  padding-top: 10%;
+  padding-right: 5%; }
+
 /* Group Boxes #QGroupBox */
 QGroupBox {
   border-color: #3F3F46;

--- a/src/stylesheets/vs15 Dark-Purple.qss
+++ b/src/stylesheets/vs15 Dark-Purple.qss
@@ -210,6 +210,13 @@ QToolButton {
   QToolButton:pressed {
     background-color: #7E2AD2; }
 
+QToolButton::menu-indicator {
+  image: url(./vs15/combobox-down.png);
+  subcontrol-origin: padding;
+  subcontrol-position: center right;
+  padding-top: 10%;
+  padding-right: 5%; }
+
 /* Group Boxes #QGroupBox */
 QGroupBox {
   border-color: #3F3F46;

--- a/src/stylesheets/vs15 Dark-Red.qss
+++ b/src/stylesheets/vs15 Dark-Red.qss
@@ -210,6 +210,13 @@ QToolButton {
   QToolButton:pressed {
     background-color: #990000; }
 
+QToolButton::menu-indicator {
+  image: url(./vs15/combobox-down.png);
+  subcontrol-origin: padding;
+  subcontrol-position: center right;
+  padding-top: 10%;
+  padding-right: 5%; }
+
 /* Group Boxes #QGroupBox */
 QGroupBox {
   border-color: #3F3F46;

--- a/src/stylesheets/vs15 Dark-Yellow.qss
+++ b/src/stylesheets/vs15 Dark-Yellow.qss
@@ -210,6 +210,13 @@ QToolButton {
   QToolButton:pressed {
     background-color: #9A9A00; }
 
+QToolButton::menu-indicator {
+  image: url(./vs15/combobox-down.png);
+  subcontrol-origin: padding;
+  subcontrol-position: center right;
+  padding-top: 10%;
+  padding-right: 5%; }
+
 /* Group Boxes #QGroupBox */
 QGroupBox {
   border-color: #3F3F46;

--- a/src/stylesheets/vs15 Dark.qss
+++ b/src/stylesheets/vs15 Dark.qss
@@ -209,6 +209,13 @@ QToolButton {
   QToolButton:pressed {
     background-color: #3399FF; }
 
+QToolButton::menu-indicator {
+  image: url(./vs15/combobox-down.png);
+  subcontrol-origin: padding;
+  subcontrol-position: center right;
+  padding-top: 10%;
+  padding-right: 5%; }
+
 /* Group Boxes #QGroupBox */
 QGroupBox {
   border-color: #3F3F46;


### PR DESCRIPTION
- Disallow empty titles, trim whitespace
- Changed the Add button to a menu, added "Add from file..." and "Clone selected"
- The dialog will initially select the executable that's selected in the main window
- Removed separators and backups from the mod list
- Fixed tab order and keyboard navigation problems
- Added a "Hide" option, hides the executable in the main window