### PR TITLE
ModInfo improvements

### DIFF
--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -186,6 +186,7 @@ add_filter(NAME src/utilities GROUPS
 	shared/util
 	usvfsconnector
 	shared/windows_error
+	thread_utils
 	json
 )
 

--- a/src/mainwindow.cpp
+++ b/src/mainwindow.cpp
@@ -3061,8 +3061,6 @@ void MainWindow::ignoreMissingData_clicked()
     for (QModelIndex idx : selection->selectedRows()) {
       int row_idx = idx.data(Qt::UserRole + 1).toInt();
       ModInfo::Ptr info = ModInfo::getByIndex(row_idx);
-      //QDir(info->absolutePath()).mkdir("textures");
-      info->diskContentModified();
       info->markValidated(true);
       connect(this, SIGNAL(modListDataChanged(QModelIndex, QModelIndex)), m_OrganizerCore.modList(), SIGNAL(dataChanged(QModelIndex, QModelIndex)));
 
@@ -3070,8 +3068,6 @@ void MainWindow::ignoreMissingData_clicked()
     }
   } else {
     ModInfo::Ptr info = ModInfo::getByIndex(m_ContextRow);
-    //QDir(info->absolutePath()).mkdir("textures");
-    info->diskContentModified();
     info->markValidated(true);
     connect(this, SIGNAL(modListDataChanged(QModelIndex, QModelIndex)), m_OrganizerCore.modList(), SIGNAL(dataChanged(QModelIndex, QModelIndex)));
 

--- a/src/mainwindow.cpp
+++ b/src/mainwindow.cpp
@@ -3062,7 +3062,7 @@ void MainWindow::ignoreMissingData_clicked()
       int row_idx = idx.data(Qt::UserRole + 1).toInt();
       ModInfo::Ptr info = ModInfo::getByIndex(row_idx);
       //QDir(info->absolutePath()).mkdir("textures");
-      info->testValid();
+      info->diskContentModified();
       info->markValidated(true);
       connect(this, SIGNAL(modListDataChanged(QModelIndex, QModelIndex)), m_OrganizerCore.modList(), SIGNAL(dataChanged(QModelIndex, QModelIndex)));
 
@@ -3071,7 +3071,7 @@ void MainWindow::ignoreMissingData_clicked()
   } else {
     ModInfo::Ptr info = ModInfo::getByIndex(m_ContextRow);
     //QDir(info->absolutePath()).mkdir("textures");
-    info->testValid();
+    info->diskContentModified();
     info->markValidated(true);
     connect(this, SIGNAL(modListDataChanged(QModelIndex, QModelIndex)), m_OrganizerCore.modList(), SIGNAL(dataChanged(QModelIndex, QModelIndex)));
 

--- a/src/modinfo.cpp
+++ b/src/modinfo.cpp
@@ -306,7 +306,7 @@ void ModInfo::updateIndices()
 
 
 ModInfo::ModInfo(PluginContainer *pluginContainer)
-  : m_Valid(false), m_PrimaryCategory(-1)
+  : m_PrimaryCategory(-1)
 {
 }
 
@@ -526,11 +526,6 @@ bool ModInfo::categorySet(int categoryID) const
   }
 
   return false;
-}
-
-void ModInfo::testValid()
-{
-  m_Valid = doTestValid();
 }
 
 QUrl ModInfo::parseCustomURL() const

--- a/src/modinfo.cpp
+++ b/src/modinfo.cpp
@@ -29,6 +29,7 @@ along with Mod Organizer.  If not, see <http://www.gnu.org/licenses/>.
 #include "modinfodialog.h"
 #include "overwriteinfodialog.h"
 #include "versioninfo.h"
+#include "envfs.h"
 
 #include <iplugingame.h>
 #include <versioninfo.h>
@@ -45,6 +46,7 @@ using namespace MOBase;
 using namespace MOShared;
 
 
