### PR TITLE
Collection of small fixes

### DIFF
--- a/src/downloadmanager.cpp
+++ b/src/downloadmanager.cpp
@@ -996,8 +996,8 @@ void DownloadManager::queryInfoMd5(int index)
   QCryptographicHash hash(QCryptographicHash::Md5);
   const qint64 progressStep = 10 * 1024 * 1024;
   QProgressDialog progress(tr("Hashing download file '%1'").arg(info->m_FileName),
-                           tr("Cancel"), 
-                           0, 
+                           tr("Cancel"),
+                           0,
                            downloadFile.size() / progressStep);
   progress.setWindowModality(Qt::WindowModal);
   progress.setMinimumDuration(1000);
@@ -1606,7 +1606,7 @@ void DownloadManager::nxmFilesAvailable(QString, int, QVariant userData, QVarian
       emit showMessage(tr("No matching file found on Nexus! Maybe this file is no longer available or it was renamed?"));
     } else {
       SelectionDialog selection(tr("No file on Nexus matches the selected file by name. Please manually choose the correct one."));
-      std::sort(files.begin(), files.end(), [](const QVariant& lhs, const QVariant& rhs) 
+      std::sort(files.begin(), files.end(), [](const QVariant& lhs, const QVariant& rhs)
         {return lhs.toMap()["uploaded_timestamp"].toInt() > rhs.toMap()["uploaded_timestamp"].toInt();});
       for (QVariant file : files) {
         QVariantMap fileInfo = file.toMap();
@@ -1692,7 +1692,6 @@ static int evaluateFileInfoMap(
   }
 
   if (!found) {
-    log::error("server '{}' not found while sorting by preference", name);
     return 0;
   }
 

--- a/src/env.cpp
+++ b/src/env.cpp
@@ -157,8 +157,18 @@ void Environment::dump(const Settings& s) const
   }
 
   log::debug("security products:");
-  for (const auto& sp : securityProducts()) {
-    log::debug("  . {}", sp.toString());
+
+  {
+    // ignore products with identical names, some AVs register themselves with
+    // the same names and provider, but different guids
+    std::set<QString> productNames;
+    for (const auto& sp : securityProducts()) {
+      productNames.insert(sp.toString());
+    }
+
+    for (auto&& name : productNames) {
+      log::debug("  . {}", name);
+    }
   }
 
   log::debug("modules loaded in process:");

--- a/src/env.h
+++ b/src/env.h
@@ -119,6 +119,27 @@ private:
 };
 
 
+class ModuleNotification
+{
+public:
+  ModuleNotification(std::function<void (Module)> f);
+  ~ModuleNotification();
+
+  ModuleNotification(const ModuleNotification&) = delete;
+  ModuleNotification& operator=(const ModuleNotification&) = delete;
+
+  ModuleNotification(ModuleNotification&&) = default;
+  ModuleNotification& operator=(ModuleNotification&&) = default;
+
+  void setCookie(void* c);
+  void fire(const Module& m);
+
+private:
+  void* m_cookie;
+  std::function<void (Module)> m_f;
+};
+
+
 // represents the process's environment
 //
 class Environment
@@ -150,6 +171,9 @@ public:
   // timezone
   //
   QString timezone() const;
+
+  std::unique_ptr<ModuleNotification> onModuleLoaded(
+    std::function<void (Module)> f);
 
   // logs the environment
   //

--- a/src/env.h
+++ b/src/env.h
@@ -122,7 +122,7 @@ private:
 class ModuleNotification
 {
 public:
-  ModuleNotification(std::function<void (Module)> f);
+  ModuleNotification(QObject* o, std::function<void (Module)> f);
   ~ModuleNotification();
 
   ModuleNotification(const ModuleNotification&) = delete;
@@ -132,10 +132,12 @@ public:
   ModuleNotification& operator=(ModuleNotification&&) = default;
 
   void setCookie(void* c);
-  void fire(const Module& m);
+  void fire(QString path, std::size_t fileSize);
 
 private:
   void* m_cookie;
+  QObject* m_object;
+  std::set<QString> m_loaded;
   std::function<void (Module)> m_f;
 };
 
@@ -172,8 +174,11 @@ public:
   //
   QString timezone() const;
 
+  // will call `f` on the same thread `o` is running on every time a module
+  // is loaded in the process
+  //
   std::unique_ptr<ModuleNotification> onModuleLoaded(
-    std::function<void (Module)> f);
+    QObject* o, std::function<void (Module)> f);
 
   // logs the environment
   //

--- a/src/env.h
+++ b/src/env.h
@@ -147,6 +147,10 @@ public:
   //
   const Metrics& metrics() const;
 
+  // timezone
+  //
+  QString timezone() const;
+
   // logs the environment
   //
   void dump(const Settings& s) const;

--- a/src/envmodule.cpp
+++ b/src/envmodule.cpp
@@ -295,10 +295,19 @@ QDateTime Module::getTimestamp(const VS_FIXEDFILEINFO& fi) const
 
 QString Module::getMD5() const
 {
-  if (m_path.contains("\\windows\\", Qt::CaseInsensitive)) {
-    // don't calculate md5 for system files, it's not really relevant and
-    // it takes a while
-    return {};
+  static const std::set<QString> ignore = {
+    "\\windows\\",
+    "\\program files\\",
+    "\\program files (x86)\\",
+    "\\programdata\\"
+  };
+
+  // don't calculate md5 for system files, it's not really relevant and
+  // it takes a while
+  for (auto&& i : ignore) {
+    if (m_path.contains(i, Qt::CaseInsensitive)) {
+      return {};
+    }
   }
 
   // opening the file

--- a/src/envsecurity.cpp
+++ b/src/envsecurity.cpp
@@ -207,13 +207,6 @@ QString SecurityProduct::toString() const
     s += ", definitions outdated";
   }
 
-  // all products have a guid, but the windows firewall is not actually a real
-  // one from wmi, it's queried independently in getWindowsFirewall() and has a
-  // null guid, so just don't log it
-  if (!m_guid.isNull()) {
-    s += ", " + m_guid.toString(QUuid::QUuid::WithoutBraces);
-  }
-
   return s;
 }
 

--- a/src/envsecurity.cpp
+++ b/src/envsecurity.cpp
@@ -383,7 +383,18 @@ std::optional<SecurityProduct> getWindowsFirewall()
     hr = policy->get_FirewallEnabled(NET_FW_PROFILE2_PUBLIC, &enabledVariant);
     if (FAILED(hr))
     {
-      log::error("get_FirewallEnabled failed, {}", formatSystemMessage(hr));
+      // EPT_S_NOT_REGISTERED is "There are no more endpoints available from the
+      // endpoint mapper", which seems to happen sometimes on Windows 7 when the
+      // firewall has been disabled, so treat it as such and don't log it
+      //
+      // however the user reported the error was actually 0x800706d9, not just
+      // 0x6d9 (1753, what EPT_S_NOT_REGISTERED is defined to), so this is
+      // testing for both because it's not clear which it is and nobody can
+      // reproduce it
+      if (hr != EPT_S_NOT_REGISTERED && hr != 0x800706d9) {
+        log::error("get_FirewallEnabled failed, {}", formatSystemMessage(hr));
+      }
+
       return {};
     }
   }

