### PR TITLE
Mod colors

### DIFF
--- a/src/mainwindow.cpp
+++ b/src/mainwindow.cpp
@@ -4644,6 +4644,7 @@ void MainWindow::on_modList_customContextMenuRequested(const QPoint &pos)
 
     m_ContextIdx = mapToModel(m_OrganizerCore.modList(), modList->indexAt(pos));
     m_ContextRow = m_ContextIdx.row();
+    int contextColumn = m_ContextIdx.column();
 
     if (m_ContextRow == -1) {
       // no selection
@@ -4766,12 +4767,14 @@ void MainWindow::on_modList_customContextMenuRequested(const QPoint &pos)
 
         menu.addSeparator();
 
-        menu.addAction(tr("Select Color..."), this, SLOT(setColor_clicked()));
+        if (contextColumn == ModList::COL_NOTES) {
+          menu.addAction(tr("Select Color..."), this, SLOT(setColor_clicked()));
 
-        if (info->getColor().isValid())
-          menu.addAction(tr("Reset Color"), this, SLOT(resetColor_clicked()));
+          if (info->getColor().isValid())
+            menu.addAction(tr("Reset Color"), this, SLOT(resetColor_clicked()));
 
-        menu.addSeparator();
+          menu.addSeparator();
+        }
 
         if (info->getNexusID() > 0 && Settings::instance().nexus().endorsementIntegration()) {
           switch (info->endorsedState()) {

--- a/src/mainwindow.cpp
+++ b/src/mainwindow.cpp
@@ -3649,11 +3649,7 @@ void MainWindow::setColor_clicked()
   if (selection->hasSelection() && selection->selectedRows().count() > 1) {
     for (QModelIndex idx : selection->selectedRows()) {
       ModInfo::Ptr info = ModInfo::getByIndex(idx.data(Qt::UserRole + 1).toInt());
-      auto flags = info->getFlags();
-      if (std::find(flags.begin(), flags.end(), ModInfo::FLAG_SEPARATOR) != flags.end())
-      {
-        info->setColor(currentColor);
-      }
+       info->setColor(currentColor);
     }
   }
   else {
@@ -3669,11 +3665,7 @@ void MainWindow::resetColor_clicked()
   if (selection->hasSelection() && selection->selectedRows().count() > 1) {
     for (QModelIndex idx : selection->selectedRows()) {
       ModInfo::Ptr info = ModInfo::getByIndex(idx.data(Qt::UserRole + 1).toInt());
-      auto flags = info->getFlags();
-      if (std::find(flags.begin(), flags.end(), ModInfo::FLAG_SEPARATOR) != flags.end())
-      {
-        info->setColor(color);
-      }
+       info->setColor(color);
     }
   }
   else {
@@ -4771,6 +4763,13 @@ void MainWindow::on_modList_customContextMenuRequested(const QPoint &pos)
         if (std::find(flags.begin(), flags.end(), ModInfo::FLAG_HIDDEN_FILES) != flags.end()) {
           menu.addAction(tr("Restore hidden files"), this, SLOT(restoreHiddenFiles_clicked()));
         }
+
+        menu.addSeparator();
+
+        menu.addAction(tr("Select Color..."), this, SLOT(setColor_clicked()));
+
+        if (info->getColor().isValid())
+          menu.addAction(tr("Reset Color"), this, SLOT(resetColor_clicked()));
 
         menu.addSeparator();
 

--- a/src/modinfodialog.ui
+++ b/src/modinfodialog.ui
@@ -1204,17 +1204,35 @@ p, li { white-space: pre-wrap; }
       </attribute>
       <layout class="QVBoxLayout" name="verticalLayout_10">
        <item>
-        <widget class="QLineEdit" name="comments">
-         <property name="toolTip">
-          <string>Enter comments about the mod here.  These are displayed in the notes column of the mod list.</string>
-         </property>
-         <property name="whatsThis">
-          <string>Enter comments about the mod here.  These are displayed in the notes column of the mod list.</string>
-         </property>
-         <property name="placeholderText">
-          <string>Enter comments about the mod here.  These are displayed in the notes column of the mod list.</string>
-         </property>
-        </widget>
+        <layout class="QHBoxLayout" name="horizontalLayout_11">
+         <item>
+          <widget class="QLineEdit" name="comments">
+           <property name="toolTip">
+            <string>Enter comments about the mod here.  These are displayed in the notes column of the mod list.</string>
+           </property>
+           <property name="whatsThis">
+            <string>Enter comments about the mod here.  These are displayed in the notes column of the mod list.</string>
+           </property>
+           <property name="placeholderText">
+            <string>Enter comments about the mod here.  These are displayed in the notes column of the mod list.</string>
+           </property>
+          </widget>
+         </item>
+         <item>
+          <widget class="QPushButton" name="setColorButton">
+           <property name="text">
+            <string>Set Color</string>
+           </property>
+          </widget>
+         </item>
+         <item>
+          <widget class="QPushButton" name="resetColorButton">
+           <property name="text">
+            <string>Reset Color</string>
+           </property>
+          </widget>
+         </item>
+        </layout>
        </item>
        <item>
         <widget class="HTMLEditor" name="notes">

--- a/src/modinfodialogtab.h
+++ b/src/modinfodialogtab.h
@@ -253,15 +253,15 @@ protected:
   //
   void setFocus();
 
+  // parent widget, used to display modal dialogs
+  QWidget* m_parent;
+
 private:
   // core
   OrganizerCore& m_core;
 
   // plugin
   PluginContainer& m_plugin;
-
-  // parent widget, used to display modal dialogs
-  QWidget* m_parent;
 
   // current mod, never null
   ModInfoPtr m_mod;
@@ -299,8 +299,11 @@ public:
   bool usesOriginFiles() const override;
 
 private:
+  void updateCommentsColor(bool clear = false);
   void onComments();
   void onNotes();
+  void onSetColor();
+  void onResetColor();
   void checkHasData();
 };
 

--- a/src/modlist.cpp
+++ b/src/modlist.cpp
@@ -404,7 +404,7 @@ QVariant ModList::data(const QModelIndex &modelIndex, int role) const
     }
     return QVariant();
   } else if (role == Qt::ForegroundRole) {
-    if (modInfo->hasFlag(ModInfo::FLAG_SEPARATOR) && modInfo->getColor().isValid()) {
+    if (modInfo->hasFlag(ModInfo::FLAG_SEPARATOR) || (column == COL_NOTES) && modInfo->getColor().isValid()) {
       return ColorSettings::idealTextColor(modInfo->getColor());
     } else if (column == COL_NAME) {
       int highlight = modInfo->getHighlight();
@@ -430,7 +430,9 @@ QVariant ModList::data(const QModelIndex &modelIndex, int role) const
     bool overwritten = m_Overwritten.find(modIndex) != m_Overwritten.end();
     bool archiveOverwritten = m_ArchiveOverwritten.find(modIndex) != m_ArchiveOverwritten.end();
     bool archiveLooseOverwritten = m_ArchiveLooseOverwritten.find(modIndex) != m_ArchiveLooseOverwritten.end();
-    if (modInfo->getHighlight() & ModInfo::HIGHLIGHT_PLUGIN) {
+    if (column == COL_NOTES && modInfo->getColor().isValid()) {
+      return modInfo->getColor();
+    } else if (modInfo->getHighlight() & ModInfo::HIGHLIGHT_PLUGIN) {
       return Settings::instance().colors().modlistContainsPlugin();
     } else if (overwritten || archiveLooseOverwritten) {
       return Settings::instance().colors().modlistOverwritingLoose();


### PR DESCRIPTION
Add the ability to color the Notes column of mods. 
This can be done via right clicking the notes column -> Set Color. Reset Color is also offered like with separators.
Added Set Color and Reset Color buttons to modinfodialog Notes tab.