### PR TITLE
Use a Job to capture all child processes

### DIFF
--- a/src/envmodule.h
+++ b/src/envmodule.h
@@ -136,6 +136,7 @@ public:
 
   void addChild(Process p);
   std::vector<Process>& children();
+  const std::vector<Process>& children() const;
 
 private:
   DWORD m_pid;
@@ -148,7 +149,9 @@ private:
 std::vector<Process> getRunningProcesses();
 std::vector<Module> getLoadedModules();
 
-Process getProcessTree(HANDLE parent);
+// works for both jobs and processes
+//
+Process getProcessTree(HANDLE h);
 
 QString getProcessName(DWORD pid);
 QString getProcessName(HANDLE process);

--- a/src/loot.h
+++ b/src/loot.h
@@ -79,10 +79,10 @@ public:
   };
 
 
-  Loot();
+  Loot(OrganizerCore& core);
   ~Loot();
 
-  bool start(QWidget* parent, OrganizerCore& core, bool didUpdateMasterList);
+  bool start(QWidget* parent, bool didUpdateMasterList);
   void cancel();
   bool result() const;
   const QString& outPath() const;
@@ -95,6 +95,7 @@ signals:
   void finished();
 
 private:
+  OrganizerCore& m_core;
   std::unique_ptr<QThread> m_thread;
   std::atomic<bool> m_cancel;
   std::atomic<bool> m_result;
@@ -104,8 +105,7 @@ private:
   Report m_report;
 
   bool spawnLootcli(
-    QWidget* parent, OrganizerCore& core, bool didUpdateMasterList,
-    env::HandlePtr stdoutHandle);
+    QWidget* parent, bool didUpdateMasterList, env::HandlePtr stdoutHandle);
 
   void lootThread();
   bool waitForCompletion();

--- a/src/uilocker.cpp
+++ b/src/uilocker.cpp
@@ -377,6 +377,8 @@ UILocker::~UILocker()
       unlock(s.get());
     }
   }
+
+  g_instance = nullptr;
 }
 
 UILocker& UILocker::instance()
@@ -449,6 +451,12 @@ void UILocker::unlockCurrent()
 
 void UILocker::updateLabel()
 {
+  if (!m_ui) {
+    // this can happen if the lock overlay was destroyed while a cross-thread
+    // call for updateLabel() was in flight
+    return;
+  }
+
   QStringList labels;
 
   for (auto itor=m_sessions.rbegin(); itor!=m_sessions.rend(); ++itor) {

--- a/src/usvfsconnector.cpp
+++ b/src/usvfsconnector.cpp
@@ -280,13 +280,17 @@ std::vector<HANDLE> getRunningUSVFSProcesses()
   const auto thisPid = GetCurrentProcessId();
   std::vector<HANDLE> v;
 
+  const auto rights =
+    PROCESS_QUERY_LIMITED_INFORMATION |    // exit code, image name, etc.
+    SYNCHRONIZE |                          // wait functions
+    PROCESS_SET_QUOTA | PROCESS_TERMINATE; // add to job
+
   for (auto&& pid : pids) {
     if (pid == thisPid) {
       continue; // obviously don't wait for MO process
     }
 
-    HANDLE handle = ::OpenProcess(
-      PROCESS_QUERY_LIMITED_INFORMATION | SYNCHRONIZE, FALSE, pid);
+    HANDLE handle = ::OpenProcess(rights, FALSE, pid);
 
     if (handle == INVALID_HANDLE_VALUE) {
       const auto e = GetLastError();

--- a/src/version.rc
+++ b/src/version.rc
@@ -3,8 +3,8 @@
 // If VS_FF_PRERELEASE is not set, MO labels the build as a release and uses VER_FILEVERSION to determine version number.
 // Otherwise, if letters are used in VER_FILEVERSION_STR, uses the full MOBase::VersionInfo parser
 // Otherwise, uses the numbers from VER_FILEVERSION and sets the release type as pre-alpha
-#define VER_FILEVERSION     2,2,2,7
-#define VER_FILEVERSION_STR "2.2.2alpha7.1\0"
+#define VER_FILEVERSION     2,2,2,8
+#define VER_FILEVERSION_STR "2.2.2alpha8\0"
 
 VS_VERSION_INFO VERSIONINFO
 FILEVERSION     VER_FILEVERSION


### PR DESCRIPTION
The original lock dialog would always stay up while _any_ usvfs processes were running. This created situations like: launch process A, ui locked for A, user unlocks; launch B, ui locked for B, quit B, ui locked for A again. My goal was to make the ui lock only for the process that's started, ignoring older processes that were unlocked. Attempting to quit MO would lock for all processes, as before.

This worked fine for simple processes, but failed for processes that spawned children and then exited, such as skse. I'm now using a job handle to gather all the processes started from the one that was launched in MO.

I've also fixed what I think was a rare crash, where a cross-thread request to update the lock overlay would be in flight (process waiting is in a thread), during which the overlay was destroyed.

I also took the opportunity to ignore disabled plugins from the loot report.