### PR TITLE
Filterwidget updates

### DIFF
--- a/src/datatab.cpp
+++ b/src/datatab.cpp
@@ -29,6 +29,7 @@ DataTab::DataTab(
   m_filter.setFilterColumn(FileTreeModel::FileName);
   m_filter.setEdit(mwui->dataTabFilter);
   m_filter.setList(mwui->dataTree);
+  m_filter.setUpdateDelay(true);
 
   if (auto* m=m_filter.proxyModel()) {
     m->setDynamicSortFilter(false);

--- a/src/mainwindow.ui
+++ b/src/mainwindow.ui
@@ -775,6 +775,15 @@ p, li { white-space: pre-wrap; }
              <string>Plugins</string>
             </attribute>
             <layout class="QVBoxLayout" name="verticalLayout_4">
+             <property name="spacing">
+              <number>2</number>
+             </property>
+             <property name="topMargin">
+              <number>6</number>
+             </property>
+             <property name="bottomMargin">
+              <number>0</number>
+             </property>
              <item>
               <layout class="QHBoxLayout" name="horizontalLayout_7">
                <item>
@@ -795,20 +804,17 @@ p, li { white-space: pre-wrap; }
                 </widget>
                </item>
                <item>
-                <widget class="MOBase::LineEditClear" name="espFilterEdit">
-                 <property name="toolTip">
-                  <string>Filter the list of plugins.</string>
+                <spacer name="horizontalSpacer_3">
+                 <property name="orientation">
+                  <enum>Qt::Horizontal</enum>
                  </property>
-                 <property name="whatsThis">
-                  <string>Filter the list of plugins.</string>
+                 <property name="sizeHint" stdset="0">
+                  <size>
+                   <width>40</width>
+                   <height>20</height>
+                  </size>
                  </property>
-                 <property name="text">
-                  <string/>
-                 </property>
-                 <property name="placeholderText">
-                  <string>Filter</string>
-                 </property>
-                </widget>
+                </spacer>
                </item>
                <item>
                 <widget class="QPushButton" name="restoreButton">
@@ -942,6 +948,39 @@ p, li { white-space: pre-wrap; }
                </attribute>
               </widget>
              </item>
+             <item>
+              <layout class="QHBoxLayout" name="horizontalLayout_10">
+               <item>
+                <spacer name="horizontalSpacer_2">
+                 <property name="orientation">
+                  <enum>Qt::Horizontal</enum>
+                 </property>
+                 <property name="sizeHint" stdset="0">
+                  <size>
+                   <width>40</width>
+                   <height>20</height>
+                  </size>
+                 </property>
+                </spacer>
+               </item>
+               <item>
+                <widget class="MOBase::LineEditClear" name="espFilterEdit">
+                 <property name="toolTip">
+                  <string>Filter the list of plugins.</string>
+                 </property>
+                 <property name="whatsThis">
+                  <string>Filter the list of plugins.</string>
+                 </property>
+                 <property name="text">
+                  <string/>
+                 </property>
+                 <property name="placeholderText">
+                  <string>Filter</string>
+                 </property>
+                </widget>
+               </item>
+              </layout>
+             </item>
             </layout>
            </widget>
            <widget class="QWidget" name="bsaTab">
@@ -952,6 +991,15 @@ p, li { white-space: pre-wrap; }
              <string>Archives</string>
             </attribute>
             <layout class="QVBoxLayout" name="verticalLayout_9">
+             <property name="spacing">
+              <number>2</number>
+             </property>
+             <property name="topMargin">
+              <number>6</number>
+             </property>
+             <property name="bottomMargin">
+              <number>0</number>
+             </property>
              <item>
               <layout class="QHBoxLayout" name="horizontalLayout_9" stretch="0">
                <item>
@@ -1010,6 +1058,15 @@ p, li { white-space: pre-wrap; }
              <string>Data</string>
             </attribute>
             <layout class="QVBoxLayout" name="verticalLayout_5">
+             <property name="spacing">
+              <number>2</number>
+             </property>
+             <property name="topMargin">
+              <number>6</number>
+             </property>
+             <property name="bottomMargin">
+              <number>0</number>
+             </property>
              <item>
               <layout class="QHBoxLayout" name="horizontalLayout_12">
                <item>
@@ -1030,43 +1087,17 @@ p, li { white-space: pre-wrap; }
                 </widget>
                </item>
                <item>
-                <widget class="QLineEdit" name="dataTabFilter">
-                 <property name="toolTip">
-                  <string>Filter the Data tree.</string>
+                <spacer name="horizontalSpacer_4">
+                 <property name="orientation">
+                  <enum>Qt::Horizontal</enum>
                  </property>
-                 <property name="whatsThis">
-                  <string>Filter the Data tree.</string>
+                 <property name="sizeHint" stdset="0">
+                  <size>
+                   <width>40</width>
+                   <height>20</height>
+                  </size>
                  </property>
-                </widget>
-               </item>
-               <item>
-                <widget class="QCheckBox" name="dataTabShowOnlyConflicts">
-                 <property name="toolTip">
-                  <string>Filter the list so that only conflicts are displayed.</string>
-                 </property>
-                 <property name="whatsThis">
-                  <string>Filter the list so that only conflicts are displayed.</string>
-                 </property>
-                 <property name="text">
-                  <string>Conflicts only</string>
-                 </property>
-                </widget>
-               </item>
-               <item>
-                <widget class="QCheckBox" name="dataTabShowFromArchives">
-                 <property name="toolTip">
-                  <string>Filter the list so that files from archives are shown.</string>
-                 </property>
-                 <property name="statusTip">
-                  <string/>
-                 </property>
-                 <property name="whatsThis">
-                  <string>Filter the list so that files from archives are shown.</string>
-                 </property>
-                 <property name="text">
-                  <string>Archives</string>
-                 </property>
-                </widget>
+                </spacer>
                </item>
               </layout>
              </item>
@@ -1096,6 +1127,49 @@ p, li { white-space: pre-wrap; }
                </item>
               </layout>
              </item>
+             <item>
+              <layout class="QHBoxLayout" name="horizontalLayout_13" stretch="1,1,2">
+               <item>
+                <widget class="QCheckBox" name="dataTabShowOnlyConflicts">
+                 <property name="toolTip">
+                  <string>Filter the list so that only conflicts are displayed.</string>
+                 </property>
+                 <property name="whatsThis">
+                  <string>Filter the list so that only conflicts are displayed.</string>
+                 </property>
+                 <property name="text">
+                  <string>Conflicts only</string>
+                 </property>
+                </widget>
+               </item>
+               <item>
+                <widget class="QCheckBox" name="dataTabShowFromArchives">
+                 <property name="toolTip">
+                  <string>Filter the list so that files from archives are shown.</string>
+                 </property>
+                 <property name="statusTip">
+                  <string/>
+                 </property>
+                 <property name="whatsThis">
+                  <string>Filter the list so that files from archives are shown.</string>
+                 </property>
+                 <property name="text">
+                  <string>Archives</string>
+                 </property>
+                </widget>
+               </item>
+               <item>
+                <widget class="QLineEdit" name="dataTabFilter">
+                 <property name="toolTip">
+                  <string>Filter the Data tree.</string>
+                 </property>
+                 <property name="whatsThis">
+                  <string>Filter the Data tree.</string>
+                 </property>
+                </widget>
+               </item>
+              </layout>
+             </item>
             </layout>
            </widget>
            <widget class="QWidget" name="savesTab">
@@ -1103,6 +1177,15 @@ p, li { white-space: pre-wrap; }
              <string>Saves</string>
             </attribute>
             <layout class="QVBoxLayout" name="verticalLayout_3">
+             <property name="spacing">
+              <number>2</number>
+             </property>
+             <property name="topMargin">
+              <number>6</number>
+             </property>
+             <property name="bottomMargin">
+              <number>0</number>
+             </property>
              <item>
               <widget class="QListWidget" name="savegameList">
                <property name="contextMenuPolicy">
@@ -1138,8 +1221,17 @@ p, li { white-space: pre-wrap; }
              <string>Downloads</string>
             </attribute>
             <layout class="QVBoxLayout" name="verticalLayout_7">
+             <property name="spacing">
+              <number>2</number>
+             </property>
+             <property name="topMargin">
+              <number>6</number>
+             </property>
+             <property name="bottomMargin">
+              <number>0</number>
+             </property>
              <item>
-              <layout class="QHBoxLayout" name="horizontalLayout" stretch="0,0,0">
+              <layout class="QHBoxLayout" name="horizontalLayout" stretch="0,0">
                <item>
                 <widget class="QPushButton" name="btnRefreshDownloads">
                  <property name="toolTip">
@@ -1158,30 +1250,17 @@ p, li { white-space: pre-wrap; }
                 </widget>
                </item>
                <item>
-                <widget class="MOBase::LineEditClear" name="downloadFilterEdit">
-                 <property name="toolTip">
-                  <string>Filter the list of downloads.</string>
+                <spacer name="horizontalSpacer_7">
+                 <property name="orientation">
+                  <enum>Qt::Horizontal</enum>
                  </property>
-                 <property name="whatsThis">
-                  <string>Filter the list of downloads.</string>
+                 <property name="sizeHint" stdset="0">
+                  <size>
+                   <width>40</width>
+                   <height>20</height>
+                  </size>
                  </property>
-                 <property name="placeholderText">
-                  <string>Filter</string>
-                 </property>
-                </widget>
-               </item>
-               <item>
-                <widget class="QCheckBox" name="showHiddenBox">
-                 <property name="toolTip">
-                  <string>Show downloads marked as hidden.</string>
-                 </property>
-                 <property name="whatsThis">
-                  <string>Show downloads marked as hidden.</string>
-                 </property>
-                 <property name="text">
-                  <string>Hidden files</string>
-                 </property>
-                </widget>
+                </spacer>
                </item>
               </layout>
              </item>
@@ -1230,6 +1309,49 @@ p, li { white-space: pre-wrap; }
                  </property>
                  <property name="sortingEnabled">
                   <bool>true</bool>
+                 </property>
+                </widget>
+               </item>
+              </layout>
+             </item>
+             <item>
+              <layout class="QHBoxLayout" name="horizontalLayout_16" stretch="1,1,2">
+               <item>
+                <widget class="QCheckBox" name="showHiddenBox">
+                 <property name="toolTip">
+                  <string>Show downloads marked as hidden.</string>
+                 </property>
+                 <property name="whatsThis">
+                  <string>Show downloads marked as hidden.</string>
+                 </property>
+                 <property name="text">
+                  <string>Hidden files</string>
+                 </property>
+                </widget>
+               </item>
+               <item>
+                <spacer name="horizontalSpacer_6">
+                 <property name="orientation">
+                  <enum>Qt::Horizontal</enum>
+                 </property>
+                 <property name="sizeHint" stdset="0">
+                  <size>
+                   <width>40</width>
+                   <height>20</height>
+                  </size>
+                 </property>
+                </spacer>
+               </item>
+               <item>
+                <widget class="MOBase::LineEditClear" name="downloadFilterEdit">
+                 <property name="toolTip">
+                  <string>Filter the list of downloads.</string>
+                 </property>
+                 <property name="whatsThis">
+                  <string>Filter the list of downloads.</string>
+                 </property>
+                 <property name="placeholderText">
+                  <string>Filter</string>
                  </property>
                 </widget>
                </item>

--- a/src/settings.cpp
+++ b/src/settings.cpp
@@ -2009,6 +2009,7 @@ FilterWidget::Options InterfaceSettings::filterOptions() const
   o.useRegex = get<bool>(m_Settings, "Settings", "filter_regex", false);
   o.regexCaseSensitive = get<bool>(m_Settings, "Settings", "regex_case_sensitive", false);
   o.regexExtended = get<bool>(m_Settings, "Settings", "regex_extended", false);
+  o.scrollToSelection = get<bool>(m_Settings, "Settings", "filter_scroll_to_selection", false);
 
   return o;
 }
@@ -2018,6 +2019,7 @@ void InterfaceSettings::setFilterOptions(const FilterWidget::Options& o)
   set(m_Settings, "Settings", "filter_regex", o.useRegex);
   set(m_Settings, "Settings", "regex_case_sensitive", o.regexCaseSensitive);
   set(m_Settings, "Settings", "regex_extended", o.regexExtended);
+  set(m_Settings, "Settings", "filter_scroll_to_selection", o.scrollToSelection);
 }
 
 


### PR DESCRIPTION
- Added option to keep selection in view while filtering with filterwidget
- Add 100ms buffer after text input before filtering the data tab
- Moved all right pane filters back to the bottom right
- Improved alignment and size of filters and other elements such as buttons and check-boxes in the right pane.