### PR TITLE
Fix crash when changing categories on mods while a filter is selected

### DIFF
--- a/src/modlist.h
+++ b/src/modlist.h
@@ -341,6 +341,7 @@ private:
   std::set<int> m_RequestIDs;
 
   mutable bool m_Modified;
+  bool m_InNotifyChange;
 
   QFontMetrics m_FontMetrics;
 


### PR DESCRIPTION
The comment in `modlist.cpp` explains it all. Fixes #723.