### PR TITLE
Fix problems button not updating on startup in some cases.

### DIFF
--- a/src/mainwindow.cpp
+++ b/src/mainwindow.cpp
@@ -325,7 +325,6 @@ MainWindow::MainWindow(Settings &settings
 
   ui->logList->setCore(m_OrganizerCore);
 
-  updateProblemsButton();
 
   setupToolbar();
   toggleMO2EndorseState();
@@ -520,6 +519,7 @@ MainWindow::MainWindow(Settings &settings
 
   QApplication::instance()->installEventFilter(this);
 
+  scheduleCheckForProblems();
   refreshExecutablesList();
   updatePinnedExecutables();
   resetActionIcons();


### PR DESCRIPTION
Mainwindow wasn't guaranteed to exist after first directory structure refresh was complete so there was no mainwindow slot triggered to check for problems.
Added a proper problems check in the mainwindow constructor.