### PR TITLE
Lock, hook, shell

### DIFF
--- a/src/env.h
+++ b/src/env.h
@@ -246,6 +246,26 @@ Service getService(const QString& name);
 QString toString(Service::StartType st);
 QString toString(Service::Status st);
 
+
+struct Association
+{
+  // path to the executable associated with the file
+  QFileInfo executable;
+
+  // full command line associated with the file, no replacements
+  QString commandLine;
+
+  // command line _without_ the executable and with placeholders such as %1
+  // replaced by the given file
+  QString formattedCommandLine;
+};
+
+// returns the associated executable and command line, executable is empty on
+// error
+//
+Association getAssociation(const QFileInfo& file);
+
+
 enum class CoreDumpTypes
 {
   Mini = 1,

--- a/src/mainwindow.h
+++ b/src/mainwindow.h
@@ -440,6 +440,7 @@ private slots:
   // data-tree context menu
   void writeDataToFile();
   void openDataFile();
+  void runDataFileHooked();
   void addAsExecutable();
   void previewDataFile();
   void hideFile();

--- a/src/mainwindow.h
+++ b/src/mainwindow.h
@@ -440,6 +440,7 @@ private slots:
   // data-tree context menu
   void writeDataToFile();
   void openDataFile();
+  void openDataFile(QTreeWidgetItem* item);
   void runDataFileHooked();
   void addAsExecutable();
   void previewDataFile();
@@ -589,6 +590,7 @@ private slots:
 
   void refreshSavesIfOpen();
   void expandDataTreeItem(QTreeWidgetItem *item);
+  void activateDataTreeItem(QTreeWidgetItem *item, int column);
   void about();
   void delayedRemove();
 

--- a/src/mainwindow.ui
+++ b/src/mainwindow.ui
@@ -1073,9 +1073,6 @@ p, li { white-space: pre-wrap; }
                  <property name="uniformRowHeights">
                   <bool>true</bool>
                  </property>
-                 <property name="animated">
-                  <bool>true</bool>
-                 </property>
                  <attribute name="headerDefaultSectionSize">
                   <number>400</number>
                  </attribute>

--- a/src/modinfodialog.cpp
+++ b/src/modinfodialog.cpp
@@ -61,10 +61,27 @@ bool canPreviewFile(
   return pluginContainer.previewGenerator().previewSupported(ext);
 }
 
-bool canOpenFile(bool isArchive, const QString&)
+bool isExecutableFilename(const QString& filename)
 {
-  // can open anything as long as it's not in an archive
-  return !isArchive;
+  static const std::set<QString> exeExtensions = {
+    "exe", "cmd", "bat"
+  };
+
+  const auto ext = QFileInfo(filename).suffix().toLower();
+
+  return exeExtensions.contains(ext);
+}
+
+bool canRunFile(bool isArchive, const QString& filename)
+{
+  // can run executables that are not archives
+  return !isArchive && isExecutableFilename(filename);
+}
+
+bool canOpenFile(bool isArchive, const QString& filename)
+{
+  // can open non-executables that are not archives
+  return !isArchive && !isExecutableFilename(filename);
 }
 
 bool canExploreFile(bool isArchive, const QString&)

--- a/src/modinfodialogconflicts.cpp
+++ b/src/modinfodialogconflicts.cpp
@@ -587,6 +587,10 @@ void ConflictsTab::showContextMenu(const QPoint &pos, QTreeView* tree)
       openItems(tree);
     });
 
+    auto bold = actions.open->font();
+    bold.setBold(true);
+    actions.open->setFont(bold);
+
     menu.addAction(actions.open);
   }
 
