### PR TITLE
Allow relative paths for binaries in the executables settings

### DIFF
--- a/src/editexecutablesdialog.cpp
+++ b/src/editexecutablesdialog.cpp
@@ -327,7 +327,7 @@ void EditExecutablesDialog::clearEdits()
 void EditExecutablesDialog::setEdits(const Executable& e)
 {
   ui->title->setText(e.title());
-  ui->binary->setText(QDir::toNativeSeparators(e.binaryInfo().absoluteFilePath()));
+  ui->binary->setText(QDir::toNativeSeparators(e.binaryInfo().filePath()));
   ui->workingDirectory->setText(QDir::toNativeSeparators(e.workingDirectory()));
   ui->arguments->setText(e.arguments());
   ui->overwriteSteamAppID->setChecked(!e.steamAppID().isEmpty());

--- a/src/executableslist.cpp
+++ b/src/executableslist.cpp
@@ -120,7 +120,7 @@ void ExecutablesList::store(Settings& s)
     map["toolbar"] = item.isShownOnToolbar();
     map["ownicon"] = item.usesOwnIcon();
     map["hide"] = item.hide();
-    map["binary"] = item.binaryInfo().absoluteFilePath();
+    map["binary"] = item.binaryInfo().filePath();
     map["arguments"] = item.arguments();
     map["workingDirectory"] = item.workingDirectory();
     map["steamAppID"] = item.steamAppID();
@@ -358,7 +358,7 @@ void ExecutablesList::dump() const
       "    steam ID: {}\n"
       "    directory: {}\n"
       "    flags: {} ({})",
-      e.title(), e.binaryInfo().absoluteFilePath(), e.arguments(),
+      e.title(), e.binaryInfo().filePath(), e.arguments(),
       e.steamAppID(), e.workingDirectory(), flags.join("|"), e.flags());
   }
 }
@@ -374,7 +374,7 @@ Executable::Executable(const MOBase::ExecutableInfo& info, Flags flags) :
   m_binaryInfo(info.binary()),
   m_arguments(info.arguments().join(" ")),
   m_steamAppID(info.steamAppID()),
-  m_workingDirectory(info.workingDirectory().absolutePath()),
+  m_workingDirectory(info.workingDirectory().path()),
   m_flags(flags)
 {
 }

--- a/src/sanitychecks.cpp
+++ b/src/sanitychecks.cpp
@@ -222,7 +222,8 @@ int checkIncompatibleModule(const env::Module& m)
 
   static const std::map<QString, QString> names = {
     {"NahimicOSD.dll", "Nahimic"},
-    {"RTSSHooks64.dll", "RivaTuner Statistics Server"}
+    {"RTSSHooks64.dll", "RivaTuner Statistics Server"},
+    {"SSAudioOSD.dll", "SteelSeries Audio"}
   };
 
   const QFileInfo file(m.path());


### PR DESCRIPTION
Also added `SSAudioOSD.dll` to checks. Fixes #669.