+env::ThreadPool<ModInfo::ModThread> ModInfo::s_Threads(10);
 std::vector<ModInfo::Ptr> ModInfo::s_Collection;
 std::map<QString, unsigned int> ModInfo::s_ModsByName;
 std::map<std::pair<QString, int>, std::vector<unsigned int>> ModInfo::s_ModsByModID;
@@ -287,6 +289,12 @@ void ModInfo::updateFromDisc(const QString &modDirectory,
   std::sort(s_Collection.begin(), s_Collection.end(), ModInfo::ByName);
 
   updateIndices();
+
+  for (auto& p : s_Collection) {
+    auto &t = s_Threads.request();
+    t.ptr = p;
+    t.wakeup();
+  }
 }
 
 

--- a/src/modinfo.cpp
+++ b/src/modinfo.cpp
@@ -288,7 +288,7 @@ void ModInfo::updateFromDisc(const QString &modDirectory,
 
   std::sort(s_Collection.begin(), s_Collection.end(), ModInfo::ByName);
   
-  parallelMap(std::begin(s_Collection), std::end(s_Collection), &ModInfo::isValid, refreshThreadCount);
+  parallelMap(std::begin(s_Collection), std::end(s_Collection), &ModInfo::prefetch, refreshThreadCount);
 
   updateIndices();
 

--- a/src/modinfo.h
+++ b/src/modinfo.h
@@ -22,7 +22,6 @@ along with Mod Organizer.  If not, see <http://www.gnu.org/licenses/>.
 
 #include "imodinterface.h"
 #include "versioninfo.h"
-#include "envfs.h"
 
 class PluginContainer;
 class QDir;
@@ -840,36 +839,6 @@ protected:
   bool m_PluginSelected = false;
 
 private:
-
-  struct ModThread
-  {
-    ModInfo::Ptr ptr;
-
-    std::condition_variable cv;
-    std::mutex mutex;
-    bool ready = false;
-
-    void wakeup()
-    {
-      {
-        std::scoped_lock lock(mutex);
-        ready = true;
-      }
-
-      cv.notify_one();
-    }
-
-    void run()
-    {
-      std::unique_lock lock(mutex);
-      cv.wait(lock, [&] { return ready; });
-
-      ptr->isValid();
-      ready = false;
-    }
-  };
-
-  static env::ThreadPool<ModThread> s_Threads;
 
   static QMutex s_Mutex;
   static std::map<std::pair<QString, int>, std::vector<unsigned int> > s_ModsByModID;

--- a/src/modinfo.h
+++ b/src/modinfo.h
@@ -22,6 +22,7 @@ along with Mod Organizer.  If not, see <http://www.gnu.org/licenses/>.
 
 #include "imodinterface.h"
 #include "versioninfo.h"
+#include "envfs.h"
 
 class PluginContainer;
 class QDir;
@@ -838,6 +839,36 @@ protected:
   bool m_PluginSelected = false;
 
 private:
+
+  struct ModThread
+  {
+    ModInfo::Ptr ptr;
+
+    std::condition_variable cv;
+    std::mutex mutex;
+    bool ready = false;
+
+    void wakeup()
+    {
+      {
+        std::scoped_lock lock(mutex);
+        ready = true;
+      }
+
+      cv.notify_one();
+    }
+
+    void run()
+    {
+      std::unique_lock lock(mutex);
+      cv.wait(lock, [&] { return ready; });
+
+      ptr->isValid();
+      ready = false;
+    }
+  };
+
+  static env::ThreadPool<ModThread> s_Threads;
 
   static QMutex s_Mutex;
   static std::map<std::pair<QString, int>, std::vector<unsigned int> > s_ModsByModID;

--- a/src/modinfo.h
+++ b/src/modinfo.h
@@ -143,6 +143,7 @@ public:
                              MOShared::DirectoryEntry **directoryStructure,
                              PluginContainer *pluginContainer,
                              bool displayForeign,
+                             std::size_t refreshThreadCount,
                              MOBase::IPluginGame const *game);
 
   static void clear() { s_Collection.clear(); s_ModsByName.clear(); s_ModsByModID.clear(); }

