### PR TITLE
Archive lib refactoring

### DIFF
--- a/src/archivefiletree.cpp
+++ b/src/archivefiletree.cpp
@@ -120,8 +120,8 @@ public: // Overrides:
   /**
    *
    */
-  void mapToArchive(Archive* archive) const override {
-    mapToArchive(*this, "", archive->getFileList());
+  void mapToArchive(Archive &archive) const override {
+    mapToArchive(*this, "", archive.getFileList());
   }
 
 protected:
@@ -214,9 +214,9 @@ private:
   mutable std::vector<File> m_Files;
 };
 
-std::shared_ptr<ArchiveFileTree> ArchiveFileTree::makeTree(Archive* archive) 
+std::shared_ptr<ArchiveFileTree> ArchiveFileTree::makeTree(Archive const& archive) 
 {
-  auto const& data = archive->getFileList();
+  auto const& data = archive.getFileList();
 
   std::vector<ArchiveFileTreeImpl::File> files;
   files.reserve(data.size());
@@ -255,6 +255,6 @@ void mapToArchive(std::vector<FileData*> const& data, It begin, It end) {
   }
 }
 
-void ArchiveFileTree::mapToArchive(Archive* archive, std::vector<std::shared_ptr<const FileTreeEntry>> const& entries) {
-  ::mapToArchive(archive->getFileList(), entries.cbegin(), entries.cend());
+void ArchiveFileTree::mapToArchive(Archive &archive, std::vector<std::shared_ptr<const FileTreeEntry>> const& entries) {
+  ::mapToArchive(archive.getFileList(), entries.cbegin(), entries.cend());
 }

--- a/src/archivefiletree.cpp
+++ b/src/archivefiletree.cpp
@@ -104,14 +104,14 @@ public: // Overrides:
         const ArchiveFileTreeImpl& archiveEntry = dynamic_cast<const ArchiveFileTreeImpl&>(*entry);
         QString tmp = path + archiveEntry.name();
         if (archiveEntry.m_Index != -1) {
-          data[archiveEntry.m_Index]->addOutputFileName(tmp.toStdWString());
+          data[archiveEntry.m_Index]->addOutputFilePath(tmp.toStdWString());
         }
         mapToArchive(*archiveEntry.astree(), tmp, data);
       }
       else {
         const ArchiveFileEntry& archiveFileEntry = dynamic_cast<const ArchiveFileEntry&>(*entry);
         if (archiveFileEntry.m_Index != -1) {
-          data[archiveFileEntry.m_Index]->addOutputFileName((path + archiveFileEntry.name()).toStdWString());
+          data[archiveFileEntry.m_Index]->addOutputFilePath((path + archiveFileEntry.name()).toStdWString());
         }
       }
     }
