### PR TITLE
Add IOrganizer signal when a plugin setting is changed.

### DIFF
--- a/src/organizerproxy.cpp
+++ b/src/organizerproxy.cpp
@@ -3,7 +3,9 @@
 #include "shared/appconfig.h"
 #include "organizercore.h"
 #include "plugincontainer.h"
+#include "settings.h"
 
+#include <QObject>
 #include <QApplication>
 
 using namespace MOBase;
@@ -11,10 +13,17 @@ using namespace MOShared;
 
 
 OrganizerProxy::OrganizerProxy(OrganizerCore *organizer, PluginContainer *pluginContainer, const QString &pluginName)
-  : m_Proxied(organizer)
+  : IOrganizer(organizer)
+  , m_Proxied(organizer)
   , m_PluginContainer(pluginContainer)
   , m_PluginName(pluginName)
 {
+
+  PluginSettings& pluginSettings = m_Proxied->settings().plugins();
+
+  connect(&pluginSettings, &PluginSettings::pluginSettingChanged, [this](auto const& ...args) {
+    emit pluginSettingChanged(args...);
+  });
 }
 
 IModRepositoryBridge *OrganizerProxy::createNexusBridge() const

--- a/src/settings.h
+++ b/src/settings.h
@@ -287,8 +287,10 @@ private:
 
 // settings about plugins
 //
-class PluginSettings
+class PluginSettings: public QObject
 {
+  Q_OBJECT
+
 public:
   PluginSettings(QSettings& settings);
 
@@ -356,6 +358,13 @@ public:
   // commits all the settings to the ini
   //
   void save();
+
+Q_SIGNALS:
+
+  /**
+   * Emitted when a plugin setting changes.
+   */
+  void pluginSettingChanged(QString const& pluginName, const QString& key, const QVariant& oldValue, const QVariant& newValue);
 
 private:
   QSettings& m_Settings;


### PR DESCRIPTION
Add a signal to `IOrganizer` to which plugin can connect to notify that a plugin setting has been changed. 

I thought about adding it to `IPlugin`, but `IPlugin` does not inherit `QObject`, and everything related to plugin setting goes through `IOrganizer` so I thought this would be more consistent.

I used Qt signals instead of the `onXXX` methods of `IOrganizer` which uses boost signals. I don't really know if there is a preference (other interfaces use Qt signals).