### PR TITLE
Fixed exe cloning

### DIFF
--- a/src/editexecutablesdialog.cpp
+++ b/src/editexecutablesdialog.cpp
@@ -408,7 +408,7 @@ void EditExecutablesDialog::save()
 
   // get the new title, but ignore it if it's conflicting with an already
   // existing executable
-  QString newTitle = ui->title->text();
+  QString newTitle = ui->title->text().trimmed();
   if (isTitleConflicting(newTitle)) {
     newTitle = e->title();
   }


### PR DESCRIPTION
Title wasn't always trimmed, so all sorts of weird things happened with spaces.