--- a/src/modinfo.h
+++ b/src/modinfo.h
@@ -702,7 +702,7 @@ public:
   /**
    * @return true if this mod is considered "valid", that is: it contains data used by the game
    **/
-  virtual bool isValid() const { return m_Valid; }
+  virtual bool isValid() const = 0;
 
   /**
    * @return true if the file has been endorsed on nexus
@@ -713,11 +713,6 @@ public:
    * @return true if the file is being tracked on nexus
    */
   virtual ETrackedState trackedState() const { return TRACKED_FALSE; }
-
-  /**
-   * @brief updates the valid-flag for this mod
-   */
-  void testValid();
 
   /**
    * @brief updates the mod to flag it as converted in order to ignore the alternate game warning
@@ -801,6 +796,13 @@ public:
    **/
   QUrl parseCustomURL() const;
 
+public slots:
+
+  /**
+   * @brief Notify this mod that the content of the disk may have changed.
+   */
+  virtual void diskContentModified() = 0;
+
 signals:
 
   /**
@@ -816,13 +818,6 @@ protected:
 
   static void updateIndices();
   static bool ByName(const ModInfo::Ptr &LHS, const ModInfo::Ptr &RHS);
-
-  /**
-   * @brief check if the content of this mod is valid.
-   *
-   * @return true if the content is valid, false otherwize.
-   **/
-  virtual bool doTestValid() const = 0;
 
 private:
 
@@ -847,8 +842,6 @@ private:
   static QMutex s_Mutex;
   static std::map<std::pair<QString, int>, std::vector<unsigned int> > s_ModsByModID;
   static int s_NextID;
-
-  bool m_Valid;
 
 };
 

--- a/src/modinfo.h
+++ b/src/modinfo.h
@@ -815,7 +815,19 @@ signals:
 
 protected:
 
+  /**
+   *
+   */
   ModInfo(PluginContainer *pluginContainer);
+
+  /**
+   * @brief Prefetch content for this mod.
+   *
+   * This method can be used to prefetch content from the mod, e.g., for isValid()
+   * or getContents(). This method will only be called when first creating the mod
+   * using multiple threads for all the mods.
+   */
+  virtual void prefetch() = 0;
 
   static void updateIndices();
   static bool ByName(const ModInfo::Ptr &LHS, const ModInfo::Ptr &RHS);

--- a/src/modinfooverwrite.cpp
+++ b/src/modinfooverwrite.cpp
@@ -9,7 +9,6 @@
 ModInfoOverwrite::ModInfoOverwrite(PluginContainer *pluginContainer, const MOBase::IPluginGame *game, MOShared::DirectoryEntry **directoryStructure) 
   : ModInfoWithConflictInfo(pluginContainer, game, directoryStructure)
 {
-  testValid();
 }
 
 bool ModInfoOverwrite::isEmpty() const

