### PR TITLE
Use QEventLoop instead of manually calling ProcessEvents

### DIFF
--- a/src/organizercore.h
+++ b/src/organizercore.h
@@ -371,6 +371,10 @@ signals:
 
   void close();
 
+  // Notify that the directory structure is ready to be used on the main thread
+  // Use queued connections
+  void directoryStructureReady();
+
 private:
 
   void saveCurrentProfile();


### PR DESCRIPTION
This will allow ui to remain responsive while the main thread waits on some operation to complete. Before the main thread would use a while loop with sleep() and ProcessEvents.