### PR TITLE
Manually unload plugins to avoid issue with automatic unloading.

### DIFF
--- a/src/plugincontainer.cpp
+++ b/src/plugincontainer.cpp
@@ -28,6 +28,10 @@ PluginContainer::PluginContainer(OrganizerCore *organizer)
 {
 }
 
+PluginContainer::~PluginContainer() {
+  m_Organizer = nullptr;
+  unloadPlugins();
+}
 
 void PluginContainer::setUserInterface(IUserInterface *userInterface, QWidget *widget)
 {
@@ -213,7 +217,9 @@ void PluginContainer::unloadPlugins()
   }
 
   // disconnect all slots before unloading plugins so plugins don't have to take care of that
-  m_Organizer->disconnectPlugins();
+  if (m_Organizer != nullptr) {
+    m_Organizer->disconnectPlugins();
+  }
 
   bf::for_each(m_Plugins, clearPlugins());
 

--- a/src/plugincontainer.h
+++ b/src/plugincontainer.h
@@ -49,6 +49,7 @@ private:
 public:
 
   PluginContainer(OrganizerCore *organizer);
+  virtual ~PluginContainer();
 
   void setUserInterface(IUserInterface *userInterface, QWidget *widget);
 


### PR DESCRIPTION
Should fix the crash when closing MO2 due to Qt unloading plugins in `atexit()`. The idea is to unload plugins manually.

There were some ordering issues between `OrganizerCore` and `PluginContainer`: `pluginContainer` is created after `organizer`, so it's destroyed before, but the destructor of `OrganizerCore` uses plugins, so unloading the plugins in `~PluginContainer` would break everything.

The easiest way I found was to keep the initialization order (since you need a `OrganizerCore` to create a `PluginContainer`), but destroy `PluginContainer` after by allocating it.