### PR TITLE
Hacky fix to installation progress dialog flashing

### DIFF
--- a/src/installationmanager.cpp
+++ b/src/installationmanager.cpp
@@ -191,6 +191,8 @@ bool InstallationManager::unpackSingleFile(const QString &fileName)
   m_InstallationProgress->setWindowTitle(tr("Extracting files"));
   m_InstallationProgress->setWindowModality(Qt::WindowModal);
   m_InstallationProgress->setFixedSize(600, 100);
+  m_InstallationProgress->setAutoClose(false);
+  m_InstallationProgress->setAutoReset(false);
   m_InstallationProgress->show();
 
   QFuture<bool> future = QtConcurrent::run([&]() -> bool {
@@ -290,6 +292,8 @@ QStringList InstallationManager::extractFiles(const QStringList &filesOrig, bool
   m_InstallationProgress->setWindowTitle(tr("Extracting files"));
   m_InstallationProgress->setWindowModality(Qt::WindowModal);
   m_InstallationProgress->setFixedSize(600, 100);
+  m_InstallationProgress->setAutoClose(false);
+  m_InstallationProgress->setAutoReset(false);
   m_InstallationProgress->show();
 
   // unpack only the files we need for the installer
@@ -601,6 +605,8 @@ IPluginInstaller::EInstallResult InstallationManager::doInstall(GuessedValue<QSt
         m_InstallationProgress->windowFlags() & (~Qt::WindowContextHelpButtonHint));
   m_InstallationProgress->setWindowModality(Qt::WindowModal);
   m_InstallationProgress->setFixedSize(600, 100);
+  m_InstallationProgress->setAutoClose(false);
+  m_InstallationProgress->setAutoReset(false);
   m_InstallationProgress->show();
   QFuture<bool> future = QtConcurrent::run([&]() -> bool {
     return m_ArchiveHandler->extract(


### PR DESCRIPTION
Alright, so this is a bit of an interesting one.  I'll be copying this over to an issue to hopefully properly fix down the line.

**The symptom**:  Flashing progress dialog when installing certain mods.  The test case for this fix was Collision Meshes FNV (https://www.nexusmods.com/newvegas/mods/59149/).  

**The initial cause**:  Files were still being extracted after the progress dialog reached 100%, causing the progress dialog to be opened and instantly closed for every progress update.

**The hacky fix**:  Prevent the progress dialog from automatically closing and automatically resetting.  This is not ideal as the progress quickly reaches 100% and then stays there.

**The root-ish cause**:  Something with 7-zip or the integration of 7-zip has changed/broken.  In the test case, the 0% to 100% progress is all about \meshes\vehicles\wreckage.  Why?  No clue.  