### PR TITLE
Only flag plugins as light if the game supports light plugins

### DIFF
--- a/src/pluginlist.h
+++ b/src/pluginlist.h
@@ -296,7 +296,7 @@ private:
 
   struct ESPInfo {
 
-    ESPInfo(const QString &name, bool enabled, const QString &originName, const QString &fullPath, bool hasIni, std::set<QString> archives);
+    ESPInfo(const QString &name, bool enabled, const QString &originName, const QString &fullPath, bool hasIni, std::set<QString> archives, bool lightSupported);
     QString m_Name;
     QString m_FullPath;
     bool m_Enabled;


### PR DESCRIPTION
Some user has been backporting Skyrim SE plugins to Skyrim LE and reported that plugins are being incorrectly flagged as "light" despite the game not supporting and not caring about that.  This removes that behavior for all games except Skyrim SE and FO4.  