### PR TITLE
Use the broom icon for dirty plugins

### DIFF
--- a/src/loot.cpp
+++ b/src/loot.cpp
@@ -252,7 +252,7 @@ QString Loot::Report::toMarkdown() const
   }
 
   if (s.isEmpty()) {
-    s += "**" + QObject::tr("No messages.") + "**";
+    s += "**" + QObject::tr("No messages.") + "**\n";
   }
 
   s += stats.toMarkdown();
@@ -833,7 +833,10 @@ bool runLoot(QWidget* parent, OrganizerCore& core, bool didUpdateMasterList)
     Loot loot;
     LootDialog dialog(parent, core, loot);
 
-    loot.start(parent, core, didUpdateMasterList);
+    if (!loot.start(parent, core, didUpdateMasterList)) {
+      return false;
+    }
+
     dialog.exec();
 
     return dialog.result();

--- a/src/lootdialog.cpp
+++ b/src/lootdialog.cpp
@@ -262,12 +262,16 @@ void LootDialog::log(log::Levels lv, const QString& s)
 
 void LootDialog::showReport()
 {
-  const auto& lootReport = m_loot.report();
+  if (m_loot.result()) {
+    const auto& lootReport = m_loot.report();
 
-  m_core.pluginList()->clearAdditionalInformation();
-  for (auto&& p : lootReport.plugins) {
-    m_core.pluginList()->addLootReport(p.name, p);
+    m_core.pluginList()->clearAdditionalInformation();
+    for (auto&& p : lootReport.plugins) {
+      m_core.pluginList()->addLootReport(p.name, p);
+    }
+
+    m_report.setText(lootReport.toMarkdown());
+  } else {
+    m_report.setText("**" + tr("Loot failed to run") + "**");
   }
-
-  m_report.setText(lootReport.toMarkdown());
 }

--- a/src/pluginlist.cpp
+++ b/src/pluginlist.cpp
@@ -1214,8 +1214,12 @@ QVariant PluginList::iconData(const QModelIndex &modelIndex) const
     result.append(":/MO/gui/archive_conflict_neutral");
   }
 
-  if (esp.isLightFlagged && !m_ESPs[index].isLight) {
+  if (esp.isLightFlagged && !esp.isLight) {
     result.append(":/MO/gui/awaiting");
+  }
+
+  if (info && !info->loot.dirty.empty()) {
+    result.append(":/MO/gui/edit_clear");
   }
 
   return result;
@@ -1248,10 +1252,6 @@ bool PluginList::hasInfo(const ESPInfo& esp, const AdditionalInfo* info) const
     }
 
     if (!info->loot.messages.empty()) {
-      return true;
-    }
-
-    if (!info->loot.dirty.empty()) {
       return true;
     }
   }

--- a/src/version.rc
+++ b/src/version.rc
@@ -3,8 +3,8 @@
 // If VS_FF_PRERELEASE is not set, MO labels the build as a release and uses VER_FILEVERSION to determine version number.
 // Otherwise, if letters are used in VER_FILEVERSION_STR, uses the full MOBase::VersionInfo parser
 // Otherwise, uses the numbers from VER_FILEVERSION and sets the release type as pre-alpha
-#define VER_FILEVERSION     2,2,2,5
-#define VER_FILEVERSION_STR "2.2.2alpha5\0"
+#define VER_FILEVERSION     2,2,2,7
+#define VER_FILEVERSION_STR "2.2.2alpha7\0"
 
 VS_VERSION_INFO VERSIONINFO
 FILEVERSION     VER_FILEVERSION


### PR DESCRIPTION
- bumped to 2.2.2alpha7
- better handling of failing to spawn loot