### PR TITLE
Update for the new file tree implementation and minor fixes

### DIFF
--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -26,6 +26,7 @@ add_filter(NAME src/browser GROUPS
 
 add_filter(NAME src/core GROUPS
 	categories
+	archivefiletree
 	installationmanager
 	instancemanager
 	loadmechanism

--- a/src/archivefiletree.cpp
+++ b/src/archivefiletree.cpp
@@ -158,7 +158,7 @@ protected:
 
     // We know that the files are sorted:
     QString currentName = "";
-    int currentIndex;
+    int currentIndex = -1;
     std::vector<File> currentFiles;
     for (auto& p : m_Files) {
 
@@ -167,7 +167,6 @@ protected:
       // one for a/b while we would want the one for a, but we correct that later):
       if (currentName == "") {
         currentName = std::get<0>(p)[0];
-        currentIndex = std::get<2>(p);
       }
 
       // If the name is different, we need to create a directory from what we have 
@@ -178,7 +177,7 @@ protected:
         currentFiles.clear(); // Back to a valid state.
 
         // Retrieve the next index:
-        currentIndex = std::get<2>(p);
+        currentIndex = -1;
       }
 
       // We can always override the current name:

--- a/src/archivefiletree.cpp
+++ b/src/archivefiletree.cpp
@@ -1,0 +1,252 @@
+/*
+Copyright (C) MO2 Team. All rights reserved.
+
+This file is part of Mod Organizer.
+
+Mod Organizer is free software: you can redistribute it and/or modify
+it under the terms of the GNU General Public License as published by
+the Free Software Foundation, either version 3 of the License, or
+(at your option) any later version.
+
+Mod Organizer is distributed in the hope that it will be useful,
+but WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+GNU General Public License for more details.
+
+You should have received a copy of the GNU General Public License
+along with Mod Organizer.  If not, see <http://www.gnu.org/licenses/>.
+*/
+
+// For QObject::tr:
+#include <QObject>
+
+#include "archivefiletree.h"
+
+#include "log.h"
+
+using namespace MOBase;
+
+/**
+ * We use custom file entries to store the index.
+ */
+class ArchiveFileEntry : public virtual FileTreeEntry {
+public:
+
+  /**
+   * @brief Create a new entry corresponding to a file.
+   *
+   * @param parent The tree containing this file.
+   * @param name The name of this file.
+   * @param index The index of the file in the archive.
+   * @param time The modification time of this file.
+   */
+  ArchiveFileEntry(std::shared_ptr<IFileTree> parent, QString name, int index, QDateTime time) :
+    FileTreeEntry(parent, name, time), m_Index(index) {
+  }
+
+  /**
+   * @brief Create a new entry corresponding to a directory.
+   *
+   * @param parent The tree containing this directory.
+   * @param name The name of this directory.
+   * @param index The index of the directory in the archive, or -1.
+   */
+  ArchiveFileEntry(std::shared_ptr<IFileTree> parent, QString name, int index) :
+    FileTreeEntry(parent, name), m_Index(index) {
+  }
+
+  // No private since we are in an implementation file:
+  const int m_Index;
+};
+
+
+/**
+ *
+ */
+class ArchiveFileTreeImpl: public virtual ArchiveFileTree, public virtual ArchiveFileEntry {
+public:
+
+  using File = std::tuple<QStringList, bool, int>;
+
+public: // Public for make_shared (but not accessible by other since not exposed in .h):
+
+  ArchiveFileTreeImpl(std::shared_ptr<IFileTree> parent, QString name, int index, std::vector<File>&& files)
+    : FileTreeEntry(parent, name), ArchiveFileEntry(parent, name, index), IFileTree(), m_Files(std::move(files)) { }
+
+public: // Overrides:
+
+  /**
+   * @override
+   */
+  std::shared_ptr<FileTreeEntry> addFile(QString path, QDateTime time = QDateTime()) override {
+    // Cannot add file to an archive.
+    throw UnsupportedOperationException(QObject::tr("Cannot create file within an archive."));
+  }
+
+  /**
+   *
+   */
+  static void mapToArchive(IFileTree const& tree, QString path, FileData* const* data)
+  {
+    if (path.length() > 0) {
+      // when using a long windows path (starting with \\?\) we apparently can have redundant
+      // . components in the path. This wasn't a problem with "regular" path names.
+      if (path == ".") {
+        path.clear();
+      }
+      else {
+        path.append("\\");
+      }
+    }
+
+    for (auto const& entry : tree) {
+      if (entry->isDir()) {
+        const ArchiveFileTreeImpl& archiveEntry = dynamic_cast<const ArchiveFileTreeImpl&>(*entry);
+        QString tmp = path + archiveEntry.name();
+        if (archiveEntry.m_Index != -1) {
+          data[archiveEntry.m_Index]->addOutputFileName(tmp);
+        }
+        mapToArchive(*archiveEntry.astree(), tmp, data);
+      }
+      else {
+        const ArchiveFileEntry& archiveFileEntry = dynamic_cast<const ArchiveFileEntry&>(*entry);
+        data[archiveFileEntry.m_Index]->addOutputFileName(path + archiveFileEntry.name());
+      }
+    }
+  }
+
+  /**
+   *
+   */
+  void mapToArchive(Archive* archive) const override {
+    FileData* const* data;
+    size_t size;
+    archive->getFileList(data, size);
+    mapToArchive(*this, "", data);
+  }
+
+protected:
+
+  /*
+   * Overriding this to create custom FileTreeEntry with index set to -1. No need to
+   * override makeFile() since we addFile is overriden. Note that this will not be
+   * used to create existing tree since we do this manually in doPopulate.
+   *
+   * @override
+   */
+  virtual std::shared_ptr<IFileTree> makeDirectory(
+    std::shared_ptr<IFileTree> parent, QString name) const override {
+    return std::make_shared<ArchiveFileTreeImpl>(parent, name, -1, std::vector<File>{});
+  }
+
+  virtual void doPopulate(std::shared_ptr<IFileTree> parent, std::vector<std::shared_ptr<FileTreeEntry>>& entries) const override {
+
+    // Sort by name:
+    std::sort(std::begin(m_Files), std::end(m_Files),
+      [](const auto& a, const auto& b) {
+        return std::get<0>(a)[0].compare(std::get<0>(b)[0], Qt::CaseInsensitive) < 0; });
+
+    // We know that the files are sorted:
+    QString currentName = "";
+    int currentIndex;
+    std::vector<File> currentFiles;
+    for (auto& p : m_Files) {
+
+      // At the start or if we have reset, just retrieve the current name and index - The
+      // index might not be valid in this case (e.g., if the path is a/b, the index is the 
+      // one for a/b while we would want the one for a, but we correct that later):
+      if (currentName == "") {
+        currentName = std::get<0>(p)[0];
+        currentIndex = std::get<2>(p);
+      }
+
+      // If the name is different, we need to create a directory from what we have 
+      // accumulated:
+      if (currentName != std::get<0>(p)[0]) {
+        // No index here since this is not an empty tree:
+        entries.push_back(std::make_shared<ArchiveFileTreeImpl>(parent, currentName, currentIndex, std::move(currentFiles)));
+        currentFiles.clear(); // Back to a valid state.
+
+        // Retrieve the next index:
+        currentIndex = std::get<2>(p);
+      }
+
+      // We can always override the current name:
+      currentName = std::get<0>(p)[0];
+
+      // If the current path contains only one components:
+      if (std::get<0>(p).size() == 1) {
+        // If it is not a directory, then it is a file in directly under this tree:
+        if (!std::get<1>(p)) {
+          entries.push_back(
+            std::make_shared<ArchiveFileEntry>(parent, currentName, std::get<2>(p), QDateTime()));
+          currentName = "";
+        }
+        // Otherwize, it is the actual "file" corresponding to the directory, so we can retrieve
+        // the index here:
+        currentIndex = std::get<2>(p);
+      }
+      else {
+        currentFiles.push_back({
+          QStringList(std::get<0>(p).begin() + 1, std::get<0>(p).end()), std::get<1>(p), std::get<2>(p)
+        });
+      }
+    }
+
+    if (currentName != "") {
+      entries.push_back(std::make_shared<ArchiveFileTreeImpl>(parent, currentName, currentIndex, std::move(currentFiles)));
+    }
+  }
+
+private:
+
+  mutable std::vector<File> m_Files;
+};
+
+std::shared_ptr<ArchiveFileTree> ArchiveFileTree::makeTree(Archive* archive) {
+
+  FileData* const* data;
+  size_t size;
+  archive->getFileList(data, size);
+
+  std::vector<ArchiveFileTreeImpl::File> files;
+  files.reserve(size);
+
+  for (size_t i = 0; i < size; ++i) {
+    files.push_back(std::make_tuple(data[i]->getFileName().replace("\\", "/").split("/", Qt::SkipEmptyParts), data[i]->isDirectory(), (int) i));
+  }
+
+  auto tree = std::make_shared<ArchiveFileTreeImpl>(nullptr, "", -1, std::move(files));
+  return tree;
+}
+
+/**
+ * @brief Recursive function for the ArchiveFileTree::mapToArchive method. Need a template
+ * here because iterators from a vector of entries are not exactly the same as the iterators
+ * returned by a IFileTree.
+ *
+ */
+template <class It>
+void mapToArchive(FileData* const* data, It begin, It end) {
+  for (auto it = begin; it != end; ++it) {
+    auto entry = *it;
+    auto* aentry = dynamic_cast<const ArchiveFileEntry*>(entry.get());
+
+    if (aentry->m_Index != -1) {
+      data[aentry->m_Index]->addOutputFileName(aentry->path());
+    }
+
+    if (entry->isDir()) {
+      auto tree = entry->astree();
+      mapToArchive(data, tree->begin(), tree->end());
+    }
+  }
+}
+
+void ArchiveFileTree::mapToArchive(Archive* archive, std::vector<std::shared_ptr<const FileTreeEntry>> const& entries) {
+  FileData* const* data;
+  size_t size;
+  archive->getFileList(data, size);
+
+  ::mapToArchive(data, entries.cbegin(), entries.cend());
+}

--- a/src/archivefiletree.cpp
+++ b/src/archivefiletree.cpp
@@ -73,6 +73,16 @@ public: // Public for make_shared (but not accessible by other since not exposed
   ArchiveFileTreeImpl(std::shared_ptr<IFileTree> parent, QString name, int index, std::vector<File>&& files)
     : FileTreeEntry(parent, name), ArchiveFileEntry(parent, name, index), IFileTree(), m_Files(std::move(files)) { }
 
+public: // Override to avoid VS warnings:
+
+  virtual std::shared_ptr<IFileTree> astree() override {
+    return IFileTree::astree();
+  }
+
+  virtual std::shared_ptr<const IFileTree> astree() const override {
+    return IFileTree::astree();
+  }
+
 public: // Overrides:
 
   /**

--- a/src/archivefiletree.cpp
+++ b/src/archivefiletree.cpp
@@ -162,9 +162,7 @@ protected:
     std::vector<File> currentFiles;
     for (auto& p : m_Files) {
 
-      // At the start or if we have reset, just retrieve the current name and index - The
-      // index might not be valid in this case (e.g., if the path is a/b, the index is the 
-      // one for a/b while we would want the one for a, but we correct that later):
+      // At the start or if we have reset, just retrieve the current name:
       if (currentName == "") {
         currentName = std::get<0>(p)[0];
       }
@@ -172,11 +170,14 @@ protected:
       // If the name is different, we need to create a directory from what we have 
       // accumulated:
       if (currentName != std::get<0>(p)[0]) {
-        // No index here since this is not an empty tree:
+
+        // We may or may not have an index here, it depends on the type of archive (some archives list
+        // intermediate non-empty folders, some don't):
         entries.push_back(std::make_shared<ArchiveFileTreeImpl>(parent, currentName, currentIndex, std::move(currentFiles)));
+        
         currentFiles.clear(); // Back to a valid state.
 
-        // Retrieve the next index:
+        // Reset the index:
         currentIndex = -1;
       }
 
@@ -185,6 +186,7 @@ protected:
 
       // If the current path contains only one components:
       if (std::get<0>(p).size() == 1) {
+
         // If it is not a directory, then it is a file in directly under this tree:
         if (!std::get<1>(p)) {
           entries.push_back(
@@ -192,7 +194,7 @@ protected:
           currentName = "";
         }
         else {
-          // Otherwize, it is the actual "file" corresponding to the directory, so we can retrieve
+          // Otherwize, it is the actual "file" corresponding to the directory we are listing, so we can retrieve
           // the index here:
           currentIndex = std::get<2>(p);
         }

--- a/src/archivefiletree.cpp
+++ b/src/archivefiletree.cpp
@@ -55,6 +55,10 @@ public:
     FileTreeEntry(parent, name), m_Index(index) {
   }
 
+  virtual std::shared_ptr<FileTreeEntry> clone() const override {
+    return std::make_shared<ArchiveFileEntry>(nullptr, name(), m_Index);
+  }
+
   // No private since we are in an implementation file:
   const int m_Index;
 };
@@ -70,7 +74,7 @@ public:
 
 public: // Public for make_shared (but not accessible by other since not exposed in .h):
 
-  ArchiveFileTreeImpl(std::shared_ptr<const IFileTree> parent, QString name, int index, std::vector<File>&& files)
+  ArchiveFileTreeImpl(std::shared_ptr<const IFileTree> parent, QString name, int index, std::vector<File> files)
     : FileTreeEntry(parent, name), ArchiveFileEntry(parent, name, index), IFileTree(), m_Files(std::move(files)) { }
 
 public: // Override to avoid VS warnings:
@@ -81,6 +85,12 @@ public: // Override to avoid VS warnings:
 
   virtual std::shared_ptr<const IFileTree> astree() const override {
     return IFileTree::astree();
+  }
+
+protected:
+
+  virtual std::shared_ptr<FileTreeEntry> clone() const override {
+    return IFileTree::clone();
   }
 
 public: // Overrides:
@@ -209,6 +219,10 @@ protected:
     if (currentName != "") {
       entries.push_back(std::make_shared<ArchiveFileTreeImpl>(parent, currentName, currentIndex, std::move(currentFiles)));
     }
+  }
+
+  virtual std::shared_ptr<IFileTree> doClone() const override {
+    return std::make_shared<ArchiveFileTreeImpl>(nullptr, name(), m_Index, m_Files);
   }
 
 private:

--- a/src/archivefiletree.cpp
+++ b/src/archivefiletree.cpp
@@ -40,7 +40,7 @@ public:
    * @param index The index of the file in the archive.
    * @param time The modification time of this file.
    */
-  ArchiveFileEntry(std::shared_ptr<IFileTree> parent, QString name, int index, QDateTime time) :
+  ArchiveFileEntry(std::shared_ptr<const IFileTree> parent, QString name, int index, QDateTime time) :
     FileTreeEntry(parent, name, time), m_Index(index) {
   }
 
@@ -51,7 +51,7 @@ public:
    * @param name The name of this directory.
    * @param index The index of the directory in the archive, or -1.
    */
-  ArchiveFileEntry(std::shared_ptr<IFileTree> parent, QString name, int index) :
+  ArchiveFileEntry(std::shared_ptr<const IFileTree> parent, QString name, int index) :
     FileTreeEntry(parent, name), m_Index(index) {
   }
 
@@ -70,7 +70,7 @@ public:
 
 public: // Public for make_shared (but not accessible by other since not exposed in .h):
 
-  ArchiveFileTreeImpl(std::shared_ptr<IFileTree> parent, QString name, int index, std::vector<File>&& files)
+  ArchiveFileTreeImpl(std::shared_ptr<const IFileTree> parent, QString name, int index, std::vector<File>&& files)
     : FileTreeEntry(parent, name), ArchiveFileEntry(parent, name, index), IFileTree(), m_Files(std::move(files)) { }
 
 public: // Override to avoid VS warnings:
@@ -145,11 +145,11 @@ protected:
    * @override
    */
   virtual std::shared_ptr<IFileTree> makeDirectory(
-    std::shared_ptr<IFileTree> parent, QString name) const override {
+    std::shared_ptr<const IFileTree> parent, QString name) const override {
     return std::make_shared<ArchiveFileTreeImpl>(parent, name, -1, std::vector<File>{});
   }
 
-  virtual void doPopulate(std::shared_ptr<IFileTree> parent, std::vector<std::shared_ptr<FileTreeEntry>>& entries) const override {
+  virtual void doPopulate(std::shared_ptr<const IFileTree> parent, std::vector<std::shared_ptr<FileTreeEntry>>& entries) const override {
 
     // Sort by name:
     std::sort(std::begin(m_Files), std::end(m_Files),

--- a/src/archivefiletree.cpp
+++ b/src/archivefiletree.cpp
@@ -191,9 +191,11 @@ protected:
             std::make_shared<ArchiveFileEntry>(parent, currentName, std::get<2>(p), QDateTime()));
           currentName = "";
         }
-        // Otherwize, it is the actual "file" corresponding to the directory, so we can retrieve
-        // the index here:
-        currentIndex = std::get<2>(p);
+        else {
+          // Otherwize, it is the actual "file" corresponding to the directory, so we can retrieve
+          // the index here:
+          currentIndex = std::get<2>(p);
+        }
       }
       else {
         currentFiles.push_back({

--- a/src/archivefiletree.h
+++ b/src/archivefiletree.h
@@ -1,0 +1,72 @@
+/*
+Copyright (C) MO2 Team. All rights reserved.
+
+This file is part of Mod Organizer.
+
+Mod Organizer is free software: you can redistribute it and/or modify
+it under the terms of the GNU General Public License as published by
+the Free Software Foundation, either version 3 of the License, or
+(at your option) any later version.
+
+Mod Organizer is distributed in the hope that it will be useful,
+but WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+GNU General Public License for more details.
+
+You should have received a copy of the GNU General Public License
+along with Mod Organizer.  If not, see <http://www.gnu.org/licenses/>.
+*/
+
+#ifndef ARCHIVEFILENETRY_H
+#define ARCHIVEFILENTRY_H
+
+#include "archive.h"
+#include "ifiletree.h"
+
+
+/**
+ *
+ */
+class ArchiveFileTree: public virtual MOBase::IFileTree {
+public:
+
+  /**
+   * @brief Create a new file tree representing the given archive.
+   *
+   * @param archive Archive to represent by the file tree.
+   *
+   * @return a file tree representing the given archive.
+   */
+  static std::shared_ptr<ArchiveFileTree> makeTree(Archive* archive);
+
+  /**
+   * @brief Update the given archive to reflect change in this tree.
+   *
+   * This method disables files that have been removed from the file
+   * tree and move the ones that have been moved.
+   *
+   * @param archive The archive to update. Must be the one used to
+   *     create the tree.
+   */
+  virtual void mapToArchive(Archive *archive) const = 0;
+
+  /**
+   * @brief Update the given archive to prepare for the extraction
+   *     of the given entries.
+   *
+   * This method "enables" files that correspond to the given entry.
+   *
+   * @param archive The archive to update. Must be the one used to
+   *     create the tree.
+   * @param entries List of entries to mark for extraction. All the entries must
+   *     come from a tree created with the given archive.
+   */
+  static void mapToArchive(Archive* archive, std::vector<std::shared_ptr<const FileTreeEntry>> const& entries);
+
+protected:
+
+  using IFileTree::IFileTree;
+
+};
+
+#endif

--- a/src/directoryrefresher.cpp
+++ b/src/directoryrefresher.cpp
@@ -216,9 +216,12 @@ void DirectoryRefresher::addModBSAToStructure(
 {
   const IPluginGame *game = qApp->property("managed_game").value<IPluginGame*>();
 
-  GamePlugins *gamePlugins = game->feature<GamePlugins>();
   QStringList loadOrder = QStringList();
-  gamePlugins->getLoadOrder(loadOrder);
+
+  GamePlugins* gamePlugins = game->feature<GamePlugins>();
+  if (gamePlugins) {
+    gamePlugins->getLoadOrder(loadOrder);
+  }
 
   std::vector<std::wstring> lo;
   for (auto&& s : loadOrder) {
@@ -364,9 +367,11 @@ struct ModThread
     if (Settings::instance().archiveParsing()) {
       const IPluginGame *game = qApp->property("managed_game").value<IPluginGame*>();
 
-      GamePlugins *gamePlugins = game->feature<GamePlugins>();
       QStringList loadOrder = QStringList();
-      gamePlugins->getLoadOrder(loadOrder);
+      GamePlugins* gamePlugins = game->feature<GamePlugins>();
+      if (gamePlugins) {
+        gamePlugins->getLoadOrder(loadOrder);
+      }
 
       std::vector<std::wstring> lo;
       for (auto&& s : loadOrder) {

--- a/src/modinfo.cpp
+++ b/src/modinfo.cpp
@@ -25,11 +25,9 @@ along with Mod Organizer.  If not, see <http://www.gnu.org/licenses/>.
 #include "modinfooverwrite.h"
 #include "modinfoseparator.h"
 
-#include "installationtester.h"
 #include "categories.h"
 #include "modinfodialog.h"
 #include "overwriteinfodialog.h"
-#include "filenamestring.h"
 #include "versioninfo.h"
 
 #include <iplugingame.h>
@@ -475,7 +473,7 @@ bool ModInfo::removeCategory(const QString &categoryName)
   return true;
 }
 
-QStringList ModInfo::categories()
+QStringList ModInfo::categories() const
 {
   QStringList result;
 
@@ -529,28 +527,7 @@ bool ModInfo::categorySet(int categoryID) const
 
 void ModInfo::testValid()
 {
-  m_Valid = false;
-  QDirIterator dirIter(absolutePath());
-  while (dirIter.hasNext()) {
-    dirIter.next();
-    if (dirIter.fileInfo().isDir()) {
-      if (InstallationTester::isTopLevelDirectory(dirIter.fileName())) {
-        m_Valid = true;
-        break;
-      }
-    } else {
-      if (InstallationTester::isTopLevelSuffix(dirIter.fileName())) {
-        m_Valid = true;
-        break;
-      }
-    }
-  }
-
-  // NOTE: in Qt 4.7 it seems that QDirIterator leaves a file handle open if it is not iterated to the
-  // end
-  while (dirIter.hasNext()) {
-    dirIter.next();
-  }
+  m_Valid = doTestValid();
 }
 
 QUrl ModInfo::parseCustomURL() const

--- a/src/modinfo.h
+++ b/src/modinfo.h
@@ -319,11 +319,23 @@ public:
   virtual void setNotes(const QString &notes) = 0;
 
   /**
-  * @brief set/change the source game of this mod
+  * @brief set/change the game plgin for this mod
   *
-  * @param gameName the source game shortName
+  * @param gamePlugin the game plugin
   */
-  virtual void setGameName(const QString &gameName) = 0;
+  virtual void setGamePlugin(const MOBase::IPluginGame* gamePlugin) = 0;
+
+  /**
+   * @brief set the name of this mod
+   *
+   * set the name of this mod. This will also update the name of the
+   * directory that contains this mod
+   *
+   * @param name new name of the mod
+   * @return true on success, false if the new name can't be used (i.e. because the new
+   *         directory name wouldn't be valid)
+   **/
+  virtual bool setName(const QString& name) = 0;
 
   /**
    * @brief set/change the nexus mod id of this mod
@@ -336,7 +348,7 @@ public:
    * @brief set/change the version of this mod
    * @param version new version of the mod
    */
-  virtual void setVersion(const MOBase::VersionInfo &version);
+  virtual void setVersion(const MOBase::VersionInfo &version) override;
 
   /**
   * @brief Controls if mod should be highlighted based on plugin selection
@@ -382,7 +394,7 @@ public:
 
   virtual void addCategory(const QString &categoryName) override;
   virtual bool removeCategory(const QString &categoryName) override;
-  virtual QStringList categories() override;
+  virtual QStringList categories() const override;
 
   /**
    * update the endorsement state for the mod. This only changes the
@@ -645,12 +657,12 @@ public:
   /*
    *@return the color choosen by the user for the mod/separator
    */
-  virtual QColor getColor() { return QColor(); }
+  virtual QColor getColor() const { return QColor(); }
 
   /*
    *@return true if the color has been set successfully.
    */
-  virtual void setColor(QColor color) { }
+  virtual void setColor(QColor) { }
 
   /**
    * @brief adds the information that a file has been installed into this mod
@@ -709,12 +721,12 @@ public:
   /**
    * @brief updates the mod to flag it as converted in order to ignore the alternate game warning
    */
-  virtual void markConverted(bool converted) {}
+  virtual void markConverted(bool) {}
 
   /**
   * @brief updates the mod to flag it as valid in order to ignore the invalid game data flag
   */
-  virtual void markValidated(bool validated) {}
+  virtual void markValidated(bool) {}
 
   /**
    * @brief reads meta information from disk
@@ -729,32 +741,32 @@ public:
   /**
    * @return retrieve list of mods (as mod index) that are overwritten by this one. Updates may be delayed
    */
-  virtual std::set<unsigned int> getModOverwrite() { return std::set<unsigned int>(); }
+  virtual std::set<unsigned int> getModOverwrite() const { return std::set<unsigned int>(); }
 
   /**
    * @return list of mods (as mod index) that overwrite this one. Updates may be delayed
    */
-  virtual std::set<unsigned int> getModOverwritten() { return std::set<unsigned int>(); }
+  virtual std::set<unsigned int> getModOverwritten() const { return std::set<unsigned int>(); }
 
   /**
    * @return retrieve list of mods (as mod index) with archives that are overwritten by this one. Updates may be delayed
   */
-  virtual std::set<unsigned int> getModArchiveOverwrite() { return std::set<unsigned int>(); }
+  virtual std::set<unsigned int> getModArchiveOverwrite() const { return std::set<unsigned int>(); }
 
   /**
   * @return list of mods (as mod index) with archives that overwrite this one. Updates may be delayed
   */
-  virtual std::set<unsigned int> getModArchiveOverwritten() { return std::set<unsigned int>(); }
+  virtual std::set<unsigned int> getModArchiveOverwritten() const { return std::set<unsigned int>(); }
 
   /**
   * @return retrieve list of mods (as mod index) with archives that are overwritten by thos mod's loose files. Updates may be delayed
   */
-  virtual std::set<unsigned int> getModArchiveLooseOverwrite() { return std::set<unsigned int>(); }
+  virtual std::set<unsigned int> getModArchiveLooseOverwrite() const { return std::set<unsigned int>(); }
 
   /**
   * @return list of mods (as mod index) with loose files that overwrite this one's archive files. Updates may be delayed
   */
-  virtual std::set<unsigned int> getModArchiveLooseOverwritten() { return std::set<unsigned int>(); }
+  virtual std::set<unsigned int> getModArchiveLooseOverwritten() const { return std::set<unsigned int>(); }
 
   /**
    * @brief update conflict information
@@ -803,6 +815,13 @@ protected:
 
   static void updateIndices();
   static bool ByName(const ModInfo::Ptr &LHS, const ModInfo::Ptr &RHS);
+
+  /**
+   * @brief check if the content of this mod is valid.
+   *
+   * @return true if the content is valid, false otherwize.
+   **/
+  virtual bool doTestValid() const = 0;
 
 private:
 

--- a/src/modinfo.h
+++ b/src/modinfo.h
@@ -319,11 +319,11 @@ public:
   virtual void setNotes(const QString &notes) = 0;
 
   /**
-  * @brief set/change the game plgin for this mod
-  *
-  * @param gamePlugin the game plugin
-  */
-  virtual void setGamePlugin(const MOBase::IPluginGame* gamePlugin) = 0;
+   * @brief set/change the source game of this mod
+   *
+   * @param gameName the source game shortName
+   */
+  virtual void setGameName(const QString& gameName) = 0;
 
   /**
    * @brief set the name of this mod

--- a/src/modinfobackup.h
+++ b/src/modinfobackup.h
@@ -12,35 +12,32 @@ class ModInfoBackup : public ModInfoRegular
 
 public:
 
-  virtual bool updateAvailable() const { return false; }
-  virtual bool updateIgnored() const { return false; }
-  virtual bool downgradeAvailable() const { return false; }
-  virtual bool updateNXMInfo() { return false; }
-  virtual void setGameName(const QString&) {}
-  virtual void setNexusID(int) {}
-  virtual void endorse(bool) {}
-  virtual void parseNexusInfo() {}
-  virtual int getFixedPriority() const { return -1; }
-  virtual void ignoreUpdate(bool) {}
-  virtual bool canBeUpdated() const { return false; }
-  virtual QDateTime getExpires() const { return QDateTime(); }
-  virtual bool canBeEnabled() const { return false; }
-  virtual std::vector<QString> getIniTweaks() const { return std::vector<QString>(); }
-  virtual std::vector<EFlag> getFlags() const;
-  virtual QString getDescription() const;
-  virtual int getNexusFileStatus() const { return 0; }
-  virtual void setNexusFileStatus(int) {}
-  virtual QDateTime getLastNexusQuery() const { return QDateTime(); }
-  virtual void setLastNexusQuery(QDateTime) {}
-  virtual QDateTime getLastNexusUpdate() const { return QDateTime(); }
-  virtual void setLastNexusUpdate(QDateTime) {}
-  virtual QDateTime getNexusLastModified() const { return QDateTime(); }
-  virtual void setNexusLastModified(QDateTime) {}
-  virtual void getNexusFiles(QList<MOBase::ModRepositoryFileInfo*>::const_iterator&,
-                             QList<MOBase::ModRepositoryFileInfo*>::const_iterator&) {}
-  virtual QString getNexusDescription() const { return QString(); }
+  virtual bool updateAvailable() const override { return false; }
+  virtual bool updateIgnored() const override { return false; }
+  virtual bool downgradeAvailable() const override { return false; }
+  virtual bool updateNXMInfo() override { return false; }
+  virtual void setGamePlugin(const MOBase::IPluginGame*) override {}
+  virtual void setNexusID(int) override {}
+  virtual void endorse(bool) override {}
+  virtual int getFixedPriority() const override { return -1; }
+  virtual void ignoreUpdate(bool) override {}
+  virtual bool canBeUpdated() const override { return false; }
+  virtual QDateTime getExpires() const override { return QDateTime(); }
+  virtual bool canBeEnabled() const override { return false; }
+  virtual std::vector<QString> getIniTweaks() const override { return std::vector<QString>(); }
+  virtual std::vector<EFlag> getFlags() const override;
+  virtual QString getDescription() const override;
+  virtual int getNexusFileStatus() const override { return 0; }
+  virtual void setNexusFileStatus(int) override {}
+  virtual QDateTime getLastNexusQuery() const override { return QDateTime(); }
+  virtual void setLastNexusQuery(QDateTime) override {}
+  virtual QDateTime getLastNexusUpdate() const override { return QDateTime(); }
+  virtual void setLastNexusUpdate(QDateTime) override {}
+  virtual QDateTime getNexusLastModified() const override { return QDateTime(); }
+  virtual void setNexusLastModified(QDateTime) override {}
+  virtual QString getNexusDescription() const override { return QString(); }
 
-  virtual void addInstalledFile(int, int) {}
+  virtual void addInstalledFile(int, int) override {}
 
 private:
 

--- a/src/modinfobackup.h
+++ b/src/modinfobackup.h
@@ -16,7 +16,7 @@ public:
   virtual bool updateIgnored() const override { return false; }
   virtual bool downgradeAvailable() const override { return false; }
   virtual bool updateNXMInfo() override { return false; }
-  virtual void setGamePlugin(const MOBase::IPluginGame*) override {}
+  virtual void setGameName(const QString& gameName) override {}
   virtual void setNexusID(int) override {}
   virtual void endorse(bool) override {}
   virtual int getFixedPriority() const override { return -1; }

--- a/src/modinfodialognexus.cpp
+++ b/src/modinfodialognexus.cpp
@@ -324,7 +324,7 @@ void NexusTab::onSourceGameChanged()
 
   for (auto game : plugin().plugins<MOBase::IPluginGame>()) {
     if (game->gameName() == ui->sourceGame->currentText()) {
-      mod().setGameName(game->gameShortName());
+      mod().setGamePlugin(game);
       mod().setLastNexusQuery(QDateTime::fromSecsSinceEpoch(0));
       refreshData(mod().getNexusID());
       return;

--- a/src/modinfodialognexus.cpp
+++ b/src/modinfodialognexus.cpp
@@ -324,7 +324,7 @@ void NexusTab::onSourceGameChanged()
 
   for (auto game : plugin().plugins<MOBase::IPluginGame>()) {
     if (game->gameName() == ui->sourceGame->currentText()) {
-      mod().setGamePlugin(game);
+      mod().setGameName(game->gameShortName()); 
       mod().setLastNexusQuery(QDateTime::fromSecsSinceEpoch(0));
       refreshData(mod().getNexusID());
       return;

--- a/src/modinfoforeign.h
+++ b/src/modinfoforeign.h
@@ -1,9 +1,11 @@
 #ifndef MODINFOFOREIGN_H
 #define MODINFOFOREIGN_H
 
+#include <limits>
+
 #include "modinfowithconflictinfo.h"
 
-class ModInfoForeign : public ModInfoWithConflictInfo
+class ModInfoForeign: public ModInfoWithConflictInfo
 {
 
   Q_OBJECT
@@ -12,65 +14,66 @@ class ModInfoForeign : public ModInfoWithConflictInfo
 
 public:
 
-  virtual bool updateAvailable() const { return false; }
-  virtual bool updateIgnored() const { return false; }
-  virtual bool downgradeAvailable() const { return false; }
-  virtual bool updateNXMInfo() { return false; }
-  virtual void setCategory(int, bool) {}
-  virtual bool setName(const QString&) { return false; }
-  virtual void setComments(const QString&) {}
-  virtual void setNotes(const QString&) {}
-  virtual void setGameName(const QString&) {}
-  virtual void setNexusID(int) {}
-  virtual void setNewestVersion(const MOBase::VersionInfo&) {}
-  virtual void ignoreUpdate(bool) {}
-  virtual void setNexusDescription(const QString&) {}
-  virtual void setInstallationFile(const QString&) {}
-  virtual void addNexusCategory(int) {}
-  virtual void setIsEndorsed(bool) {}
-  virtual void setNeverEndorse() {}
-  virtual void setIsTracked(bool) {}
-  virtual bool remove() { return false; }
-  virtual void endorse(bool) {}
-  virtual void track(bool) {}
-  virtual void parseNexusInfo() {}
-  virtual bool isEmpty() const { return false; }
-  virtual QString name() const { return m_Name; }
-  virtual QString internalName() const { return m_InternalName; }
-  virtual QString comments() const { return ""; }
-  virtual QString notes() const { return ""; }
-  virtual QDateTime creationTime() const;
-  virtual QString absolutePath() const;
-  virtual MOBase::VersionInfo getNewestVersion() const { return QString(); }
-  virtual QString getInstallationFile() const { return ""; }
-  virtual QString getGameName() const { return ""; }
-  virtual int getNexusID() const { return -1; }
-  virtual QDateTime getExpires() const { return QDateTime(); }
-  virtual std::vector<QString> getIniTweaks() const { return std::vector<QString>(); }
-  virtual std::vector<ModInfo::EFlag> getFlags() const;
-  virtual int getHighlight() const;
-  virtual QString getDescription() const;
-  virtual int getNexusFileStatus() const { return 0; }
-  virtual void setNexusFileStatus(int) {}
-  virtual QDateTime getLastNexusUpdate() const { return QDateTime(); }
-  virtual void setLastNexusUpdate(QDateTime) {}
-  virtual QDateTime getLastNexusQuery() const { return QDateTime(); }
-  virtual void setLastNexusQuery(QDateTime) {}
-  virtual QDateTime getNexusLastModified() const { return QDateTime(); }
-  virtual void setNexusLastModified(QDateTime) {}
-  virtual QString getNexusDescription() const { return QString(); }
-  virtual int getFixedPriority() const { return INT_MIN; }
-  virtual QStringList archives(bool checkOnDisk = false)  { return m_Archives; }
-  virtual QStringList stealFiles() const { return m_Archives + QStringList(m_ReferenceFile); }
-  virtual bool alwaysEnabled() const { return true; }
-  virtual void addInstalledFile(int, int) {}
+  virtual bool updateAvailable() const override { return false; }
+  virtual bool updateIgnored() const override { return false; }
+  virtual bool downgradeAvailable() const override { return false; }
+  virtual bool updateNXMInfo() override { return false; }
+  virtual void setCategory(int, bool) override {}
+  virtual bool setName(const QString&) override { return false; }
+  virtual void setComments(const QString&) override {}
+  virtual void setNotes(const QString&) override {}
+  virtual void setGamePlugin(const MOBase::IPluginGame*) override {}
+  virtual void setNexusID(int) override {}
+  virtual void setNewestVersion(const MOBase::VersionInfo&) override {}
+  virtual void ignoreUpdate(bool) override {}
+  virtual void setNexusDescription(const QString&) override {}
+  virtual void setInstallationFile(const QString&) override {}
+  virtual void addNexusCategory(int) override {}
+  virtual void setIsEndorsed(bool) override {}
+  virtual void setNeverEndorse() override {}
+  virtual void setIsTracked(bool) override {}
+  virtual bool remove() override { return false; }
+  virtual void endorse(bool) override {}
+  virtual void track(bool) override {}
+  virtual bool isEmpty() const override { return false; }
+  virtual QString name() const override { return m_Name; }
+  virtual QString internalName() const override { return m_InternalName; }
+  virtual QString comments() const override { return ""; }
+  virtual QString notes() const override { return ""; }
+  virtual QDateTime creationTime() const override;
+  virtual QString absolutePath() const override;
+  virtual MOBase::VersionInfo getNewestVersion() const override { return QString(); }
+  virtual QString getInstallationFile() const override { return ""; }
+  virtual QString getGameName() const override { return ""; }
+  virtual int getNexusID() const override { return -1; }
+  virtual QDateTime getExpires() const override { return QDateTime(); }
+  virtual std::vector<QString> getIniTweaks() const override { return std::vector<QString>(); }
+  virtual std::vector<ModInfo::EFlag> getFlags() const override;
+  virtual int getHighlight() const override;
+  virtual QString getDescription() const override;
+  virtual int getNexusFileStatus() const override { return 0; }
+  virtual void setNexusFileStatus(int) override {}
+  virtual QDateTime getLastNexusUpdate() const override { return QDateTime(); }
+  virtual void setLastNexusUpdate(QDateTime) override {}
+  virtual QDateTime getLastNexusQuery() const override { return QDateTime(); }
+  virtual void setLastNexusQuery(QDateTime) override {}
+  virtual QDateTime getNexusLastModified() const override { return QDateTime(); }
+  virtual void setNexusLastModified(QDateTime) override {}
+  virtual QString getNexusDescription() const override { return QString(); }
+  virtual int getFixedPriority() const override { return std::numeric_limits<int>::min(); }
+  virtual QStringList archives(bool = false) override { return m_Archives; }
+  virtual QStringList stealFiles() const override { return m_Archives + QStringList(m_ReferenceFile); }
+  virtual bool alwaysEnabled() const override { return true; }
+  virtual void addInstalledFile(int, int) override {}
 
   ModInfo::EModType modType() const { return m_ModType; }
 
 protected:
   ModInfoForeign(const QString &modName, const QString &referenceFile,
                  const QStringList &archives, ModInfo::EModType modType,
-                 MOShared::DirectoryEntry **directoryStructure, PluginContainer *pluginContainer);
+                 MOShared::DirectoryEntry **directoryStructure, PluginContainer *pluginContainer);  
+  
+  virtual bool doTestValid() const { return true;  }
 private:
 
   QString m_Name;

--- a/src/modinfoforeign.h
+++ b/src/modinfoforeign.h
@@ -73,7 +73,6 @@ protected:
                  const QStringList &archives, ModInfo::EModType modType,
                  MOShared::DirectoryEntry **directoryStructure, PluginContainer *pluginContainer);  
   
-  virtual bool doTestValid() const { return true;  }
 private:
 
   QString m_Name;

--- a/src/modinfoforeign.h
+++ b/src/modinfoforeign.h
@@ -22,7 +22,7 @@ public:
   virtual bool setName(const QString&) override { return false; }
   virtual void setComments(const QString&) override {}
   virtual void setNotes(const QString&) override {}
-  virtual void setGamePlugin(const MOBase::IPluginGame*) override {}
+  virtual void setGameName(const QString& gameName) override {}
   virtual void setNexusID(int) override {}
   virtual void setNewestVersion(const MOBase::VersionInfo&) override {}
   virtual void ignoreUpdate(bool) override {}

--- a/src/modinfooverwrite.h
+++ b/src/modinfooverwrite.h
@@ -46,7 +46,7 @@ public:
   virtual QString absolutePath() const override;
   virtual MOBase::VersionInfo getNewestVersion() const override { return QString(); }
   virtual QString getInstallationFile() const override { return ""; }
-  virtual int getFixedPriority() const override { return std::numeric_limits<int>::min(); }
+  virtual int getFixedPriority() const override { return std::numeric_limits<int>::max(); }
   virtual QString getGameName() const override { return ""; }
   virtual int getNexusID() const override { return -1; }
   virtual QDateTime getExpires() const override { return QDateTime(); }
@@ -66,9 +66,6 @@ public:
   virtual QString getNexusDescription() const override { return QString(); }
   virtual QStringList archives(bool checkOnDisk = false) override;
   virtual void addInstalledFile(int, int) override {}
-
-protected:
-  virtual bool doTestValid() const { return true; }
 
 private:
   ModInfoOverwrite(PluginContainer *pluginContainer, MOShared::DirectoryEntry **directoryStructure );

--- a/src/modinfooverwrite.h
+++ b/src/modinfooverwrite.h
@@ -1,6 +1,8 @@
 #ifndef MODINFOOVERWRITE_H
 #define MODINFOOVERWRITE_H
 
+#include <limits>
+
 #include "modinfowithconflictinfo.h"
 
 #include <QDateTime>
@@ -14,60 +16,61 @@ class ModInfoOverwrite : public ModInfoWithConflictInfo
 
 public:
 
-  virtual bool updateAvailable() const { return false; }
-  virtual bool updateIgnored() const { return false; }
-  virtual bool downgradeAvailable() const { return false; }
-  virtual bool updateNXMInfo() { return false; }
-  virtual void setCategory(int, bool) {}
-  virtual bool setName(const QString&) { return false; }
-  virtual void setComments(const QString&) {}
-  virtual void setNotes(const QString&) {}
-  virtual void setGameName(const QString&) {}
-  virtual void setNexusID(int) {}
-  virtual void setNewestVersion(const MOBase::VersionInfo&) {}
-  virtual void ignoreUpdate(bool) {}
-  virtual void setNexusDescription(const QString&) {}
-  virtual void setInstallationFile(const QString&) {}
-  virtual void addNexusCategory(int) {}
-  virtual void setIsEndorsed(bool) {}
-  virtual void setNeverEndorse() {}
-  virtual void setIsTracked(bool) {}
-  virtual bool remove() { return false; }
-  virtual void endorse(bool) {}
-  virtual void track(bool) {}
-  virtual void parseNexusInfo() {}
-  virtual bool alwaysEnabled() const { return true; }
-  virtual bool isEmpty() const;
-  virtual QString name() const { return "Overwrite"; }
-  virtual QString comments() const { return ""; }
-  virtual QString notes() const { return ""; }
-  virtual QDateTime creationTime() const { return QDateTime(); }
-  virtual QString absolutePath() const;
-  virtual MOBase::VersionInfo getNewestVersion() const { return QString(); }
-  virtual QString getInstallationFile() const { return ""; }
-  virtual int getFixedPriority() const { return INT_MAX; }
-  virtual QString getGameName() const { return ""; }
-  virtual int getNexusID() const { return -1; }
-  virtual QDateTime getExpires() const { return QDateTime(); }
-  virtual std::vector<QString> getIniTweaks() const { return std::vector<QString>(); }
-  virtual std::vector<ModInfo::EFlag> getFlags() const;
-  virtual std::vector<ModInfo::EConflictFlag> getConflictFlags() const;
-  virtual int getHighlight() const;
-  virtual QString getDescription() const;
-  virtual int getNexusFileStatus() const { return 0; }
-  virtual void setNexusFileStatus(int) {}
-  virtual QDateTime getLastNexusUpdate() const { return QDateTime(); }
-  virtual void setLastNexusUpdate(QDateTime) {}
-  virtual QDateTime getLastNexusQuery() const { return QDateTime(); }
-  virtual void setLastNexusQuery(QDateTime) {}
-  virtual QDateTime getNexusLastModified() const { return QDateTime(); }
-  virtual void setNexusLastModified(QDateTime) {}
-  virtual QString getNexusDescription() const { return QString(); }
-  virtual QStringList archives(bool checkOnDisk = false);
-  virtual void addInstalledFile(int, int) {}
+  virtual bool updateAvailable() const override { return false; }
+  virtual bool updateIgnored() const override { return false; }
+  virtual bool downgradeAvailable() const override { return false; }
+  virtual bool updateNXMInfo() override { return false; }
+  virtual void setCategory(int, bool) override {}
+  virtual bool setName(const QString&) override { return false; }
+  virtual void setComments(const QString&) override {}
+  virtual void setNotes(const QString&) override {}
+  virtual void setGamePlugin(const MOBase::IPluginGame*) override {}
+  virtual void setNexusID(int) override {}
+  virtual void setNewestVersion(const MOBase::VersionInfo&) override {}
+  virtual void ignoreUpdate(bool) override {}
+  virtual void setNexusDescription(const QString&) override {}
+  virtual void setInstallationFile(const QString&) override {}
+  virtual void addNexusCategory(int) override {}
+  virtual void setIsEndorsed(bool) override {}
+  virtual void setNeverEndorse() override {}
+  virtual void setIsTracked(bool) override {}
+  virtual bool remove() override { return false; }
+  virtual void endorse(bool) override {}
+  virtual void track(bool) override {}
+  virtual bool alwaysEnabled() const override { return true; }
+  virtual bool isEmpty() const override;
+  virtual QString name() const override { return "Overwrite"; }
+  virtual QString comments() const override { return ""; }
+  virtual QString notes() const override { return ""; }
+  virtual QDateTime creationTime() const override { return QDateTime(); }
+  virtual QString absolutePath() const override;
+  virtual MOBase::VersionInfo getNewestVersion() const override { return QString(); }
+  virtual QString getInstallationFile() const override { return ""; }
+  virtual int getFixedPriority() const override { return std::numeric_limits<int>::min(); }
+  virtual QString getGameName() const override { return ""; }
+  virtual int getNexusID() const override { return -1; }
+  virtual QDateTime getExpires() const override { return QDateTime(); }
+  virtual std::vector<QString> getIniTweaks() const override { return std::vector<QString>(); }
+  virtual std::vector<ModInfo::EFlag> getFlags() const override;
+  virtual std::vector<ModInfo::EConflictFlag> getConflictFlags() const override;
+  virtual int getHighlight() const override;
+  virtual QString getDescription() const override;
+  virtual int getNexusFileStatus() const override { return 0; }
+  virtual void setNexusFileStatus(int) override {}
+  virtual QDateTime getLastNexusUpdate() const override { return QDateTime(); }
+  virtual void setLastNexusUpdate(QDateTime) override {}
+  virtual QDateTime getLastNexusQuery() const override { return QDateTime(); }
+  virtual void setLastNexusQuery(QDateTime) override {}
+  virtual QDateTime getNexusLastModified() const override { return QDateTime(); }
+  virtual void setNexusLastModified(QDateTime) override {}
+  virtual QString getNexusDescription() const override { return QString(); }
+  virtual QStringList archives(bool checkOnDisk = false) override;
+  virtual void addInstalledFile(int, int) override {}
+
+protected:
+  virtual bool doTestValid() const { return true; }
 
 private:
-
   ModInfoOverwrite(PluginContainer *pluginContainer, MOShared::DirectoryEntry **directoryStructure );
 
 };

--- a/src/modinfooverwrite.h
+++ b/src/modinfooverwrite.h
@@ -24,7 +24,7 @@ public:
   virtual bool setName(const QString&) override { return false; }
   virtual void setComments(const QString&) override {}
   virtual void setNotes(const QString&) override {}
-  virtual void setGamePlugin(const MOBase::IPluginGame*) override {}
+  virtual void setGameName(const QString& gameName) override {}
   virtual void setNexusID(int) override {}
   virtual void setNewestVersion(const MOBase::VersionInfo&) override {}
   virtual void ignoreUpdate(bool) override {}

--- a/src/modinforegular.cpp
+++ b/src/modinforegular.cpp
@@ -468,12 +468,10 @@ void ModInfoRegular::setNotes(const QString &notes)
   m_MetaInfoChanged = true;
 }
 
-void ModInfoRegular::setGamePlugin(const MOBase::IPluginGame* gamePlugin)
+void ModInfoRegular::setGameName(const QString& gameName)
 {
-  m_GamePlugin = gamePlugin;
-  m_GameName = gamePlugin->gameShortName();
+  m_GameName = gameName;
   m_MetaInfoChanged = true;
-  testValid();
 }
 
 void ModInfoRegular::setNexusID(int modID)

--- a/src/modinforegular.cpp
+++ b/src/modinforegular.cpp
@@ -1,5 +1,4 @@
 #include "modinforegular.h"
-#include "installationtester.h"
 
 #include "categories.h"
 #include "messagedialog.h"
@@ -271,34 +270,6 @@ void ModInfoRegular::saveMeta()
   }
 }
 
-bool ModInfoRegular::doTestValid() const {
-
-  bool valid = false;
-  QDirIterator dirIter(absolutePath());
-  while (dirIter.hasNext()) {
-    dirIter.next();
-    if (dirIter.fileInfo().isDir()) {
-      if (InstallationTester::isTopLevelDirectory(dirIter.fileName())) {
-        valid = true;
-        break;
-      }
-    }
-    else {
-      if (InstallationTester::isTopLevelSuffix(dirIter.fileName())) {
-        valid = true;
-        break;
-      }
-    }
-  }
-  
-  // NOTE: in Qt 4.7 it seems that QDirIterator leaves a file handle open if it is not iterated to the
-  // end
-  while (dirIter.hasNext()) {
-    dirIter.next();
-  }
-
-  return valid;
-}
 
 bool ModInfoRegular::updateAvailable() const
 {

--- a/src/modinforegular.cpp
+++ b/src/modinforegular.cpp
@@ -559,7 +559,7 @@ void ModInfoRegular::setColor(QColor color)
   m_MetaInfoChanged = true;
 }
 
-QColor ModInfoRegular::getColor()
+QColor ModInfoRegular::getColor() const
 {
   return m_Color;
 }

--- a/src/modinforegular.h
+++ b/src/modinforegular.h
@@ -388,7 +388,7 @@ public:
 
   virtual void setColor(QColor color) override;
 
-  virtual QColor getColor();
+  virtual QColor getColor() const override;
 
   virtual void addInstalledFile(int modId, int fileId) override;
 

--- a/src/modinforegular.h
+++ b/src/modinforegular.h
@@ -420,13 +420,6 @@ protected:
 
   ModInfoRegular(PluginContainer *pluginContainer, const MOBase::IPluginGame *game, const QDir &path, MOShared::DirectoryEntry **directoryStructure);
 
-  /**
-   * @brief check if the content of this mod is valid.
-   *
-   * @return true if the content is valid, false otherwize.
-   **/
-    virtual bool doTestValid() const;
-
 private:
 
   QString m_Name;

--- a/src/modinforegular.h
+++ b/src/modinforegular.h
@@ -105,11 +105,11 @@ public:
   void setNotes(const QString &notes) override;
 
   /**
-  * @brief set/change the game plgin for this mod
-  *
-  * @param gamePlugin the game plugin
-  */
-  virtual void setGamePlugin(const MOBase::IPluginGame* gamePlugin) override;
+   * @brief set/change the source game of this mod
+   *
+   * @param gameName the source game shortName
+   */
+  virtual void setGameName(const QString& gameName) override;
 
   /**
    * @brief set/change the nexus mod id of this mod
@@ -432,9 +432,11 @@ private:
   QString m_CustomURL;
   bool m_HasCustomURL;
 
-  // Storing both the game name and game plugin since we can have a game
-  // name that is not one of the primary names of the game plugin:
-  const MOBase::IPluginGame* m_GamePlugin;
+  // Current game plugin running in MO2:
+  MOBase::IPluginGame const* m_GamePlugin;
+
+  // Game name for the mod, can be different from the actual game running in MO2
+  // e.g., for Skyrim / Skyrim SE.
   QString m_GameName;
 
   mutable QStringList m_Archives;

--- a/src/modinforegular.h
+++ b/src/modinforegular.h
@@ -1,6 +1,8 @@
 #ifndef MODINFOREGULAR_H
 #define MODINFOREGULAR_H
 
+#include <limits>
+
 #include "modinfowithconflictinfo.h"
 #include "nexusinterface.h"
 
@@ -22,9 +24,9 @@ public:
 
   ~ModInfoRegular();
 
-  virtual bool isRegular() const { return true; }
+  virtual bool isRegular() const override { return true; }
 
-  virtual bool isEmpty() const;
+  virtual bool isEmpty() const override;
 
   bool isAlternate() { return m_IsAlternate; }
   bool isConverted() { return m_Converted; }
@@ -39,12 +41,12 @@ public:
    *
    * @return true if there is a newer version
    **/
-  bool updateAvailable() const;
+  bool updateAvailable() const override;
 
   /**
    * @return true if the current update is being ignored
    */
-  virtual bool updateIgnored() const { return m_IgnoredVersion.isValid() && m_IgnoredVersion == m_NewestVersion; }
+  virtual bool updateIgnored() const override { return m_IgnoredVersion.isValid() && m_IgnoredVersion == m_NewestVersion; }
 
   /**
    * @brief test if there is a newer version of the mod
@@ -55,7 +57,7 @@ public:
    *
    * @return true if there is a newer version
    **/
-  bool downgradeAvailable() const;
+  bool downgradeAvailable() const override;
 
   /**
    * @brief request an update of nexus description for this mod.
@@ -65,7 +67,7 @@ public:
    *
    * @return returns true if information for this mod will be updated, false if there is no nexus mod id to use
    **/
-  bool updateNXMInfo();
+  bool updateNXMInfo() override;
 
   /**
    * @brief assign or unassign the specified category
@@ -76,7 +78,7 @@ public:
    * @param active determines wheter the category is assigned or unassigned
    * @note this function does not test whether categoryID actually identifies a valid category
    **/
-  void setCategory(int categoryID, bool active);
+  void setCategory(int categoryID, bool active) override;
 
   /**
    * @brief set the name of this mod
@@ -88,33 +90,33 @@ public:
    * @return true on success, false if the new name can't be used (i.e. because the new
    *         directory name wouldn't be valid)
    **/
-  bool setName(const QString &name);
+  bool setName(const QString &name) override;
 
   /**
   * @brief changes the comments (manually set information displayed in the mod list) for this mod
   * @param comments new comments
   */
-  void setComments(const QString &comments);
+  void setComments(const QString &comments) override;
 
   /**
    * @brief change the notes (manually set information) for this mod
    * @param notes new notes
    */
-  void setNotes(const QString &notes);
+  void setNotes(const QString &notes) override;
 
   /**
-   * @brief set/change the source game of this mod
-   *
-   * @param gameName the source game shortName
-   */
-  void setGameName(const QString &gameName);
+  * @brief set/change the game plgin for this mod
+  *
+  * @param gamePlugin the game plugin
+  */
+  virtual void setGamePlugin(const MOBase::IPluginGame* gamePlugin) override;
 
   /**
    * @brief set/change the nexus mod id of this mod
    *
    * @param modID the nexus mod id
    **/
-  void setNexusID(int modID);
+  void setNexusID(int modID) override;
 
   /**
    * @brief set the version of this mod
@@ -124,7 +126,7 @@ public:
    *
    * @param version the new version to use
    **/
-  void setVersion(const MOBase::VersionInfo &version);
+  void setVersion(const MOBase::VersionInfo &version) override;
 
   /**
    * @brief set the newest version of this mod on the nexus
@@ -136,73 +138,73 @@ public:
    * @todo this function should be made obsolete. All queries for mod information should go through
    *       this class so no public function for this change is required
    **/
-  void setNewestVersion(const MOBase::VersionInfo &version);
+  void setNewestVersion(const MOBase::VersionInfo &version) override;
 
   /**
    * @brief changes/updates the nexus description text
    * @param description the current description text
    */
-  virtual void setNexusDescription(const QString &description);
+  virtual void setNexusDescription(const QString &description) override;
 
-  virtual void setInstallationFile(const QString &fileName);
+  virtual void setInstallationFile(const QString &fileName) override;
 
   /**
    * @brief sets the category id from a nexus category id. Conversion to MO id happens internally
    * @param categoryID the nexus category id
    * @note if a mapping is not possible, the category is set to the default value
    */
-  virtual void addNexusCategory(int categoryID);
+  virtual void addNexusCategory(int categoryID) override;
 
   /**
    * @brief sets the new primary category of the mod
    * @param categoryID the category to set
    */
-  virtual void setPrimaryCategory(int categoryID) { m_PrimaryCategory = categoryID; m_MetaInfoChanged = true; }
+  virtual void setPrimaryCategory(int categoryID) override { m_PrimaryCategory = categoryID; m_MetaInfoChanged = true; }
 
   /**
    * @brief sets the download repository
    * @param repository
    */
-  virtual void setRepository(const QString &repository) { m_Repository = repository; }
+  virtual void setRepository(const QString &repository) override { m_Repository = repository; }
 
   /**
    * update the endorsement state for the mod. This only changes the
    * buffered state, it does not sync with Nexus
    * @param endorsed the new endorsement state
    */
-  virtual void setIsEndorsed(bool endorsed);
+  virtual void setIsEndorsed(bool endorsed) override;
 
   /**
    * set the mod to "i don't intend to endorse". The mod will not show as unendorsed but can still be endorsed
    */
-  virtual void setNeverEndorse();
+  virtual void setNeverEndorse() override;
 
   /**
    * update the tracked state for the mod.  This only changes the
    * buffered state.  It does not sync with Nexus
    * @param tracked the new tracked state
    */
-  virtual void setIsTracked(bool tracked);
+  virtual void setIsTracked(bool tracked) override;
 
   /**
    * @brief delete the mod from the disc. This does not update the global ModInfo structure or indices
    * @return true if the mod was successfully removed
    **/
-  bool remove();
+  bool remove() override;
 
   /**
    * @brief endorse or un-endorse the mod
    * @param doEndorse if true, the mod is endorsed, if false, it's un-endorsed.
    * @note if doEndorse doesn't differ from the current value, nothing happens.
    */
-  virtual void endorse(bool doEndorse);
+  virtual void endorse(bool doEndorse) override;
 
   /**
   * @brief track or untrack the mod.  This will sync with nexus!
   * @param doTrack if true, the mod is tracked, if false, it's untracked.
   * @note if doTrack doesn't differ from the current value, nothing happens.
   */
-  virtual void track(bool doTrack);
+  virtual void track(bool doTrack) override;
 
   /**
   * @brief updates the mod to flag it as converted in order to ignore the alternate game warning
@@ -219,183 +221,183 @@ public:
    *
    * @return the mod name
    **/
-  QString name() const { return m_Name; }
+  QString name() const override { return m_Name; }
 
   /**
    * @brief getter for the mod path
    *
    * @return the (absolute) path to the mod
    **/
-  QString absolutePath() const;
+  QString absolutePath() const override;
 
   /**
    * @brief getter for the newest version number of this mod
    *
    * @return newest version of the mod
    **/
-  MOBase::VersionInfo getNewestVersion() const { return m_NewestVersion; }
+  MOBase::VersionInfo getNewestVersion() const override { return m_NewestVersion; }
 
   /**
    * @brief ignore the newest version for updates
    */
-  void ignoreUpdate(bool ignore);
+  void ignoreUpdate(bool ignore) override;
 
   /**
    * @brief getter for the installation file
    *
    * @return file used to install this mod from
    */
-  virtual QString getInstallationFile() const { return m_InstallationFile; }
+  virtual QString getInstallationFile() const override { return m_InstallationFile; }
 
   /**
    * @brief getter for the source game repository
    *
    * @return the source game repository. should default to the active game.
    **/
-  QString getGameName() const { return m_GameName; }
+  QString getGameName() const override { return m_GameName; }
 
   /**
    * @brief getter for the nexus mod id
    *
    * @return the nexus mod id. may be 0 if the mod id isn't known or doesn't exist
    **/
-  int getNexusID() const { return m_NexusID; }
+  int getNexusID() const override { return m_NexusID; }
 
   /**
    * @return the fixed priority of mods of this type or INT_MIN if the priority of mods
    *         needs to be user-modifiable
    */
-  virtual int getFixedPriority() const { return INT_MIN; }
+  virtual int getFixedPriority() const override { return std::numeric_limits<int>::min(); }
 
   /**
    * @return true if the mod can be updated
    */
-  virtual bool canBeUpdated() const;
+  virtual bool canBeUpdated() const override;
 
   /**
    * @return the update expiration date based on the last updated date from Nexus
    */
-  virtual QDateTime getExpires() const;
+  virtual QDateTime getExpires() const override;
 
   /**
    * @return true if the mod can be enabled/disabled
    */
-  virtual bool canBeEnabled() const { return true; }
+  virtual bool canBeEnabled() const override { return true; }
 
   /**
    * @return a list of flags for this mod
    */
-  virtual std::vector<EFlag> getFlags() const;
+  virtual std::vector<EFlag> getFlags() const override;
 
-  virtual std::vector<EContent> getContents() const;
+  virtual std::vector<EContent> getContents() const override;
 
   /**
    * @return an indicator if and how this mod should be highlighted by the UI
    */
-  virtual int getHighlight() const;
+  virtual int getHighlight() const override;
 
   /**
    * @return list of names of ini tweaks
    **/
-  std::vector<QString> getIniTweaks() const;
+  std::vector<QString> getIniTweaks() const override;
 
   /**
    * @return a description about the mod, to be displayed in the ui
    */
-  virtual QString getDescription() const;
+  virtual QString getDescription() const override;
 
 
   /**
    * @return the nexus file status (aka category ID)
    */
-  virtual int getNexusFileStatus() const;
+  virtual int getNexusFileStatus() const override;
 
 
   /**
    * @brief sets the file status (category ID) from Nexus
    * @param status the status id of the installed file
    */
-  virtual void setNexusFileStatus(int status);
+  virtual void setNexusFileStatus(int status) override;
 
   /**
   * @return comments for this mod
   */
-  virtual QString comments() const;
+  virtual QString comments() const override;
 
   /**
    * @return manually set notes for this mod
    */
-  virtual QString notes() const;
+  virtual QString notes() const override;
 
   /**
    * @return time this mod was created (file time of the directory)
    */
-  virtual QDateTime creationTime() const;
+  virtual QDateTime creationTime() const override;
 
   /**
    * @return nexus description of the mod (html)
    */
-  QString getNexusDescription() const;
+  QString getNexusDescription() const override;
 
   /**
    * @return repository from which the file was downloaded
    */
-  virtual QString repository() const;
+  virtual QString repository() const override;
 
   /**
    * @return true if the file has been endorsed on nexus
    */
-  virtual EEndorsedState endorsedState() const;
+  virtual EEndorsedState endorsedState() const override;
 
   /**
    * @return true if the file is being tracked on nexus
    */
-  virtual ETrackedState trackedState() const;
+  virtual ETrackedState trackedState() const override;
 
   /**
    * @brief get the last time nexus was checked for file updates on this mod
    */
-  virtual QDateTime getLastNexusUpdate() const;
+  virtual QDateTime getLastNexusUpdate() const override;
 
   /**
    * @brief set the last time nexus was checked for file updates on this mod
    */
-  virtual void setLastNexusUpdate(QDateTime time);
+  virtual void setLastNexusUpdate(QDateTime time) override;
 
   /**
    * @return last time nexus was queried for infos on this mod
    */
-  virtual QDateTime getLastNexusQuery() const;
+  virtual QDateTime getLastNexusQuery() const override;
 
   /**
    * @brief set the last time nexus was queried for info on this mod
    */
-  virtual void setLastNexusQuery(QDateTime time);
+  virtual void setLastNexusQuery(QDateTime time) override;
 
   /**
    * @return last time the mod was updated on Nexus
    */
-  virtual QDateTime getNexusLastModified() const;
+  virtual QDateTime getNexusLastModified() const override;
 
   /**
    * @brief set the last time the mod was updated on Nexus
    */
-  virtual void setNexusLastModified(QDateTime time);
+  virtual void setNexusLastModified(QDateTime time) override;
 
-  virtual QStringList archives(bool checkOnDisk = false);
+  virtual QStringList archives(bool checkOnDisk = false) override;
 
-  virtual void setColor(QColor color);
+  virtual void setColor(QColor color) override;
 
   virtual QColor getColor();
 
-  virtual void addInstalledFile(int modId, int fileId);
+  virtual void addInstalledFile(int modId, int fileId) override;
 
   /**
    * @brief stores meta information back to disk
    */
-  virtual void saveMeta();
+  virtual void saveMeta() override;
 
-  void readMeta();
+  void readMeta() override;
 
   virtual void setHasCustomURL(bool b) override;
   virtual bool hasCustomURL() const override;
@@ -418,6 +420,13 @@ protected:
 
   ModInfoRegular(PluginContainer *pluginContainer, const MOBase::IPluginGame *game, const QDir &path, MOShared::DirectoryEntry **directoryStructure);
 
+  /**
+   * @brief check if the content of this mod is valid.
+   *
+   * @return true if the content is valid, false otherwize.
+   **/
+    virtual bool doTestValid() const;
+
 private:
 
   QString m_Name;
@@ -429,6 +438,10 @@ private:
   QString m_Repository;
   QString m_CustomURL;
   bool m_HasCustomURL;
+
+  // Storing both the game name and game plugin since we can have a game
+  // name that is not one of the primary names of the game plugin:
+  const MOBase::IPluginGame* m_GamePlugin;
   QString m_GameName;
 
   mutable QStringList m_Archives;

--- a/src/modinfoseparator.h
+++ b/src/modinfoseparator.h
@@ -21,7 +21,7 @@ public:
   virtual bool setName(const QString& name);
 
   virtual int getNexusID() const override { return -1; }
-  virtual void setGamePlugin(const MOBase::IPluginGame* /*gamePlugin*/) override {}
+  virtual void setGameName(const QString& gameName) override {}
   virtual void setNexusID(int /*modID*/) override {}
   virtual void endorse(bool /*doEndorse*/) override {}
   virtual void ignoreUpdate(bool /*ignore*/) override {}

--- a/src/modinfoseparator.h
+++ b/src/modinfoseparator.h
@@ -12,62 +12,44 @@ class ModInfoSeparator:
 
 public:
 
-  virtual bool updateAvailable() const { return false; }
-  virtual bool updateIgnored() const { return false; }
-  virtual bool downgradeAvailable() const { return false; }
-  virtual bool updateNXMInfo() { return false; }
-  virtual bool isValid() const { return true; }
+  virtual bool updateAvailable() const override { return false; }
+  virtual bool updateIgnored() const override { return false; }
+  virtual bool downgradeAvailable() const override { return false; }
+  virtual bool updateNXMInfo() override { return false; }
+  virtual bool isValid() const override { return true; }
   //TODO: Fix renaming method to avoid priority reset
   virtual bool setName(const QString& name);
 
-  virtual int getNexusID() const { return -1; }
+  virtual int getNexusID() const override { return -1; }
+  virtual void setGamePlugin(const MOBase::IPluginGame* /*gamePlugin*/) override {}
+  virtual void setNexusID(int /*modID*/) override {}
+  virtual void endorse(bool /*doEndorse*/) override {}
+  virtual void ignoreUpdate(bool /*ignore*/) override {}
+  virtual bool canBeUpdated() const override { return false; }
+  virtual QDateTime getExpires() const override { return QDateTime(); }
+  virtual bool canBeEnabled() const override { return false; }
+  virtual std::vector<QString> getIniTweaks() const override { return std::vector<QString>(); }
+  virtual std::vector<EFlag> getFlags() const override;
+  virtual int getHighlight() const override;
+  virtual QString getDescription() const override;
+  virtual QString name() const override;
+  virtual QString getGameName() const override { return ""; }
+  virtual QString getInstallationFile() const override { return ""; }
+  virtual QString repository() const override { return ""; }
+  virtual int getNexusFileStatus() const override { return 0; }
+  virtual void setNexusFileStatus(int) override {}
+  virtual QDateTime getLastNexusUpdate() const override { return QDateTime(); }
+  virtual void setLastNexusUpdate(QDateTime) override {}
+  virtual QDateTime getLastNexusQuery() const override { return QDateTime(); }
+  virtual void setLastNexusQuery(QDateTime) override {}
+  virtual QDateTime getNexusLastModified() const override { return QDateTime(); }
+  virtual void setNexusLastModified(QDateTime) override {}
+  virtual QDateTime creationTime() const override { return QDateTime(); }
+  virtual QString getNexusDescription() const override { return QString(); }
+  virtual void addInstalledFile(int /*modId*/, int /*fileId*/) override { }
 
-  virtual void setGameName(const QString& /*gameName*/) {}
-
-  virtual void setNexusID(int /*modID*/) {}
-
-  virtual void endorse(bool /*doEndorse*/) {}
-
-  virtual void parseNexusInfo() {}
-
-  virtual void ignoreUpdate(bool /*ignore*/) {}
-
-  virtual bool canBeUpdated() const { return false; }
-  virtual QDateTime getExpires() const { return QDateTime(); }
-  virtual bool canBeEnabled() const { return false; }
-  virtual std::vector<QString> getIniTweaks() const { return std::vector<QString>(); }
-
-  virtual std::vector<EFlag> getFlags() const;
-  virtual int getHighlight() const;
-
-  virtual QString getDescription() const;
-  virtual QString name() const;
-  virtual QString getGameName() const { return ""; }
-  virtual QString getInstallationFile() const { return ""; }
-  virtual QString getURL() const { return ""; }
-  virtual QString repository() const { return ""; }
-  virtual int getNexusFileStatus() const { return 0; }
-  virtual void setNexusFileStatus(int) {}
-  virtual QDateTime getLastNexusUpdate() const { return QDateTime(); }
-  virtual void setLastNexusUpdate(QDateTime) {}
-  virtual QDateTime getLastNexusQuery() const { return QDateTime(); }
-  virtual void setLastNexusQuery(QDateTime) {}
-  virtual QDateTime getNexusLastModified() const { return QDateTime(); }
-  virtual void setNexusLastModified(QDateTime) {}
-  virtual QDateTime creationTime() const { return QDateTime(); }
-
-  virtual void getNexusFiles
-    (
-      QList<MOBase::ModRepositoryFileInfo*>::const_iterator& /*unused*/,
-      QList<MOBase::ModRepositoryFileInfo*>::const_iterator& /*unused*/)
-  {
-  }
-
-  virtual QString getNexusDescription() const { return QString(); }
-
-  virtual void addInstalledFile(int /*modId*/, int /*fileId*/)
-  {
-  }
+protected:
+  virtual bool doTestValid() const override { return true; }
 
 private:
 

--- a/src/modinfowithconflictinfo.cpp
+++ b/src/modinfowithconflictinfo.cpp
@@ -1,4 +1,5 @@
 #include "modinfowithconflictinfo.h"
+#include "installationtester.h"
 #include "utility.h"
 #include "shared/directoryentry.h"
 #include "shared/filesorigin.h"
@@ -290,4 +291,34 @@ bool ModInfoWithConflictInfo::hasHiddenFiles() const
   }
 
   return m_HasHiddenFiles;
+}
+
+
+bool ModInfoWithConflictInfo::doTestValid() const {
+
+  bool valid = false;
+  QDirIterator dirIter(absolutePath());
+  while (dirIter.hasNext()) {
+    dirIter.next();
+    if (dirIter.fileInfo().isDir()) {
+      if (InstallationTester::isTopLevelDirectory(dirIter.fileName())) {
+        valid = true;
+        break;
+      }
+    }
+    else {
+      if (InstallationTester::isTopLevelSuffix(dirIter.fileName())) {
+        valid = true;
+        break;
+      }
+    }
+  }
+
+  // NOTE: in Qt 4.7 it seems that QDirIterator leaves a file handle open if it is not iterated to the
+  // end
+  while (dirIter.hasNext()) {
+    dirIter.next();
+  }
+
+  return valid;
 }

--- a/src/modinfowithconflictinfo.h
+++ b/src/modinfowithconflictinfo.h
@@ -12,27 +12,27 @@ public:
 
   ModInfoWithConflictInfo(PluginContainer *pluginContainer, MOShared::DirectoryEntry **directoryStructure);
 
-  std::vector<ModInfo::EConflictFlag> getConflictFlags() const;
-  virtual std::vector<ModInfo::EFlag> getFlags() const;
+  std::vector<ModInfo::EConflictFlag> getConflictFlags() const override;
+  virtual std::vector<ModInfo::EFlag> getFlags() const override;
 
   /**
    * @brief clear all caches held for this mod
    */
-  virtual void clearCaches();
+  virtual void clearCaches() override;
 
-  virtual std::set<unsigned int> getModOverwrite() { return m_OverwriteList; }
+  virtual std::set<unsigned int> getModOverwrite() const override { return m_OverwriteList; }
 
-  virtual std::set<unsigned int> getModOverwritten() { return m_OverwrittenList; }
+  virtual std::set<unsigned int> getModOverwritten() const override { return m_OverwrittenList; }
 
-  virtual std::set<unsigned int> getModArchiveOverwrite() { return m_ArchiveOverwriteList; }
+  virtual std::set<unsigned int> getModArchiveOverwrite() const override { return m_ArchiveOverwriteList; }
 
-  virtual std::set<unsigned int> getModArchiveOverwritten() { return m_ArchiveOverwrittenList; }
+  virtual std::set<unsigned int> getModArchiveOverwritten() const override { return m_ArchiveOverwrittenList; }
 
-  virtual std::set<unsigned int> getModArchiveLooseOverwrite() { return m_ArchiveLooseOverwriteList; }
+  virtual std::set<unsigned int> getModArchiveLooseOverwrite() const override { return m_ArchiveLooseOverwriteList; }
 
-  virtual std::set<unsigned int> getModArchiveLooseOverwritten() { return m_ArchiveLooseOverwrittenList; }
+  virtual std::set<unsigned int> getModArchiveLooseOverwritten() const override { return m_ArchiveLooseOverwrittenList; }
 
-  virtual void doConflictCheck() const;
+  virtual void doConflictCheck() const override;
 
 private:
 

--- a/src/modinfowithconflictinfo.h
+++ b/src/modinfowithconflictinfo.h
@@ -34,6 +34,15 @@ public:
 
   virtual void doConflictCheck() const override;
 
+protected:
+
+  /**
+   * @brief check if the content of this mod is valid.
+   *
+   * @return true if the content is valid, false otherwize.
+   **/
+  virtual bool doTestValid() const;
+
 private:
 
   enum EConflictType {

--- a/src/pluginlist.cpp
+++ b/src/pluginlist.cpp
@@ -185,7 +185,8 @@ void PluginList::refresh(const QString &profileName
   ChangeBracket<PluginList> layoutChange(this);
 
   QStringList primaryPlugins = m_GamePlugin->primaryPlugins();
-  bool lightPluginsAreSupported = m_GamePlugin->feature<GamePlugins>()->lightPluginsAreSupported();
+  GamePlugins *gamePlugins = m_GamePlugin->feature<GamePlugins>();
+  const bool lightPluginsAreSupported = gamePlugins ? gamePlugins->lightPluginsAreSupported() : false;
 
   m_CurrentProfile = profileName;
 
@@ -265,8 +266,9 @@ void PluginList::refresh(const QString &profileName
   // indices need to work. priority will be off however
   updateIndices();
 
-  GamePlugins *gamePlugins = m_GamePlugin->feature<GamePlugins>();
-  gamePlugins->readPluginLists(this);
+  if (gamePlugins) {
+    gamePlugins->readPluginLists(this);
+  }
 
   testMasters();
 
@@ -521,7 +523,9 @@ void PluginList::saveTo(const QString &lockedOrderFileName
                         , bool hideUnchecked) const
 {
   GamePlugins *gamePlugins = m_GamePlugin->feature<GamePlugins>();
-  gamePlugins->writePluginLists(this);
+  if (gamePlugins) {
+    gamePlugins->writePluginLists(this);
+  }
 
   writeLockedOrder(lockedOrderFileName);
 
@@ -870,7 +874,10 @@ void PluginList::generatePluginIndexes()
 {
   int numESLs = 0;
   int numSkipped = 0;
-  bool lightPluginsSupported = m_GamePlugin->feature<GamePlugins>()->lightPluginsAreSupported();
+
+  GamePlugins* gamePlugins = m_GamePlugin->feature<GamePlugins>();
+  const bool lightPluginsSupported = gamePlugins ? gamePlugins->lightPluginsAreSupported() : false;
+
   for (int l = 0; l < m_ESPs.size(); ++l) {
     int i = m_ESPsByPriority.at(l);
     if (!m_ESPs[i].enabled) {


### PR DESCRIPTION
**Important:** This PR depends on https://github.com/ModOrganizer2/modorganizer-uibase/pull/48

Content of the PR:
- Prevent crashes when a game plugin does not expose the `GamePlugins` feature.
- Modification of the `ModInfo` implementations following change to `IModInterface` and to prepare for validation by game plugin (instead of hard-coded validation), plus minor fixes (`override` added, remove unused functions, etc.).
- Modification of the installation manager for the new file tree implementation.
