### PR TITLE
Move Problems Checks on a thread and avoid redundant calls

### DIFF
--- a/src/mainwindow.cpp
+++ b/src/mainwindow.cpp
@@ -3789,7 +3789,7 @@ void MainWindow::clearOverwrite()
       for (auto f : overwriteDir.entryList(QDir::AllDirs | QDir::Files | QDir::NoDotAndDotDot))
         delList.push_back(overwriteDir.absoluteFilePath(f));
       if (shellDelete(delList, true)) {
-        checkForProblems();
+        checkForProblemsAsync();
         m_OrganizerCore.refreshModList();
       } else {
         const auto e = GetLastError();
@@ -5880,7 +5880,7 @@ void MainWindow::on_actionNotifications_triggered()
   ProblemsDialog problems(m_PluginContainer.plugins<QObject>(), this);
   problems.exec();
 
-  checkForProblems();
+  checkForProblemsAsync();
 }
 
 void MainWindow::on_actionChange_Game_triggered()

--- a/src/mainwindow.cpp
+++ b/src/mainwindow.cpp
@@ -1098,15 +1098,15 @@ bool MainWindow::errorReported(QString &logFile)
   return false;
 }
 
-void MainWindow::checkForProblemsAsync() {
-  QtConcurrent::run([this]() {
-    checkForProblems();
+QFuture<void> MainWindow::checkForProblemsAsync() {
+  return QtConcurrent::run([this]() {
+    checkForProblemsImpl();
     });
 }
 
-void MainWindow::checkForProblems()
+void MainWindow::checkForProblemsImpl()
 {
-  TimeThis tt("MainWindow::checkForProblems()");
+  TimeThis tt("MainWindow::checkForProblemsImpl()");
   {
     QMutexLocker lk(&m_CheckForProblemsMutex);
     if (m_CheckingForProblems) {
@@ -5886,7 +5886,9 @@ void MainWindow::on_bsaList_itemChanged(QTreeWidgetItem*, int)
 
 void MainWindow::on_actionNotifications_triggered()
 {
-  checkForProblems();
+  auto future = checkForProblemsAsync();
+
+  future.waitForFinished();
 
   ProblemsDialog problems(m_PluginContainer.plugins<QObject>(), this);
   problems.exec();

--- a/src/mainwindow.cpp
+++ b/src/mainwindow.cpp
@@ -1106,8 +1106,6 @@ QFuture<void> MainWindow::checkForProblemsAsync() {
 
 void MainWindow::checkForProblemsImpl()
 {
-  TimeThis tt("MainWindow::checkForProblemsImpl()");
-
   m_ProblemsCheckRequired = true;
 
   std::scoped_lock lk(m_CheckForProblemsMutex);
@@ -1115,6 +1113,7 @@ void MainWindow::checkForProblemsImpl()
   // another thread might already have checked while this one was waiting on the lock
   if (m_ProblemsCheckRequired) {
     m_ProblemsCheckRequired = false;
+    TimeThis tt("MainWindow::checkForProblemsImpl()");
     size_t numProblems = 0;
     for (QObject *pluginObj : m_PluginContainer.plugins<QObject>()) {
       IPlugin *plugin = qobject_cast<IPlugin*>(pluginObj);

--- a/src/mainwindow.h
+++ b/src/mainwindow.h
@@ -360,6 +360,8 @@ private:
   QIcon m_originalNotificationIcon;
 
   std::atomic<std::size_t> m_NumberOfProblems;
+  std::atomic<bool> m_CheckingForProblems;
+  QMutex m_CheckForProblemsMutex;
 
   Executable* getSelectedExecutable();
 

--- a/src/mainwindow.h
+++ b/src/mainwindow.h
@@ -178,6 +178,8 @@ signals:
 
   void modListDataChanged(const QModelIndex &topLeft, const QModelIndex &bottomRight);
 
+  void checkForProblemsDone();
+
 protected:
 
   virtual void showEvent(QShowEvent *event);
@@ -244,8 +246,9 @@ private:
   void fixCategories();
 
   bool extractProgress(QProgressDialog &extractProgress, int percentage, std::string fileName);
-
-  size_t checkForProblems();
+   
+  // Performs checks, sets the problemCount and singnals checkForProblemsDone().
+  void checkForProblems();
 
   void setCategoryListVisible(bool visible);
 
@@ -266,8 +269,6 @@ private:
   void addPluginSendToContextMenu(QMenu *menu);
 
   QMenu *openFolderMenu();
-
-  void scheduleUpdateButton();
 
   QDir currentSavesDir() const;
 
@@ -357,6 +358,8 @@ private:
   // icon set by the stylesheet, used to remember its original appearance
   // when painting the count
   QIcon m_originalNotificationIcon;
+
+  size_t m_NumberOfProblems;
 
   Executable* getSelectedExecutable();
 
@@ -523,7 +526,14 @@ private slots:
 
   void checkBSAList();
 
+  // Only visually update the problems icon.
   void updateProblemsButton();
+
+  // Queue a problem check to allow collapsing of multiple requests in short amount of time.
+  void scheduleCheckForProblems();
+
+  // Perform the actual problem check in another thread.
+  void checkForProblemsAsync();
 
   void saveModMetas();
 

--- a/src/mainwindow.h
+++ b/src/mainwindow.h
@@ -247,7 +247,7 @@ private:
 
   bool extractProgress(QProgressDialog &extractProgress, int percentage, std::string fileName);
    
-  // Performs checks, sets the problemCount and singnals checkForProblemsDone().
+  // Performs checks, sets the m_NumberOfProblems and signals checkForProblemsDone().
   void checkForProblems();
 
   void setCategoryListVisible(bool visible);

--- a/src/mainwindow.h
+++ b/src/mainwindow.h
@@ -359,7 +359,7 @@ private:
   // when painting the count
   QIcon m_originalNotificationIcon;
 
-  size_t m_NumberOfProblems;
+  std::atomic<std::size_t> m_NumberOfProblems;
 
   Executable* getSelectedExecutable();
 

--- a/src/mainwindow.h
+++ b/src/mainwindow.h
@@ -360,8 +360,8 @@ private:
   QIcon m_originalNotificationIcon;
 
   std::atomic<std::size_t> m_NumberOfProblems;
-  std::atomic<bool> m_CheckingForProblems;
-  QMutex m_CheckForProblemsMutex;
+  std::atomic<bool> m_ProblemsCheckRequired;
+  std::mutex m_CheckForProblemsMutex;
 
   Executable* getSelectedExecutable();
 

--- a/src/mainwindow.h
+++ b/src/mainwindow.h
@@ -248,7 +248,7 @@ private:
   bool extractProgress(QProgressDialog &extractProgress, int percentage, std::string fileName);
    
   // Performs checks, sets the m_NumberOfProblems and signals checkForProblemsDone().
-  void checkForProblems();
+  void checkForProblemsImpl();
 
   void setCategoryListVisible(bool visible);
 
@@ -535,7 +535,7 @@ private slots:
   void scheduleCheckForProblems();
 
   // Perform the actual problem check in another thread.
-  void checkForProblemsAsync();
+  QFuture<void> checkForProblemsAsync();
 
   void saveModMetas();
 


### PR DESCRIPTION
Since we saw updateProblemsButton() being executed multiple times on startup and refresh and the problems check could be expensive since plugins can define custom checks I looked into it to avoid repeating calls and move them to another thread when possible to keep ui responsive.
Here are the instances that I found:
1) was mainwindow ctor, which I changed to just updating the icon (performing checks here failed since stuff was missing anyways).
2) was in mainwindow::show() which I also changed to just updating the icon (this call could be redundant but this time it's not like it actually matters) (performing checks here failed since stuff was missing anyways).
4) was translation applied which I completely removed since I don't see a point.
5) was MainWindow::directory_refreshed() which now is changed to use a scheduled async call on another thread to perform the checks. Scheduled means that there is a 1 second timer where other scheduled calls are collapsed into one (and reset the timer).
6) was one or more diagnosisUpdate() from one or more the diagnose plugins, which I changed to a scheduled async call to another thread to perform the checks.
7) Changing style which I chamged to just update the Icon.
8) Clearing overwrite and opening/closing the notifications dialog, which I changed to perform synchronous checks on the main thread.
the diagnosisUpdate() can trigger on other occasions as well, like enabling mods, enabling plugins etc.
