### PR TITLE
Slow search in data tab

### DIFF
--- a/src/filetreemodel.cpp
+++ b/src/filetreemodel.cpp
@@ -226,7 +226,7 @@ void FileTreeModel::clear()
 void FileTreeModel::recursiveFetchMore(const QModelIndex& m)
 {
   if (canFetchMore(m)) {
-    fetchMore(m);
+    doFetchMore(m, false);
   }
 
   for (int i=0; i<rowCount(m); ++i) {
@@ -338,6 +338,11 @@ bool FileTreeModel::canFetchMore(const QModelIndex& parent) const
 
 void FileTreeModel::fetchMore(const QModelIndex& parent)
 {
+  doFetchMore(parent, true);
+}
+
+void FileTreeModel::doFetchMore(const QModelIndex& parent, bool forFetch)
+{
   FileTreeItem* item = itemFromIndex(parent);
   if (!item) {
     return;
@@ -354,7 +359,7 @@ void FileTreeModel::fetchMore(const QModelIndex& parent)
   }
 
   const auto parentPath = item->dataRelativeParentPath();
-  update(*item, *parentEntry, parentPath.toStdWString(), true);
+  update(*item, *parentEntry, parentPath.toStdWString(), forFetch);
 }
 
 QVariant FileTreeModel::data(const QModelIndex& index, int role) const

--- a/src/filetreemodel.h
+++ b/src/filetreemodel.h
@@ -113,6 +113,8 @@ private:
     FileTreeItem& parentItem, const MOShared::DirectoryEntry& parentEntry,
     const std::wstring& parentPath, bool forFetching);
 
+  void doFetchMore(const QModelIndex& parent, bool forFetch);
+
   void queueRemoveItem(FileTreeItem* item);
   void removeItems();
 

--- a/src/organizer_en.ts
+++ b/src/organizer_en.ts
@@ -1462,54 +1462,54 @@ Right now the only case I know of where this needs to be overwritten is for the 
 <context>
     <name>FileTreeModel</name>
     <message>
-        <location filename="filetreemodel.cpp" line="422"/>
+        <location filename="filetreemodel.cpp" line="427"/>
         <source>Name</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="filetreemodel.cpp" line="422"/>
+        <location filename="filetreemodel.cpp" line="427"/>
         <source>Mod</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="filetreemodel.cpp" line="422"/>
+        <location filename="filetreemodel.cpp" line="427"/>
         <source>Type</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="filetreemodel.cpp" line="422"/>
+        <location filename="filetreemodel.cpp" line="427"/>
         <source>Size</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="filetreemodel.cpp" line="422"/>
+        <location filename="filetreemodel.cpp" line="427"/>
         <source>Date modified</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="filetreemodel.cpp" line="1118"/>
+        <location filename="filetreemodel.cpp" line="1123"/>
         <source>Directory</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="filetreemodel.cpp" line="1119"/>
-        <location filename="filetreemodel.cpp" line="1136"/>
+        <location filename="filetreemodel.cpp" line="1124"/>
+        <location filename="filetreemodel.cpp" line="1141"/>
         <source>Virtual path</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="filetreemodel.cpp" line="1137"/>
+        <location filename="filetreemodel.cpp" line="1142"/>
         <source>Real path</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="filetreemodel.cpp" line="1138"/>
+        <location filename="filetreemodel.cpp" line="1143"/>
         <source>From</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="filetreemodel.cpp" line="1154"/>
-        <location filename="filetreemodel.cpp" line="1156"/>
+        <location filename="filetreemodel.cpp" line="1159"/>
+        <location filename="filetreemodel.cpp" line="1161"/>
         <source>Also in</source>
         <translation type="unfinished"></translation>
     </message>


### PR DESCRIPTION
Some of the changes I did for alpha 7 was to queue sorting so it's done in a timer after expanding nodes because it would crash Qt. This was only meant to happen when expanding nodes, but it also got used from `ensureFullyLoaded()` (called before searching) because it ends up in `fetchMore()`, which assumes it's being called because nodes are being expanded. I added a `doFetchMore()` with a `bool` to know where it's called from.