### PR TITLE
Crash when starting multiple downloads with dialog boxes opened

### DIFF
--- a/src/downloadmanager.h
+++ b/src/downloadmanager.h
@@ -137,6 +137,8 @@ public:
 
   ~DownloadManager();
 
+  void setParentWidget(QWidget* w);
+
   /**
    * @brief determine if a download is currently in progress
    *
@@ -368,6 +370,7 @@ public:
    * @return index of that download or -1 if it wasn't found
    */
   int indexByName(const QString &fileName) const;
+  int indexByInfo(const DownloadInfo* info) const;
 
   void pauseAll();
 
@@ -529,6 +532,7 @@ private:
   NexusInterface *m_NexusInterface;
 
   OrganizerCore *m_OrganizerCore;
+  QWidget* m_ParentWidget;
 
   QVector<std::tuple<QString, int, int>> m_PendingDownloads;
 

--- a/src/organizercore.cpp
+++ b/src/organizercore.cpp
@@ -251,6 +251,7 @@ void OrganizerCore::setUserInterface(IUserInterface* ui)
   m_InstallationManager.setParentWidget(w);
   m_Updater.setUserInterface(w);
   m_UILocker.setUserInterface(w);
+  m_DownloadManager.setParentWidget(w);
 
   checkForUpdates();
 }


### PR DESCRIPTION
`startDownload()` used to call `indexByName()` so it could call `resumeDownload()` or `downloadFinished()`, both of which require an index. The problem is that there's a window during which there can be multiple downloads with the same filenames in the list: when the user adds a duplicate download but hasn't handled the confirmation dialog box yet. During that time, `indexByName()` can return the index of _another_ download.

In my tests, I've seen it return the index of both running and paused downloads. For running downloads, it seems to try to resume the new download, but the file sizes don't match and there's an error about a bad range trying to resume the transfer. For paused/unstarted downloads, the `m_Reply` field hasn't been set yet, and it crashes on a null pointer.

Since `startDownload()` actually has the `DownloadInfo` I added a new `indexByInfo()`, which returns the index in the list for that particular download info. I thought of just remembering the index just after the info is added to `m_ActiveDownloads`, but I'm scared that stuff can happen in between and change the index.

I also fixed dialog boxes not having a parent. They weren't modal and were displayed all over the place. They're now modal and centered.