### PR TITLE
Don't use reference as class member

### DIFF
--- a/src/organizerproxy.h
+++ b/src/organizerproxy.h
@@ -65,7 +65,7 @@ private:
   OrganizerCore *m_Proxied;
   PluginContainer *m_PluginContainer;
 
-  const QString &m_PluginName;
+  QString m_PluginName;
 
 };
 


### PR DESCRIPTION
This particular QString was only ever constructed from a temporary, so it was literally never going to work. We only hadn't noticed this earlier as no one had tried using the mod repository bridge from a plugin before (which is fairly bad given that three people have theoretically tested it while working on its Python bindings in the past).

IMO this should be cherry-picked for 2.3.2 as it's a bugfix even if it's not a regression, and is obviously safe.

Relevant other bits of code:
* Where we construct the organizer proxy: https://github.com/ModOrganizer2/modorganizer/blob/master/src/plugincontainer.cpp#L76
* The declaration of `IPlugin::name` so we can see it returns by value, so we *definitely* end up with a temporary: https://github.com/ModOrganizer2/modorganizer-uibase/blob/master/src/iplugin.h#L52