### PR TITLE
File tree crashes

### DIFF
--- a/src/filetree.cpp
+++ b/src/filetree.cpp
@@ -145,7 +145,6 @@ FileTree::FileTree(OrganizerCore& core, PluginContainer& pc, QTreeView* tree)
   connect(
     m_tree, &QTreeView::activated,
     [&](auto&& index){ onItemActivated(index); });
-
 }
 
 FileTreeModel* FileTree::model()

--- a/src/filetreeitem.cpp
+++ b/src/filetreeitem.cpp
@@ -366,8 +366,7 @@ void FileTreeItem::unload()
     return;
   }
 
-  m_loaded = false;
-  m_children.clear();
+  clear();
 }
 
 bool FileTreeItem::areChildrenVisible() const

--- a/src/filetreemodel.h
+++ b/src/filetreemodel.h
@@ -93,6 +93,13 @@ private:
   SortInfo m_sort;
   bool m_fullyLoaded;
 
+  // see top of filetreemodel.cpp
+  std::vector<FileTreeItem*> m_removeItems;
+  QTimer m_removeTimer;
+  std::vector<FileTreeItem*> m_sortItems;
+  QTimer m_sortTimer;
+
+
   bool showConflictsOnly() const
   {
     return (m_flags & ConflictsOnly);
@@ -101,18 +108,28 @@ private:
   bool showArchives() const;
 
 
+  // for `forFetching`, see top of filetreemodel.cpp
   void update(
     FileTreeItem& parentItem, const MOShared::DirectoryEntry& parentEntry,
-    const std::wstring& parentPath);
+    const std::wstring& parentPath, bool forFetching);
+
+  void queueRemoveItem(FileTreeItem* item);
+  void removeItems();
+
+  void queueSortItem(FileTreeItem* item);
+  void sortItems();
 
 
+  // for `forFetching`, see top of filetreemodel.cpp
   bool updateDirectories(
     FileTreeItem& parentItem, const std::wstring& path,
-    const MOShared::DirectoryEntry& parentEntry);
+    const MOShared::DirectoryEntry& parentEntry, bool forFetching);
 
+  // for `forFetching`, see top of filetreemodel.cpp
   void removeDisappearingDirectories(
     FileTreeItem& parentItem, const MOShared::DirectoryEntry& parentEntry,
-    const std::wstring& parentPath, std::unordered_set<std::wstring_view>& seen);
+    const std::wstring& parentPath, std::unordered_set<std::wstring_view>& seen,
+    bool forFetching);
 
   bool addNewDirectories(
     FileTreeItem& parentItem, const MOShared::DirectoryEntry& parentEntry,


### PR DESCRIPTION
Fixed the various crashes and empty items in the file tree. Most of the details are at the top of `filetreemodel.cpp`. Sorting and removing items have to be queued since they corrupt various internal structures in Qt when done during layout