### PR TITLE
Remove mention of 32-bit Java

### DIFF
--- a/src/editexecutablesdialog.cpp
+++ b/src/editexecutablesdialog.cpp
@@ -804,8 +804,8 @@ void EditExecutablesDialog::setJarBinary(const QFileInfo& binary)
 
   if (java.isEmpty()) {
     QMessageBox::information(
-      this, tr("Java (32-bit) required"),
-      tr("MO requires 32-bit java to run this application. If you already "
+      this, tr("Java required"),
+      tr("MO requires Java to run this application. If you already "
          "have it installed, select javaw.exe from that installation as "
          "the binary."));
   }


### PR DESCRIPTION
MO doesn't really care about which version of Java is installed.
Saying that 32-bit Java is required is misleading.