### PR TITLE
Fix consecutive mod update checks checking some mods again

### DIFF
--- a/src/mainwindow.cpp
+++ b/src/mainwindow.cpp
@@ -5644,9 +5644,10 @@ void MainWindow::nxmModInfoAvailable(QString gameName, int modID, QVariant userD
       // with an older version than the main mod version.
       if (mod->getNexusFileStatus() != 3 && mod->getNexusFileStatus() != 5) {
         mod->setNewestVersion(result["version"].toString());
-        mod->setLastNexusUpdate(QDateTime::currentDateTimeUtc());
         foundUpdate = true;
       }
+      // update the LastNexusUpdate time in any case since we did perform the check.
+      mod->setLastNexusUpdate(QDateTime::currentDateTimeUtc());
     }
     mod->setNexusDescription(result["description"].toString());
     if ((mod->endorsedState() != ModInfo::ENDORSED_NEVER) && (result.contains("endorsement"))) {

--- a/src/modinfo.cpp
+++ b/src/modinfo.cpp
@@ -300,7 +300,7 @@ bool ModInfo::checkAllForUpdate(PluginContainer *pluginContainer, QObject *recei
   bool updatesAvailable = true;
 
   QDateTime earliest = QDateTime::currentDateTimeUtc();
-  QDateTime latest;
+  QDateTime latest = QDateTime::fromMSecsSinceEpoch(0);
   std::set<QString> games;
   for (auto mod : s_Collection) {
     if (mod->canBeUpdated()) {


### PR DESCRIPTION
by correctly setting the last nexus update timestamp on a missed case.
Addresses #712 