### PR TITLE
Lock fixes

### DIFF
--- a/src/main.cpp
+++ b/src/main.cpp
@@ -745,7 +745,6 @@ int runApplication(MOApplication &application, SingleInstance &instance,
       splash.finish(&mainWindow);
 
       res = application.exec();
-      mainWindow.onBeforeClose();
       mainWindow.close();
 
       NexusInterface::instance(&pluginContainer)

--- a/src/mainwindow.cpp
+++ b/src/mainwindow.cpp
@@ -1317,18 +1317,25 @@ void MainWindow::closeEvent(QCloseEvent* event)
   //
   // for 2), the settings have been saved and the window can just close
 
-  if (ModOrganizerExiting()) {
+  if (ModOrganizerCanCloseNow()) {
     // the user has confirmed if necessary and all settings have been saved,
     // just close it
     QMainWindow::closeEvent(event);
-  } else {
-    // never close the window because settings might need to be changed
-    event->ignore();
-
-    // start the process of exiting, which may require confirmation by calling
-    // canExit(), among other things
-    ExitModOrganizer();
+    return;
   }
+
+  if (ModOrganizerExiting()) {
+    // ignore repeated attempts
+    event->ignore();
+    return;
+  }
+
+  // never close the window because settings might need to be changed
+  event->ignore();
+
+  // start the process of exiting, which may require confirmation by calling
+  // canExit(), among other things
+  ExitModOrganizer();
 }
 
 bool MainWindow::canExit()

--- a/src/shared/util.cpp
+++ b/src/shared/util.cpp
@@ -294,6 +294,7 @@ QString getUsvfsVersionString()
 
 
 static bool g_exiting = false;
+static bool g_canClose = false;
 
 MainWindow* findMainWindow()
 {
@@ -312,6 +313,9 @@ bool ExitModOrganizer(ExitFlags e)
     return true;
   }
 
+  g_exiting = true;
+  MOBase::Guard g([&]{ g_exiting = false; });
+
   if (!e.testFlag(Exit::Force)) {
     if (auto* mw=findMainWindow()) {
       if (!mw->canExit()) {
@@ -320,12 +324,17 @@ bool ExitModOrganizer(ExitFlags e)
     }
   }
 
-  g_exiting = true;
+  g_canClose = true;
 
   const int code = (e.testFlag(Exit::Restart) ? RestartExitCode : 0);
   qApp->exit(code);
 
   return true;
+}
+
+bool ModOrganizerCanCloseNow()
+{
+  return g_canClose;
 }
 
 bool ModOrganizerExiting()

--- a/src/shared/util.h
+++ b/src/shared/util.h
@@ -65,6 +65,7 @@ Q_DECLARE_OPERATORS_FOR_FLAGS(ExitFlags);
 
 bool ExitModOrganizer(ExitFlags e=Exit::Normal);
 bool ModOrganizerExiting();
+bool ModOrganizerCanCloseNow();
 void ResetExitFlag();
 
 #endif // UTIL_H

--- a/src/spawn.cpp
+++ b/src/spawn.cpp
@@ -498,14 +498,16 @@ DWORD spawn(const SpawnParameters& sp, HANDLE& processHandle)
   const auto wcommandLine = commandLine.toStdWString();
   const auto wcwd = cwd.toStdWString();
 
+  const DWORD flags = CREATE_BREAKAWAY_FROM_JOB;
+
   if (sp.hooked) {
     success = ::CreateProcessHooked(
       nullptr, const_cast<wchar_t*>(wcommandLine.c_str()), nullptr, nullptr,
-      inheritHandles, 0, nullptr, wcwd.c_str(), &si, &pi);
+      inheritHandles, flags, nullptr, wcwd.c_str(), &si, &pi);
   } else {
     success = ::CreateProcess(
       nullptr, const_cast<wchar_t*>(wcommandLine.c_str()), nullptr, nullptr,
-      inheritHandles, 0, nullptr, wcwd.c_str(), &si, &pi);
+      inheritHandles, flags, nullptr, wcwd.c_str(), &si, &pi);
   }
 
   const auto e = GetLastError();

--- a/src/uilocker.cpp
+++ b/src/uilocker.cpp
@@ -461,6 +461,11 @@ std::shared_ptr<UILocker::Session> UILocker::lock(Reasons reason)
   return ls;
 }
 
