### PR TITLE
Use the ModDataChecker feature to check mod validity

### DIFF
--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -36,6 +36,7 @@ add_filter(NAME src/core GROUPS
 	organizerproxy
 	apiuseraccount
 	processrunner
+	qdirfiletree
 	uilocker
 )
 

--- a/src/installationmanager.cpp
+++ b/src/installationmanager.cpp
@@ -34,7 +34,6 @@ along with Mod Organizer.  If not, see <http://www.gnu.org/licenses/>.
 #include "selectiondialog.h"
 #include "modinfo.h"
 #include <scopeguard.h>
-#include <installationtester.h>
 #include <utility.h>
 #include <scopeguard.h>
 

--- a/src/modinfo.cpp
+++ b/src/modinfo.cpp
@@ -97,11 +97,12 @@ ModInfo::Ptr ModInfo::createFromPlugin(const QString &modName,
                                        const QString &espName,
                                        const QStringList &bsaNames,
                                        ModInfo::EModType modType,
+                                       const MOBase::IPluginGame* game,
                                        DirectoryEntry **directoryStructure,
                                        PluginContainer *pluginContainer) {
   QMutexLocker locker(&s_Mutex);
   ModInfo::Ptr result = ModInfo::Ptr(
-      new ModInfoForeign(modName, espName, bsaNames, modType, directoryStructure, pluginContainer));
+      new ModInfoForeign(modName, espName, bsaNames, modType, game, directoryStructure, pluginContainer));
   s_Collection.push_back(result);
   return result;
 }
@@ -128,11 +129,12 @@ QString ModInfo::getContentTypeName(int contentType)
 }
 
 void ModInfo::createFromOverwrite(PluginContainer *pluginContainer,
+                                  const MOBase::IPluginGame* game,
                                   MOShared::DirectoryEntry **directoryStructure)
 {
   QMutexLocker locker(&s_Mutex);
 
-  s_Collection.push_back(ModInfo::Ptr(new ModInfoOverwrite(pluginContainer, directoryStructure)));
+  s_Collection.push_back(ModInfo::Ptr(new ModInfoOverwrite(pluginContainer, game, directoryStructure)));
 }
 
 unsigned int ModInfo::getNumMods()
@@ -274,12 +276,13 @@ void ModInfo::updateFromDisc(const QString &modDirectory,
                        unmanaged->referenceFile(modName).absoluteFilePath(),
                        unmanaged->secondaryFiles(modName),
                        modType,
+                       game,
                        directoryStructure,
                        pluginContainer);
     }
   }
 
-  createFromOverwrite(pluginContainer, directoryStructure);
+  createFromOverwrite(pluginContainer, game, directoryStructure);
 
   std::sort(s_Collection.begin(), s_Collection.end(), ModInfo::ByName);
 

--- a/src/modinfo.h
+++ b/src/modinfo.h
@@ -232,7 +232,8 @@ public:
    * @param bsaNames names of archives
    * @return a new mod
    */
-  static ModInfo::Ptr createFromPlugin(const QString &modName, const QString &espName, const QStringList &bsaNames, ModInfo::EModType modType, MOShared::DirectoryEntry **directoryStructure, PluginContainer *pluginContainer);
+  static ModInfo::Ptr createFromPlugin(const QString &modName, const QString &espName, const QStringList &bsaNames, ModInfo::EModType modType, 
+    const MOBase::IPluginGame* game, MOShared::DirectoryEntry **directoryStructure, PluginContainer *pluginContainer);
 
   // whether the given name is used for separators
   //
@@ -826,6 +827,7 @@ protected:
 private:
 
   static void createFromOverwrite(PluginContainer *pluginContainer,
+                                  const MOBase::IPluginGame* game,
                                   MOShared::DirectoryEntry **directoryStructure);
 
 protected:

--- a/src/modinfoforeign.cpp
+++ b/src/modinfoforeign.cpp
@@ -46,9 +46,10 @@ ModInfoForeign::ModInfoForeign(const QString &modName,
                                const QString &referenceFile,
                                const QStringList &archives,
                                ModInfo::EModType modType,
+                               const MOBase::IPluginGame* gamePlugin,
                                DirectoryEntry **directoryStructure,
                                PluginContainer *pluginContainer)