--- a/src/instancemanager.cpp
+++ b/src/instancemanager.cpp
@@ -259,7 +259,22 @@ QString InstanceManager::instancePath() const
 
 QStringList InstanceManager::instances() const
 {
-  return QDir(instancePath()).entryList(QDir::Dirs | QDir::NoDotAndDotDot);
+  const std::set<QString> ignore = {
+    "cache", "qtwebengine",
+  };
+
+  const auto dirs = QDir(instancePath())
+    .entryList(QDir::Dirs | QDir::NoDotAndDotDot);
+
+  QStringList list;
+
+  for (auto&& d : dirs) {
+    if (!ignore.contains(QFileInfo(d).fileName().toLower())) {
+      list.push_back(d);
+    }
+  }
+
+  return list;
 }
 
 

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -554,6 +554,20 @@ int runApplication(MOApplication &application, SingleInstance &instance,
       return 1;
     }
 
+    {
+      // log if there are any dmp files
+      const auto hasCrashDumps =
+        !QDir(QString::fromStdWString(organizer.crashDumpsPath()))
+          .entryList({"*.dmp"}, QDir::Files)
+          .empty();
+
+      if (hasCrashDumps) {
+        log::debug(
+          "there are crash dumps in '{}'",
+          QString::fromStdWString(organizer.crashDumpsPath()));
+      }
+    }
+
     log::debug("initializing plugins");
     PluginContainer pluginContainer(&organizer);
     pluginContainer.loadPlugins();

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -93,6 +93,7 @@ using namespace MOShared;
 
 
 void sanityChecks(const env::Environment& env);
