### PR TITLE
Fix zedit not starting

### DIFF
--- a/src/processrunner.cpp
+++ b/src/processrunner.cpp
@@ -520,9 +520,9 @@ ProcessRunner& ProcessRunner::setFromExecutable(const Executable& exe)
     forcedLibraries = profile->determineForcedLibraries(exe.title());
   }
 
-  QDir currentDirectory = exe.workingDirectory();
+  QString currentDirectory = exe.workingDirectory();
   if (currentDirectory.isEmpty()) {
-    currentDirectory.setPath(exe.binaryInfo().absolutePath());
+    currentDirectory = exe.binaryInfo().absolutePath();
   }
 
   setBinary(exe.binaryInfo());


### PR DESCRIPTION
The cwd was MO's instead of the binary's if none was specified in the exe settings.