+bool UILocker::locked() const
+{
+  return !m_sessions.empty();
+}
+
 void UILocker::unlock(Session* s)
 {
   auto itor = m_sessions.begin();

--- a/src/uilocker.cpp
+++ b/src/uilocker.cpp
@@ -20,6 +20,9 @@ public:
 
   ~UILockerInterface()
   {
+    if (m_topLevel) {
+      delete m_topLevel.data();
+    }
   }
 
   void checkTarget()
@@ -31,14 +34,8 @@ public:
 
   bool set()
   {
-    QWidget* newTarget = nullptr;
-
-    newTarget = m_mainUI;
-    if (auto* w = QApplication::activeModalWidget()) {
-      newTarget = w;
-    }
-
-    if (newTarget == m_target) {
+    QWidget* newTarget = findTarget();
+    if (m_topLevel && newTarget == m_target) {
       return false;
     }
 
@@ -98,8 +95,8 @@ public:
 
   QWidget* topLevel()
   {
-    return m_topLevel.get();
-  }
+    return m_topLevel.data();
+   }
 
 private:
   class Filter : public QObject
@@ -129,7 +126,7 @@ private:
   std::unique_ptr<QTimer> m_timer;
   QWidget* m_mainUI;
   QWidget* m_target;
-  std::unique_ptr<QWidget> m_topLevel;
+  QPointer<QWidget> m_topLevel;
   QLabel* m_message;
   QLabel* m_info;
   QStringList m_labels;
@@ -141,6 +138,55 @@ private:
   bool hasMainUI() const
   {
     return (m_target != nullptr);
+  }
+
+  QWidget* findTarget()
+  {
+    auto isValidTarget = [](QWidget* w) {
+      // skip message boxes
+      if (dynamic_cast<QMessageBox*>(w)) {
+        return false;
+      }
+
+      // skip invisible widgets
+      if (!w->isVisible()) {
+        return false;
+      }
+
+      // skip windows that are too small
+      if (w->height() < 150) {
+        return false;
+      }
+
+      return true;
+    };
+
+
+    // find a modal dialog
+    QWidget* w = QApplication::activeModalWidget();
+
+    while (w && w != m_mainUI) {
+      if (isValidTarget(w)) {
+        return w;
+      }
+
+      w = w->parentWidget();
+    }
+
+    // find a non-modal dialog that's a child of the main window
+    if (m_mainUI) {
+      const auto topLevels = QApplication::topLevelWidgets();
+
+      for (auto* w : topLevels) {
+        if (w && w->parentWidget() == m_mainUI) {
+          if (isValidTarget(w)) {
+            return w;
+          }
+        }
+      }
+    }
+
+    return m_mainUI;
   }
 
   QWidget* createTransparentWidget(QWidget* parent=nullptr)
@@ -156,7 +202,12 @@ private:
 
   QFrame* createOverlay(QWidget* mainUI)
   {
-    m_topLevel.reset(createTransparentWidget(mainUI));
+    if (m_topLevel) {
+      delete m_topLevel.data();
+      m_topLevel.clear();
+    }
+
+    m_topLevel = createTransparentWidget(mainUI);
     m_topLevel->setWindowFlags(m_topLevel->windowFlags() & Qt::FramelessWindowHint);
     m_topLevel->setGeometry(mainUI->rect());
 
@@ -171,7 +222,12 @@ private:
 
   QFrame* createDialog()
   {
-    m_topLevel.reset(new QDialog);
+    if (m_topLevel) {
+      delete m_topLevel.data();
+      m_topLevel.clear();
+    }
+
+    m_topLevel = new QDialog;
 
     return createFrame();
   }
@@ -195,7 +251,7 @@ private:
       ly->setContentsMargins(0, 0, 0, 0);
     }
 
-    auto* grid = new QGridLayout(m_topLevel.get());
+    auto* grid = new QGridLayout(m_topLevel.data());
     grid->addWidget(createTransparentWidget(), 0, 1);
     grid->addWidget(createTransparentWidget(), 2, 1);
     grid->addWidget(createTransparentWidget(), 1, 0);

--- a/src/uilocker.h
+++ b/src/uilocker.h
@@ -70,6 +70,7 @@ public:
   void setUserInterface(QWidget* parent);
 
   std::shared_ptr<Session> lock(Reasons reason);
+  bool locked() const;
 
   Results result() const;
 


### PR DESCRIPTION
- Make sure MO stays locked for all processes when quitting
- Some settings weren't saved when pressing X twice when MO gets locked, could also crash
- Fixed the overlay getting shown on dialog boxes or windows too small to show the unlock button
- Better handling of moving the overlay to non-modal dialogs
- Fixed crash when closing an overlayed dialog