### PR TITLE
Dracula theme fix for redrawing the images tab

### DIFF
--- a/src/stylesheets/dracula.qss
+++ b/src/stylesheets/dracula.qss
@@ -4,7 +4,7 @@
 
 QWidget, QStackedWidget,
 QScrollArea, QAbstractScrollArea {
-    background-color: transparent;
+    background-color: #3c3f41;
     color: #bbbbbb;
 	}
 


### PR DESCRIPTION
Changed widget background colour to opaque since it's used in the images tab to redraw the background when moving the splitter.