### PR TITLE
Appveyor fix for new cmake files

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -5,7 +5,13 @@ set(project_type exe)
 set(executable_name ModOrganizer)
 set(enable_warnings OFF)
 
-include(../cmake_common/project.cmake)
+# appveyor does not build modorganizer in its standard location, so use
+# DEPENDENCIES_DIR to find cmake_common
+if(DEFINED DEPENDENCIES_DIR)
+	include(${DEPENDENCIES_DIR}/modorganizer_super/cmake_common/project.cmake)
+else()
+	include(../cmake_common/project.cmake)
+endif()
 
 set(additional_translations ${uibase_path}/src)
 

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -1,5 +1,13 @@
 cmake_minimum_required(VERSION 3.16)
-include(../../cmake_common/src.cmake)
+
+# appveyor does not build modorganizer in its standard location, so use
+# DEPENDENCIES_DIR to find cmake_common
+if(DEFINED DEPENDENCIES_DIR)
+	include(${DEPENDENCIES_DIR}/modorganizer_super/cmake_common/src.cmake)
+else()
+	include(../cmake_common/src.cmake)
+endif()
+
 
 add_filter(NAME src/application GROUPS
 	iuserinterface


### PR DESCRIPTION
Appveyor does not build `modorganizer` in its standard location, so use `DEPENDENCIES_DIR` to find `cmake_common`