-    : ModInfoWithConflictInfo(pluginContainer, directoryStructure),
+    : ModInfoWithConflictInfo(pluginContainer, gamePlugin, directoryStructure),
       m_ReferenceFile(referenceFile), m_Archives(archives), m_ModType(modType)
 {
   m_CreationTime = QFileInfo(referenceFile).birthTime();

--- a/src/modinfoforeign.h
+++ b/src/modinfoforeign.h
@@ -71,6 +71,7 @@ public:
 protected:
   ModInfoForeign(const QString &modName, const QString &referenceFile,
                  const QStringList &archives, ModInfo::EModType modType,
+                 const MOBase::IPluginGame *gamePlugin,
                  MOShared::DirectoryEntry **directoryStructure, PluginContainer *pluginContainer);  
   
 private:

--- a/src/modinfooverwrite.cpp
+++ b/src/modinfooverwrite.cpp
@@ -6,8 +6,8 @@
 #include <QApplication>
 #include <QDirIterator>
 
-ModInfoOverwrite::ModInfoOverwrite(PluginContainer *pluginContainer, MOShared::DirectoryEntry **directoryStructure) 
-  : ModInfoWithConflictInfo(pluginContainer, directoryStructure)
+ModInfoOverwrite::ModInfoOverwrite(PluginContainer *pluginContainer, const MOBase::IPluginGame *game, MOShared::DirectoryEntry **directoryStructure) 
+  : ModInfoWithConflictInfo(pluginContainer, game, directoryStructure)
 {
   testValid();
 }

--- a/src/modinfooverwrite.h
+++ b/src/modinfooverwrite.h
@@ -68,7 +68,7 @@ public:
   virtual void addInstalledFile(int, int) override {}
 
 private:
-  ModInfoOverwrite(PluginContainer *pluginContainer, MOShared::DirectoryEntry **directoryStructure );
+  ModInfoOverwrite(PluginContainer *pluginContainer, const MOBase::IPluginGame* game, MOShared::DirectoryEntry **directoryStructure);
 
 };
 

--- a/src/modinforegular.cpp
+++ b/src/modinforegular.cpp
@@ -25,11 +25,10 @@ namespace {
 }
 
 ModInfoRegular::ModInfoRegular(PluginContainer *pluginContainer, const IPluginGame *game, const QDir &path, DirectoryEntry **directoryStructure)
-  : ModInfoWithConflictInfo(pluginContainer, directoryStructure)
+  : ModInfoWithConflictInfo(pluginContainer, game, directoryStructure)
   , m_Name(path.dirName())
   , m_Path(path.absolutePath())
   , m_Repository()
-  , m_GamePlugin(game)
   , m_GameName(game->gameShortName())
   , m_IsAlternate(false)
   , m_Converted(false)

--- a/src/modinforegular.h
+++ b/src/modinforegular.h
@@ -432,9 +432,6 @@ private:
   QString m_CustomURL;
   bool m_HasCustomURL;
 
-  // Current game plugin running in MO2:
-  MOBase::IPluginGame const* m_GamePlugin;
-
   // Game name for the mod, can be different from the actual game running in MO2
   // e.g., for Skyrim / Skyrim SE.
   QString m_GameName;

--- a/src/modinfoseparator.h
+++ b/src/modinfoseparator.h
@@ -53,10 +53,10 @@ protected:
 
 private:
 
-  ModInfoSeparator
-    (
-      PluginContainer* pluginContainer, const MOBase::IPluginGame* game, const QDir& path,
-      MOShared::DirectoryEntry** directoryStructure);
+  ModInfoSeparator(
+    PluginContainer* pluginContainer, 
+    const MOBase::IPluginGame* game, const QDir& path,
+    MOShared::DirectoryEntry** directoryStructure);
 };
 
 #endif

--- a/src/modinfowithconflictinfo.cpp
+++ b/src/modinfowithconflictinfo.cpp
@@ -6,12 +6,15 @@
 #include "shared/fileentry.h"
 #include <filesystem>
 
+#include "qdirfiletree.h"
+
 using namespace MOBase;
 using namespace MOShared;
 namespace fs = std::filesystem;
 
