### PR TITLE
rc6 fixes

### DIFF
--- a/src/env.cpp
+++ b/src/env.cpp
@@ -101,6 +101,7 @@ void ModuleNotification::fire(QString path, std::size_t fileSize)
 {
   if (m_loaded.contains(path)) {
     // don't notify if it's been loaded before
+    return;
   }
 
   m_loaded.insert(path);

--- a/src/nxmaccessmanager.cpp
+++ b/src/nxmaccessmanager.cpp
@@ -333,8 +333,8 @@ void NexusSSOLogin::onDisconnected()
 void NexusSSOLogin::onError(QAbstractSocket::SocketError e)
 {
   if (m_active) {
-    setState(Error, m_socket.errorString());
     close();
+    setState(Error, m_socket.errorString());
   }
 }
 

--- a/src/organizer_en.ts
+++ b/src/organizer_en.ts
@@ -6317,9 +6317,9 @@ If the folder was still in use, restart MO and try again.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="processrunner.cpp" line="539"/>
-        <location filename="processrunner.cpp" line="592"/>
-        <location filename="processrunner.cpp" line="738"/>
+        <location filename="processrunner.cpp" line="557"/>
+        <location filename="processrunner.cpp" line="610"/>
+        <location filename="processrunner.cpp" line="756"/>
         <source>No profile set</source>
         <translation type="unfinished"></translation>
     </message>

--- a/src/processrunner.h
+++ b/src/processrunner.h
@@ -156,6 +156,7 @@ private:
 
 
   bool shouldRunShell() const;
+  bool shouldRefresh(Results r) const;
 
   // runs the command in m_shellOpen; returns empty if it can be waited for
   //

--- a/src/version.rc
+++ b/src/version.rc
@@ -4,7 +4,7 @@
 // Otherwise, if letters are used in VER_FILEVERSION_STR, uses the full MOBase::VersionInfo parser
 // Otherwise, uses the numbers from VER_FILEVERSION and sets the release type as pre-alpha
 #define VER_FILEVERSION     2,2,2
-#define VER_FILEVERSION_STR "2.2.2rc5\0"
+#define VER_FILEVERSION_STR "2.2.2rc6\0"
 
 VS_VERSION_INFO VERSIONINFO
 FILEVERSION     VER_FILEVERSION


### PR DESCRIPTION
- Refresh after manually unlocking the UI
- Fixed "Connect to Nexus" button staying as "Cancel" in case of errors
- Don't log the same DLL getting loaded multiple times
- Bumped to rc6