### PR TITLE
Crash dump path and toString()

### DIFF
--- a/src/organizercore.cpp
+++ b/src/organizercore.cpp
@@ -485,10 +485,12 @@ void OrganizerCore::prepareVFS()
 
 void OrganizerCore::updateVFSParams(
   log::Levels logLevel, CrashDumpsType crashDumpsType,
+  const QString& crashDumpsPath,
   std::chrono::seconds spawnDelay, QString executableBlacklist)
 {
   setGlobalCrashDumpsType(crashDumpsType);
-  m_USVFS.updateParams(logLevel, crashDumpsType, spawnDelay, executableBlacklist);
+  m_USVFS.updateParams(
+    logLevel, crashDumpsType, crashDumpsPath, spawnDelay, executableBlacklist);
 }
 
 void OrganizerCore::setLogLevel(log::Levels level)
@@ -498,6 +500,7 @@ void OrganizerCore::setLogLevel(log::Levels level)
   updateVFSParams(
     m_Settings.diagnostics().logLevel(),
     m_Settings.diagnostics().crashDumpsType(),
+    QString::fromStdWString(crashDumpsPath()),
     m_Settings.diagnostics().spawnDelay(),
     m_Settings.executablesBlacklist());
 

--- a/src/organizercore.h
+++ b/src/organizercore.h
@@ -195,7 +195,8 @@ public:
 
   void updateVFSParams(
     MOBase::log::Levels logLevel, CrashDumpsType crashDumpsType,
-    std::chrono::seconds spawnDelay, QString executableBlacklist);
+    const QString& crashDumpsPath, std::chrono::seconds spawnDelay,
+    QString executableBlacklist);
 
   void setLogLevel(MOBase::log::Levels level);
 

--- a/src/usvfsconnector.cpp
+++ b/src/usvfsconnector.cpp
@@ -118,48 +118,6 @@ CrashDumpsType crashDumpsType(int type)
   }
 }
 
-QString toString(LogLevel lv)
-{
-  switch (lv)
-  {
-    case LogLevel::Debug:
-      return "debug";
-
-    case LogLevel::Info:
-      return "info";
-
-    case LogLevel::Warning:
-      return "warning";
-
-    case LogLevel::Error:
-      return "error";
-
-    default:
-      return QString("%1").arg(static_cast<int>(lv));
-  }
-}
-
-QString toString(CrashDumpsType t)
-{
-  switch (t)
-  {
-    case CrashDumpsType::None:
-      return "none";
-
-    case CrashDumpsType::Mini:
-      return "mini";
-
-    case CrashDumpsType::Data:
-      return "data";
-
-    case CrashDumpsType::Full:
-      return "full";
-
-    default:
-      return QString("%1").arg(static_cast<int>(t));
-  }
-}
-
 UsvfsConnector::UsvfsConnector()
 {
   using namespace std::chrono;
@@ -188,9 +146,9 @@ UsvfsConnector::UsvfsConnector()
     " . log: {}\n"
     " . dump: {} ({})",
     SHMID,
-    toString(logLevel),
+    usvfsLogLevelToString(logLevel),
     dumpPath.c_str(),
-    toString(dumpType));
+    usvfsCrashDumpTypeToString(dumpType));
 
   usvfsCreateVFS(params);
   usvfsFreeParameters(params);
@@ -263,14 +221,17 @@ void UsvfsConnector::updateMapping(const MappingType &mapping)
 
 void UsvfsConnector::updateParams(
   MOBase::log::Levels logLevel, CrashDumpsType crashDumpsType,
-  std::chrono::seconds spawnDelay, QString executableBlacklist)
+  const QString& crashDumpsPath, std::chrono::seconds spawnDelay,
+  QString executableBlacklist)
 {
   using namespace std::chrono;
 
   usvfsParameters* p = usvfsCreateParameters();
 
+  usvfsSetDebugMode(p, FALSE);
   usvfsSetLogLevel(p, toUsvfsLogLevel(logLevel));
   usvfsSetCrashDumpType(p, crashDumpsType);
+  usvfsSetCrashDumpPath(p, crashDumpsPath.toStdString().c_str());
   usvfsSetProcessDelay(p, duration_cast<milliseconds>(spawnDelay).count());
 
   usvfsUpdateParameters(p);

--- a/src/usvfsconnector.h
+++ b/src/usvfsconnector.h
@@ -88,9 +88,11 @@ public:
 
   void updateParams(
     MOBase::log::Levels logLevel, CrashDumpsType crashDumpsType,
-    std::chrono::seconds spawnDelay, QString executableBlacklist);
+    const QString& crashDumpsPath, std::chrono::seconds spawnDelay,
+    QString executableBlacklist);
 
-  void updateForcedLibraries(const QList<MOBase::ExecutableForcedLoadSetting> &forcedLibraries);
+  void updateForcedLibraries(
+    const QList<MOBase::ExecutableForcedLoadSetting> &forcedLibraries);
 
 private:
 


### PR DESCRIPTION
- Added crash dump path to parameters, if a mechanism to customize it is ever created
- Moved `toString()` for log level and dump type to usvfs, which needs them for logging

Goes with https://github.com/ModOrganizer2/usvfs/pull/26.