### PR TITLE
Double click previews

### DIFF
--- a/src/mainwindow.h
+++ b/src/mainwindow.h
@@ -444,6 +444,7 @@ private slots:
   void runDataFileHooked();
   void addAsExecutable();
   void previewDataFile();
+  void previewDataFile(QTreeWidgetItem* item);
   void hideFile();
   void unhideFile();
   void openDataOriginExplorer_clicked();

--- a/src/modinfodialogconflicts.h
+++ b/src/modinfodialogconflicts.h
@@ -107,11 +107,14 @@ public:
   void restoreState(const Settings& s) override;
   bool canHandleUnmanaged() const override;
 
+  void activateItems(QTreeView* tree);
   void openItems(QTreeView* tree);
   void runItemsHooked(QTreeView* tree);
   void previewItems(QTreeView* tree);
   void exploreItems(QTreeView* tree);
 
+  void openItem(const ConflictItem* item);
+  void previewItem(const ConflictItem* item);
   void changeItemsVisibility(QTreeView* tree, bool visible);
 
   void showContextMenu(const QPoint &pos, QTreeView* tree);

--- a/src/modinfodialogfiletree.h
+++ b/src/modinfodialogfiletree.h
@@ -35,6 +35,7 @@ private:
   Actions m_actions;
 
   void onCreateDirectory();
+  void onActivated();
   void onOpen();
   void onRunHooked();
   void onPreview();

--- a/src/settings.cpp
+++ b/src/settings.cpp
@@ -1966,9 +1966,19 @@ bool InterfaceSettings::showChangeGameConfirmation() const
   return get<bool>(m_Settings, "Settings", "show_change_game_confirmation", true);
 }
 
-void InterfaceSettings::setShowChangeGameConfirmation(bool b) const
+void InterfaceSettings::setShowChangeGameConfirmation(bool b)
 {
   set(m_Settings, "Settings", "show_change_game_confirmation", b);
+}
+
+bool InterfaceSettings::doubleClicksOpenPreviews() const
+{
+  return get<bool>(m_Settings, "Settings", "double_click_previews", false);
+}
+
+void InterfaceSettings::setDoubleClicksOpenPreviews(bool b)
+{
+  set(m_Settings, "Settings", "double_click_previews", b);
 }
 
 

--- a/src/settings.h
+++ b/src/settings.h
@@ -608,7 +608,12 @@ public:
   // whether to show the confirmation when switching instances
   //
   bool showChangeGameConfirmation() const;
-  void setShowChangeGameConfirmation(bool b) const;
+  void setShowChangeGameConfirmation(bool b);
+
+  // whether double-clicks on files should try to open previews first
+  //
+  bool doubleClicksOpenPreviews() const;
+  void setDoubleClicksOpenPreviews(bool b);
 
 private:
   QSettings& m_Settings;

--- a/src/settingsdialog.ui
+++ b/src/settingsdialog.ui
@@ -101,6 +101,9 @@
              </item>
              <item row="1" column="1" colspan="2">
               <widget class="LinkLabel" name="label_33">
+               <property name="toolTip">
+                <string>https://www.transifex.com/tannin/mod-organizer/</string>
+               </property>
                <property name="text">
                 <string>&lt;a href=&quot;https://www.transifex.com/tannin/mod-organizer/&quot;&gt;Help translate Mod Organizer&lt;/a&gt;</string>
                </property>
@@ -129,6 +132,13 @@
            <widget class="QCheckBox" name="changeGameConfirmation">
             <property name="text">
              <string>Show confirmation when changing instance</string>
+            </property>
+           </widget>
+          </item>
+          <item>
+           <widget class="QCheckBox" name="doubleClickPreviews">
+            <property name="text">
+             <string>Open previews on double-click</string>
             </property>
            </widget>
           </item>

--- a/src/settingsdialog.ui
+++ b/src/settingsdialog.ui
@@ -137,6 +137,9 @@
           </item>
           <item>
            <widget class="QCheckBox" name="doubleClickPreviews">
+            <property name="toolTip">
+             <string>Whether double-clicking on a file opens the preview window or launches the program associated with it. This applies to the Data tab as well as the Conflicts and Filetree tabs in the mod info window.</string>
+            </property>
             <property name="text">
              <string>Open previews on double-click</string>
             </property>

--- a/src/settingsdialoggeneral.cpp
+++ b/src/settingsdialoggeneral.cpp
@@ -21,6 +21,7 @@ GeneralSettingsTab::GeneralSettingsTab(Settings& s, SettingsDialog& d)
 
   ui->centerDialogs->setChecked(settings().geometry().centerDialogs());
   ui->changeGameConfirmation->setChecked(settings().interface().showChangeGameConfirmation());
+  ui->doubleClickPreviews->setChecked(settings().interface().doubleClicksOpenPreviews());
   ui->compactBox->setChecked(settings().interface().compactDownloads());
   ui->showMetaBox->setChecked(settings().interface().metaDownloads());
   ui->checkForUpdates->setChecked(settings().checkForUpdates());
@@ -63,6 +64,7 @@ void GeneralSettingsTab::update()
 
   settings().geometry().setCenterDialogs(ui->centerDialogs->isChecked());
   settings().interface().setShowChangeGameConfirmation(ui->changeGameConfirmation->isChecked());
+  settings().interface().setDoubleClicksOpenPreviews(ui->doubleClickPreviews->isChecked());
   settings().interface().setCompactDownloads(ui->compactBox->isChecked());
   settings().interface().setMetaDownloads(ui->showMetaBox->isChecked());
   settings().setCheckForUpdates(ui->checkForUpdates->isChecked());


### PR DESCRIPTION
- Added "preview on double-clicks" option, implemented for data tab, conflicts and filetree
- Added `setDefaultActivationActionForFile()` used by all three to bold the appropriate menu item. Note that the bolded item is not always on top, which is non-standard, but that would require more changes than I want to make for now.