### PR TITLE
Fix refresh events of tabs in the right panel when some tabs are hidden.

### DIFF
--- a/src/mainwindow.cpp
+++ b/src/mainwindow.cpp
@@ -1865,7 +1865,7 @@ void MainWindow::refreshExecutablesList()
 
 void MainWindow::refreshSavesIfOpen()
 {
-  if (ui->tabWidget->currentIndex() == 3) {
+  if (ui->tabWidget->currentIndex() == ui->tabWidget->indexOf(ui->savesTab)) {
     refreshSaveList();
   }
 }
@@ -2276,13 +2276,13 @@ void MainWindow::on_btnRefreshDownloads_clicked()
 
 void MainWindow::on_tabWidget_currentChanged(int index)
 {
-  if (index == 0) {
+  if (index == ui->tabWidget->indexOf(ui->espTab)) {
     m_OrganizerCore.refreshESPList();
-  } else if (index == 1) {
+  } else if (index == ui->tabWidget->indexOf(ui->bsaTab)) {
     m_OrganizerCore.refreshBSAList();
-  } else if (index == 2) {
+  } else if (index == ui->tabWidget->indexOf(ui->dataTab)) {
     m_DataTab->activated();
-  } else if (index == 3) {
+  } else if (index == ui->tabWidget->indexOf(ui->savesTab)) {
     refreshSaveList();
   }
 }
@@ -2495,8 +2495,7 @@ void MainWindow::directory_refreshed()
   // now
   scheduleCheckForProblems();
 
-  //Some better check for the current tab is needed.
-  if (ui->tabWidget->currentIndex() == 2) {
+  if (ui->tabWidget->currentIndex() == ui->tabWidget->indexOf(ui->dataTab)) {
     m_DataTab->updateTree();
   }
 }

--- a/src/mainwindow.cpp
+++ b/src/mainwindow.cpp
@@ -1865,7 +1865,7 @@ void MainWindow::refreshExecutablesList()
 
 void MainWindow::refreshSavesIfOpen()
 {
-  if (ui->tabWidget->currentIndex() == ui->tabWidget->indexOf(ui->savesTab)) {
+  if (ui->tabWidget->currentWidget() == ui->savesTab) {
     refreshSaveList();
   }
 }
@@ -2276,13 +2276,14 @@ void MainWindow::on_btnRefreshDownloads_clicked()
 
 void MainWindow::on_tabWidget_currentChanged(int index)
 {
-  if (index == ui->tabWidget->indexOf(ui->espTab)) {
+  QWidget* currentWidget = ui->tabWidget->widget(index);
+  if (currentWidget == ui->espTab) {
     m_OrganizerCore.refreshESPList();
-  } else if (index == ui->tabWidget->indexOf(ui->bsaTab)) {
+  } else if (currentWidget == ui->bsaTab) {
     m_OrganizerCore.refreshBSAList();
-  } else if (index == ui->tabWidget->indexOf(ui->dataTab)) {
+  } else if (currentWidget == ui->dataTab) {
     m_DataTab->activated();
-  } else if (index == ui->tabWidget->indexOf(ui->savesTab)) {
+  } else if (currentWidget == ui->savesTab) {
     refreshSaveList();
   }
 }
@@ -2495,7 +2496,7 @@ void MainWindow::directory_refreshed()
   // now
   scheduleCheckForProblems();
 
-  if (ui->tabWidget->currentIndex() == ui->tabWidget->indexOf(ui->dataTab)) {
+  if (ui->tabWidget->currentWidget() == ui->dataTab) {
     m_DataTab->updateTree();
   }
 }


### PR DESCRIPTION
The events used to refresh the contents of the tab in the right panel (ESP, Archives, Data, etc.) used row int value to check the index. This cause issues when some tabs are hidden after https://github.com/ModOrganizer2/modorganizer/pull/1120 

This PR should fix it.