@@ -223,7 +223,7 @@ std::shared_ptr<ArchiveFileTree> ArchiveFileTree::makeTree(Archive const& archiv
 
   for (size_t i = 0; i < data.size(); ++i) {
     files.push_back(std::make_tuple(
-      QString::fromStdWString(data[i]->getFileName()).replace("\\", "/").split("/", Qt::SkipEmptyParts), 
+      QString::fromStdWString(data[i]->getArchiveFilePath()).replace("\\", "/").split("/", Qt::SkipEmptyParts), 
       data[i]->isDirectory(), 
       (int) i));
   }
@@ -245,7 +245,7 @@ void mapToArchive(std::vector<FileData*> const& data, It begin, It end) {
     auto* aentry = dynamic_cast<const ArchiveFileEntry*>(entry.get());
 
     if (aentry->m_Index != -1) {
-      data[aentry->m_Index]->addOutputFileName(aentry->path().toStdWString());
+      data[aentry->m_Index]->addOutputFilePath(aentry->path().toStdWString());
     }
 
     if (entry->isDir()) {

--- a/src/archivefiletree.cpp
+++ b/src/archivefiletree.cpp
@@ -86,7 +86,7 @@ public: // Overrides:
   /**
    *
    */
-  static void mapToArchive(IFileTree const& tree, QString path, FileData* const* data)
+  static void mapToArchive(IFileTree const& tree, QString path, std::vector<FileData*> const& data)
   {
     if (path.length() > 0) {
       // when using a long windows path (starting with \\?\) we apparently can have redundant
@@ -104,14 +104,14 @@ public: // Overrides:
         const ArchiveFileTreeImpl& archiveEntry = dynamic_cast<const ArchiveFileTreeImpl&>(*entry);
         QString tmp = path + archiveEntry.name();
         if (archiveEntry.m_Index != -1) {
-          data[archiveEntry.m_Index]->addOutputFileName(tmp);
+          data[archiveEntry.m_Index]->addOutputFileName(tmp.toStdWString());
         }
         mapToArchive(*archiveEntry.astree(), tmp, data);
       }
       else {
         const ArchiveFileEntry& archiveFileEntry = dynamic_cast<const ArchiveFileEntry&>(*entry);
         if (archiveFileEntry.m_Index != -1) {
-          data[archiveFileEntry.m_Index]->addOutputFileName(path + archiveFileEntry.name());
+          data[archiveFileEntry.m_Index]->addOutputFileName((path + archiveFileEntry.name()).toStdWString());
         }
       }
     }
@@ -121,10 +121,7 @@ public: // Overrides:
    *
    */
   void mapToArchive(Archive* archive) const override {
-    FileData* const* data;
-    size_t size;
-    archive->getFileList(data, size);
-    mapToArchive(*this, "", data);
+    mapToArchive(*this, "", archive->getFileList());
   }
 
 protected:
@@ -217,17 +214,18 @@ private:
   mutable std::vector<File> m_Files;
 };
 
-std::shared_ptr<ArchiveFileTree> ArchiveFileTree::makeTree(Archive* archive) {
-
-  FileData* const* data;
-  size_t size;
-  archive->getFileList(data, size);
+std::shared_ptr<ArchiveFileTree> ArchiveFileTree::makeTree(Archive* archive) 
+{
+  auto const& data = archive->getFileList();
 
   std::vector<ArchiveFileTreeImpl::File> files;
-  files.reserve(size);
+  files.reserve(data.size());
 
-  for (size_t i = 0; i < size; ++i) {
-    files.push_back(std::make_tuple(data[i]->getFileName().replace("\\", "/").split("/", Qt::SkipEmptyParts), data[i]->isDirectory(), (int) i));
+  for (size_t i = 0; i < data.size(); ++i) {
+    files.push_back(std::make_tuple(
+      QString::fromStdWString(data[i]->getFileName()).replace("\\", "/").split("/", Qt::SkipEmptyParts), 
+      data[i]->isDirectory(), 
+      (int) i));
   }
 
   auto tree = std::make_shared<ArchiveFileTreeImpl>(nullptr, "", -1, std::move(files));
@@ -241,13 +239,13 @@ std::shared_ptr<ArchiveFileTree> ArchiveFileTree::makeTree(Archive* archive) {
  *
  */
 template <class It>
-void mapToArchive(FileData* const* data, It begin, It end) {
+void mapToArchive(std::vector<FileData*> const& data, It begin, It end) {
   for (auto it = begin; it != end; ++it) {
     auto entry = *it;
     auto* aentry = dynamic_cast<const ArchiveFileEntry*>(entry.get());
 
     if (aentry->m_Index != -1) {
-      data[aentry->m_Index]->addOutputFileName(aentry->path());
+      data[aentry->m_Index]->addOutputFileName(aentry->path().toStdWString());
     }
 
     if (entry->isDir()) {
@@ -258,9 +256,5 @@ void mapToArchive(FileData* const* data, It begin, It end) {
 }
 
 void ArchiveFileTree::mapToArchive(Archive* archive, std::vector<std::shared_ptr<const FileTreeEntry>> const& entries) {
-  FileData* const* data;
-  size_t size;
-  archive->getFileList(data, size);
-
-  ::mapToArchive(data, entries.cbegin(), entries.cend());
+  ::mapToArchive(archive->getFileList(), entries.cbegin(), entries.cend());
 }

--- a/src/archivefiletree.h
+++ b/src/archivefiletree.h
@@ -37,7 +37,7 @@ public:
    *
    * @return a file tree representing the given archive.
    */
-  static std::shared_ptr<ArchiveFileTree> makeTree(Archive* archive);
+  static std::shared_ptr<ArchiveFileTree> makeTree(Archive const& archive);
 
   /**
    * @brief Update the given archive to reflect change in this tree.
@@ -48,7 +48,7 @@ public:
    * @param archive The archive to update. Must be the one used to
    *     create the tree.
    */
-  virtual void mapToArchive(Archive *archive) const = 0;
+  virtual void mapToArchive(Archive &archive) const = 0;
 
   /**
    * @brief Update the given archive to prepare for the extraction
@@ -61,7 +61,7 @@ public:
    * @param entries List of entries to mark for extraction. All the entries must
    *     come from a tree created with the given archive.
    */
-  static void mapToArchive(Archive* archive, std::vector<std::shared_ptr<const FileTreeEntry>> const& entries);
+  static void mapToArchive(Archive &archive, std::vector<std::shared_ptr<const FileTreeEntry>> const& entries);
 
 protected:
 

--- a/src/installationmanager.cpp
+++ b/src/installationmanager.cpp
@@ -64,10 +64,6 @@ using namespace MOBase;
 using namespace MOShared;
 
 
-typedef Archive* (*CreateArchiveType)();
-
-
-
 template <typename T>
 static T resolveFunction(QLibrary &lib, const char *name)
 {
@@ -116,7 +112,6 @@ InstallationManager::InstallationManager()
 
 InstallationManager::~InstallationManager()
 {
-  delete m_ArchiveHandler;
 }
 
 void InstallationManager::setParentWidget(QWidget *widget)
@@ -238,7 +233,7 @@ QStringList InstallationManager::extractFiles(std::vector<std::shared_ptr<const 
     [](auto const& entry) { return entry->isFile(); });
 
   // Update the archive:
-  ArchiveFileTree::mapToArchive(m_ArchiveHandler, files);
+  ArchiveFileTree::mapToArchive(*m_ArchiveHandler, files);
 
   // Retrieve the file path:
   QStringList result;
@@ -663,7 +658,7 @@ IPluginInstaller::EInstallResult InstallationManager::install(const QString &fil
   ON_BLOCK_EXIT(std::bind(&InstallationManager::postInstallCleanup, this));
 
   std::shared_ptr<IFileTree> filesTree = 
-    archiveOpen ? ArchiveFileTree::makeTree(m_ArchiveHandler) : nullptr;
+    archiveOpen ? ArchiveFileTree::makeTree(*m_ArchiveHandler) : nullptr;
   IPluginInstaller::EInstallResult installResult = IPluginInstaller::RESULT_NOTATTEMPTED;
 
   std::sort(m_Installers.begin(), m_Installers.end(), [] (IPluginInstaller *LHS, IPluginInstaller *RHS) {
@@ -707,7 +702,7 @@ IPluginInstaller::EInstallResult InstallationManager::install(const QString &fil
             // stops at this root):
             p->detach();
 
-            p->mapToArchive(m_ArchiveHandler);
+            p->mapToArchive(*m_ArchiveHandler);
 
             // Clean the created files:
             cleanCreatedFiles(filesTree);

--- a/src/installationmanager.cpp
+++ b/src/installationmanager.cpp
@@ -90,17 +90,18 @@ InstallationManager::InstallationManager()
     throw MyException(getErrorString(m_ArchiveHandler->getLastError()));
   }
   m_ArchiveHandler->setLogCallback([](auto level, auto const& message) {
+    using LogLevel = ArchiveCallbacks::LogLevel;
     switch (level) {
-    case NArchive::LogLevel::Debug:
+    case LogLevel::Debug:
       log::debug("{}", message);
       break;
-    case NArchive::LogLevel::Info:
+    case LogLevel::Info:
       log::info("{}", message);
       break;
-    case NArchive::LogLevel::Warning:
+    case LogLevel::Warning:
       log::warn("{}", message);
       break;
-    case NArchive::LogLevel::Error:
+    case LogLevel::Error:
       log::error("{}", message);
       break;
     }
@@ -169,11 +170,11 @@ bool InstallationManager::extractFiles(QString extractPath, QString title, bool 
   QString errorMessage;
 
   // The callbacks:
-  ProgressCallback progressCallback = [&progress](float p) { progress = static_cast<int>(p * 100.0); };
-  FileChangeCallback fileChangeCallback = [&progressFile](std::wstring const& file) {
+  ArchiveCallbacks::ProgressCallback progressCallback = [&progress](float p) { progress = static_cast<int>(p * 100.0); };
+  ArchiveCallbacks::FileChangeCallback fileChangeCallback = [&progressFile](std::wstring const& file) {
     progressFile = QString::fromStdWString(file);
   };
-  ErrorCallback errorCallback = [&errorMessage, this](std::wstring const& message) {
+  ArchiveCallbacks::ErrorCallback errorCallback = [&errorMessage, this](std::wstring const& message) {
     m_ArchiveHandler->cancel();
     errorMessage = QString::fromStdWString(message);
   };

--- a/src/installationmanager.cpp
+++ b/src/installationmanager.cpp
@@ -125,12 +125,6 @@ void InstallationManager::setURL(QString const &url)
   m_URL = url;
 }
 
-void InstallationManager::queryPassword(QString *password)
-{
-  *password = QInputDialog::getText(nullptr, tr("Password required"),
-                                    tr("Password"), QLineEdit::Password);
-}
-
 bool InstallationManager::extractFiles(QString extractPath, QString title, bool showFilenames)
 {
   QProgressDialog *installationProgress = new QProgressDialog(m_ParentWidget);
@@ -630,8 +624,8 @@ IPluginInstaller::EInstallResult InstallationManager::install(const QString &fil
   // open the archive and construct the directory tree the installers work on
   bool archiveOpen = m_ArchiveHandler->open(
     fileName.toStdWString(), [this]() {
-      QString password;
-      queryPassword(&password);
+      QString password = QInputDialog::getText(m_ParentWidget, tr("Password required"),
+        tr("Password"), QLineEdit::Password);
       return password.toStdWString();
     });
   if (!archiveOpen) {

--- a/src/installationmanager.h
+++ b/src/installationmanager.h
@@ -256,10 +256,9 @@ private:
   std::vector<MOBase::IPluginInstaller*> m_Installers;
   std::set<QString, CaseInsensitive> m_SupportedExtensions;
 
-  Archive *m_ArchiveHandler;
+  // Archive management:
+  std::unique_ptr<Archive> m_ArchiveHandler;
   QString m_CurrentFile;
-
-  // Current password:
   QString m_Password;
 
   // Map from entries in the tree that is used by the installer and absolute

--- a/src/installationmanager.h
+++ b/src/installationmanager.h
@@ -189,14 +189,6 @@ public:
 
 private:
 
-  void queryPassword(QString *password);
-  void updateProgress(float percentage);
-  void updateProgressFile(const QString &fileName);
-  void report7ZipError(const QString &errorMessage);
-
-  // Recursive worker function for mapToArchive (takes raw reference for "speed").
-  bool unpackSingleFile(const QString &fileName);
-
   MOBase::IPluginInstaller::EInstallResult doInstall(MOBase::GuessedValue<QString> &modName, QString gameName,
                  int modID, const QString &version, const QString &newestVersion, int categoryID, int fileCategoryID, const QString &repository);
 

--- a/src/installationmanager.h
+++ b/src/installationmanager.h
@@ -204,10 +204,16 @@ private:
 
   void postInstallCleanup();
 
+private slots:
+
+  /**
+   * @brief Query user for password and update the m_Password field.
+   */
+  void queryPassword();
+
 signals:
 
-  void progressUpdate(float percentage);
-  void progressUpdate(QString const fileName);
+  void passwordRequested();
 
 private:
 
@@ -252,6 +258,9 @@ private:
 
   Archive *m_ArchiveHandler;
   QString m_CurrentFile;
+
+  // Current password:
+  QString m_Password;
 
   // Map from entries in the tree that is used by the installer and absolute
   // paths to temporary files:

--- a/src/installationmanager.h
+++ b/src/installationmanager.h
@@ -244,7 +244,7 @@ private:
    * @return true if the extraction was successful, false if the extraciton was
    *     cancelled. If an error occured, an exception is thrown.
    */
-  bool extractFiles(QDir extractPath);
+  bool extractFiles(QString extractPath, QString title, bool showFilenames);
 
 private:
 
@@ -260,16 +260,10 @@ private:
 
   Archive *m_ArchiveHandler;
   QString m_CurrentFile;
-  QString m_ErrorMessage;
 
   // Map from entries in the tree that is used by the installer and absolute
   // paths to temporary files:
   std::map<std::shared_ptr<const MOBase::FileTreeEntry>, QString> m_CreatedFiles;
-
-  QProgressDialog *m_InstallationProgress { nullptr };
-  int m_Progress;
-  QString m_ProgressFile;
-
   std::set<QString> m_TempFilesToDelete;
 
   QString m_URL;

--- a/src/installationmanager.h
+++ b/src/installationmanager.h
@@ -213,7 +213,20 @@ private slots:
 
 signals:
 
+  /**
+   * @brief Emitted when a password is requested from the archive wrapper.
+   */
   void passwordRequested();
+
+  /**
+   * @brief Progress update from the extraction.
+   */
+  void progressUpdate(int percentage);
+
+  /**
+   * @brief File change update from the extraction.
+   */
+  void progressFileChange(QString const& value);
 
 private:
 

--- a/src/selfupdater.cpp
+++ b/src/selfupdater.cpp
@@ -71,45 +71,18 @@ along with Mod Organizer.  If not, see <http://www.gnu.org/licenses/>.
 using namespace MOBase;
 using namespace MOShared;
 
-
-typedef Archive* (*CreateArchiveType)();
-
-
-template <typename T> static T resolveFunction(QLibrary &lib, const char *name)
-{
-  T temp = reinterpret_cast<T>(lib.resolve(name));
-  if (temp == nullptr) {
-    throw std::runtime_error(QObject::tr("invalid 7-zip32.dll: %1").arg(lib.errorString()).toLatin1().constData());
-  }
-  return temp;
-}
-
-
 SelfUpdater::SelfUpdater(NexusInterface *nexusInterface)
   : m_Parent(nullptr)
   , m_Interface(nexusInterface)
   , m_Reply(nullptr)
   , m_Attempts(3)
 {
-  QLibrary archiveLib(QCoreApplication::applicationDirPath() + "\\dlls\\archive.dll");
-  if (!archiveLib.load()) {
-    throw MyException(tr("archive.dll not loaded: \"%1\"").arg(archiveLib.errorString()));
-  }
-
-  CreateArchiveType CreateArchiveFunc = resolveFunction<CreateArchiveType>(archiveLib, "CreateArchive");
-
-  m_ArchiveHandler = CreateArchiveFunc();
-  if (!m_ArchiveHandler->isValid()) {
-    throw MyException(InstallationManager::getErrorString(m_ArchiveHandler->getLastError()));
-  }
-
   m_MOVersion = createVersionInfo();
 }
 
 
 SelfUpdater::~SelfUpdater()
 {
-  delete m_ArchiveHandler;
 }
 
 void SelfUpdater::setUserInterface(QWidget *widget)

--- a/src/selfupdater.cpp
+++ b/src/selfupdater.cpp
@@ -19,10 +19,7 @@ along with Mod Organizer.  If not, see <http://www.gnu.org/licenses/>.
 
 #include "selfupdater.h"
 
-#include "archive.h"
-#include "callback.h"
 #include "utility.h"
-#include "installationmanager.h"
 #include "iplugingame.h"
 #include "messagedialog.h"
 #include "downloadmanager.h"

--- a/src/selfupdater.h
+++ b/src/selfupdater.h
@@ -140,8 +140,6 @@ private:
   bool m_Canceled;
   int m_Attempts;
 
-  Archive *m_ArchiveHandler;
-
   GitHub m_GitHub;
   QJsonObject m_UpdateCandidate;
 


### PR DESCRIPTION
Change to the installation manager following https://github.com/ModOrganizer2/modorganizer-archive/pull/17

**Other stuffs:**
- Fix a bug with encrypted archives where the QInputDialog would break MO2 due to queryPassword being called in a separate thread.
- Since archive now uses std::function, some member variables or functions are not needed anymore, so I’m using small lambda instead.
- Before there were two functions to extract files: one before the installation and one after. The two were very similar so I merged them.