### PR TITLE
Filetree bugs and improvements

### DIFF
--- a/src/datatab.cpp
+++ b/src/datatab.cpp
@@ -118,9 +118,9 @@ void DataTab::updateTree()
 void DataTab::ensureFullyLoaded()
 {
   if (!m_filetree->fullyLoaded()) {
-    m_filter.proxyModel()->setRecursiveFilteringEnabled(false);
+    m_filter.setFilteringEnabled(false);
     m_filetree->ensureFullyLoaded();
-    m_filter.proxyModel()->setRecursiveFilteringEnabled(true);
+    m_filter.setFilteringEnabled(true);
   }
 }
 

--- a/src/filetree.cpp
+++ b/src/filetree.cpp
@@ -802,11 +802,11 @@ void FileTree::addCommonMenus(QMenu& menu)
     .addTo(menu);
 
   MenuItem(tr("Ex&pand All"))
-    .callback([&]{ m_tree->expandAll(); })
+    .callback([&]{ expandAll(); })
     .addTo(menu);
 
   MenuItem(tr("&Collapse All"))
-    .callback([&]{ m_tree->collapseAll(); })
+    .callback([&]{ collapseAll(); })
     .addTo(menu);
 }
 
@@ -819,4 +819,16 @@ QModelIndex FileTree::proxiedIndex(const QModelIndex& index)
   } else {
     return index;
   }
+}
+
+void FileTree::collapseAll()
+{
+  m_tree->collapseAll();
+}
+
+void FileTree::expandAll()
+{
+  m_model->aboutToExpandAll();
+  m_tree->expandAll();
+  m_model->expandedAll();
 }

--- a/src/filetree.h
+++ b/src/filetree.h
@@ -25,6 +25,9 @@ public:
   bool fullyLoaded() const;
   void ensureFullyLoaded();
 
+  void expandAll();
+  void collapseAll();
+
   void open(FileTreeItem* item=nullptr);
   void openHooked(FileTreeItem* item=nullptr);
   void preview(FileTreeItem* item=nullptr);

--- a/src/filetreeitem.h
+++ b/src/filetreeitem.h
@@ -93,6 +93,7 @@ public:
   }
 
   void sort(int column, Qt::SortOrder order, bool force);
+  void makeSortingStale();
 
   FileTreeItem* parent()
   {
@@ -223,7 +224,7 @@ public:
     m_expanded = b;
 
     if (m_expanded && m_sortingStale) {
-      sort();
+      queueSort();
     }
   }
 
@@ -314,7 +315,7 @@ private:
     std::wstring dataRelativeParentPath, bool isDirectory, std::wstring file);
 
   void getFileType() const;
-  void sort();
+  void queueSort();
 };
 
 #endif // MODORGANIZER_FILETREEITEM_INCLUDED

--- a/src/filetreemodel.cpp
+++ b/src/filetreemodel.cpp
@@ -196,13 +196,13 @@ void* makeInternalPointer(FileTreeItem* item)
 FileTreeModel::FileTreeModel(OrganizerCore& core, QObject* parent) :
   QAbstractItemModel(parent), m_core(core), m_enabled(true),
   m_root(FileTreeItem::createDirectory(this, nullptr, L"", L"")),
-  m_flags(NoFlags), m_fullyLoaded(false)
+  m_flags(NoFlags), m_fullyLoaded(false), m_sortingEnabled(true)
 {
   m_root->setExpanded(true);
+  m_sortTimer.setSingleShot(true);
 
   connect(&m_removeTimer, &QTimer::timeout, [&]{ removeItems(); });
   connect(&m_sortTimer, &QTimer::timeout, [&]{ sortItems(); });
-
   connect(&m_iconPendingTimer, &QTimer::timeout, [&]{ updatePendingIcons(); });
 }
 
@@ -212,6 +212,7 @@ void FileTreeModel::refresh()
 
   m_fullyLoaded = false;
   update(*m_root, *m_core.directoryStructure(), L"", false);
+  sortItem(*m_root, false);
 }
 
 void FileTreeModel::clear()
@@ -251,6 +252,17 @@ bool FileTreeModel::enabled() const
 void FileTreeModel::setEnabled(bool b)
 {
   m_enabled = b;
+}
+
+void FileTreeModel::aboutToExpandAll()
+{
+  m_sortingEnabled = false;
+}
+
+void FileTreeModel::expandedAll()
+{
+  m_sortingEnabled = true;
+  sortItem(*m_root, false);
 }
 
 const FileTreeModel::SortInfo& FileTreeModel::sortInfo() const
@@ -360,6 +372,10 @@ void FileTreeModel::doFetchMore(const QModelIndex& parent, bool forFetch)
 
   const auto parentPath = item->dataRelativeParentPath();
   update(*item, *parentEntry, parentPath.toStdWString(), forFetch);
+
+  if (!forFetch) {
+    sortItem(*item, false);
+  }
 }
 
 QVariant FileTreeModel::data(const QModelIndex& index, int role) const
@@ -485,7 +501,7 @@ void FileTreeModel::sort(int column, Qt::SortOrder order)
   m_sort.column = column;
   m_sort.order = order;
 
-  sortItem(*m_root, false);
+  sortItem(*m_root, true);
 }
 
 FileTreeItem* FileTreeModel::itemFromIndex(const QModelIndex& index) const