+int checkIncompatibleModule(const env::Module& m);
 
 bool createAndMakeWritable(const std::wstring &subPath) {
   QString const dataPath = qApp->property("dataPath").toString();
@@ -547,8 +548,9 @@ int runApplication(MOApplication &application, SingleInstance &instance,
     settings.dump();
     sanityChecks(env);
 
-    const auto moduleNotification = env.onModuleLoaded([](auto&& m) {
+    const auto moduleNotification = env.onModuleLoaded(qApp, [](auto&& m) {
       log::debug("loaded module {}", m.toString());
+      checkIncompatibleModule(m);
     });
 
     log::debug("initializing core");

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -547,6 +547,10 @@ int runApplication(MOApplication &application, SingleInstance &instance,
     settings.dump();
     sanityChecks(env);
 
+    const auto moduleNotification = env.onModuleLoaded([](auto&& m) {
+      log::debug("loaded module {}", m.toString());
+    });
+
     log::debug("initializing core");
     OrganizerCore organizer(settings);
     if (!organizer.bootstrap()) {

--- a/src/mainwindow.cpp
+++ b/src/mainwindow.cpp
@@ -6139,14 +6139,18 @@ void MainWindow::on_actionNotifications_triggered()
 
 void MainWindow::on_actionChange_Game_triggered()
 {
-  const auto r = QMessageBox::question(
-    this, tr("Are you sure?"), tr("This will restart MO, continue?"),
-    QMessageBox::Yes | QMessageBox::Cancel);
+  if (m_OrganizerCore.settings().interface().showChangeGameConfirmation()) {
+    const auto r = QMessageBox::question(
+      this, tr("Are you sure?"), tr("This will restart MO, continue?"),
+      QMessageBox::Yes | QMessageBox::Cancel);
 
-  if (r == QMessageBox::Yes) {
-    InstanceManager::instance().clearCurrentInstance();
-    ExitModOrganizer(Exit::Restart);
+    if (r != QMessageBox::Yes) {
+      return;
+    }
   }
+
+  InstanceManager::instance().clearCurrentInstance();
+  ExitModOrganizer(Exit::Restart);
 }
 
 void MainWindow::setCategoryListVisible(bool visible)

--- a/src/mainwindow.cpp
+++ b/src/mainwindow.cpp
@@ -277,6 +277,7 @@ MainWindow::MainWindow(Settings &settings
   ui->espList->installEventFilter(m_OrganizerCore.pluginList());
 
   ui->bsaList->setLocalMoveOnly(true);
+  ui->bsaList->setHeaderHidden(true);
 
   initDownloadView();
 

--- a/src/mainwindow.cpp
+++ b/src/mainwindow.cpp
@@ -5428,6 +5428,27 @@ void MainWindow::openDataOriginExplorer_clicked()
   shell::Explore(fullPath);
 }
 
+void MainWindow::openDataModInfo_clicked()
+{
+  if (m_ContextItem == nullptr) {
+    return;
+  }
+
+  const auto originID = m_ContextItem->data(1, Qt::UserRole + 1).toInt();
+  const auto& origin = m_OrganizerCore.directoryStructure()->getOriginByID(originID);
+  const auto& name = QString::fromStdWString(origin.getName());
+
+  unsigned int index = ModInfo::getIndex(name);
+  if (index == UINT_MAX) {
+    return;
+  }
+
+  ModInfo::Ptr modInfo = ModInfo::getByIndex(index);
+  if (modInfo) {
+    displayModInformation(modInfo, index, ModInfoTabIDs::None);
+  }
+}
+
 void MainWindow::updateAvailable()
 {
   ui->actionUpdate->setEnabled(true);
@@ -5472,6 +5493,8 @@ void MainWindow::on_dataTree_customContextMenuRequested(const QPoint &pos)
     if (!isArchive && !isDirectory) {
       menu.addAction("Open Origin in Explorer", this, SLOT(openDataOriginExplorer_clicked()));
     }
+
+    menu.addAction("Open Mod Info", this, SLOT(openDataModInfo_clicked()));
 
     // offer to hide/unhide file, but not for files from archives
     if (!isArchive) {

--- a/src/mainwindow.h
+++ b/src/mainwindow.h
@@ -448,6 +448,7 @@ private slots:
   void hideFile();
   void unhideFile();
   void openDataOriginExplorer_clicked();
+  void openDataModInfo_clicked();
 
   // pluginlist context menu
   void enableSelectedPlugins_clicked();

--- a/src/modinfodialog.ui
+++ b/src/modinfodialog.ui
@@ -1258,6 +1258,9 @@ p, li { white-space: pre-wrap; }
          <property name="uniformRowHeights">
           <bool>true</bool>
          </property>
+         <property name="sortingEnabled">
+          <bool>true</bool>
+         </property>
         </widget>
        </item>
       </layout>

--- a/src/modinfodialogfiletree.cpp
+++ b/src/modinfodialogfiletree.cpp
@@ -21,7 +21,6 @@ FileTreeTab::FileTreeTab(ModInfoDialogTabContext cx)
   m_fs->setReadOnly(false);
   ui->filetree->setModel(m_fs);
   ui->filetree->setColumnWidth(0, 300);
-  ui->filetree->sortByColumn(0, Qt::AscendingOrder);
 
   m_actions.newFolder = new QAction(tr("&New Folder"), ui->filetree);
   m_actions.open = new QAction(tr("&Open/Execute"), ui->filetree);
@@ -63,7 +62,9 @@ void FileTreeTab::saveState(Settings& s)
 
 void FileTreeTab::restoreState(const Settings& s)
 {
-  s.geometry().restoreState(ui->filetree->header());
+  if (!s.geometry().restoreState(ui->filetree->header())) {
+    ui->filetree->sortByColumn(0, Qt::AscendingOrder);
+  }
 }
 
 void FileTreeTab::update()

--- a/src/modinfodialogfiletree.cpp
+++ b/src/modinfodialogfiletree.cpp
@@ -21,6 +21,7 @@ FileTreeTab::FileTreeTab(ModInfoDialogTabContext cx)
   m_fs->setReadOnly(false);
   ui->filetree->setModel(m_fs);
   ui->filetree->setColumnWidth(0, 300);
+  ui->filetree->sortByColumn(0, Qt::AscendingOrder);
 
   m_actions.newFolder = new QAction(tr("&New Folder"), ui->filetree);
   m_actions.open = new QAction(tr("&Open/Execute"), ui->filetree);
@@ -53,6 +54,16 @@ void FileTreeTab::clear()
 
   // always has data; even if the mod is empty, it still has a meta.ini
   setHasData(true);
+}
+
+void FileTreeTab::saveState(Settings& s)
+{
+  s.geometry().saveState(ui->filetree->header());
+}
+
+void FileTreeTab::restoreState(const Settings& s)
+{
+  s.geometry().restoreState(ui->filetree->header());
 }
 
 void FileTreeTab::update()

--- a/src/modinfodialogfiletree.h
+++ b/src/modinfodialogfiletree.h
@@ -12,6 +12,8 @@ public:
   FileTreeTab(ModInfoDialogTabContext cx);
 
   void clear() override;
+  void saveState(Settings& s);
+  void restoreState(const Settings& s);
   void update() override;
   bool deleteRequested() override;
 

--- a/src/organizercore.cpp
+++ b/src/organizercore.cpp
@@ -484,12 +484,6 @@ bool OrganizerCore::cycleDiagnostics()
     removeOldFiles(path, "*.dmp", maxDumps, QDir::Time|QDir::Reversed);
   }
 
-  // log if there are any files left
-  const auto files = QDir(path).entryList({"*.dmp"}, QDir::Files);
-  if (!files.isEmpty()) {
-    log::debug("there are crash dumps in '{}'", path);
-  }
-
   return true;
 }
 

--- a/src/overwriteinfodialog.cpp
+++ b/src/overwriteinfodialog.cpp
@@ -85,7 +85,6 @@ OverwriteInfoDialog::OverwriteInfoDialog(ModInfo::Ptr modInfo, QWidget *parent)
   ui->filesView->setModel(m_FileSystemModel);
   ui->filesView->setRootIndex(m_FileSystemModel->index(modInfo->absolutePath()));
   ui->filesView->setColumnWidth(0, 250);
-  ui->filesView->sortByColumn(0, Qt::AscendingOrder);
 
   m_DeleteAction = new QAction(tr("&Delete"), ui->filesView);
   m_RenameAction = new QAction(tr("&Rename"), ui->filesView);
@@ -110,7 +109,10 @@ void OverwriteInfoDialog::showEvent(QShowEvent* e)
   const auto& s = Settings::instance();
 
   s.geometry().restoreGeometry(this);
-  s.geometry().restoreState(ui->filesView->header());
+
+  if (!s.geometry().restoreState(ui->filesView->header())) {
+    ui->filesView->sortByColumn(0, Qt::AscendingOrder);
+  }
 
   QDialog::showEvent(e);
 }

--- a/src/overwriteinfodialog.cpp
+++ b/src/overwriteinfodialog.cpp
@@ -85,6 +85,7 @@ OverwriteInfoDialog::OverwriteInfoDialog(ModInfo::Ptr modInfo, QWidget *parent)
   ui->filesView->setModel(m_FileSystemModel);
   ui->filesView->setRootIndex(m_FileSystemModel->index(modInfo->absolutePath()));
   ui->filesView->setColumnWidth(0, 250);
+  ui->filesView->sortByColumn(0, Qt::AscendingOrder);
 
   m_DeleteAction = new QAction(tr("&Delete"), ui->filesView);
   m_RenameAction = new QAction(tr("&Rename"), ui->filesView);
@@ -106,13 +107,21 @@ OverwriteInfoDialog::~OverwriteInfoDialog()
 
 void OverwriteInfoDialog::showEvent(QShowEvent* e)
 {
-  Settings::instance().geometry().restoreGeometry(this);
+  const auto& s = Settings::instance();
+
+  s.geometry().restoreGeometry(this);
+  s.geometry().restoreState(ui->filesView->header());
+
   QDialog::showEvent(e);
 }
 
 void OverwriteInfoDialog::done(int r)
 {
-  Settings::instance().geometry().saveGeometry(this);
+  auto& s = Settings::instance();
+
+  s.geometry().saveGeometry(this);
+  s.geometry().saveState(ui->filesView->header());
+
   QDialog::done(r);
 }
 

--- a/src/sanitychecks.cpp
+++ b/src/sanitychecks.cpp
@@ -177,9 +177,14 @@ int checkMissingFiles()
 {
   // files that are likely to be eaten
   static const QStringList files({
-    "helper.exe", "nxmhandler.exe",
-    "usvfs_proxy_x64.exe", "usvfs_proxy_x86.exe",
-    "usvfs_x64.dll", "usvfs_x86.dll"
+    "helper.exe",
+    "nxmhandler.exe",
+    "usvfs_proxy_x64.exe",
+    "usvfs_proxy_x86.exe",
+    "usvfs_x64.dll",
+    "usvfs_x86.dll",
+    "loot/loot.dll",
+    "loot/lootcli.exe"
     });
 
   log::debug("  . missing files");

--- a/src/sanitychecks.cpp
+++ b/src/sanitychecks.cpp
@@ -202,29 +202,36 @@ int checkMissingFiles()
   return n;
 }
 
-bool checkNahimic(const env::Environment& e)
+int checkIncompatibleModule(const env::Module& m)
 {
-  // Nahimic seems to interfere mostly with dialogs, like the mod info dialog:
-  // it renders dialogs fully white and makes it impossible to interact with
-  // them
+  // these dlls seems to interfere mostly with dialogs, like the mod info
+  // dialog: it renders dialogs fully white and makes it impossible to interact
+  // with them
   //
-  // NahimicOSD.dll is usually loaded on startup, but there has been some
-  // reports where it got loaded later, so this check is not entirely accurate
+  // the dlls is usually loaded on startup, but there has been some  reports
+  // where it got loaded later, so this is also called every time a new module
+  // is loaded into this process
 
-  for (auto&& m : e.loadedModules()) {
-    const QFileInfo file(m.path());
+  static const std::map<QString, QString> names = {
+    {"NahimicOSD.dll", "Nahimic"},
+    {"RTSSHooks64.dll", "RivaTuner Statistics Server"}
+  };
 
-    if (file.fileName().compare("NahimicOSD.dll", Qt::CaseInsensitive) == 0) {
+  const QFileInfo file(m.path());
+  int n = 0;
+
+  for (auto&& p : names) {
+    if (file.fileName().compare(p.first, Qt::CaseInsensitive) == 0) {
       log::warn(
-        "NahimicOSD.dll is loaded. Nahimic is known to cause issues with "
+        "{} is loaded. This program is known to cause issues with "
         "Mod Organizer, such as freezing or blank windows. Consider "
-        "uninstalling it.");
+        "uninstalling it. ({})", p.second, file.absoluteFilePath());
 
-      return true;
+      ++n;
     }
   }
 
-  return false;
+  return n;
 }
 
 int checkIncompatibilities(const env::Environment& e)
@@ -233,8 +240,8 @@ int checkIncompatibilities(const env::Environment& e)
 
   int n = 0;
 
-  if (checkNahimic(e)) {
-    ++n;
+  for (auto&& m : e.loadedModules()) {
+    n += checkIncompatibleModule(m);
   }
 
   return n;

--- a/src/settings.cpp
+++ b/src/settings.cpp
@@ -1961,6 +1961,16 @@ void InterfaceSettings::setTutorialCompleted(const QString& windowName, bool b)
   set(m_Settings, "CompletedWindowTutorials", windowName, b);
 }
 
+bool InterfaceSettings::showChangeGameConfirmation() const
+{
+  return get<bool>(m_Settings, "Settings", "show_change_game_confirmation", true);
+}
+
+void InterfaceSettings::setShowChangeGameConfirmation(bool b) const
+{
+  set(m_Settings, "Settings", "show_change_game_confirmation", b);
+}
+
 
 DiagnosticsSettings::DiagnosticsSettings(QSettings& settings)
   : m_Settings(settings)

--- a/src/settings.h
+++ b/src/settings.h
@@ -605,6 +605,11 @@ public:
   bool isTutorialCompleted(const QString& windowName) const;
   void setTutorialCompleted(const QString& windowName, bool b=true);
 
+  // whether to show the confirmation when switching instances
+  //
+  bool showChangeGameConfirmation() const;
+  void setShowChangeGameConfirmation(bool b) const;
+
 private:
   QSettings& m_Settings;
 };

--- a/src/settingsdialog.ui
+++ b/src/settingsdialog.ui
@@ -109,6 +109,13 @@
            </widget>
           </item>
           <item>
+           <widget class="QCheckBox" name="changeGameConfirmation">
+            <property name="text">
+             <string>Show confirmation when changing instance</string>
+            </property>
+           </widget>
+          </item>
+          <item>
            <widget class="QPushButton" name="resetDialogsButton">
             <property name="maximumSize">
              <size>

--- a/src/settingsdialoggeneral.cpp
+++ b/src/settingsdialoggeneral.cpp
@@ -17,6 +17,7 @@ GeneralSettingsTab::GeneralSettingsTab(Settings& s, SettingsDialog& d)
   ui->colorTable->load(s);
 
   ui->centerDialogs->setChecked(settings().geometry().centerDialogs());
+  ui->changeGameConfirmation->setChecked(settings().interface().showChangeGameConfirmation());
   ui->compactBox->setChecked(settings().interface().compactDownloads());
   ui->showMetaBox->setChecked(settings().interface().metaDownloads());
   ui->checkForUpdates->setChecked(settings().checkForUpdates());
@@ -59,6 +60,7 @@ void GeneralSettingsTab::update()
   ui->colorTable->commitColors();
 
   settings().geometry().setCenterDialogs(ui->centerDialogs->isChecked());
+  settings().interface().setShowChangeGameConfirmation(ui->changeGameConfirmation->isChecked());
   settings().interface().setCompactDownloads(ui->compactBox->isChecked());
   settings().interface().setMetaDownloads(ui->showMetaBox->isChecked());
   settings().setCheckForUpdates(ui->checkForUpdates->isChecked());


### PR DESCRIPTION
Logging:

 - I added a log to says whether crash dumps are present in the folder, but it was output on every cycling of files. It's now only on startup.
 - Timezone is logged on startup.
 - Simplified security products: guids are not logged, identical names are merged.
 - Don't log md5 for any system file.
 - Removed incorrect error log when a server isn't found while sorting.
 - Any module loaded after startup is now also logged and checked for known issues. Added RivaTuner to the checks.
 - Added loot files to the missing files check.
 - Remove rare spurious error when checking the windows firewall on windows 7.

UI:
 - Added toggle in the settings to hide the dialog box when switching instances.
 - Some folders are ignored in the instance dialog. Right now, it's only "cache" and "qtwebengine".
 - Overwrite dialog now sorts ascending by default instead of descending. Added sort to filetree in mod info dialog. Both remember settings.
 - Removed useless header in the Archives list.
 - Added "open mod info" to the context menu in the Data tab.
 - Changed mod name from "data" to translatable "\<Unmanaged\>" in the Data and Archives tab.

Fixes #261.