### PR TITLE
Negative filters

### DIFF
--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -144,6 +144,7 @@ SET(organizer_SRCS
 	uilocker.cpp
 	loot.cpp
 	lootdialog.cpp
+	filterlist.cpp
 
     shared/windows_error.cpp
     shared/error_report.cpp
@@ -268,6 +269,7 @@ SET(organizer_HDRS
 	loot.h
 	lootdialog.h
 	json.h
+	filterlist.h
 
     shared/windows_error.h
     shared/error_report.h
@@ -320,6 +322,7 @@ SET(organizer_RCS
 source_group(src REGULAR_EXPRESSION ".*\\.(h|cpp|ui)")
 
 set(application
+	filterlist
 	iuserinterface
 	main
 	mainwindow

--- a/src/categories.cpp
+++ b/src/categories.cpp
@@ -320,6 +320,40 @@ QString CategoryFactory::getCategoryName(unsigned int index) const
   return m_Categories[index].m_Name;
 }
 
+QString CategoryFactory::getSpecialCategoryName(int type) const
+{
+  switch (type)
+  {
+    case CATEGORY_SPECIAL_CHECKED:         return QObject::tr("<Checked>");
+    case CATEGORY_SPECIAL_UNCHECKED:       return QObject::tr("<Unchecked>");
+    case CATEGORY_SPECIAL_UPDATEAVAILABLE: return QObject::tr("<Update>");
+    case CATEGORY_SPECIAL_NOCATEGORY:      return QObject::tr("<Mod Backup>");
+    case CATEGORY_SPECIAL_CONFLICT:        return QObject::tr("<Managed by MO>");
+    case CATEGORY_SPECIAL_NOTENDORSED:     return QObject::tr("<Managed outside MO>");
+    case CATEGORY_SPECIAL_BACKUP:          return QObject::tr("<No category>");
+    case CATEGORY_SPECIAL_MANAGED:         return QObject::tr("<Conflicted>");
+    case CATEGORY_SPECIAL_UNMANAGED:       return QObject::tr("<Not Endorsed>");
+    case CATEGORY_SPECIAL_NOGAMEDATA:      return QObject::tr("<No Nexus ID>");
+    case CATEGORY_SPECIAL_NONEXUSID:       return QObject::tr("<No valid game data>");
+    default: return {};
+  }
+}
+
+QString CategoryFactory::getCategoryNameByID(int id) const
+{
+  auto itor = m_IDMap.find(id);
+
+  if (itor == m_IDMap.end()) {
+    return getSpecialCategoryName(id);
+  } else {
+    const auto index = itor->second;
+    if (index >= m_Categories.size()) {
+      return {};
+    }
+
+    return m_Categories[index].m_Name;
+  }
+}
 
 int CategoryFactory::getCategoryID(unsigned int index) const
 {

--- a/src/categories.cpp
+++ b/src/categories.cpp
@@ -320,21 +320,19 @@ QString CategoryFactory::getCategoryName(unsigned int index) const
   return m_Categories[index].m_Name;
 }
 
-QString CategoryFactory::getSpecialCategoryName(int type) const
+QString CategoryFactory::getSpecialCategoryName(SpecialCategories type) const
 {
   switch (type)
   {
-    case CATEGORY_SPECIAL_CHECKED:         return QObject::tr("<Checked>");
-    case CATEGORY_SPECIAL_UNCHECKED:       return QObject::tr("<Unchecked>");
-    case CATEGORY_SPECIAL_UPDATEAVAILABLE: return QObject::tr("<Update>");
-    case CATEGORY_SPECIAL_NOCATEGORY:      return QObject::tr("<No category>");
-    case CATEGORY_SPECIAL_CONFLICT:        return QObject::tr("<Conflicted>");
-    case CATEGORY_SPECIAL_NOTENDORSED:     return QObject::tr("<Not Endorsed>");
-    case CATEGORY_SPECIAL_BACKUP:          return QObject::tr("<Mod Backup>");
-    case CATEGORY_SPECIAL_MANAGED:         return QObject::tr("<Managed by MO>");
-    case CATEGORY_SPECIAL_UNMANAGED:       return QObject::tr("<Managed outside MO>");
-    case CATEGORY_SPECIAL_NOGAMEDATA:      return QObject::tr("<No valid game data>");
-    case CATEGORY_SPECIAL_NONEXUSID:       return QObject::tr("<No Nexus ID>");
+    case Checked:         return QObject::tr("<Checked>");
+    case UpdateAvailable: return QObject::tr("<Update>");
+    case HasNoCategory:      return QObject::tr("<No category>");
+    case Conflict:        return QObject::tr("<Conflicted>");
+    case NotEndorsed:     return QObject::tr("<Not Endorsed>");
+    case Backup:          return QObject::tr("<Mod Backup>");
+    case Managed:         return QObject::tr("<Managed by MO>");
+    case NoGameData:      return QObject::tr("<No valid game data>");
+    case NoNexusID:       return QObject::tr("<No Nexus ID>");
     default: return {};
   }
 }
@@ -344,7 +342,7 @@ QString CategoryFactory::getCategoryNameByID(int id) const
   auto itor = m_IDMap.find(id);
 
   if (itor == m_IDMap.end()) {
-    return getSpecialCategoryName(id);
+    return getSpecialCategoryName(static_cast<SpecialCategories>(id));
   } else {
     const auto index = itor->second;
     if (index >= m_Categories.size()) {

--- a/src/categories.cpp
+++ b/src/categories.cpp
@@ -324,15 +324,15 @@ QString CategoryFactory::getSpecialCategoryName(SpecialCategories type) const
 {
   switch (type)
   {
-    case Checked:         return QObject::tr("<Checked>");
-    case UpdateAvailable: return QObject::tr("<Update>");
-    case HasNoCategory:      return QObject::tr("<No category>");
+    case Checked:         return QObject::tr("<Active>");
+    case UpdateAvailable: return QObject::tr("<Update available>");
+    case HasCategory:     return QObject::tr("<Has category>");
     case Conflict:        return QObject::tr("<Conflicted>");
-    case NotEndorsed:     return QObject::tr("<Not Endorsed>");
-    case Backup:          return QObject::tr("<Mod Backup>");
-    case Managed:         return QObject::tr("<Managed by MO>");
-    case NoGameData:      return QObject::tr("<No valid game data>");
-    case NoNexusID:       return QObject::tr("<No Nexus ID>");
+    case Endorsed:        return QObject::tr("<Endorsed>");
+    case Backup:          return QObject::tr("<Has backup>");
+    case Managed:         return QObject::tr("<Managed>");
+    case HasGameData:     return QObject::tr("<Has valid game data>");
+    case HasNexusID:      return QObject::tr("<Has Nexus ID>");
     default: return {};
   }
 }

--- a/src/categories.cpp
+++ b/src/categories.cpp
@@ -327,14 +327,14 @@ QString CategoryFactory::getSpecialCategoryName(int type) const
     case CATEGORY_SPECIAL_CHECKED:         return QObject::tr("<Checked>");
     case CATEGORY_SPECIAL_UNCHECKED:       return QObject::tr("<Unchecked>");
     case CATEGORY_SPECIAL_UPDATEAVAILABLE: return QObject::tr("<Update>");
-    case CATEGORY_SPECIAL_NOCATEGORY:      return QObject::tr("<Mod Backup>");
-    case CATEGORY_SPECIAL_CONFLICT:        return QObject::tr("<Managed by MO>");
-    case CATEGORY_SPECIAL_NOTENDORSED:     return QObject::tr("<Managed outside MO>");
-    case CATEGORY_SPECIAL_BACKUP:          return QObject::tr("<No category>");
-    case CATEGORY_SPECIAL_MANAGED:         return QObject::tr("<Conflicted>");
-    case CATEGORY_SPECIAL_UNMANAGED:       return QObject::tr("<Not Endorsed>");
-    case CATEGORY_SPECIAL_NOGAMEDATA:      return QObject::tr("<No Nexus ID>");
-    case CATEGORY_SPECIAL_NONEXUSID:       return QObject::tr("<No valid game data>");
+    case CATEGORY_SPECIAL_NOCATEGORY:      return QObject::tr("<No category>");
+    case CATEGORY_SPECIAL_CONFLICT:        return QObject::tr("<Conflicted>");
+    case CATEGORY_SPECIAL_NOTENDORSED:     return QObject::tr("<Not Endorsed>");
+    case CATEGORY_SPECIAL_BACKUP:          return QObject::tr("<Mod Backup>");
+    case CATEGORY_SPECIAL_MANAGED:         return QObject::tr("<Managed by MO>");
+    case CATEGORY_SPECIAL_UNMANAGED:       return QObject::tr("<Managed outside MO>");
+    case CATEGORY_SPECIAL_NOGAMEDATA:      return QObject::tr("<No valid game data>");
+    case CATEGORY_SPECIAL_NONEXUSID:       return QObject::tr("<No Nexus ID>");
     default: return {};
   }
 }

--- a/src/categories.h
+++ b/src/categories.h
@@ -37,25 +37,20 @@ class CategoryFactory {
   friend class CategoriesDialog;
 
 public:
-
-  static const int CATEGORY_NONE = 0;
-
-  static const int CATEGORY_SPECIAL_FIRST = 10000;
-  static const int CATEGORY_SPECIAL_CHECKED = CATEGORY_SPECIAL_FIRST;
-  static const int CATEGORY_SPECIAL_UNCHECKED = 10001;
-  static const int CATEGORY_SPECIAL_UPDATEAVAILABLE = 10002;
-  static const int CATEGORY_SPECIAL_NOCATEGORY = 10003;
-  static const int CATEGORY_SPECIAL_CONFLICT = 10004;
-  static const int CATEGORY_SPECIAL_NOTENDORSED = 10005;
-  static const int CATEGORY_SPECIAL_BACKUP = 10006;
-  static const int CATEGORY_SPECIAL_MANAGED = 10007;
-  static const int CATEGORY_SPECIAL_UNMANAGED = 10008;
-  static const int CATEGORY_SPECIAL_NOGAMEDATA = 10009;
-  static const int CATEGORY_SPECIAL_NONEXUSID = 10010;
-
+  enum SpecialCategories
+  {
+    Checked = 10000,
+    UpdateAvailable,
+    HasNoCategory,
+    Conflict,
+    NotEndorsed,
+    Backup,
+    Managed,
+    NoGameData,
+    NoNexusID
+  };
 
 public:
-
   struct Category {
     Category(int sortValue, int id, const QString &name, const std::vector<int> &nexusIDs, int parentID)
       : m_SortValue(sortValue), m_ID(id), m_Name(name), m_HasChildren(false),
@@ -144,7 +139,7 @@ public:
    * @return QString name of the category
    **/
   QString getCategoryName(unsigned int index) const;
-  QString getSpecialCategoryName(int type) const;
+  QString getSpecialCategoryName(SpecialCategories type) const;
   QString getCategoryNameByID(int id) const;
 
   /**

--- a/src/categories.h
+++ b/src/categories.h
@@ -41,13 +41,13 @@ public:
   {
     Checked = 10000,
     UpdateAvailable,
-    HasNoCategory,
+    HasCategory,
     Conflict,
-    NotEndorsed,
+    Endorsed,
     Backup,
     Managed,
-    NoGameData,
-    NoNexusID
+    HasGameData,
+    HasNexusID
   };
 
 public:

--- a/src/categories.h
+++ b/src/categories.h
@@ -144,6 +144,8 @@ public:
    * @return QString name of the category
    **/
   QString getCategoryName(unsigned int index) const;
+  QString getSpecialCategoryName(int type) const;
+  QString getCategoryNameByID(int id) const;
 
   /**
    * @brief look up the id of a category by its index

--- a/src/filterlist.cpp
+++ b/src/filterlist.cpp
@@ -11,7 +11,7 @@ using Criteria = ModListSortProxy::Criteria;
 class FilterList::CriteriaItem : public QTreeWidgetItem
 {
 public:
-  enum States : int
+  enum States
   {
     FirstState = 0,
 
@@ -234,11 +234,11 @@ void FilterList::refresh()
   addSpecialCriteria(F::UpdateAvailable);
   addSpecialCriteria(F::Backup);
   addSpecialCriteria(F::Managed);
-  addSpecialCriteria(F::HasNoCategory);
+  addSpecialCriteria(F::HasCategory);
   addSpecialCriteria(F::Conflict);
-  addSpecialCriteria(F::NotEndorsed);
-  addSpecialCriteria(F::NoNexusID);
-  addSpecialCriteria(F::NoGameData);
+  addSpecialCriteria(F::Endorsed);
+  addSpecialCriteria(F::HasNexusID);
+  addSpecialCriteria(F::HasGameData);
 
   addContentCriteria();
 

--- a/src/filterlist.cpp
+++ b/src/filterlist.cpp
@@ -94,6 +94,8 @@ FilterList::FilterList(Ui::MainWindow* ui, CategoryFactory& factory)
 
   ui->filters->header()->setSectionResizeMode(0, QHeaderView::Stretch);
   ui->filters->header()->resizeSection(1, 50);
+  ui->categoriesSplitter->setCollapsible(0, false);
+  ui->categoriesSplitter->setCollapsible(1, false);
 }
 
 QTreeWidgetItem* FilterList::addCriteriaItem(
@@ -142,8 +144,10 @@ void FilterList::addCategoryCriteria(QTreeWidgetItem *root, const std::set<int> 
 
 void FilterList::addSpecialCriteria(int type)
 {
+  const auto sc = static_cast<CategoryFactory::SpecialCategories>(type);
+
   addCriteriaItem(
-    nullptr, m_factory.getSpecialCategoryName(type),
+    nullptr, m_factory.getSpecialCategoryName(sc),
     type, ModListSortProxy::TYPE_SPECIAL);
 }
 
@@ -157,17 +161,15 @@ void FilterList::refresh()
   ui->filters->clear();
 
   using F = CategoryFactory;
-  addSpecialCriteria(F::CATEGORY_SPECIAL_CHECKED);
-  addSpecialCriteria(F::CATEGORY_SPECIAL_UNCHECKED);
-  addSpecialCriteria(F::CATEGORY_SPECIAL_UPDATEAVAILABLE);
-  addSpecialCriteria(F::CATEGORY_SPECIAL_BACKUP);
-  addSpecialCriteria(F::CATEGORY_SPECIAL_MANAGED);
-  addSpecialCriteria(F::CATEGORY_SPECIAL_UNMANAGED);
-  addSpecialCriteria(F::CATEGORY_SPECIAL_NOCATEGORY);
-  addSpecialCriteria(F::CATEGORY_SPECIAL_CONFLICT);
-  addSpecialCriteria(F::CATEGORY_SPECIAL_NOTENDORSED);
-  addSpecialCriteria(F::CATEGORY_SPECIAL_NONEXUSID);
-  addSpecialCriteria(F::CATEGORY_SPECIAL_NOGAMEDATA);
+  addSpecialCriteria(F::Checked);
+  addSpecialCriteria(F::UpdateAvailable);
+  addSpecialCriteria(F::Backup);
+  addSpecialCriteria(F::Managed);
+  addSpecialCriteria(F::HasNoCategory);
+  addSpecialCriteria(F::Conflict);
+  addSpecialCriteria(F::NotEndorsed);
+  addSpecialCriteria(F::NoNexusID);
+  addSpecialCriteria(F::NoGameData);
 
   addContentCriteria();
 
@@ -211,7 +213,7 @@ void FilterList::setSelection(std::vector<int> categories)
       continue;
     }
 
-    if (item->id() == CategoryFactory::CATEGORY_SPECIAL_UPDATEAVAILABLE) {
+    if (item->id() == CategoryFactory::UpdateAvailable) {
       ui->filters->setCurrentItem(ui->filters->topLevelItem(i));
       break;
     }

--- a/src/filterlist.cpp
+++ b/src/filterlist.cpp
@@ -203,7 +203,7 @@ void FilterList::refresh()
   }
 }
 
-void FilterList::setSelection(std::vector<int> categories)
+void FilterList::setSelection(const std::vector<Criteria>& criteria)
 {
   for (int i = 0; i < ui->filters->topLevelItemCount(); ++i) {
     const auto* item = dynamic_cast<CriteriaItem*>(
@@ -213,9 +213,11 @@ void FilterList::setSelection(std::vector<int> categories)
       continue;
     }
 
-    if (item->id() == CategoryFactory::UpdateAvailable) {
-      ui->filters->setCurrentItem(ui->filters->topLevelItem(i));
-      break;
+    for (auto&& c : criteria) {
+      if (item->type() == c.type && item->id() == c.id) {
+        ui->filters->setCurrentItem(ui->filters->topLevelItem(i));
+        break;
+      }
     }
   }
 }

--- a/src/filterlist.cpp
+++ b/src/filterlist.cpp
@@ -50,6 +50,11 @@ public:
     return m_checkbox->isChecked();
   }
 
+  void setInverted(bool b)
+  {
+    m_checkbox->setChecked(b);
+  }
+
 private:
   const int IDRole = Qt::UserRole;
   const int TypeRole = Qt::UserRole + 1;
@@ -223,7 +228,7 @@ void FilterList::onSelection()
   const QModelIndexList indices = ui->filters->selectionModel()->selectedRows();
   std::vector<Criteria> criteria;
 
-  for (auto* item: ui->filters->selectedItems()) {
+  for (auto* item : ui->filters->selectedItems()) {
     const auto* ci = dynamic_cast<CriteriaItem*>(item);
     if (!ci) {
       continue;
@@ -242,8 +247,11 @@ void FilterList::onSelection()
 void FilterList::onContextMenu(const QPoint &pos)
 {
   QMenu menu;
+  menu.addAction(tr("Deselect filters"), [&]{ clearSelection(); });
+  menu.addAction(tr("Set inverted"), [&]{ toggleInverted(true); });
+  menu.addAction(tr("Unset inverted"), [&]{ toggleInverted(false); });
+  menu.addSeparator();
   menu.addAction(tr("Edit Categories..."), [&]{ editCategories(); });
-  menu.addAction(tr("Deselect filter"), [&]{ clearSelection(); });
 
   menu.exec(ui->filters->viewport()->mapToGlobal(pos));
 }
@@ -254,6 +262,27 @@ void FilterList::editCategories()
 
   if (dialog.exec() == QDialog::Accepted) {
     dialog.commitChanges();
+  }
+}
+
+void FilterList::toggleInverted(bool b)
+{
+  bool changed = false;
+
+  for (auto* item : ui->filters->selectedItems()) {
+    auto* ci = dynamic_cast<CriteriaItem*>(item);
+    if (!ci) {
+      continue;
+    }
+
+    if (ci->inverse() != b) {
+      ci->setInverted(b);
+      changed = true;
+    }
+  }
+
+  if (changed) {
+    onSelection();
   }
 }
 

--- a/src/filterlist.cpp
+++ b/src/filterlist.cpp
@@ -1,0 +1,189 @@
+#include "filterlist.h"
+#include "ui_mainwindow.h"
+#include "categories.h"
+#include "categoriesdialog.h"
+#include <utility.h>
+
+using namespace MOBase;
+
+FilterList::FilterList(Ui::MainWindow* ui, CategoryFactory& factory)
+  : ui(ui), m_factory(factory)
+{
+  QObject::connect(
+    ui->categoriesList, &QTreeWidget::customContextMenuRequested,
+    [&](auto&& pos){ onContextMenu(pos); });
+
+  QObject::connect(
+    ui->categoriesList, &QTreeWidget::itemSelectionChanged,
+    [&]{ onSelection(); });
+}
+
+QTreeWidgetItem* FilterList::addFilterItem(
+  QTreeWidgetItem *root, const QString &name, int categoryID,
+  ModListSortProxy::FilterType type)
+{
+  QTreeWidgetItem *item = new QTreeWidgetItem(QStringList(name));
+  item->setData(0, Qt::ToolTipRole, name);
+  item->setData(0, Qt::UserRole, categoryID);
+  item->setData(0, Qt::UserRole + 1, type);
+  if (root != nullptr) {
+    root->addChild(item);
+  } else {
+    ui->categoriesList->addTopLevelItem(item);
+  }
+  return item;
+}
+
+void FilterList::addContentFilters()
+{
+  for (unsigned i = 0; i < ModInfo::NUM_CONTENT_TYPES; ++i) {
+    addFilterItem(nullptr, tr("<Contains %1>").arg(ModInfo::getContentTypeName(i)), i, ModListSortProxy::TYPE_CONTENT);
+  }
+}
+
+void FilterList::addCategoryFilters(QTreeWidgetItem *root, const std::set<int> &categoriesUsed, int targetID)
+{
+  for (unsigned int i = 1;
+    i < static_cast<unsigned int>(m_factory.numCategories()); ++i) {
+    if ((m_factory.getParentID(i) == targetID)) {
+      int categoryID = m_factory.getCategoryID(i);
+      if (categoriesUsed.find(categoryID) != categoriesUsed.end()) {
+        QTreeWidgetItem *item =
+          addFilterItem(root, m_factory.getCategoryName(i),
+            categoryID, ModListSortProxy::TYPE_CATEGORY);
+        if (m_factory.hasChildren(i)) {
+          addCategoryFilters(item, categoriesUsed, categoryID);
+        }
+      }
+    }
+  }
+}
+
+void FilterList::refresh()
+{
+  QItemSelection currentSelection = ui->modList->selectionModel()->selection();
+
+  QVariant currentIndexName = ui->modList->currentIndex().data();
+  ui->modList->setCurrentIndex(QModelIndex());
+
+  QStringList selectedItems;
+  for (QTreeWidgetItem *item : ui->categoriesList->selectedItems()) {
+    selectedItems.append(item->text(0));
+  }
+
+  ui->categoriesList->clear();
+  addFilterItem(nullptr, tr("<Checked>"), CategoryFactory::CATEGORY_SPECIAL_CHECKED, ModListSortProxy::TYPE_SPECIAL);
+  addFilterItem(nullptr, tr("<Unchecked>"), CategoryFactory::CATEGORY_SPECIAL_UNCHECKED, ModListSortProxy::TYPE_SPECIAL);
+  addFilterItem(nullptr, tr("<Update>"), CategoryFactory::CATEGORY_SPECIAL_UPDATEAVAILABLE, ModListSortProxy::TYPE_SPECIAL);
+  addFilterItem(nullptr, tr("<Mod Backup>"), CategoryFactory::CATEGORY_SPECIAL_BACKUP, ModListSortProxy::TYPE_SPECIAL);
+  addFilterItem(nullptr, tr("<Managed by MO>"), CategoryFactory::CATEGORY_SPECIAL_MANAGED, ModListSortProxy::TYPE_SPECIAL);
+  addFilterItem(nullptr, tr("<Managed outside MO>"), CategoryFactory::CATEGORY_SPECIAL_UNMANAGED, ModListSortProxy::TYPE_SPECIAL);
+  addFilterItem(nullptr, tr("<No category>"), CategoryFactory::CATEGORY_SPECIAL_NOCATEGORY, ModListSortProxy::TYPE_SPECIAL);
+  addFilterItem(nullptr, tr("<Conflicted>"), CategoryFactory::CATEGORY_SPECIAL_CONFLICT, ModListSortProxy::TYPE_SPECIAL);
+  addFilterItem(nullptr, tr("<Not Endorsed>"), CategoryFactory::CATEGORY_SPECIAL_NOTENDORSED, ModListSortProxy::TYPE_SPECIAL);
+  addFilterItem(nullptr, tr("<No Nexus ID>"), CategoryFactory::CATEGORY_SPECIAL_NONEXUSID, ModListSortProxy::TYPE_SPECIAL);
+  addFilterItem(nullptr, tr("<No valid game data>"), CategoryFactory::CATEGORY_SPECIAL_NOGAMEDATA, ModListSortProxy::TYPE_SPECIAL);
+
+  addContentFilters();
+  std::set<int> categoriesUsed;
+  for (unsigned int modIdx = 0; modIdx < ModInfo::getNumMods(); ++modIdx) {
+    ModInfo::Ptr modInfo = ModInfo::getByIndex(modIdx);
+    for (int categoryID : modInfo->getCategories()) {
+      int currentID = categoryID;
+      std::set<int> cycleTest;
+      // also add parents so they show up in the tree
+      while (currentID != 0) {
+        categoriesUsed.insert(currentID);
+        if (!cycleTest.insert(currentID).second) {
+          log::warn("cycle in categories: {}", SetJoin(cycleTest, ", "));
+          break;
+        }
+        currentID = m_factory.getParentID(m_factory.getCategoryIndex(currentID));
+      }
+    }
+  }
+
+  addCategoryFilters(nullptr, categoriesUsed, 0);
+
+  for (const QString &item : selectedItems) {
+    QList<QTreeWidgetItem*> matches = ui->categoriesList->findItems(item, Qt::MatchFixedString | Qt::MatchRecursive);
+    if (matches.size() > 0) {
+      matches.at(0)->setSelected(true);
+    }
+  }
+  ui->modList->selectionModel()->select(currentSelection, QItemSelectionModel::Select);
+  QModelIndexList matchList;
+  if (currentIndexName.isValid()) {
+    matchList = ui->modList->model()->match(ui->modList->model()->index(0, 0), Qt::DisplayRole, currentIndexName);
+  }
+
+  if (matchList.size() > 0) {
+    ui->modList->setCurrentIndex(matchList.at(0));
+  }
+}
+
+void FilterList::setSelection(std::vector<int> categories)
+{
+  for (int i = 0; i < ui->categoriesList->topLevelItemCount(); ++i) {
+    if (ui->categoriesList->topLevelItem(i)->data(0, Qt::UserRole) == CategoryFactory::CATEGORY_SPECIAL_UPDATEAVAILABLE) {
+      ui->categoriesList->setCurrentItem(ui->categoriesList->topLevelItem(i));
+      break;
+    }
+  }
+}
+
+void FilterList::clearSelection()
+{
+  ui->categoriesList->clearSelection();
+}
+
+void FilterList::onSelection()
+{
+  QModelIndexList indices = ui->categoriesList->selectionModel()->selectedRows();
+  std::vector<int> categories;
+  std::vector<int> content;
+  for (const QModelIndex &index : indices) {
+    int filterType = index.data(Qt::UserRole + 1).toInt();
+    if ((filterType == ModListSortProxy::TYPE_CATEGORY)
+      || (filterType == ModListSortProxy::TYPE_SPECIAL)) {
+      int categoryId = index.data(Qt::UserRole).toInt();
+      if (categoryId != CategoryFactory::CATEGORY_NONE) {
+        categories.push_back(categoryId);
+      }
+    } else if (filterType == ModListSortProxy::TYPE_CONTENT) {
+      int contentId = index.data(Qt::UserRole).toInt();
+      content.push_back(contentId);
+    }
+  }
+
+  emit changed(categories, content);
+
+  ui->clickBlankButton->setEnabled(categories.size() > 0 || content.size() >0);
+
+  if (indices.count() == 0) {
+    ui->currentCategoryLabel->setText(QString("(%1)").arg(tr("<All>")));
+  } else if (indices.count() > 1) {
+    ui->currentCategoryLabel->setText(QString("(%1)").arg(tr("<Multiple>")));
+  } else {
+    ui->currentCategoryLabel->setText(QString("(%1)").arg(indices.first().data().toString()));
+  }
+  ui->modList->reset();
+}
+
+void FilterList::onContextMenu(const QPoint &pos)
+{
+  QMenu menu;
+  menu.addAction(tr("Edit Categories..."), [&]{ editCategories(); });
+  menu.addAction(tr("Deselect filter"), [&]{ clearSelection(); });
+
+  menu.exec(ui->categoriesList->viewport()->mapToGlobal(pos));
+}
+
+void FilterList::editCategories()
+{
+  CategoriesDialog dialog(qApp->activeWindow());
+
+  if (dialog.exec() == QDialog::Accepted) {
+    dialog.commitChanges();
+  }
+}

--- a/src/filterlist.h
+++ b/src/filterlist.h
@@ -19,8 +19,8 @@ public:
   void refresh();
 
 signals:
-  void filtersChanged(std::vector<int> categories, std::vector<int> content);
-  void criteriaChanged(ModListSortProxy::FilterMode mode, bool inverse, bool separators);
+  void criteriaChanged(std::vector<ModListSortProxy::Criteria> criteria);
+  void optionsChanged(ModListSortProxy::FilterMode mode, bool separators);
 
 private:
   Ui::MainWindow* ui;
@@ -32,14 +32,14 @@ private:
 
   void editCategories();
 
-  QTreeWidgetItem* addFilterItem(
+  QTreeWidgetItem* addCriteriaItem(
     QTreeWidgetItem *root, const QString &name, int categoryID,
-    ModListSortProxy::FilterType type);
+    ModListSortProxy::CriteriaType type);
 
-  void addContentFilters();
-  void addCategoryFilters(
+  void addContentCriteria();
+  void addCategoryCriteria(
     QTreeWidgetItem *root, const std::set<int> &categoriesUsed, int targetID);
-  void addSpecialFilterItem(int type);
+  void addSpecialCriteria(int type);
 
 };
 

--- a/src/filterlist.h
+++ b/src/filterlist.h
@@ -19,7 +19,8 @@ public:
   void refresh();
 
 signals:
-  void changed(std::vector<int> categories, std::vector<int> content);
+  void filtersChanged(std::vector<int> categories, std::vector<int> content);
+  void criteriaChanged(ModListSortProxy::FilterMode mode, bool inverse, bool separators);
 
 private:
   Ui::MainWindow* ui;
@@ -27,6 +28,7 @@ private:
 
   void onContextMenu(const QPoint &pos);
   void onSelection();
+  void onCriteriaChanged();
 
   void editCategories();
 
@@ -37,6 +39,8 @@ private:
   void addContentFilters();
   void addCategoryFilters(
     QTreeWidgetItem *root, const std::set<int> &categoriesUsed, int targetID);
+  void addSpecialFilterItem(int type);
+
 };
 
 #endif // MODORGANIZER_CATEGORIESLIST_INCLUDED

--- a/src/filterlist.h
+++ b/src/filterlist.h
@@ -6,6 +6,7 @@
 
 namespace Ui { class MainWindow; };
 class CategoryFactory;
+class Settings;
 
 class FilterList : public QObject
 {
@@ -14,13 +15,17 @@ class FilterList : public QObject
 public:
   FilterList(Ui::MainWindow* ui, CategoryFactory& factory);
 
+  void restoreState(const Settings& s);
+  void saveState(Settings& s) const;
+
   void setSelection(const std::vector<ModListSortProxy::Criteria>& criteria);
   void clearSelection();
   void refresh();
 
 signals:
   void criteriaChanged(std::vector<ModListSortProxy::Criteria> criteria);
-  void optionsChanged(ModListSortProxy::FilterMode mode, bool separators);
+  void optionsChanged(
+    ModListSortProxy::FilterMode mode, ModListSortProxy::SeparatorsMode sep);
 
 private:
   class CriteriaItem;

--- a/src/filterlist.h
+++ b/src/filterlist.h
@@ -23,6 +23,8 @@ signals:
   void optionsChanged(ModListSortProxy::FilterMode mode, bool separators);
 
 private:
+  class CriteriaItem;
+
   Ui::MainWindow* ui;
   CategoryFactory& m_factory;
 

--- a/src/filterlist.h
+++ b/src/filterlist.h
@@ -33,6 +33,7 @@ private:
   void onCriteriaChanged();
 
   void editCategories();
+  void toggleInverted(bool b);
 
   QTreeWidgetItem* addCriteriaItem(
     QTreeWidgetItem *root, const QString &name, int categoryID,

--- a/src/filterlist.h
+++ b/src/filterlist.h
@@ -1,0 +1,42 @@
+#ifndef MODORGANIZER_CATEGORIESLIST_INCLUDED
+#define MODORGANIZER_CATEGORIESLIST_INCLUDED
+
+#include "modlistsortproxy.h"
+#include <QTreeWidgetItem>
+
+namespace Ui { class MainWindow; };
+class CategoryFactory;
+
+class FilterList : public QObject
+{
+  Q_OBJECT;
+
+public:
+  FilterList(Ui::MainWindow* ui, CategoryFactory& factory);
+
+  void setSelection(std::vector<int> categories);
+  void clearSelection();
+  void refresh();
+
+signals:
+  void changed(std::vector<int> categories, std::vector<int> content);
+
+private:
+  Ui::MainWindow* ui;
+  CategoryFactory& m_factory;
+
+  void onContextMenu(const QPoint &pos);
+  void onSelection();
+
+  void editCategories();
+
+  QTreeWidgetItem* addFilterItem(
+    QTreeWidgetItem *root, const QString &name, int categoryID,
+    ModListSortProxy::FilterType type);
+
+  void addContentFilters();
+  void addCategoryFilters(
+    QTreeWidgetItem *root, const std::set<int> &categoriesUsed, int targetID);
+};
+
+#endif // MODORGANIZER_CATEGORIESLIST_INCLUDED

--- a/src/filterlist.h
+++ b/src/filterlist.h
@@ -14,7 +14,7 @@ class FilterList : public QObject
 public:
   FilterList(Ui::MainWindow* ui, CategoryFactory& factory);
 
-  void setSelection(std::vector<int> categories);
+  void setSelection(const std::vector<ModListSortProxy::Criteria>& criteria);
   void clearSelection();
   void refresh();
 

--- a/src/filterlist.h
+++ b/src/filterlist.h
@@ -28,13 +28,11 @@ private:
   Ui::MainWindow* ui;
   CategoryFactory& m_factory;
 
-  void onContextMenu(const QPoint &pos);
-  void onSelection();
-  void onCriteriaChanged();
+  bool onClick(QMouseEvent* e);
+  void onOptionsChanged();
 
-  void clear();
-  void toggleInverted(bool b);
   void editCategories();
+  void checkCriteria();
 
   QTreeWidgetItem* addCriteriaItem(
     QTreeWidgetItem *root, const QString &name, int categoryID,

--- a/src/filterlist.h
+++ b/src/filterlist.h
@@ -32,8 +32,9 @@ private:
   void onSelection();
   void onCriteriaChanged();
 
-  void editCategories();
+  void clear();
   void toggleInverted(bool b);
+  void editCategories();
 
   QTreeWidgetItem* addCriteriaItem(
     QTreeWidgetItem *root, const QString &name, int categoryID,

--- a/src/mainwindow.cpp
+++ b/src/mainwindow.cpp
@@ -269,7 +269,7 @@ MainWindow::MainWindow(Settings &settings
 
   connect(
     m_Filters.get(), &FilterList::optionsChanged,
-    [&](auto mode, bool sep) { onFiltersOptions(mode, sep); });
+    [&](auto&& mode, auto&& sep) { onFiltersOptions(mode, sep); });
 
   ui->logList->setCore(m_OrganizerCore);
 
@@ -2205,6 +2205,7 @@ void MainWindow::readSettings()
   }
 
   s.widgets().restoreIndex(ui->groupCombo);
+  m_Filters->restoreState(s);
 
   {
     s.geometry().restoreVisibility(ui->categoriesGroup, false);
@@ -2283,6 +2284,8 @@ void MainWindow::storeSettings()
 
   s.widgets().saveIndex(ui->groupCombo);
   s.widgets().saveIndex(ui->executablesListBox);
+
+  m_Filters->saveState(s);
 }
 
 QWidget* MainWindow::qtWidget()
@@ -4125,13 +4128,13 @@ void MainWindow::checkModsForUpdates()
 
   if (updatesAvailable || checkingModsForUpdate) {
     m_ModListSortProxy->setCriteria({{
-        ModListSortProxy::TYPE_SPECIAL,
+        ModListSortProxy::TypeSpecial,
         CategoryFactory::UpdateAvailable,
         false}
     });
 
     m_Filters->setSelection({{
-      ModListSortProxy::TYPE_SPECIAL,
+      ModListSortProxy::TypeSpecial,
       CategoryFactory::UpdateAvailable,
       false
     }});
@@ -6131,7 +6134,7 @@ void MainWindow::onFiltersCriteria(const std::vector<ModListSortProxy::Criteria>
   } else if (criteria.size() == 1) {
     const auto& c = criteria[0];
 
-    if (c.type == ModListSortProxy::TYPE_CONTENT) {
+    if (c.type == ModListSortProxy::TypeContent) {
       label = ModInfo::getContentTypeName(c.id);
     } else {
       label = m_CategoryFactory.getCategoryNameByID(c.id);
@@ -6148,9 +6151,10 @@ void MainWindow::onFiltersCriteria(const std::vector<ModListSortProxy::Criteria>
   ui->modList->reset();
 }
 
-void MainWindow::onFiltersOptions(ModListSortProxy::FilterMode mode, bool separators)
+void MainWindow::onFiltersOptions(
+  ModListSortProxy::FilterMode mode, ModListSortProxy::SeparatorsMode sep)
 {
-  m_ModListSortProxy->setOptions(mode, separators);
+  m_ModListSortProxy->setOptions(mode, sep);
 }
 
 void MainWindow::updateESPLock(bool locked)

--- a/src/mainwindow.cpp
+++ b/src/mainwindow.cpp
@@ -6557,6 +6557,11 @@ void MainWindow::on_categoriesNotBtn_toggled(bool checked)
   m_ModListSortProxy->setFilterNot(checked);
 }
 
+void MainWindow::on_categoriesSeparators_toggled(bool checked)
+{
+  m_ModListSortProxy->setFilterSeparators(checked);
+}
+
 void MainWindow::on_managedArchiveLabel_linkHovered(const QString&)
 {
   QToolTip::showText(QCursor::pos(),

--- a/src/mainwindow.cpp
+++ b/src/mainwindow.cpp
@@ -4130,7 +4130,11 @@ void MainWindow::checkModsForUpdates()
         false}
     });
 
-    m_Filters->setSelection({CategoryFactory::UpdateAvailable});
+    m_Filters->setSelection({{
+      ModListSortProxy::TYPE_SPECIAL,
+      CategoryFactory::UpdateAvailable,
+      false
+    }});
   }
 }
 

--- a/src/mainwindow.cpp
+++ b/src/mainwindow.cpp
@@ -4126,11 +4126,11 @@ void MainWindow::checkModsForUpdates()
   if (updatesAvailable || checkingModsForUpdate) {
     m_ModListSortProxy->setCriteria({{
         ModListSortProxy::TYPE_SPECIAL,
-        CategoryFactory::CATEGORY_SPECIAL_UPDATEAVAILABLE,
+        CategoryFactory::UpdateAvailable,
         false}
     });
 
-    m_Filters->setSelection({CategoryFactory::CATEGORY_SPECIAL_UPDATEAVAILABLE});
+    m_Filters->setSelection({CategoryFactory::UpdateAvailable});
   }
 }
 

--- a/src/mainwindow.cpp
+++ b/src/mainwindow.cpp
@@ -6552,6 +6552,11 @@ void MainWindow::on_categoriesOrBtn_toggled(bool checked)
   }
 }
 
+void MainWindow::on_categoriesNotBtn_toggled(bool checked)
+{
+  m_ModListSortProxy->setFilterNot(checked);
+}
+
 void MainWindow::on_managedArchiveLabel_linkHovered(const QString&)
 {
   QToolTip::showText(QCursor::pos(),

--- a/src/mainwindow.cpp
+++ b/src/mainwindow.cpp
@@ -6126,9 +6126,15 @@ void MainWindow::onFiltersCriteria(const std::vector<ModListSortProxy::Criteria>
     label = "";
   } else if (criteria.size() == 1) {
     const auto& c = criteria[0];
-    label = m_CategoryFactory.getCategoryNameByID(c.id);
+
+    if (c.type == ModListSortProxy::TYPE_CONTENT) {
+      label = ModInfo::getContentTypeName(c.id);
+    } else {
+      label = m_CategoryFactory.getCategoryNameByID(c.id);
+    }
+
     if (label.isEmpty()) {
-      log::error("category '{}' not found", c.id);
+      log::error("category {}:{} not found", c.type, c.id);
     }
   } else {
     label = tr("<Multiple>");

--- a/src/mainwindow.cpp
+++ b/src/mainwindow.cpp
@@ -75,6 +75,7 @@ along with Mod Organizer.  If not, see <http://www.gnu.org/licenses/>.
 #include "appconfig.h"
 #include "eventfilter.h"
 #include "statusbar.h"
+#include "filterlist.h"
 #include <utility.h>
 #include <dataarchives.h>
 #include <bsainvalidation.h>
@@ -260,6 +261,11 @@ MainWindow::MainWindow(Settings &settings
   languageChange(settings.interface().language());
 
   m_CategoryFactory.loadCategories();
+  m_Filters.reset(new FilterList(ui, m_CategoryFactory));
+  connect(m_Filters.get(), &FilterList::changed, [&](auto&& cats, auto&& content) {
+    m_ModListSortProxy->setCategoryFilter(cats);
+    m_ModListSortProxy->setContentFilter(content);
+  });
 
   ui->logList->setCore(m_OrganizerCore);
 
@@ -1223,7 +1229,7 @@ void MainWindow::showEvent(QShowEvent *event)
 
   if (!m_WasVisible) {
     readSettings();
-    refreshFilters();
+    m_Filters->refresh();
 
     // this needs to be connected here instead of in the constructor because the
     // actual changing of the stylesheet is done by MOApplication, which
@@ -2646,108 +2652,6 @@ void MainWindow::fileMoved(const QString &filePath, const QString &oldOriginName
   }
 }
 
-QTreeWidgetItem *MainWindow::addFilterItem(QTreeWidgetItem *root, const QString &name, int categoryID, ModListSortProxy::FilterType type)
-{
-  QTreeWidgetItem *item = new QTreeWidgetItem(QStringList(name));
-  item->setData(0, Qt::ToolTipRole, name);
-  item->setData(0, Qt::UserRole, categoryID);
-  item->setData(0, Qt::UserRole + 1, type);
-  if (root != nullptr) {
-    root->addChild(item);
-  } else {
-    ui->categoriesList->addTopLevelItem(item);
-  }
-  return item;
-}
-
-void MainWindow::addContentFilters()
-{
-  for (unsigned i = 0; i < ModInfo::NUM_CONTENT_TYPES; ++i) {
-    addFilterItem(nullptr, tr("<Contains %1>").arg(ModInfo::getContentTypeName(i)), i, ModListSortProxy::TYPE_CONTENT);
-  }
-}
-
-void MainWindow::addCategoryFilters(QTreeWidgetItem *root, const std::set<int> &categoriesUsed, int targetID)
-{
-  for (unsigned int i = 1;
-       i < static_cast<unsigned int>(m_CategoryFactory.numCategories()); ++i) {
-    if ((m_CategoryFactory.getParentID(i) == targetID)) {
-      int categoryID = m_CategoryFactory.getCategoryID(i);
-      if (categoriesUsed.find(categoryID) != categoriesUsed.end()) {
-        QTreeWidgetItem *item =
-            addFilterItem(root, m_CategoryFactory.getCategoryName(i),
-                          categoryID, ModListSortProxy::TYPE_CATEGORY);
-        if (m_CategoryFactory.hasChildren(i)) {
-          addCategoryFilters(item, categoriesUsed, categoryID);
-        }
-      }
-    }
-  }
-}
-
-void MainWindow::refreshFilters()
-{
-  QItemSelection currentSelection = ui->modList->selectionModel()->selection();
-
-  QVariant currentIndexName = ui->modList->currentIndex().data();
-  ui->modList->setCurrentIndex(QModelIndex());
-
-  QStringList selectedItems;
-  for (QTreeWidgetItem *item : ui->categoriesList->selectedItems()) {
-    selectedItems.append(item->text(0));
-  }
-
-  ui->categoriesList->clear();
-  addFilterItem(nullptr, tr("<Checked>"), CategoryFactory::CATEGORY_SPECIAL_CHECKED, ModListSortProxy::TYPE_SPECIAL);
-  addFilterItem(nullptr, tr("<Unchecked>"), CategoryFactory::CATEGORY_SPECIAL_UNCHECKED, ModListSortProxy::TYPE_SPECIAL);
-  addFilterItem(nullptr, tr("<Update>"), CategoryFactory::CATEGORY_SPECIAL_UPDATEAVAILABLE, ModListSortProxy::TYPE_SPECIAL);
-  addFilterItem(nullptr, tr("<Mod Backup>"), CategoryFactory::CATEGORY_SPECIAL_BACKUP, ModListSortProxy::TYPE_SPECIAL);
-  addFilterItem(nullptr, tr("<Managed by MO>"), CategoryFactory::CATEGORY_SPECIAL_MANAGED, ModListSortProxy::TYPE_SPECIAL);
-  addFilterItem(nullptr, tr("<Managed outside MO>"), CategoryFactory::CATEGORY_SPECIAL_UNMANAGED, ModListSortProxy::TYPE_SPECIAL);
-  addFilterItem(nullptr, tr("<No category>"), CategoryFactory::CATEGORY_SPECIAL_NOCATEGORY, ModListSortProxy::TYPE_SPECIAL);
-  addFilterItem(nullptr, tr("<Conflicted>"), CategoryFactory::CATEGORY_SPECIAL_CONFLICT, ModListSortProxy::TYPE_SPECIAL);
-  addFilterItem(nullptr, tr("<Not Endorsed>"), CategoryFactory::CATEGORY_SPECIAL_NOTENDORSED, ModListSortProxy::TYPE_SPECIAL);
-  addFilterItem(nullptr, tr("<No Nexus ID>"), CategoryFactory::CATEGORY_SPECIAL_NONEXUSID, ModListSortProxy::TYPE_SPECIAL);
-  addFilterItem(nullptr, tr("<No valid game data>"), CategoryFactory::CATEGORY_SPECIAL_NOGAMEDATA, ModListSortProxy::TYPE_SPECIAL);
-
-  addContentFilters();
-  std::set<int> categoriesUsed;
-  for (unsigned int modIdx = 0; modIdx < ModInfo::getNumMods(); ++modIdx) {
-    ModInfo::Ptr modInfo = ModInfo::getByIndex(modIdx);
-    for (int categoryID : modInfo->getCategories()) {
-      int currentID = categoryID;
-      std::set<int> cycleTest;
-      // also add parents so they show up in the tree
-      while (currentID != 0) {
-        categoriesUsed.insert(currentID);
-        if (!cycleTest.insert(currentID).second) {
-          log::warn("cycle in categories: {}", SetJoin(cycleTest, ", "));
-          break;
-        }
-        currentID = m_CategoryFactory.getParentID(m_CategoryFactory.getCategoryIndex(currentID));
-      }
-    }
-  }
-
-  addCategoryFilters(nullptr, categoriesUsed, 0);
-
-  for (const QString &item : selectedItems) {
-    QList<QTreeWidgetItem*> matches = ui->categoriesList->findItems(item, Qt::MatchFixedString | Qt::MatchRecursive);
-    if (matches.size() > 0) {
-      matches.at(0)->setSelected(true);
-    }
-  }
-  ui->modList->selectionModel()->select(currentSelection, QItemSelectionModel::Select);
-  QModelIndexList matchList;
-  if (currentIndexName.isValid()) {
-    matchList = ui->modList->model()->match(ui->modList->model()->index(0, 0), Qt::DisplayRole, currentIndexName);
-  }
-
-  if (matchList.size() > 0) {
-    ui->modList->setCurrentIndex(matchList.at(0));
-  }
-}
-
 
 void MainWindow::renameMod_clicked()
 {
@@ -4121,7 +4025,7 @@ void MainWindow::addRemoveCategories_MenuHandler() {
     m_OrganizerCore.modList()->notifyChange(m_ContextRow);
   }
 
-  refreshFilters();
+  m_Filters->refresh();
 }
 
 void MainWindow::replaceCategories_MenuHandler() {
@@ -4165,7 +4069,7 @@ void MainWindow::replaceCategories_MenuHandler() {
     m_OrganizerCore.modList()->notifyChange(m_ContextRow);
   }
 
-  refreshFilters();
+  m_Filters->refresh();
 }
 
 void MainWindow::saveArchiveList()
@@ -4217,12 +4121,7 @@ void MainWindow::checkModsForUpdates()
 
   if (updatesAvailable || checkingModsForUpdate) {
     m_ModListSortProxy->setCategoryFilter(boost::assign::list_of(CategoryFactory::CATEGORY_SPECIAL_UPDATEAVAILABLE));
-    for (int i = 0; i < ui->categoriesList->topLevelItemCount(); ++i) {
-      if (ui->categoriesList->topLevelItem(i)->data(0, Qt::UserRole) == CategoryFactory::CATEGORY_SPECIAL_UPDATEAVAILABLE) {
-        ui->categoriesList->setCurrentItem(ui->categoriesList->topLevelItem(i));
-        break;
-      }
-    }
+    m_Filters->setSelection({CategoryFactory::CATEGORY_SPECIAL_UPDATEAVAILABLE});
   }
 }
 
@@ -4848,40 +4747,6 @@ void MainWindow::on_modList_customContextMenuRequested(const QPoint &pos)
 }
 
 
-void MainWindow::on_categoriesList_itemSelectionChanged()
-{
-  QModelIndexList indices = ui->categoriesList->selectionModel()->selectedRows();
-  std::vector<int> categories;
-  std::vector<int> content;
-  for (const QModelIndex &index : indices) {
-    int filterType = index.data(Qt::UserRole + 1).toInt();
-    if ((filterType == ModListSortProxy::TYPE_CATEGORY)
-        || (filterType == ModListSortProxy::TYPE_SPECIAL)) {
-      int categoryId = index.data(Qt::UserRole).toInt();
-      if (categoryId != CategoryFactory::CATEGORY_NONE) {
-        categories.push_back(categoryId);
-      }
-    } else if (filterType == ModListSortProxy::TYPE_CONTENT) {
-      int contentId = index.data(Qt::UserRole).toInt();
-      content.push_back(contentId);
-    }
-  }
-
-  m_ModListSortProxy->setCategoryFilter(categories);
-  m_ModListSortProxy->setContentFilter(content);
-  ui->clickBlankButton->setEnabled(categories.size() > 0 || content.size() >0);
-
-  if (indices.count() == 0) {
-    ui->currentCategoryLabel->setText(QString("(%1)").arg(tr("<All>")));
-  } else if (indices.count() > 1) {
-    ui->currentCategoryLabel->setText(QString("(%1)").arg(tr("<Multiple>")));
-  } else {
-    ui->currentCategoryLabel->setText(QString("(%1)").arg(indices.first().data().toString()));
-  }
-  ui->modList->reset();
-}
-
-
 void MainWindow::deleteSavegame_clicked()
 {
   SaveGameInfo const *info = m_OrganizerCore.managedGame()->feature<SaveGameInfo>();
@@ -5071,7 +4936,7 @@ void MainWindow::on_actionSettings_triggered()
   instManager->setDownloadDirectory(settings.paths().downloads());
 
   fixCategories();
-  refreshFilters();
+  m_Filters->refresh();
 
   if (settings.paths().profiles() != oldProfilesDirectory) {
     refreshProfiles();
@@ -6213,27 +6078,9 @@ void MainWindow::on_displayCategoriesBtn_toggled(bool checked)
   setCategoryListVisible(checked);
 }
 
-void MainWindow::editCategories()
-{
-  CategoriesDialog dialog(this);
-
-  if (dialog.exec() == QDialog::Accepted) {
-    dialog.commitChanges();
-  }
-}
-
 void MainWindow::deselectFilters()
 {
-  ui->categoriesList->clearSelection();
-}
-
-void MainWindow::on_categoriesList_customContextMenuRequested(const QPoint &pos)
-{
-  QMenu menu;
-  menu.addAction(tr("Edit Categories..."), this, SLOT(editCategories()));
-  menu.addAction(tr("Deselect filter"), this, SLOT(deselectFilters()));
-
-  menu.exec(ui->categoriesList->viewport()->mapToGlobal(pos));
+  m_Filters->clearSelection();
 }
 
 

--- a/src/mainwindow.h
+++ b/src/mainwindow.h
@@ -514,8 +514,8 @@ private slots:
 
   void deselectFilters();
   void refreshFilters();
-  void onFilters(const std::vector<int>& categories, const std::vector<int>& content);
-  void onFiltersCriteria(ModListSortProxy::FilterMode mode, bool inverse, bool separators);
+  void onFiltersCriteria(const std::vector<ModListSortProxy::Criteria>& filters);
+  void onFiltersOptions(ModListSortProxy::FilterMode mode, bool separators);
 
   void displayModInformation(const QString &modName, ModInfoTabIDs tabID);
 

--- a/src/mainwindow.h
+++ b/src/mainwindow.h
@@ -39,6 +39,7 @@ along with Mod Organizer.  If not, see <http://www.gnu.org/licenses/>.
 class Executable;
 class CategoryFactory;
 class OrganizerCore;
+class FilterList;
 
 class PluginListSortProxy;
 namespace BSA { class Archive; }
@@ -235,8 +236,6 @@ private:
 
   void writeDataToFile(QFile &file, const QString &directory, const MOShared::DirectoryEntry &directoryEntry);
 
-  void refreshFilters();
-
   /**
    * Sets category selections from menu; for multiple mods, this will only apply
    * the changes made in the menu (which is the delta between the current menu selection and the reference mod)
@@ -265,10 +264,6 @@ private:
   bool extractProgress(QProgressDialog &extractProgress, int percentage, std::string fileName);
 
   size_t checkForProblems();
-
-  QTreeWidgetItem *addFilterItem(QTreeWidgetItem *root, const QString &name, int categoryID, ModListSortProxy::FilterType type);
-  void addContentFilters();
-  void addCategoryFilters(QTreeWidgetItem *root, const std::set<int> &categoriesUsed, int targetID);
 
   void setCategoryListVisible(bool visible);
 
@@ -326,6 +321,8 @@ private:
   QAction* m_linksSeparator;
 
   MOBase::TutorialControl m_Tutorial;
+
+  std::unique_ptr<FilterList> m_Filters;
 
   int m_OldProfileIndex;
 
@@ -515,7 +512,6 @@ private slots:
 
   void onRequestsChanged(const APIStats& stats, const APIUserAccount& user);
 
-  void editCategories();
   void deselectFilters();
 
   void displayModInformation(const QString &modName, ModInfoTabIDs tabID);
@@ -630,7 +626,6 @@ private slots: // ui slots
   void on_clearFiltersButton_clicked();
   void on_btnRefreshData_clicked();
   void on_btnRefreshDownloads_clicked();
-  void on_categoriesList_customContextMenuRequested(const QPoint &pos);
   void on_conflictsCheckBox_toggled(bool checked);
   void on_showArchiveDataCheckBox_toggled(bool checked);
   void on_dataTree_customContextMenuRequested(const QPoint &pos);
@@ -647,7 +642,6 @@ private slots: // ui slots
   void on_espList_customContextMenuRequested(const QPoint &pos);
   void on_displayCategoriesBtn_toggled(bool checked);
   void on_groupCombo_currentIndexChanged(int index);
-  void on_categoriesList_itemSelectionChanged();
   void on_linkButton_pressed();
   void on_showHiddenBox_toggled(bool checked);
   void on_bsaList_itemChanged(QTreeWidgetItem *item, int column);

--- a/src/mainwindow.h
+++ b/src/mainwindow.h
@@ -515,7 +515,8 @@ private slots:
   void deselectFilters();
   void refreshFilters();
   void onFiltersCriteria(const std::vector<ModListSortProxy::Criteria>& filters);
-  void onFiltersOptions(ModListSortProxy::FilterMode mode, bool separators);
+  void onFiltersOptions(
+    ModListSortProxy::FilterMode mode, ModListSortProxy::SeparatorsMode sep);
 
   void displayModInformation(const QString &modName, ModInfoTabIDs tabID);
 

--- a/src/mainwindow.h
+++ b/src/mainwindow.h
@@ -513,6 +513,9 @@ private slots:
   void onRequestsChanged(const APIStats& stats, const APIUserAccount& user);
 
   void deselectFilters();
+  void refreshFilters();
+  void onFilters(const std::vector<int>& categories, const std::vector<int>& content);
+  void onFiltersCriteria(ModListSortProxy::FilterMode mode, bool inverse, bool separators);
 
   void displayModInformation(const QString &modName, ModInfoTabIDs tabID);
 
@@ -651,10 +654,6 @@ private slots: // ui slots
   void on_restoreButton_clicked();
   void on_restoreModsButton_clicked();
   void on_saveModsButton_clicked();
-  void on_categoriesAndBtn_toggled(bool checked);
-  void on_categoriesOrBtn_toggled(bool checked);
-  void on_categoriesNotBtn_toggled(bool checked);
-  void on_categoriesSeparators_toggled(bool checked);
   void on_managedArchiveLabel_linkHovered(const QString &link);
 
   void storeSettings();

--- a/src/mainwindow.h
+++ b/src/mainwindow.h
@@ -660,6 +660,7 @@ private slots: // ui slots
   void on_categoriesAndBtn_toggled(bool checked);
   void on_categoriesOrBtn_toggled(bool checked);
   void on_categoriesNotBtn_toggled(bool checked);
+  void on_categoriesSeparators_toggled(bool checked);
   void on_managedArchiveLabel_linkHovered(const QString &link);
 
   void storeSettings();

--- a/src/mainwindow.h
+++ b/src/mainwindow.h
@@ -659,6 +659,7 @@ private slots: // ui slots
   void on_saveModsButton_clicked();
   void on_categoriesAndBtn_toggled(bool checked);
   void on_categoriesOrBtn_toggled(bool checked);
+  void on_categoriesNotBtn_toggled(bool checked);
   void on_managedArchiveLabel_linkHovered(const QString &link);
 
   void storeSettings();

--- a/src/mainwindow.ui
+++ b/src/mainwindow.ui
@@ -114,9 +114,6 @@
         </item>
         <item>
          <widget class="QPushButton" name="filtersClear">
-          <property name="enabled">
-           <bool>false</bool>
-          </property>
           <property name="sizePolicy">
            <sizepolicy hsizetype="Minimum" vsizetype="Maximum">
             <horstretch>0</horstretch>
@@ -131,9 +128,6 @@
           </property>
           <property name="text">
            <string>Clear</string>
-          </property>
-          <property name="flat">
-           <bool>true</bool>
           </property>
          </widget>
         </item>

--- a/src/mainwindow.ui
+++ b/src/mainwindow.ui
@@ -159,6 +159,13 @@
              </property>
             </widget>
            </item>
+           <item>
+            <widget class="QCheckBox" name="categoriesSeparators">
+             <property name="text">
+              <string>Separators</string>
+             </property>
+            </widget>
+           </item>
           </layout>
          </widget>
         </item>

--- a/src/mainwindow.ui
+++ b/src/mainwindow.ui
@@ -153,6 +153,18 @@
            </sizepolicy>
           </property>
           <layout class="QHBoxLayout" name="horizontalLayout_11">
+           <property name="leftMargin">
+            <number>0</number>
+           </property>
+           <property name="topMargin">
+            <number>2</number>
+           </property>
+           <property name="rightMargin">
+            <number>0</number>
+           </property>
+           <property name="bottomMargin">
+            <number>0</number>
+           </property>
            <item>
             <widget class="QRadioButton" name="filtersAnd">
              <property name="toolTip">
@@ -177,12 +189,11 @@
             </widget>
            </item>
            <item>
-            <widget class="QCheckBox" name="filtersSeparators">
+            <widget class="QComboBox" name="filtersSeparators">
              <property name="toolTip">
-              <string>Include separators</string>
-             </property>
-             <property name="text">
-              <string>Separators</string>
+              <string>Filter: only show the separators that match the current filters
+Show: always show separators
+Hide: never show separators</string>
              </property>
             </widget>
            </item>

--- a/src/mainwindow.ui
+++ b/src/mainwindow.ui
@@ -76,59 +76,69 @@
             <height>0</height>
            </size>
           </property>
-          <property name="contextMenuPolicy">
-           <enum>Qt::CustomContextMenu</enum>
-          </property>
           <property name="selectionMode">
-           <enum>QAbstractItemView::ExtendedSelection</enum>
+           <enum>QAbstractItemView::NoSelection</enum>
           </property>
           <property name="indentation">
            <number>0</number>
+          </property>
+          <property name="rootIsDecorated">
+           <bool>false</bool>
           </property>
           <property name="uniformRowHeights">
            <bool>true</bool>
           </property>
           <property name="headerHidden">
-           <bool>false</bool>
+           <bool>true</bool>
           </property>
           <attribute name="headerVisible">
-           <bool>true</bool>
-          </attribute>
-          <attribute name="headerCascadingSectionResizes">
-           <bool>true</bool>
-          </attribute>
-          <attribute name="headerStretchLastSection">
            <bool>false</bool>
           </attribute>
+          <attribute name="headerCascadingSectionResizes">
+           <bool>false</bool>
+          </attribute>
+          <column>
+           <property name="text">
+            <string/>
+           </property>
+          </column>
           <column>
            <property name="text">
             <string notr="true">Category</string>
            </property>
           </column>
-          <column>
-           <property name="text">
-            <string>Invert</string>
-           </property>
-          </column>
          </widget>
         </item>
         <item>
-         <widget class="QPushButton" name="filtersClear">
-          <property name="sizePolicy">
-           <sizepolicy hsizetype="Minimum" vsizetype="Maximum">
-            <horstretch>0</horstretch>
-            <verstretch>0</verstretch>
-           </sizepolicy>
-          </property>
-          <property name="minimumSize">
-           <size>
-            <width>0</width>
-            <height>25</height>
-           </size>
-          </property>
-          <property name="text">
-           <string>Clear</string>
-          </property>
+         <widget class="QWidget" name="widget_2" native="true">
+          <layout class="QHBoxLayout" name="horizontalLayout_8">
+           <property name="leftMargin">
+            <number>0</number>
+           </property>
+           <property name="topMargin">
+            <number>2</number>
+           </property>
+           <property name="rightMargin">
+            <number>0</number>
+           </property>
+           <property name="bottomMargin">
+            <number>0</number>
+           </property>
+           <item>
+            <widget class="QPushButton" name="filtersClear">
+             <property name="text">
+              <string>Clear</string>
+             </property>
+            </widget>
+           </item>
+           <item>
+            <widget class="QPushButton" name="filtersEdit">
+             <property name="text">
+              <string>Edit...</string>
+             </property>
+            </widget>
+           </item>
+          </layout>
          </widget>
         </item>
         <item>

--- a/src/mainwindow.ui
+++ b/src/mainwindow.ui
@@ -76,6 +76,9 @@
             <height>0</height>
            </size>
           </property>
+          <property name="contextMenuPolicy">
+           <enum>Qt::NoContextMenu</enum>
+          </property>
           <property name="selectionMode">
            <enum>QAbstractItemView::NoSelection</enum>
           </property>

--- a/src/mainwindow.ui
+++ b/src/mainwindow.ui
@@ -47,7 +47,7 @@
         </size>
        </property>
        <property name="title">
-        <string>Categories</string>
+        <string>Filters</string>
        </property>
        <layout class="QVBoxLayout" name="verticalLayout_10" stretch="6,0,0">
         <property name="spacing">

--- a/src/mainwindow.ui
+++ b/src/mainwindow.ui
@@ -132,7 +132,7 @@
            <item>
             <widget class="QRadioButton" name="categoriesAndBtn">
              <property name="toolTip">
-              <string>If checked, only mods that match all selected categories are displayed.</string>
+              <string>Display mods that match all selected categories.</string>
              </property>
              <property name="text">
               <string>And</string>
@@ -145,7 +145,7 @@
            <item>
             <widget class="QRadioButton" name="categoriesOrBtn">
              <property name="toolTip">
-              <string>If checked, all mods that match at least one of the selected categories are displayed.</string>
+              <string>Display mods that match at least one of the selected categories</string>
              </property>
              <property name="text">
               <string>Or</string>
@@ -154,6 +154,9 @@
            </item>
            <item>
             <widget class="QCheckBox" name="categoriesNotBtn">
+             <property name="toolTip">
+              <string>Invert each selected category</string>
+             </property>
              <property name="text">
               <string>Not</string>
              </property>
@@ -161,6 +164,9 @@
            </item>
            <item>
             <widget class="QCheckBox" name="categoriesSeparators">
+             <property name="toolTip">
+              <string>Include separators</string>
+             </property>
              <property name="text">
               <string>Separators</string>
              </property>

--- a/src/mainwindow.ui
+++ b/src/mainwindow.ui
@@ -152,6 +152,13 @@
              </property>
             </widget>
            </item>
+           <item>
+            <widget class="QCheckBox" name="categoriesNotBtn">
+             <property name="text">
+              <string>Not</string>
+             </property>
+            </widget>
+           </item>
           </layout>
          </widget>
         </item>

--- a/src/mainwindow.ui
+++ b/src/mainwindow.ui
@@ -85,12 +85,26 @@
           <property name="uniformRowHeights">
            <bool>true</bool>
           </property>
+          <property name="headerHidden">
+           <bool>false</bool>
+          </property>
           <attribute name="headerVisible">
+           <bool>true</bool>
+          </attribute>
+          <attribute name="headerCascadingSectionResizes">
+           <bool>true</bool>
+          </attribute>
+          <attribute name="headerStretchLastSection">
            <bool>false</bool>
           </attribute>
           <column>
            <property name="text">
-            <string notr="true">1</string>
+            <string notr="true">Category</string>
+           </property>
+          </column>
+          <column>
+           <property name="text">
+            <string>Invert</string>
            </property>
           </column>
          </widget>
@@ -149,16 +163,6 @@
              </property>
              <property name="text">
               <string>Or</string>
-             </property>
-            </widget>
-           </item>
-           <item>
-            <widget class="QCheckBox" name="filtersNot">
-             <property name="toolTip">
-              <string>Invert each selected category</string>
-             </property>
-             <property name="text">
-              <string>Not</string>
              </property>
             </widget>
            </item>
@@ -351,9 +355,6 @@ p, li { white-space: pre-wrap; }
            <property name="contextMenuPolicy">
             <enum>Qt::CustomContextMenu</enum>
            </property>
-           <property name="toolTip">
-            <string>List of available mods.</string>
-           </property>
            <property name="whatsThis">
             <string>This is a list of installed mods. Use the checkboxes to activate/deactivate mods and drag &amp; drop mods to change their &quot;installation&quot; orders.</string>
            </property>
@@ -448,14 +449,7 @@ p, li { white-space: pre-wrap; }
             </widget>
            </item>
            <item>
-            <widget class="QLabel" name="currentCategoryLabel">
-             <property name="font">
-              <font>
-               <pointsize>8</pointsize>
-               <italic>true</italic>
-              </font>
-             </property>
-            </widget>
+            <widget class="QLabel" name="currentCategoryLabel"/>
            </item>
            <item>
             <spacer name="horizontalSpacer_5">

--- a/src/mainwindow.ui
+++ b/src/mainwindow.ui
@@ -39,6 +39,9 @@
       <property name="orientation">
        <enum>Qt::Horizontal</enum>
       </property>
+      <property name="childrenCollapsible">
+       <bool>false</bool>
+      </property>
       <widget class="QGroupBox" name="categoriesGroup">
        <property name="maximumSize">
         <size>

--- a/src/mainwindow.ui
+++ b/src/mainwindow.ui
@@ -66,7 +66,7 @@
          <number>1</number>
         </property>
         <item>
-         <widget class="QTreeWidget" name="categoriesList">
+         <widget class="QTreeWidget" name="filters">
           <property name="minimumSize">
            <size>
             <width>120</width>
@@ -96,7 +96,7 @@
          </widget>
         </item>
         <item>
-         <widget class="QPushButton" name="clickBlankButton">
+         <widget class="QPushButton" name="filtersClear">
           <property name="enabled">
            <bool>false</bool>
           </property>
@@ -130,7 +130,7 @@
           </property>
           <layout class="QHBoxLayout" name="horizontalLayout_11">
            <item>
-            <widget class="QRadioButton" name="categoriesAndBtn">
+            <widget class="QRadioButton" name="filtersAnd">
              <property name="toolTip">
               <string>Display mods that match all selected categories.</string>
              </property>
@@ -143,7 +143,7 @@
             </widget>
            </item>
            <item>
-            <widget class="QRadioButton" name="categoriesOrBtn">
+            <widget class="QRadioButton" name="filtersOr">
              <property name="toolTip">
               <string>Display mods that match at least one of the selected categories</string>
              </property>
@@ -153,7 +153,7 @@
             </widget>
            </item>
            <item>
-            <widget class="QCheckBox" name="categoriesNotBtn">
+            <widget class="QCheckBox" name="filtersNot">
              <property name="toolTip">
               <string>Invert each selected category</string>
              </property>
@@ -163,7 +163,7 @@
             </widget>
            </item>
            <item>
-            <widget class="QCheckBox" name="categoriesSeparators">
+            <widget class="QCheckBox" name="filtersSeparators">
              <property name="toolTip">
               <string>Include separators</string>
              </property>

--- a/src/modlistsortproxy.cpp
+++ b/src/modlistsortproxy.cpp
@@ -305,18 +305,35 @@ bool ModListSortProxy::filterMatchesModOr(ModInfo::Ptr info, bool enabled) const
 bool ModListSortProxy::criteriaMatchesMod(
   ModInfo::Ptr info, bool enabled, const Criteria& c) const
 {
+  bool b = false;
+
   switch (c.type)
   {
     case TYPE_SPECIAL:  // fall-through
     case TYPE_CATEGORY:
-      return categoryMatchesMod(info, enabled, c.id);
+    {
+      b = categoryMatchesMod(info, enabled, c.id);
+      break;
+    }
 
     case TYPE_CONTENT:
-      return contentMatchesMod(info, enabled, c.id);
+    {
+      b = contentMatchesMod(info, enabled, c.id);
+      break;
+    }
 
     default:
-      return false;
+    {
+      log::error("bad criteria type {}", c.type);
+      break;
+    }
   }
+
+  if (c.inverse) {
+    b = !b;
+  }
+
+  return b;
 }
 
 bool ModListSortProxy::categoryMatchesMod(

--- a/src/modlistsortproxy.cpp
+++ b/src/modlistsortproxy.cpp
@@ -371,9 +371,9 @@ bool ModListSortProxy::categoryMatchesMod(
       break;
     }
 
-    case CategoryFactory::HasNoCategory:
+    case CategoryFactory::HasCategory:
     {
-      b = (info->getCategories().size() == 0);
+      b = !info->getCategories().empty();
       break;
     }
 
@@ -383,10 +383,9 @@ bool ModListSortProxy::categoryMatchesMod(
       break;
     }
 
-    case CategoryFactory::NotEndorsed:
+    case CategoryFactory::Endorsed:
     {
-      ModInfo::EEndorsedState state = info->endorsedState();
-      b = (state != ModInfo::ENDORSED_TRUE);
+      b = (info->endorsedState() == ModInfo::ENDORSED_TRUE);
       break;
     }
 
@@ -402,20 +401,24 @@ bool ModListSortProxy::categoryMatchesMod(
       break;
     }
 
-    case CategoryFactory::NoGameData:
+    case CategoryFactory::HasGameData:
     {
-      b = (info->hasFlag(ModInfo::FLAG_INVALID));
+      b = !info->hasFlag(ModInfo::FLAG_INVALID);
       break;
     }
 
-    case CategoryFactory::NoNexusID:
+    case CategoryFactory::HasNexusID:
     {
-      b = (
-        info->getNexusID() == -1 &&
-        !info->hasFlag(ModInfo::FLAG_FOREIGN) &&
-        !info->hasFlag(ModInfo::FLAG_BACKUP) &&
-        !info->hasFlag(ModInfo::FLAG_OVERWRITE));
+      // never show these
+      if (
+        info->hasFlag(ModInfo::FLAG_FOREIGN) ||
+        info->hasFlag(ModInfo::FLAG_BACKUP) ||
+        info->hasFlag(ModInfo::FLAG_OVERWRITE))
+      {
+        return false;
+      }
 
+      b = (info->getNexusID() > 0);
       break;
     }
 

--- a/src/modlistsortproxy.cpp
+++ b/src/modlistsortproxy.cpp
@@ -61,7 +61,7 @@ void ModListSortProxy::setCriteria(const std::vector<Criteria>& criteria)
   const bool changed = (criteria != m_Criteria);
   const bool isForUpdates = (
     !criteria.empty() &&
-    criteria[0].id == CategoryFactory::CATEGORY_SPECIAL_UPDATEAVAILABLE);
+    criteria[0].id == CategoryFactory::UpdateAvailable);
 
   if (changed || isForUpdates) {
     m_Criteria = criteria;
@@ -343,68 +343,56 @@ bool ModListSortProxy::categoryMatchesMod(
 
   switch (category)
   {
-    case CategoryFactory::CATEGORY_SPECIAL_CHECKED:
+    case CategoryFactory::Checked:
     {
       b = (enabled || info->alwaysEnabled());
       break;
     }
 
-    case CategoryFactory::CATEGORY_SPECIAL_UNCHECKED:
-    {
-      b = (!enabled && !info->alwaysEnabled());
-      break;
-    }
-
-    case CategoryFactory::CATEGORY_SPECIAL_UPDATEAVAILABLE:
+    case CategoryFactory::UpdateAvailable:
     {
       b = (info->updateAvailable() || info->downgradeAvailable());
       break;
     }
 
-    case CategoryFactory::CATEGORY_SPECIAL_NOCATEGORY:
+    case CategoryFactory::HasNoCategory:
     {
       b = (info->getCategories().size() == 0);
       break;
     }
 
-    case CategoryFactory::CATEGORY_SPECIAL_CONFLICT:
+    case CategoryFactory::Conflict:
     {
       b = (hasConflictFlag(info->getFlags()));
       break;
     }
 
-    case CategoryFactory::CATEGORY_SPECIAL_NOTENDORSED:
+    case CategoryFactory::NotEndorsed:
     {
       ModInfo::EEndorsedState state = info->endorsedState();
       b = (state != ModInfo::ENDORSED_TRUE);
       break;
     }
 
-    case CategoryFactory::CATEGORY_SPECIAL_BACKUP:
+    case CategoryFactory::Backup:
     {
       b = (info->hasFlag(ModInfo::FLAG_BACKUP));
       break;
     }
 
-    case CategoryFactory::CATEGORY_SPECIAL_MANAGED:
+    case CategoryFactory::Managed:
     {
       b = (!info->hasFlag(ModInfo::FLAG_FOREIGN));
       break;
     }
 
-    case CategoryFactory::CATEGORY_SPECIAL_UNMANAGED:
-    {
-      b = (info->hasFlag(ModInfo::FLAG_FOREIGN));
-      break;
-    }
-
-    case CategoryFactory::CATEGORY_SPECIAL_NOGAMEDATA:
+    case CategoryFactory::NoGameData:
     {
       b = (info->hasFlag(ModInfo::FLAG_INVALID));
       break;
     }
 
-    case CategoryFactory::CATEGORY_SPECIAL_NONEXUSID:
+    case CategoryFactory::NoNexusID:
     {
       b = (
         info->getNexusID() == -1 &&

--- a/src/modlistsortproxy.cpp
+++ b/src/modlistsortproxy.cpp
@@ -269,12 +269,12 @@ bool ModListSortProxy::hasConflictFlag(const std::vector<ModInfo::EFlag> &flags)
 
 bool ModListSortProxy::filterMatchesModAnd(ModInfo::Ptr info, bool enabled) const
 {
-  if (info->hasFlag(ModInfo::FLAG_SEPARATOR) && !m_FilterSeparators) {
+  if (!optionsMatchMod(info, enabled)) {
     return false;
   }
 
   for (auto&& c : m_Criteria) {
-    if (!criteriaMatchesMod(info, enabled, c)) {
+    if (!criteriaMatchMod(info, enabled, c)) {
       return false;
     }
   }
@@ -284,12 +284,12 @@ bool ModListSortProxy::filterMatchesModAnd(ModInfo::Ptr info, bool enabled) cons
 
 bool ModListSortProxy::filterMatchesModOr(ModInfo::Ptr info, bool enabled) const
 {
-  if (info->hasFlag(ModInfo::FLAG_SEPARATOR) && !m_FilterSeparators) {
+  if (!optionsMatchMod(info, enabled)) {
     return false;
   }
 
   for (auto&& c : m_Criteria) {
-    if (criteriaMatchesMod(info, enabled, c)) {
+    if (criteriaMatchMod(info, enabled, c)) {
       return true;
     }
   }
@@ -302,7 +302,23 @@ bool ModListSortProxy::filterMatchesModOr(ModInfo::Ptr info, bool enabled) const
   return true;
 }
 
-bool ModListSortProxy::criteriaMatchesMod(
+bool ModListSortProxy::optionsMatchMod(ModInfo::Ptr info, bool) const
+{
+  // don't check options if there are no filters selected
+  if (!m_FilterActive) {
+    return true;
+  }
+
+  if (!m_FilterSeparators) {
+    if (info->hasFlag(ModInfo::FLAG_SEPARATOR)) {
+      return false;
+    }
+  }
+
+  return true;
+}
+
+bool ModListSortProxy::criteriaMatchMod(
   ModInfo::Ptr info, bool enabled, const Criteria& c) const
 {
   bool b = false;

--- a/src/modlistsortproxy.cpp
+++ b/src/modlistsortproxy.cpp
@@ -36,10 +36,9 @@ using namespace MOBase;
 ModListSortProxy::ModListSortProxy(Profile* profile, QObject *parent)
   : QSortFilterProxyModel(parent)
   , m_Profile(profile)
-  , m_CategoryFilter()
-  , m_CurrentFilter()
   , m_FilterActive(false)
   , m_FilterMode(FILTER_AND)
+  , m_FilterNot(false)
 {
   setDynamicSortFilter(true); // this seems to work without dynamicsortfilter
                               // but I don't know why. This should be necessary
@@ -312,8 +311,8 @@ bool ModListSortProxy::filterMatchesModAnd(ModInfo::Ptr info, bool enabled) cons
         if (!info->hasFlag(ModInfo::FLAG_INVALID)) return false;
       } break;
       case CategoryFactory::CATEGORY_SPECIAL_NONEXUSID: {
-        if (!(info->getNexusID() == -1 && !info->hasFlag(ModInfo::FLAG_FOREIGN) && 
-            !info->hasFlag(ModInfo::FLAG_BACKUP) && 
+        if (!(info->getNexusID() == -1 && !info->hasFlag(ModInfo::FLAG_FOREIGN) &&
+            !info->hasFlag(ModInfo::FLAG_BACKUP) &&
             !info->hasFlag(ModInfo::FLAG_SEPARATOR) &&
             !info->hasFlag(ModInfo::FLAG_OVERWRITE))) return false;
       } break;
@@ -381,7 +380,7 @@ bool ModListSortProxy::filterMatchesModOr(ModInfo::Ptr info, bool enabled) const
     if (info->hasContent(static_cast<ModInfo::EContent>(content))) return true;
   }
 
-  return false;
+  return m_CategoryFilter.empty() && m_ContentFilter.empty();
 }
 
 bool ModListSortProxy::filterMatchesMod(ModInfo::Ptr info, bool enabled) const
@@ -483,6 +482,14 @@ void ModListSortProxy::setFilterMode(ModListSortProxy::FilterMode mode)
 {
   if (m_FilterMode != mode) {
     m_FilterMode = mode;
+    this->invalidate();
+  }
+}
+
+void ModListSortProxy::setFilterNot(bool b)
+{
+  if (b != m_FilterNot) {
+    m_FilterNot = b;
     this->invalidate();
   }
 }

--- a/src/modlistsortproxy.h
+++ b/src/modlistsortproxy.h
@@ -31,16 +31,23 @@ class ModListSortProxy : public QSortFilterProxyModel
   Q_OBJECT
 
 public:
-
-  enum FilterMode {
-    FILTER_AND,
-    FILTER_OR
+  enum FilterMode
+  {
+    FilterAnd,
+    FilterOr
   };
 
   enum CriteriaType {
-    TYPE_SPECIAL,
-    TYPE_CATEGORY,
-    TYPE_CONTENT
+    TypeSpecial,
+    TypeCategory,
+    TypeContent
+  };
+
+  enum SeparatorsMode
+  {
+    SeparatorFilter,
+    SeparatorShow,
+    SeparatorHide
   };
 
   struct Criteria
@@ -101,7 +108,7 @@ public:
   bool isFilterActive() const { return m_FilterActive; }
 
   void setCriteria(const std::vector<Criteria>& criteria);
-  void setOptions(FilterMode mode, bool separators);
+  void setOptions(FilterMode mode, SeparatorsMode separators);
 
   /**
    * @brief tests if the specified index has child nodes
@@ -153,7 +160,7 @@ private:
 
   bool m_FilterActive;
   FilterMode m_FilterMode;
-  bool m_FilterSeparators;
+  SeparatorsMode m_FilterSeparators;
 
   std::vector<Criteria> m_PreChangeCriteria;
 

--- a/src/modlistsortproxy.h
+++ b/src/modlistsortproxy.h
@@ -37,10 +37,30 @@ public:
     FILTER_OR
   };
 
-  enum FilterType {
+  enum CriteriaType {
     TYPE_SPECIAL,
     TYPE_CATEGORY,
     TYPE_CONTENT
+  };
+
+  struct Criteria
+  {
+    CriteriaType type;
+    int id;
+    bool inverse;
+
+    bool operator==(const Criteria& other) const
+    {
+      return
+        (type == other.type) &&
+        (id == other.id) &&
+        (inverse == other.inverse);
+    }
+
+    bool operator!=(const Criteria& other) const
+    {
+      return !(*this == other);
+    }
   };
 
 public:
@@ -49,10 +69,6 @@ public:
 
   void setProfile(Profile *profile);
 
-  void setCategoryFilter(const std::vector<int> &categories);
-  std::vector<int> categoryFilter() const { return m_CategoryFilter; }
-
-  void setContentFilter(const std::vector<int> &content);
 
   virtual Qt::ItemFlags flags(const QModelIndex &modelIndex) const;
   virtual bool dropMimeData(const QMimeData *data, Qt::DropAction action,
@@ -84,9 +100,8 @@ public:
    */
   bool isFilterActive() const { return m_FilterActive; }
 
-  void setFilterMode(FilterMode mode);
-  void setFilterNot(bool b);
-  void setFilterSeparators(bool b);
+  void setCriteria(const std::vector<Criteria>& criteria);
+  void setOptions(FilterMode mode, bool separators);
 
   /**
    * @brief tests if the specified index has child nodes
@@ -131,19 +146,18 @@ private slots:
   void postDataChanged();
 
 private:
-  Profile *m_Profile;
-  std::vector<int> m_CategoryFilter;
-  std::vector<int> m_ContentFilter;
+  Profile* m_Profile;
+  std::vector<Criteria> m_Criteria;
+  QString m_Filter;
   std::bitset<ModList::COL_LASTCOLUMN + 1> m_EnabledColumns;
-  QString m_CurrentFilter;
 
   bool m_FilterActive;
   FilterMode m_FilterMode;
-  bool m_FilterNot;
   bool m_FilterSeparators;
 
-  std::vector<int> m_PreChangeFilters;
+  std::vector<Criteria> m_PreChangeCriteria;
 
+  bool criteriaMatchesMod(ModInfo::Ptr info, bool enabled, const Criteria& c) const;
   bool categoryMatchesMod(ModInfo::Ptr info, bool enabled, int category) const;
   bool contentMatchesMod(ModInfo::Ptr info, bool enabled, int content) const;
 };

--- a/src/modlistsortproxy.h
+++ b/src/modlistsortproxy.h
@@ -142,6 +142,8 @@ private:
 
   std::vector<int> m_PreChangeFilters;
 
+  bool categoryMatchesMod(ModInfo::Ptr info, bool enabled, int category) const;
+  bool contentMatchesMod(ModInfo::Ptr info, bool enabled, int content) const;
 };
 
 #endif // MODLISTSORTPROXY_H

--- a/src/modlistsortproxy.h
+++ b/src/modlistsortproxy.h
@@ -157,7 +157,8 @@ private:
 
   std::vector<Criteria> m_PreChangeCriteria;
 
-  bool criteriaMatchesMod(ModInfo::Ptr info, bool enabled, const Criteria& c) const;
+  bool optionsMatchMod(ModInfo::Ptr info, bool enabled) const;
+  bool criteriaMatchMod(ModInfo::Ptr info, bool enabled, const Criteria& c) const;
   bool categoryMatchesMod(ModInfo::Ptr info, bool enabled, int category) const;
   bool contentMatchesMod(ModInfo::Ptr info, bool enabled, int content) const;
 };

--- a/src/modlistsortproxy.h
+++ b/src/modlistsortproxy.h
@@ -86,6 +86,7 @@ public:
 
   void setFilterMode(FilterMode mode);
   void setFilterNot(bool b);
+  void setFilterSeparators(bool b);
 
   /**
    * @brief tests if the specified index has child nodes
@@ -139,6 +140,7 @@ private:
   bool m_FilterActive;
   FilterMode m_FilterMode;
   bool m_FilterNot;
+  bool m_FilterSeparators;
 
   std::vector<int> m_PreChangeFilters;
 

--- a/src/modlistsortproxy.h
+++ b/src/modlistsortproxy.h
@@ -85,6 +85,7 @@ public:
   bool isFilterActive() const { return m_FilterActive; }
 
   void setFilterMode(FilterMode mode);
+  void setFilterNot(bool b);
 
   /**
    * @brief tests if the specified index has child nodes
@@ -129,9 +130,7 @@ private slots:
   void postDataChanged();
 
 private:
-
   Profile *m_Profile;
-
   std::vector<int> m_CategoryFilter;
   std::vector<int> m_ContentFilter;
   std::bitset<ModList::COL_LASTCOLUMN + 1> m_EnabledColumns;
@@ -139,6 +138,7 @@ private:
 
   bool m_FilterActive;
   FilterMode m_FilterMode;
+  bool m_FilterNot;
 
   std::vector<int> m_PreChangeFilters;
 


### PR DESCRIPTION
This changes the filter list from being selection-based to handling single clicks on individual items. Each item is tristate: not included, included, inverted. The first column in the list will show either empty, a check mark, or the "not" string. Left clicks cycle forwards, right clicks cycle backwards.

Because filters can now be easily inverted, I've removed two redundant ones (unchecked and unmanaged) and I've made them all positive ("not endorsed" is now "endorsed").

I've refactored some stuff in `ModListSortProxy` to avoid repeating the filter matching for both AND and OR. There was also a bug where selecting the OR option without selecting filters would show an empty mod list.

Since mouse clicks are now controlling item states, there's no more context menu. The "clear selection" item was redundant anyway, and I've moved the "edit" item as a button next to "clear". There's also a new combobox to set whether separators are filtered normally (old behaviour), always visible or never visible.

All the stuff for the filter list has been moved to filterlist.cpp/h.

Fixes #553.