@@ -824,11 +828,15 @@ GeneralConflictsTab::GeneralConflictsTab(
 
   QObject::connect(
     ui->overwriteTree, &QTreeView::doubleClicked,
-    [&](auto&& item){ onOverwriteActivated(item); });
+    [&](auto&&){ m_tab->openItems(ui->overwriteTree); });
 
   QObject::connect(
     ui->overwrittenTree, &QTreeView::doubleClicked,
-    [&](auto&& item){ onOverwrittenActivated(item); });
+    [&](auto&& item){ m_tab->openItems(ui->overwrittenTree); });
+
+  QObject::connect(
+    ui->noConflictTree, &QTreeView::doubleClicked,
+    [&](auto&& item){ m_tab->openItems(ui->noConflictTree); });
 
   QObject::connect(
     ui->overwriteTree, &QTreeView::customContextMenuRequested,
@@ -1038,6 +1046,10 @@ AdvancedConflictsTab::AdvancedConflictsTab(
   QObject::connect(
     ui->conflictsAdvancedShowNearest, &QRadioButton::clicked,
     [&]{ update(); });
+
+  QObject::connect(
+    ui->conflictsAdvancedList, &QTreeView::activated,
+    [&]{ m_tab->openItems(ui->conflictsAdvancedList); });
 
   QObject::connect(
     ui->conflictsAdvancedList, &QTreeView::customContextMenuRequested,

--- a/src/modinfodialogconflicts.cpp
+++ b/src/modinfodialogconflicts.cpp
@@ -608,6 +608,19 @@ void ConflictsTab::showContextMenu(const QPoint &pos, QTreeView* tree)
     menu.addAction(actions.preview);
   }
 
+  // goto
+  if (actions.gotoMenu) {
+    menu.addMenu(actions.gotoMenu);
+
+    for (auto* a : actions.gotoActions) {
+      connect(a, &QAction::triggered, [&, name=a->text()]{
+        emitModOpen(name);
+        });
+
+      actions.gotoMenu->addAction(a);
+    }
+  }
+
   // explore
   if (actions.explore) {
     connect(actions.explore, &QAction::triggered, [&]{
@@ -616,6 +629,8 @@ void ConflictsTab::showContextMenu(const QPoint &pos, QTreeView* tree)
 
     menu.addAction(actions.explore);
   }
+
+  menu.addSeparator();
 
   // hide
   if (actions.hide) {
@@ -633,19 +648,6 @@ void ConflictsTab::showContextMenu(const QPoint &pos, QTreeView* tree)
     });
 
     menu.addAction(actions.unhide);
-  }
-
-  // goto
-  if (actions.gotoMenu) {
-    menu.addMenu(actions.gotoMenu);
-
-    for (auto* a : actions.gotoActions) {
-      connect(a, &QAction::triggered, [&, name=a->text()]{
-        emitModOpen(name);
-       });
-
-      actions.gotoMenu->addAction(a);
-    }
   }
 
   if (!menu.isEmpty()) {
@@ -732,14 +734,6 @@ ConflictsTab::Actions ConflictsTab::createMenuActions(QTreeView* tree)
 
   Actions actions;
 
-  actions.hide = new QAction(tr("&Hide"), parentWidget());
-  actions.hide->setEnabled(enableHide);
-
-  // note that it is possible for hidden files to appear if they override other
-  // hidden files from another mod
-  actions.unhide = new QAction(tr("&Unhide"), parentWidget());
-  actions.unhide->setEnabled(enableUnhide);
-
   if (enableRun) {
     actions.open = new QAction(tr("&Execute"), parentWidget());
   } else if (enableOpen) {
@@ -750,11 +744,19 @@ ConflictsTab::Actions ConflictsTab::createMenuActions(QTreeView* tree)
   actions.preview = new QAction(tr("&Preview"), parentWidget());
   actions.preview->setEnabled(enablePreview);
 
+  actions.gotoMenu = new QMenu(tr("&Go to..."), parentWidget());
+  actions.gotoMenu->setEnabled(enableGoto);
+
   actions.explore = new QAction(tr("Open in &Explorer"), parentWidget());
   actions.explore->setEnabled(enableExplore);
 
-  actions.gotoMenu = new QMenu(tr("&Go to..."), parentWidget());
-  actions.gotoMenu->setEnabled(enableGoto);
+  actions.hide = new QAction(tr("&Hide"), parentWidget());
+  actions.hide->setEnabled(enableHide);
+
+  // note that it is possible for hidden files to appear if they override other
+  // hidden files from another mod
+  actions.unhide = new QAction(tr("&Unhide"), parentWidget());
+  actions.unhide->setEnabled(enableUnhide);
 
   if (enableGoto && n == 1) {
     const auto* item = model->getItem(static_cast<std::size_t>(

--- a/src/modinfodialogconflicts.h
+++ b/src/modinfodialogconflicts.h
@@ -60,10 +60,6 @@ private:
 
   void onOverwriteActivated(const QModelIndex& index);
   void onOverwrittenActivated(const QModelIndex& index);
-
-  void onOverwriteTreeContext(const QPoint &pos);
-  void onOverwrittenTreeContext(const QPoint &pos);
-  void onNoConflictTreeContext(const QPoint &pos);
 };
 
 

--- a/src/modinfodialogconflicts.h
+++ b/src/modinfodialogconflicts.h
@@ -112,6 +112,7 @@ public:
   bool canHandleUnmanaged() const override;
 
   void openItems(QTreeView* tree);
+  void runItemsHooked(QTreeView* tree);
   void previewItems(QTreeView* tree);
   void exploreItems(QTreeView* tree);
 
@@ -125,6 +126,7 @@ private:
     QAction* hide = nullptr;
     QAction* unhide = nullptr;
     QAction* open = nullptr;
+    QAction* runHooked = nullptr;
     QAction* preview = nullptr;
     QAction* explore = nullptr;
     QMenu* gotoMenu = nullptr;

--- a/src/modinfodialogfiletree.cpp
+++ b/src/modinfodialogfiletree.cpp
@@ -32,6 +32,10 @@ FileTreeTab::FileTreeTab(ModInfoDialogTabContext cx)
   m_actions.hide = new QAction(tr("&Hide"), ui->filetree);
   m_actions.unhide = new QAction(tr("&Unhide"), ui->filetree);
 
+  auto bold = m_actions.open->font();
+  bold.setBold(true);
+  m_actions.open->setFont(bold);
+
   connect(m_actions.newFolder, &QAction::triggered, [&]{ onCreateDirectory(); });
   connect(m_actions.open, &QAction::triggered, [&]{ onOpen(); });
   connect(m_actions.runHooked, &QAction::triggered, [&]{ onRunHooked(); });
@@ -47,6 +51,12 @@ FileTreeTab::FileTreeTab(ModInfoDialogTabContext cx)
   connect(
     ui->filetree, &QTreeView::customContextMenuRequested,
     [&](const QPoint& pos){ onContextMenu(pos); });
+
+  // disable renaming on double click, open the file instead
+  ui->filetree->setEditTriggers(
+    ui->filetree->editTriggers() & (~QAbstractItemView::DoubleClicked));
+
+  connect(ui->filetree, &QTreeView::activated, [&](auto&&){ onOpen(); });
 }
 
 void FileTreeTab::clear()

--- a/src/modinfodialogfiletree.cpp
+++ b/src/modinfodialogfiletree.cpp
@@ -140,7 +140,10 @@ void FileTreeTab::onOpen()
     return;
   }
 
-  shell::Open(m_fs->filePath(selection));
+  core().processRunner()
+    .setFromFile(parentWidget(), m_fs->filePath(selection))
+    .setWaitForCompletion()
+    .run();
 }
 
 void FileTreeTab::onPreview()

--- a/src/modinfodialogfiletree.h
+++ b/src/modinfodialogfiletree.h
@@ -20,14 +20,15 @@ public:
 private:
   struct Actions
   {
-    QAction *newFolder = nullptr;
-    QAction *open = nullptr;
-    QAction *preview = nullptr;
-    QAction *explore = nullptr;
-    QAction *rename = nullptr;
-    QAction *del = nullptr;
-    QAction *hide = nullptr;
-    QAction *unhide = nullptr;
+    QAction* newFolder = nullptr;
+    QAction* open = nullptr;
+    QAction* runHooked = nullptr;
+    QAction* preview = nullptr;
+    QAction* explore = nullptr;
+    QAction* rename = nullptr;
+    QAction* del = nullptr;
+    QAction* hide = nullptr;
+    QAction* unhide = nullptr;
   };
 
   QFileSystemModel* m_fs;
@@ -35,6 +36,7 @@ private:
 
   void onCreateDirectory();
   void onOpen();
+  void onRunHooked();
   void onPreview();
   void onExplore();
   void onRename();

--- a/src/modinfodialogfwd.h
+++ b/src/modinfodialogfwd.h
@@ -23,6 +23,7 @@ enum class ModInfoTabIDs
 class PluginContainer;
 
 bool canPreviewFile(PluginContainer& pluginContainer, bool isArchive, const QString& filename);
+bool canRunFile(bool isArchive, const QString& filename);
 bool canOpenFile(bool isArchive, const QString& filename);
 bool canExploreFile(bool isArchive, const QString& filename);
 bool canHideFile(bool isArchive, const QString& filename);

--- a/src/processrunner.cpp
+++ b/src/processrunner.cpp
@@ -3,6 +3,8 @@
 #include "instancemanager.h"
 #include "iuserinterface.h"
 #include "envmodule.h"
+#include "env.h"
+#include <iplugingame.h>
 #include <log.h>
 
 using namespace MOBase;
@@ -473,13 +475,14 @@ ProcessRunner& ProcessRunner::setWaitForCompletion(
   return *this;
 }
 
-ProcessRunner& ProcessRunner::setFromFile(QWidget* parent, const QFileInfo& targetInfo)
+ProcessRunner& ProcessRunner::setFromFile(
+  QWidget* parent, const QFileInfo& targetInfo, bool forceHook)
 {
   if (!parent && m_ui) {
     parent = m_ui->qtWidget();
   }
 
-  // if the file is a .exe, start it directory; if it's anything else, ask the
+  // if the file is a .exe, start it directly; if it's anything else, ask the
   // shell to start it
 
   const auto fec = spawn::getFileExecutionContext(parent, targetInfo);
@@ -497,6 +500,19 @@ ProcessRunner& ProcessRunner::setFromFile(QWidget* parent, const QFileInfo& targ
     case spawn::FileExecutionTypes::Other:  // fall-through
     default:
     {
+      if (forceHook) {
+        auto assoc = env::getAssociation(targetInfo);
+        if (!assoc.executable.filePath().isEmpty()) {
+          setBinary(assoc.executable);
+          setArguments(assoc.formattedCommandLine);
+          setCurrentDirectory(assoc.executable.absoluteDir());
+
+          return *this;
+        }
+
+        // if it fails, just use the regular shell open
+      }
+
       m_shellOpen = targetInfo.absoluteFilePath();
 
       // picked up by postRun()

--- a/src/processrunner.cpp
+++ b/src/processrunner.cpp
@@ -498,6 +498,10 @@ ProcessRunner& ProcessRunner::setFromFile(QWidget* parent, const QFileInfo& targ
     default:
     {
       m_shellOpen = targetInfo.absoluteFilePath();
+
+      // picked up by postRun()
+      m_sp.hooked = false;
+
       break;
     }
   }
@@ -721,6 +725,11 @@ std::optional<ProcessRunner::Results> ProcessRunner::runBinary()
 ProcessRunner::Results ProcessRunner::postRun()
 {
   const bool mustWait = (m_waitFlags & ForceWait);
+
+  if (!m_sp.hooked && !mustWait) {
+    // the process wasn't hooked and there's no force wait, don't lock
+    return Running;
+  }
 
   if (mustWait && m_lockReason == UILocker::NoReason) {
     // never lock the ui without an escape hatch for the user

--- a/src/processrunner.h
+++ b/src/processrunner.h
@@ -68,10 +68,14 @@ public:
   ProcessRunner& setWaitForCompletion(
     WaitFlags flags=NoFlags, UILocker::Reasons reason=UILocker::LockUI);
 
-  // if the target is an executable file, runs that; for anything else, calls
-  // ShellExecute() on it
+  // - if the target is an executable file, runs it hooked
+  // - if the target is a file:
+  //     - if forceHook is false, calls ShellExecute() on it
+  //     - if forceHook is true, gets the executable associated with the file
+  //       and runs that hooked by passing the file as an argument
   //
-  ProcessRunner& setFromFile(QWidget* parent, const QFileInfo& targetInfo);
+  ProcessRunner& setFromFile(
+    QWidget* parent, const QFileInfo& targetInfo, bool forceHook = false);
 
   ProcessRunner& setFromExecutable(const Executable& exe);
   ProcessRunner& setFromShortcut(const MOShortcut& shortcut);

--- a/src/processrunner.h
+++ b/src/processrunner.h
@@ -42,8 +42,9 @@ public:
     // the ui will be refreshed once the process has completed
     Refresh   = 0x01,
 
-    // the process will be waited for even if locking is disabled
-    ForceWait = 0x02
+    // the process will be waited for even if locking is disabled or the
+    // process is not hooked
+    ForceWait = 0x02,
   };
 
   using WaitFlags = QFlags<WaitFlag>;

--- a/src/usvfsconnector.cpp
+++ b/src/usvfsconnector.cpp
@@ -181,10 +181,11 @@ UsvfsConnector::~UsvfsConnector()
 
 void UsvfsConnector::updateMapping(const MappingType &mapping)
 {
-  QProgressDialog progress;
+  QProgressDialog progress(qApp->activeWindow());
   progress.setLabelText(tr("Preparing vfs"));
   progress.setMaximum(static_cast<int>(mapping.size()));
   progress.show();
+
   int value = 0;
   int files = 0;
   int dirs = 0;


### PR DESCRIPTION
This fixes a few bugs and qol issues:

- The lock overlay now isn't shown for processes that aren't hooked;
- Running a .exe from the filetree is now hooked, like the data and conflicts tabs;
- The usvfs update progress dialog is now on top of other dialogs.

For the data and conflicts tab as well as the filetree:
  - Added "Open with VFS" context menu item;
  - Changed the order of the context menu so they're uniform;
  - Double-clicking on items opens them.