--- a/src/modinforegular.cpp
+++ b/src/modinforegular.cpp
@@ -698,7 +698,7 @@ std::vector<ModInfo::EContent> ModInfoRegular::doGetContents() const
     if (e) {
       contents.push_back(CONTENT_SKSEFILES);
       for (auto f : *e) {
-        if (f->suffix().compare("dll", FileNameComparator::CaseSensitivity) == 0) {
+        if (f->hasSuffix("dll")) {
           contents.push_back(CONTENT_SKSE);
           break;
         }

--- a/src/modinforegular.cpp
+++ b/src/modinforegular.cpp
@@ -698,7 +698,7 @@ std::vector<ModInfo::EContent> ModInfoRegular::doGetContents() const
     if (e) {
       contents.push_back(CONTENT_SKSEFILES);
       for (auto f : *e) {
-        if (f->suffix().compare("dll") == 0) {
+        if (f->suffix().compare("dll", FileNameComparator::CaseSensitivity) == 0) {
           contents.push_back(CONTENT_SKSE);
           break;
         }

--- a/src/modinforegular.cpp
+++ b/src/modinforegular.cpp
@@ -667,7 +667,6 @@ std::vector<ModInfo::EContent> ModInfoRegular::getContents() const
       else if (suffix == "bsa" || suffix == "ba2") {
         contents.push_back(CONTENT_BSA);
       }
-      //use >1 for ini files since there is meta.ini in all mods already.
       else if (suffix == "ini" && e->compare("meta.ini") != 0) {
         contents.push_back(CONTENT_INI);
       }

--- a/src/modinforegular.cpp
+++ b/src/modinforegular.cpp
@@ -660,7 +660,7 @@ std::vector<ModInfo::EContent> ModInfoRegular::getContents() const
 
   for (auto e : *tree) {
     if (e->isFile()) {
-      auto suffix = e->suffix();
+      auto suffix = e->suffix().toLower();
       if (suffix == "esp" || suffix == "esm" || suffix == "esl") {
         contents.push_back(CONTENT_PLUGIN);
       }

--- a/src/modinforegular.cpp
+++ b/src/modinforegular.cpp
@@ -699,7 +699,7 @@ std::vector<ModInfo::EContent> ModInfoRegular::getContents() const
     if (e) {
       contents.push_back(CONTENT_SKSEFILES);
       for (auto f : *e) {
-        if (e->suffix().compare("dll") == 0) {
+        if (f->suffix().compare("dll") == 0) {
           contents.push_back(CONTENT_SKSE);
           break;
         }

--- a/src/modinforegular.cpp
+++ b/src/modinforegular.cpp
@@ -653,7 +653,7 @@ std::vector<ModInfo::EFlag> ModInfoRegular::getFlags() const
 }
 
 
-std::vector<ModInfo::EContent> ModInfoRegular::getContents() const
+std::vector<ModInfo::EContent> ModInfoRegular::doGetContents() const
 {
   auto tree = contentFileTree();
   std::vector<ModInfo::EContent> contents;
@@ -707,7 +707,6 @@ std::vector<ModInfo::EContent> ModInfoRegular::getContents() const
   }
 
   return contents;
-
 }
 
 

--- a/src/modinforegular.h
+++ b/src/modinforegular.h
@@ -462,9 +462,6 @@ private:
 
   NexusBridge m_NexusBridge;
 
-  mutable std::vector<ModInfo::EContent> m_CachedContent;
-  mutable QTime m_LastContentCheck;
-
   bool needsDescriptionUpdate() const;
 };
 

--- a/src/modinforegular.h
+++ b/src/modinforegular.h
@@ -289,8 +289,6 @@ public:
    */
   virtual std::vector<EFlag> getFlags() const override;
 
-  virtual std::vector<EContent> getContents() const override;
-
   /**
    * @return an indicator if and how this mod should be highlighted by the UI
    */
@@ -417,6 +415,8 @@ private slots:
   void nxmRequestFailed(QString, int modID, int fileID, QVariant userData, QNetworkReply::NetworkError error, const QString &errorMessage);
 
 protected:
+
+  virtual std::vector<EContent> doGetContents() const override;
 
   ModInfoRegular(PluginContainer *pluginContainer, const MOBase::IPluginGame *game, const QDir &path, MOShared::DirectoryEntry **directoryStructure);
 

--- a/src/modinfoseparator.h
+++ b/src/modinfoseparator.h
@@ -49,7 +49,7 @@ public:
   virtual void addInstalledFile(int /*modId*/, int /*fileId*/) override { }
 
 protected:
-  virtual bool doTestValid() const override { return true; }
+  virtual bool doIsValid() const override { return true; }
 
 private:
 

--- a/src/modinfowithconflictinfo.cpp
+++ b/src/modinfowithconflictinfo.cpp
@@ -309,6 +309,11 @@ std::shared_ptr<const IFileTree> ModInfoWithConflictInfo::contentFileTree() cons
   return m_FileTree;
 }
 
+void ModInfoWithConflictInfo::prefetch() {
+  // Populating the tree to 1-depth:
+  contentFileTree()->size();
+}
+
 bool ModInfoWithConflictInfo::doTestValid() const {
   auto mdc = m_GamePlugin->feature<ModDataChecker>();
 

--- a/src/modinfowithconflictinfo.cpp
+++ b/src/modinfowithconflictinfo.cpp
@@ -296,14 +296,30 @@ bool ModInfoWithConflictInfo::hasHiddenFiles() const
   return m_HasHiddenFiles;
 }
 
+void ModInfoWithConflictInfo::diskContentModified() {
+  std::unique_lock lock(m_Mutex);
+  m_FileTree = nullptr;
+}
+
+std::shared_ptr<const IFileTree> ModInfoWithConflictInfo::contentFileTree() const {
+  std::unique_lock lock(m_Mutex);
+  if (!m_FileTree) {
+    m_FileTree = QDirFileTree::makeTree(absolutePath());
+  }
+  return m_FileTree;
+}
 
 bool ModInfoWithConflictInfo::doTestValid() const {
   auto mdc = m_GamePlugin->feature<ModDataChecker>();
 
   if (mdc) {
-    auto qdirfiletree = QDirFileTree::makeTree(absolutePath());
+    auto qdirfiletree = contentFileTree();
     return mdc->dataLooksValid(qdirfiletree);
   }
 
   return true;
+}
+
+bool ModInfoWithConflictInfo::isValid() const {
+  return doTestValid();
 }

--- a/src/modinfowithconflictinfo.cpp
+++ b/src/modinfowithconflictinfo.cpp
@@ -307,7 +307,8 @@ void ModInfoWithConflictInfo::diskContentModified() {
 }
 
 void ModInfoWithConflictInfo::prefetch() {
-  // Populating the tree to 1-depth:
+  // Populating the tree to 1-depth (IFileTree is lazy, so size() forces the
+  // tree to populate the first level):
   contentFileTree()->size();
 }
 

--- a/src/modinfowithconflictinfo.h
+++ b/src/modinfowithconflictinfo.h
@@ -108,6 +108,15 @@ private:
 
 protected:
 
+  /**
+   * @brief Prefetch content for this mod.
+   *
+   * This method can be used to prefetch content from the mod, e.g., for isValid()
+   * or getContents(). This method will only be called when first creating the mod
+   * using multiple threads for all the mods.
+   */
+  virtual void prefetch() override;
+
   // Current game plugin running in MO2:
   MOBase::IPluginGame const * const m_GamePlugin;
 

--- a/src/modinfowithconflictinfo.h
+++ b/src/modinfowithconflictinfo.h
@@ -59,7 +59,7 @@ protected:
    *
    * @return true if the content is valid, false otherwise.
    **/
-  virtual bool doTestValid() const;
+  virtual bool doIsValid() const;
 
   /**
    * @brief Compute the contents for this mod.
@@ -135,16 +135,9 @@ protected:
 
 private:
 
-  /**
-   * @return a file tree for this mod.
-   */
-  std::shared_ptr<const MOBase::IFileTree> updateFileTree() const;
-
-  MOShared::MemoizedLocked<
-    std::shared_ptr<const MOBase::IFileTree>, 
-    decltype(&ModInfoWithConflictInfo::updateFileTree)> m_FileTree;
-  MOShared::MemoizedLocked<bool, decltype(&ModInfoWithConflictInfo::doTestValid)> m_Valid;
-  MOShared::MemoizedLocked<std::vector<EContent>, decltype(&ModInfoWithConflictInfo::doGetContents)> m_Contents;
+  MOShared::MemoizedLocked<std::shared_ptr<const MOBase::IFileTree>> m_FileTree;
+  MOShared::MemoizedLocked<bool> m_Valid;
+  MOShared::MemoizedLocked<std::vector<EContent>> m_Contents;
 
   MOShared::DirectoryEntry **m_DirectoryStructure;
 

--- a/src/modlist.cpp
+++ b/src/modlist.cpp
@@ -849,7 +849,7 @@ void ModList::modInfoChanged(ModInfo::Ptr info)
     }
 
     int row = ModInfo::getIndex(info->name());
-    info->testValid();
+    info->diskContentModified();
     emit aboutToChangeData();
     emit dataChanged(index(row, 0), index(row, columnCount()));
     emit postDataChanged();
@@ -1076,7 +1076,7 @@ bool ModList::dropURLs(const QMimeData *mimeData, int row, const QModelIndex &pa
   }
 
   if (!modInfo->isValid()) {
-    modInfo->testValid();
+    modInfo->diskContentModified();
   }
 
   return true;

--- a/src/modlist.h
+++ b/src/modlist.h
@@ -276,8 +276,6 @@ protected:
 
 private:
 
-  bool testValid(const QString &modDir);
-
   QVariant getOverwriteData(int column, int role) const;
 
   QString getFlagText(ModInfo::EFlag flag, ModInfo::Ptr modInfo) const;

--- a/src/organizercore.cpp
+++ b/src/organizercore.cpp
@@ -1629,7 +1629,7 @@ void OrganizerCore::syncOverwrite()
                                  qApp->activeWindow());
   if (syncDialog.exec() == QDialog::Accepted) {
     syncDialog.apply(QDir::fromNativeSeparators(m_Settings.paths().mods()));
-    modInfo->testValid();
+    modInfo->diskContentModified();
     refreshDirectoryStructure();
   }
 }

--- a/src/organizercore.cpp
+++ b/src/organizercore.cpp
@@ -208,7 +208,8 @@ void OrganizerCore::updateExecutablesList()
 void OrganizerCore::updateModInfoFromDisc() {
   ModInfo::updateFromDisc(
     m_Settings.paths().mods(), &m_DirectoryStructure,
-    m_PluginContainer, m_Settings.interface().displayForeign(), managedGame());
+    m_PluginContainer, m_Settings.interface().displayForeign(), 
+    m_Settings.refreshThreadCount(), managedGame());
 }
 
 void OrganizerCore::setUserInterface(IUserInterface* ui)
@@ -1097,7 +1098,8 @@ void OrganizerCore::refreshModList(bool saveChanges)
 
   ModInfo::updateFromDisc(
     m_Settings.paths().mods(), &m_DirectoryStructure,
-    m_PluginContainer, m_Settings.interface().displayForeign(), managedGame());
+    m_PluginContainer, m_Settings.interface().displayForeign(), 
+    m_Settings.refreshThreadCount(), managedGame());
 
   m_CurrentProfile->refreshModStatus();
 

--- a/src/thread_utils.h
+++ b/src/thread_utils.h
@@ -21,10 +21,14 @@ namespace MOShared {
  *
  */
 template <class It, class Callable>
-void parallelMap(It begin, It end, Callable callable, std::size_t nThreads) {
+void parallelMap(It begin, It end, Callable callable, std::size_t nThreads) 
+{
+  std::mutex m;
   std::vector<std::thread> threads(nThreads);
 
-  std::mutex m;
+  // Create the thread:
+  //  - The mutex is only used to fetch/increment the iterator.
+  //  - The callable is copied in each thread to avoid conflicts.
   for (auto &thread: threads) {
     thread = std::thread([&m, &begin, end, callable]() {
       while (true) {
@@ -42,7 +46,6 @@ void parallelMap(It begin, It end, Callable callable, std::size_t nThreads) {
       }
     });
   }
-
 
   // Join everything:
   for (auto& t : threads) {

--- a/src/thread_utils.h
+++ b/src/thread_utils.h
@@ -1,0 +1,55 @@
+#ifndef MO2_THREAD_UTILS_H
+#define MO2_THREAD_UTILS_H
+
+#include <mutex>
+#include <thread>
+
+namespace MOShared {
+
+/**
+ * @brief Apply the given callable to each element between the two given iterators
+ *     in a parallel way.
+ *
+ * The callable should be independent, or properly synchronized, and the source of
+ * the range should not change during this call.
+ *
+ * @param start Beginning of the range.
+ * @param end End of the range.
+ * @param callable Callable to apply to every element of the range. See std::invoke
+ *     requirements. Must be copiable.
+ * @param nThreads Number of threads to use.
+ *
+ */
+template <class It, class Callable>
+void parallelMap(It begin, It end, Callable callable, std::size_t nThreads) {
+  std::vector<std::thread> threads(nThreads);
+
+  std::mutex m;
+  for (auto &thread: threads) {
+    thread = std::thread([&m, &begin, end, callable]() {
+      while (true) {
+        decltype(begin) it;
+        {
+          std::scoped_lock lock(m);
+          if (begin == end) {
+            break;
+          }
+          it = begin++;
+        }
+        if (it != end) {
+          std::invoke(callable, *it);
+        }
+      }
+    });
+  }
+
+
+  // Join everything:
+  for (auto& t : threads) {
+    t.join();
+  }
+}
+
+}
+
+#endif

--- a/src/thread_utils.h
+++ b/src/thread_utils.h
@@ -7,6 +7,49 @@
 namespace MOShared {
 
 /**
+ * Class that can be used to perform thread-safe memoization.
+ *
+ * Each instance hold a flag indicating if the current value is up-to-date
+ * or not. This flag can be reset using `invalidate()`. When the value is queried,
+ * the flag is checked, and if it is not up-to-date, the given callback is used
+ * to compute the value.
+ *
+ * The computation and update of the value is locked to avoid concurrent modifications.
+ *
+ * @tparam T Type of value ot memoized.
+ * @tparam Fn Type of the callback.
+ */
+template <class T, class Fn>
+struct MemoizedLocked {
+
+  MemoizedLocked(Fn callback, T value = {}) :
+    m_Fn{ callback }, m_Value{ std::move(value) } { }
+  
+  template <class... Args>
+  T& value(Args&&... args) const {
+    if (m_NeedUpdating) {
+      std::scoped_lock lock(m_Mutex);
+      if (m_NeedUpdating) {
+        m_Value = std::invoke(m_Fn, std::forward<Args>(args)... );
+        m_NeedUpdating.store(false);
+      }
+    }
+    return m_Value;
+  }
+
+  void invalidate() const {
+    m_NeedUpdating.store(true);
+  }
+
+private:
+  mutable std::mutex m_Mutex;
+  mutable std::atomic<bool> m_NeedUpdating{ true };
+
+  Fn m_Fn;
+  mutable T m_Value;
+};
+
+/**
  * @brief Apply the given callable to each element between the two given iterators
  *     in a parallel way.
  *


### PR DESCRIPTION
Improvements to the `ModInfo` class and its implementation:
- A `IFileTree` is stored in the `ModInfoWithConflictInfo`.
- If the `m_FileTree` is a `nullptr`, it means that the tree needs to be updated, which is done in `contentFileTree()` (with proper lock-mechanism):
  - The tree is not populated here, so https://github.com/ModOrganizer2/modorganizer-uibase/pull/51 is required to have proper thread-safety.
- `testValid` has been removed (renamed) to `diskContentModified`. `diskContentModified` currently invalidates the tree, it does not reload it.
- `isValid()` and `getContents` are not cached anymore:
  - Most of the performance-heavy stuff is reading the tree from the disk, everything else is mostly free, so caching is not needed anymore (could still be added).
- When loading all the mods at startup (or when "Refresh" is used), a "prefetch" operations is used with multiple threads to prefetch the FileTree.

All the changes to `ModInfo`, the new `diskContentModified`, etc., have no impact on performance as far as I can tell, but the concurrent loading at startup or on refresh gives quite noticeable boost (with the 2000 mods with 100 folders and 100 files, I drop from ~1500ms with 1 thread to ~420ms with 10 thread for `updateFromDisc`).