### PR TITLE
Fixes for windows 7

### DIFF
--- a/src/version.rc
+++ b/src/version.rc
@@ -4,7 +4,7 @@
 // Otherwise, if letters are used in VER_FILEVERSION_STR, uses the full MOBase::VersionInfo parser
 // Otherwise, uses the numbers from VER_FILEVERSION and sets the release type as pre-alpha
 #define VER_FILEVERSION     2,2,2,7
-#define VER_FILEVERSION_STR "2.2.2alpha7\0"
+#define VER_FILEVERSION_STR "2.2.2alpha7.1\0"
 
 VS_VERSION_INFO VERSIONINFO
 FILEVERSION     VER_FILEVERSION


### PR DESCRIPTION
- Removed calls to `GetOverlappedResultEx()` and `SetThreadDescription()`, they're not available on windows 7
- Bumped to alpha7.1