### PR TITLE
Set default window size to 1300x800

### DIFF
--- a/src/mainwindow.cpp
+++ b/src/mainwindow.cpp
@@ -2201,7 +2201,10 @@ void MainWindow::readSettings()
 {
   const auto& s = m_OrganizerCore.settings();
 
-  s.geometry().restoreGeometry(this);
+  if (!s.geometry().restoreGeometry(this)) {
+    resize(1300, 800);
+  }
+
   s.geometry().restoreState(this);
   s.geometry().restoreDocks(this);
   s.geometry().restoreToolbars(this);


### PR DESCRIPTION
The default size of the main window when geometries are reset is its minimum size, which is about 1100 pixels. The addition of the Conflicts column in the mod list makes the minimum width too small and sets the mod name column to just a few pixels. Making the default width 1300 gives a much better looking mod list on an initial start.