@@ -558,11 +574,15 @@ void FileTreeModel::update(
   }
 
   if (added) {
+    parentItem.makeSortingStale();
+
     // see comment at the top of this file
-    if (forFetching)
-      queueSortItem(&parentItem);
-    else
-      sortItem(parentItem, true);
+    if (forFetching) {
+      // don't pass a specific item, this will start a timer and re-sort the
+      // whole tree, which is faster than potentially queuing every single
+      // node if the whole tree is expanded
+      queueSortItem(nullptr);
+    }
   }
 }
 
@@ -873,21 +893,32 @@ void FileTreeModel::removeItems()
 
 void FileTreeModel::queueSortItem(FileTreeItem* item)
 {
-  m_sortItems.push_back(item);
+  if (!m_sortingEnabled) {
+    return;
+  }
+
+  if (item) {
+    m_sortItems.push_back(item);
+  }
+
   m_sortTimer.start(1);
 }
 
 void FileTreeModel::sortItems()
 {
   // see comment at the top of this file
-  trace(log::debug("sort item timer: sorting {} items", m_sortItems.size()));
 
-  auto copy = std::move(m_sortItems);
-  m_sortItems.clear();
-  m_sortTimer.stop();
+  if (m_sortItems.empty()) {
+    sortItem(*m_root, false);
+  } else {
+    log::debug("sort item timer: sorting {} items", m_sortItems.size());
 
-  for (auto&& f : copy) {
-    sortItem(*f, true);
+    auto items = std::move(m_sortItems);
+    m_sortItems.clear();
+
+    for (auto* item : items) {
+      sortItem(*item, false);
+    }
   }
 }
 

--- a/src/filetreemodel.cpp
+++ b/src/filetreemodel.cpp
@@ -227,7 +227,7 @@ void FileTreeModel::clear()
 void FileTreeModel::recursiveFetchMore(const QModelIndex& m)
 {
   if (canFetchMore(m)) {
-    doFetchMore(m, false);
+    doFetchMore(m, false, false);
   }
 
   for (int i=0; i<rowCount(m); ++i) {
@@ -240,6 +240,7 @@ void FileTreeModel::ensureFullyLoaded()
   if (!m_fullyLoaded) {
     TimeThis tt("FileTreeModel:: fully loading for search");
     recursiveFetchMore(QModelIndex());
+    sortItem(*m_root, false);
     m_fullyLoaded = true;
   }
 }
@@ -350,10 +351,11 @@ bool FileTreeModel::canFetchMore(const QModelIndex& parent) const
 
 void FileTreeModel::fetchMore(const QModelIndex& parent)
 {
-  doFetchMore(parent, true);
+  doFetchMore(parent, true, true);
 }
 
-void FileTreeModel::doFetchMore(const QModelIndex& parent, bool forFetch)
+void FileTreeModel::doFetchMore(
+  const QModelIndex& parent, bool forFetch, bool doSort)
 {
   FileTreeItem* item = itemFromIndex(parent);
   if (!item) {
@@ -373,7 +375,7 @@ void FileTreeModel::doFetchMore(const QModelIndex& parent, bool forFetch)
   const auto parentPath = item->dataRelativeParentPath();
   update(*item, *parentEntry, parentPath.toStdWString(), forFetch);
 
-  if (!forFetch) {
+  if (!forFetch && doSort) {
     sortItem(*item, false);
   }
 }

--- a/src/filetreemodel.h
+++ b/src/filetreemodel.h
@@ -61,6 +61,10 @@ public:
   bool enabled() const;
   void setEnabled(bool b);
 
+  void aboutToExpandAll();
+  void expandedAll();
+
+
   const SortInfo& sortInfo() const;
 
   QModelIndex index(int row, int col, const QModelIndex& parent={}) const override;
@@ -77,6 +81,7 @@ public:
 
   FileTreeItem* itemFromIndex(const QModelIndex& index) const;
   void sortItem(FileTreeItem& item, bool force);
+  void queueSortItem(FileTreeItem* item);
 
 private:
   class Range;
@@ -92,11 +97,12 @@ private:
   mutable QTimer m_iconPendingTimer;
   SortInfo m_sort;
   bool m_fullyLoaded;
+  bool m_sortingEnabled;
 
   // see top of filetreemodel.cpp
   std::vector<FileTreeItem*> m_removeItems;
-  QTimer m_removeTimer;
   std::vector<FileTreeItem*> m_sortItems;
+  QTimer m_removeTimer;
   QTimer m_sortTimer;
 
 
@@ -118,7 +124,6 @@ private:
   void queueRemoveItem(FileTreeItem* item);
   void removeItems();
 
-  void queueSortItem(FileTreeItem* item);
   void sortItems();
 
 

--- a/src/filetreemodel.h
+++ b/src/filetreemodel.h
@@ -119,7 +119,7 @@ private:
     FileTreeItem& parentItem, const MOShared::DirectoryEntry& parentEntry,
     const std::wstring& parentPath, bool forFetching);
 
-  void doFetchMore(const QModelIndex& parent, bool forFetch);
+  void doFetchMore(const QModelIndex& parent, bool forFetch, bool doSort);
 
   void queueRemoveItem(FileTreeItem* item);
   void removeItems();


### PR DESCRIPTION
- Fixed crash because items were sorted while a node was expanded. Although I had a very verbose comment on top of the file explaining while I couldn't sort while expanding without crashing Qt, I was apparently doing exactly that.
- Fixed sorting being done way too often and recursively
- Refreshing the data tab while a search was active would close any opened nodes. Because recursive filtering was disabled to make things faster, this would close nodes that didn't match the filter. I disable filtering completely on the filter widget instead.
- Now caching file types, much faster sorting by type