-ModInfoWithConflictInfo::ModInfoWithConflictInfo(PluginContainer *pluginContainer, DirectoryEntry **directoryStructure)
-  : ModInfo(pluginContainer), m_DirectoryStructure(directoryStructure), m_HasLooseOverwrite(false), m_HasHiddenFiles(false) {}
+ModInfoWithConflictInfo::ModInfoWithConflictInfo(
+  PluginContainer *pluginContainer, const MOBase::IPluginGame* gamePlugin, DirectoryEntry **directoryStructure)
+  : ModInfo(pluginContainer), m_GamePlugin(gamePlugin), m_DirectoryStructure(directoryStructure), m_HasLooseOverwrite(false), m_HasHiddenFiles(false) {}
 
 void ModInfoWithConflictInfo::clearCaches()
 {

--- a/src/modinfowithconflictinfo.cpp
+++ b/src/modinfowithconflictinfo.cpp
@@ -1,11 +1,11 @@
 #include "modinfowithconflictinfo.h"
-#include "installationtester.h"
 #include "utility.h"
 #include "shared/directoryentry.h"
 #include "shared/filesorigin.h"
 #include "shared/fileentry.h"
 #include <filesystem>
 
+#include "moddatachecker.h"
 #include "qdirfiletree.h"
 
 using namespace MOBase;
@@ -298,30 +298,12 @@ bool ModInfoWithConflictInfo::hasHiddenFiles() const
 
 
 bool ModInfoWithConflictInfo::doTestValid() const {
+  auto mdc = m_GamePlugin->feature<ModDataChecker>();
 
-  bool valid = false;
-  QDirIterator dirIter(absolutePath());
-  while (dirIter.hasNext()) {
-    dirIter.next();
-    if (dirIter.fileInfo().isDir()) {
-      if (InstallationTester::isTopLevelDirectory(dirIter.fileName())) {
-        valid = true;
-        break;
-      }
-    }
-    else {
-      if (InstallationTester::isTopLevelSuffix(dirIter.fileName())) {
-        valid = true;
-        break;
-      }
-    }
+  if (mdc) {
+    auto qdirfiletree = QDirFileTree::makeTree(absolutePath());
+    return mdc->dataLooksValid(qdirfiletree);
   }
 
-  // NOTE: in Qt 4.7 it seems that QDirIterator leaves a file handle open if it is not iterated to the
-  // end
-  while (dirIter.hasNext()) {
-    dirIter.next();
-  }
-
-  return valid;
+  return true;
 }

--- a/src/modinfowithconflictinfo.h
+++ b/src/modinfowithconflictinfo.h
@@ -10,8 +10,6 @@ class ModInfoWithConflictInfo : public ModInfo
 
 public:
 
-  ModInfoWithConflictInfo(PluginContainer *pluginContainer, MOShared::DirectoryEntry **directoryStructure);
-
   std::vector<ModInfo::EConflictFlag> getConflictFlags() const override;
   virtual std::vector<ModInfo::EFlag> getFlags() const override;
 
@@ -42,6 +40,11 @@ protected:
    * @return true if the content is valid, false otherwize.
    **/
   virtual bool doTestValid() const;
+
+  ModInfoWithConflictInfo(
+    PluginContainer* pluginContainer,
+    const MOBase::IPluginGame* gamePlugin,
+    MOShared::DirectoryEntry** directoryStructure);
 
 private:
 
@@ -79,6 +82,9 @@ private:
   bool hasHiddenFiles() const;
 
 private:
+
+  // Current game plugin running in MO2:
+  MOBase::IPluginGame const* m_GamePlugin;
 
   MOShared::DirectoryEntry **m_DirectoryStructure;
 

--- a/src/modlist.cpp
+++ b/src/modlist.cpp
@@ -20,7 +20,6 @@ along with Mod Organizer.  If not, see <http://www.gnu.org/licenses/>.
 #include "modlist.h"
 
 #include "messagedialog.h"
-#include "installationtester.h"
 #include "qtgroupingproxy.h"
 #include "viewmarkingscrollbar.h"
 #include "modlistsortproxy.h"

--- a/src/organizercore.cpp
+++ b/src/organizercore.cpp
@@ -834,10 +834,8 @@ QStringList OrganizerCore::listDirectories(const QString &directoryName) const
   if (!directoryName.isEmpty())
     dir = dir->findSubDirectoryRecursive(ToWString(directoryName));
   if (dir != nullptr) {
-    std::vector<DirectoryEntry *>::iterator current, end;
-    dir->getSubDirectories(current, end);
-    for (; current != end; ++current) {
-      result.append(ToQString((*current)->getName()));
+    for (const auto& d : dir->getSubDirectories()) {
+      result.append(ToQString(d->getName()));
     }
   }
   return result;
@@ -1926,14 +1924,12 @@ std::vector<Mapping> OrganizerCore::fileMapping(
   }
 
   // recurse into subdirectories
-  std::vector<DirectoryEntry *>::const_iterator current, end;
-  directoryEntry->getSubDirectories(current, end);
-  for (; current != end; ++current) {
-    int origin = (*current)->anyOrigin();
+  for (const auto& d : directoryEntry->getSubDirectories()) {
+    int origin = d->anyOrigin();
 
     QString originPath
         = QString::fromStdWString(base->getOriginByID(origin).getPath());
-    QString dirName = QString::fromStdWString((*current)->getName());
+    QString dirName = QString::fromStdWString(d->getName());
     QString source  = originPath + relPath + dirName;
     QString target  = dataPath + relPath + dirName;
 
@@ -1942,7 +1938,7 @@ std::vector<Mapping> OrganizerCore::fileMapping(
 
     result.push_back({source, target, true, writeDestination});
     std::vector<Mapping> subRes = fileMapping(
-        dataPath, relPath + dirName + "\\", base, *current, createDestination);
+        dataPath, relPath + dirName + "\\", base, d, createDestination);
     result.insert(result.end(), subRes.begin(), subRes.end());
   }
   return result;

--- a/src/qdirfiletree.cpp
+++ b/src/qdirfiletree.cpp
@@ -1,0 +1,46 @@
+#include "qdirfiletree.h"
+
+#include <QDirIterator>
+
+using namespace MOBase;
+
+/**
+ *
+ */
+std::shared_ptr<const QDirFileTree> QDirFileTree::makeTree(QDir directory) {
+  return std::shared_ptr<const QDirFileTree>(new QDirFileTree(nullptr, directory));
+}
+
+/**
+ *
+ */
+QDirFileTree::QDirFileTree(std::shared_ptr<const IFileTree> parent, QDir directory) : FileTreeEntry(parent, directory.dirName()), IFileTree(), qDir(directory) {
+  qDir.setFilter(qDir.filter() | QDir::NoDotAndDotDot);
+}
+
+/**
+ * No mutable operations allowed.
+ */
+bool QDirFileTree::beforeReplace(IFileTree const* dstTree, FileTreeEntry const* destination, FileTreeEntry const* source) { return false; }
+bool QDirFileTree::beforeInsert(IFileTree const* entry, FileTreeEntry const* name) { return false; }
+bool QDirFileTree::beforeRemove(IFileTree const* entry, FileTreeEntry const* name) { return false; }
+std::shared_ptr<FileTreeEntry> QDirFileTree::makeFile(std::shared_ptr<const IFileTree> parent, QString name, QDateTime time) const { return nullptr; }
+std::shared_ptr<IFileTree> QDirFileTree::makeDirectory(std::shared_ptr<const IFileTree> parent, QString name) const { return nullptr; }
+
+void QDirFileTree::doPopulate(std::shared_ptr<const IFileTree> parent, std::vector<std::shared_ptr<FileTreeEntry>>& entries) const {
+  QDirIterator iter(qDir);
+  while (iter.hasNext()) {
+    QString name = iter.next();
+    QFileInfo info = iter.fileInfo();
+    if (info.isDir()) {
+      entries.push_back(std::shared_ptr<QDirFileTree>(new QDirFileTree(parent, QDir(info.absoluteFilePath()))));
+    }
+    else {
+      entries.push_back(createFileEntry(parent, info.fileName(), info.fileTime(QFileDevice::FileModificationTime)));
+    }
+  }
+}
+
+std::shared_ptr<IFileTree> QDirFileTree::doClone() const {
+  return std::shared_ptr<QDirFileTree>(new QDirFileTree(nullptr, qDir));
+}

--- a/src/qdirfiletree.cpp
+++ b/src/qdirfiletree.cpp
@@ -4,42 +4,69 @@
 
 using namespace MOBase;
 
+class QFileTreeEntry : public virtual FileTreeEntry {
+public:
+  using FileTreeEntry::FileTreeEntry;
+
+  QFileTreeEntry(std::shared_ptr<const IFileTree> parent, QFileInfo fileInfo) :
+    FileTreeEntry(parent, fileInfo.fileName()), m_FileInfo(fileInfo) { }
+
+  QDateTime time() const override {
+    return m_FileInfo.lastModified();
+  }
+
+protected:
+  QFileInfo m_FileInfo;
+};
+
+class QDirFileTreeImpl : public QDirFileTree {
+public:
+
+
+  /**
+   *
+   */
+  QDirFileTreeImpl(std::shared_ptr<const IFileTree> parent, QDir dir) :
+    FileTreeEntry(parent, dir.dirName()), QDirFileTree(), qDir(dir) { }
+
+protected:
+
+  /**
+   * No mutable operations allowed.
+   */
+  bool beforeReplace(IFileTree const* dstTree, FileTreeEntry const* destination, FileTreeEntry const* source) override { return false; }
+  bool beforeInsert(IFileTree const* entry, FileTreeEntry const* name) override { return false; }
+  bool beforeRemove(IFileTree const* entry, FileTreeEntry const* name) override { return false; }
+  std::shared_ptr<FileTreeEntry> makeFile(std::shared_ptr<const IFileTree> parent, QString name) const override { return nullptr; }
+  std::shared_ptr<IFileTree> makeDirectory(std::shared_ptr<const IFileTree> parent, QString name) const override { return nullptr; }
+
+  bool doPopulate(std::shared_ptr<const IFileTree> parent, std::vector<std::shared_ptr<FileTreeEntry>>& entries) const override {
+    auto infoList = qDir.entryInfoList(qDir.filter() | QDir::NoDotAndDotDot, QDir::Name | QDir::DirsFirst | QDir::IgnoreCase);
+    for (auto& info : infoList) {
+      if (info.isDir()) {
+        entries.push_back(std::make_shared<QDirFileTreeImpl>(parent, QDir(info.absoluteFilePath())));
+      }
+      else {
+        entries.push_back(std::make_shared<QFileTreeEntry>(parent, info));
+      }
+    }
+
+    // Vector is already sorted:
+    return true;
+  }
+
+  std::shared_ptr<IFileTree> QDirFileTree::doClone() const {
+    return std::make_shared<QDirFileTreeImpl>(nullptr, qDir);
+  }
+
+private:
+  QDir qDir;
+
+};
+
 /**
  *
  */
 std::shared_ptr<const QDirFileTree> QDirFileTree::makeTree(QDir directory) {
-  return std::shared_ptr<const QDirFileTree>(new QDirFileTree(nullptr, directory));
-}
-
-/**
- *
- */
-QDirFileTree::QDirFileTree(std::shared_ptr<const IFileTree> parent, QDir directory) : FileTreeEntry(parent, directory.dirName()), IFileTree(), qDir(directory) { }
-
-/**
- * No mutable operations allowed.
- */
-bool QDirFileTree::beforeReplace(IFileTree const* dstTree, FileTreeEntry const* destination, FileTreeEntry const* source) { return false; }
-bool QDirFileTree::beforeInsert(IFileTree const* entry, FileTreeEntry const* name) { return false; }
-bool QDirFileTree::beforeRemove(IFileTree const* entry, FileTreeEntry const* name) { return false; }
-std::shared_ptr<FileTreeEntry> QDirFileTree::makeFile(std::shared_ptr<const IFileTree> parent, QString name) const { return nullptr; }
-std::shared_ptr<IFileTree> QDirFileTree::makeDirectory(std::shared_ptr<const IFileTree> parent, QString name) const { return nullptr; }
-
-bool QDirFileTree::doPopulate(std::shared_ptr<const IFileTree> parent, std::vector<std::shared_ptr<FileTreeEntry>>& entries) const {
-  auto infoList = qDir.entryInfoList(qDir.filter() | QDir::NoDotAndDotDot, QDir::Name | QDir::DirsFirst | QDir::IgnoreCase);
-  for (auto& info : infoList) {
-    if (info.isDir()) {
-      entries.push_back(std::shared_ptr<QDirFileTree>(new QDirFileTree(parent, QDir(info.absoluteFilePath()))));
-    }
-    else {
-      entries.push_back(createFileEntry(parent, info.fileName()));
-    }
-  }
-
-  // Vector is already sorted:
-  return true;
-}
-
-std::shared_ptr<IFileTree> QDirFileTree::doClone() const {
-  return std::shared_ptr<QDirFileTree>(new QDirFileTree(nullptr, qDir));
+  return std::make_shared<QDirFileTreeImpl>(nullptr, directory);
 }

--- a/src/qdirfiletree.cpp
+++ b/src/qdirfiletree.cpp
@@ -4,21 +4,6 @@
 
 using namespace MOBase;
 
-class QFileTreeEntry : public virtual FileTreeEntry {
-public:
-  using FileTreeEntry::FileTreeEntry;
-
-  QFileTreeEntry(std::shared_ptr<const IFileTree> parent, QFileInfo fileInfo) :
-    FileTreeEntry(parent, fileInfo.fileName()), m_FileInfo(fileInfo) { }
-
-  QDateTime time() const override {
-    return m_FileInfo.lastModified();
-  }
-
-protected:
-  QFileInfo m_FileInfo;
-};
-
 class QDirFileTreeImpl : public QDirFileTree {
 public:
 
@@ -47,7 +32,7 @@ protected:
         entries.push_back(std::make_shared<QDirFileTreeImpl>(parent, QDir(info.absoluteFilePath())));
       }
       else {
-        entries.push_back(std::make_shared<QFileTreeEntry>(parent, info));
+        entries.push_back(createFileEntry(parent, info.fileName()));
       }
     }
 

--- a/src/qdirfiletree.h
+++ b/src/qdirfiletree.h
@@ -43,17 +43,18 @@ public:
    */
   static std::shared_ptr<const QDirFileTree> makeTree(QDir directory);
 
+  QDirFileTree(std::shared_ptr<const IFileTree> parent, QDir directory);
+
 protected:
 
-  QDirFileTree(std::shared_ptr<const IFileTree> parent, QDir directory);
 
   virtual bool beforeReplace(IFileTree const* dstTree, FileTreeEntry const* destination, FileTreeEntry const* source) override;
   virtual bool beforeInsert(IFileTree const* entry, FileTreeEntry const* name) override;
   virtual bool beforeRemove(IFileTree const* entry, FileTreeEntry const* name) override;
 
-  virtual std::shared_ptr<FileTreeEntry> makeFile(std::shared_ptr<const IFileTree> parent, QString name, QDateTime time) const override;
+  virtual std::shared_ptr<FileTreeEntry> makeFile(std::shared_ptr<const IFileTree> parent, QString name) const override;
   virtual std::shared_ptr<IFileTree> makeDirectory(std::shared_ptr<const IFileTree> parent, QString name) const override;
-  virtual void doPopulate(std::shared_ptr<const IFileTree> parent, std::vector<std::shared_ptr<FileTreeEntry>>& entries) const override;
+  virtual bool doPopulate(std::shared_ptr<const IFileTree> parent, std::vector<std::shared_ptr<FileTreeEntry>>& entries) const override;
   virtual std::shared_ptr<IFileTree> doClone() const override;
 
   QDir qDir;

--- a/src/qdirfiletree.h
+++ b/src/qdirfiletree.h
@@ -43,22 +43,11 @@ public:
    */
   static std::shared_ptr<const QDirFileTree> makeTree(QDir directory);
 
-  QDirFileTree(std::shared_ptr<const IFileTree> parent, QDir directory);
-
 protected:
 
+  using IFileTree::IFileTree;
 
-  virtual bool beforeReplace(IFileTree const* dstTree, FileTreeEntry const* destination, FileTreeEntry const* source) override;
-  virtual bool beforeInsert(IFileTree const* entry, FileTreeEntry const* name) override;
-  virtual bool beforeRemove(IFileTree const* entry, FileTreeEntry const* name) override;
-
-  virtual std::shared_ptr<FileTreeEntry> makeFile(std::shared_ptr<const IFileTree> parent, QString name) const override;
-  virtual std::shared_ptr<IFileTree> makeDirectory(std::shared_ptr<const IFileTree> parent, QString name) const override;
-  virtual bool doPopulate(std::shared_ptr<const IFileTree> parent, std::vector<std::shared_ptr<FileTreeEntry>>& entries) const override;
-  virtual std::shared_ptr<IFileTree> doClone() const override;
-
-  QDir qDir;
-
+  virtual bool doPopulate(std::shared_ptr<const IFileTree> parent, std::vector<std::shared_ptr<FileTreeEntry>>& entries) const = 0;
 };
 
 #endif

--- a/src/qdirfiletree.h
+++ b/src/qdirfiletree.h
@@ -1,0 +1,63 @@
+/*
+Copyright (C) MO2 Team. All rights reserved.
+
+This file is part of Mod Organizer.
+
+Mod Organizer is free software: you can redistribute it and/or modify
+it under the terms of the GNU General Public License as published by
+the Free Software Foundation, either version 3 of the License, or
+(at your option) any later version.
+
+Mod Organizer is distributed in the hope that it will be useful,
+but WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+GNU General Public License for more details.
+
+You should have received a copy of the GNU General Public License
+along with Mod Organizer.  If not, see <http://www.gnu.org/licenses/>.
+*/
+
+#ifndef ARCHIVEFILENETRY_H
+#define ARCHIVEFILENTRY_H
+
+#include <QDir>
+
+#include "ifiletree.h"
+
+
+/**
+ * Class that expose a directory on the drive, using QDir, as a `MOBase::IFileTree`.
+ *
+ * This class does not expose mutable operations, so any mutable operations will
+ * fail.
+ */
+class QDirFileTree : public MOBase::IFileTree {
+public:
+
+  /**
+   * @brief Create a new file tree representing the given directory.
+   *
+   * @param directory Directory to represent.
+   *
+   * @return a file tree representing the given directory.
+   */
+  static std::shared_ptr<const QDirFileTree> makeTree(QDir directory);
+
+protected:
+
+  QDirFileTree(std::shared_ptr<const IFileTree> parent, QDir directory);
+
+  virtual bool beforeReplace(IFileTree const* dstTree, FileTreeEntry const* destination, FileTreeEntry const* source) override;
+  virtual bool beforeInsert(IFileTree const* entry, FileTreeEntry const* name) override;
+  virtual bool beforeRemove(IFileTree const* entry, FileTreeEntry const* name) override;
+
+  virtual std::shared_ptr<FileTreeEntry> makeFile(std::shared_ptr<const IFileTree> parent, QString name, QDateTime time) const override;
+  virtual std::shared_ptr<IFileTree> makeDirectory(std::shared_ptr<const IFileTree> parent, QString name) const override;
+  virtual void doPopulate(std::shared_ptr<const IFileTree> parent, std::vector<std::shared_ptr<FileTreeEntry>>& entries) const override;
+  virtual std::shared_ptr<IFileTree> doClone() const override;
+
+  QDir qDir;
+
+};
+
+#endif

--- a/src/qdirfiletree.h
+++ b/src/qdirfiletree.h
@@ -26,7 +26,10 @@ along with Mod Organizer.  If not, see <http://www.gnu.org/licenses/>.
 
 
 /**
- * Class that expose a directory on the drive, using QDir, as a `MOBase::IFileTree`.
+ * @brief Class that expose a directory on the drive, using QDir, as a `MOBase::IFileTree`.
+ *
+ * The tree is lazily populated: each subtree is only populated (from the disk) when needed,
+ * as specified by IFileTree.
  *
  * This class does not expose mutable operations, so any mutable operations will
  * fail.

--- a/src/shared/directoryentry.h
+++ b/src/shared/directoryentry.h
@@ -46,10 +46,18 @@ namespace std
 namespace MOShared
 {
 
+struct DirCompareByName
+{
+    bool operator()(const DirectoryEntry* a, const DirectoryEntry* b) const;
+};
+
+
 class DirectoryEntry
 {
 public:
-  DirectoryEntry(
+    using SubDirectories = std::set<DirectoryEntry*, DirCompareByName>;
+
+    DirectoryEntry(
     std::wstring name, DirectoryEntry* parent, OriginID originID);
 
   DirectoryEntry(
@@ -137,15 +145,7 @@ public:
 
   std::vector<FileEntryPtr> getFiles() const;
 
-  void getSubDirectories(
-    std::vector<DirectoryEntry*>::const_iterator& begin,
-    std::vector<DirectoryEntry*>::const_iterator& end) const
-  {
-    begin = m_SubDirectories.begin();
-    end = m_SubDirectories.end();
-  }
-
-  const std::vector<DirectoryEntry*>& getSubDirectories() const
+  const SubDirectories& getSubDirectories() const
   {
     return m_SubDirectories;
   }
@@ -238,7 +238,6 @@ public:
 private:
   using FilesMap = std::map<std::wstring, FileIndex>;
   using FilesLookup = std::unordered_map<DirectoryEntryFileKey, FileIndex>;
-  using SubDirectories = std::vector<DirectoryEntry*>;
   using SubDirectoriesLookup = std::unordered_map<std::wstring, DirectoryEntry*>;
 
   boost::shared_ptr<FileRegister> m_FileRegister;

--- a/src/version.rc
+++ b/src/version.rc
@@ -4,7 +4,7 @@
 // Otherwise, if letters are used in VER_FILEVERSION_STR, uses the full MOBase::VersionInfo parser
 // Otherwise, uses the numbers from VER_FILEVERSION and sets the release type as pre-alpha
 #define VER_FILEVERSION     2,3,0
-#define VER_FILEVERSION_STR "2.3.0alpha8\0"
+#define VER_FILEVERSION_STR "2.3.0alpha9\0"
 
 VS_VERSION_INFO VERSIONINFO
 FILEVERSION     VER_FILEVERSION
@@ -24,7 +24,7 @@ BEGIN
         VALUE "FileDescription",  "Mod Organizer 2 GUI\0"
         VALUE "OriginalFilename", "ModOrganizer.exe\0"
         VALUE "InternalName", "ModOrganizer2\0"
-        VALUE "LegalCopyright", "Copyright 2011-2016 Sebastian Herbord\r\nCopyright 2016-2019 Mod Organizer 2 contributors\0"
+        VALUE "LegalCopyright", "Copyright 2011-2016 Sebastian Herbord\r\nCopyright 2016-2020 Mod Organizer 2 contributors\0"
         VALUE "ProductName",      "Mod Organizer 2\0"
         VALUE "ProductVersion", VER_FILEVERSION_STR
       END


### PR DESCRIPTION
Modification to `ModInfoWithConflictInfo` to use the `ModDataChecker` feature to check mod validity:

- New `QDirFileTree` that  is a `IFileTree` populated from a `QDir`.
- Add to modify some `ModInfoXXX` class to give the game plugin to the parent `ModInfoWithConflictInfo`.

I know that the new implementation is slower than the old one. With my SkyrimSE setup with ~500 mods, I see almost no difference when looking at the code that load all mods from disk (the part of the code where this has the most impact). I don't think it will matter even for 2000 mods.

I checked the speed differences with an unrealistic setup: 2000 mods where each one has 100 folders and 100 files in the root folder (since the `QDirFileTree` does not recurse unless asked to). In this case, I go from ~900ms to 2.7s... I can go down to 1.9s by removing the `fileTime` method, but it's still slightly more than twice the old time.

**Edit:** I check the timing of `updateModInfoFromDisc` to compare, and did a bit more in-depth profiling for the 2000 mods version.

I check with another fake setup with 2000 mods, each one containing 20 folders and 20 files and the `updateModInfoFromDisc`. The timing of `updateModInfoFromDisc` goes from ~520ms to ~850ms (~720ms without the `fileTime`). This also includes all the other changes, i.e., fetching the `ModDataChecker` game-feature from the game plugin and using it, so this alone might have a slight impact.

**Edit 2:** After some modifications (not fetching `fileTime()` and sorting via `QDir::SortFlags`, I have better performances.

- For the 2000 mods containing 20 files and 20 folders, it is down to ~660ms with the new version.
- For the 2000 mods containing 100 files and 100 folders, it is down to ~1500ms.
