### PR TITLE
Open Meta file from downloads list

### DIFF
--- a/src/downloadlistwidget.cpp
+++ b/src/downloadlistwidget.cpp
@@ -221,6 +221,7 @@ void DownloadListWidget::onCustomContextMenu(const QPoint &point)
         else
           menu.addAction(tr("Visit on Nexus"), this, SLOT(issueVisitOnNexus()));
         menu.addAction(tr("Open File"), this, SLOT(issueOpenFile()));
+        menu.addAction(tr("Open Meta File"), this, SLOT(issueOpenMetaFile()));
         menu.addAction(tr("Reveal in Explorer"), this, SLOT(issueOpenInDownloadsFolder()));
 
         menu.addSeparator();
@@ -313,6 +314,10 @@ void DownloadListWidget::issueVisitOnNexus()
 void DownloadListWidget::issueOpenFile()
 {
   emit openFile(m_ContextRow);
+}
+
+void DownloadListWidget::issueOpenMetaFile() {
+  emit openMetaFile(m_ContextRow);
 }
 
 void DownloadListWidget::issueOpenInDownloadsFolder()

--- a/src/downloadlistwidget.h
+++ b/src/downloadlistwidget.h
@@ -86,6 +86,7 @@ signals:
   void resumeDownload(int index);
   void visitOnNexus(int index);
   void openFile(int index);
+  void openMetaFile(int index);
   void openInDownloadsFolder(int index);
 
 private slots:
@@ -99,6 +100,7 @@ private slots:
   void issueRestoreToViewAll();
   void issueVisitOnNexus();
   void issueOpenFile();
+  void issueOpenMetaFile();
   void issueOpenInDownloadsFolder();
   void issueCancel();
   void issuePause();

--- a/src/downloadmanager.cpp
+++ b/src/downloadmanager.cpp
@@ -1093,7 +1093,7 @@ void DownloadManager::openFile(int index)
 
 void DownloadManager::openMetaFile(int index) {
   if (index < 0 || index >= m_ActiveDownloads.size()) {
-    reportError("OpenMetaFile: invalid download index "+index);
+    log::error("OpenMetaFile: invalid download index {}", index);
     return;
   }
 

--- a/src/downloadmanager.cpp
+++ b/src/downloadmanager.cpp
@@ -1091,6 +1091,29 @@ void DownloadManager::openFile(int index)
   return;
 }
 
+void DownloadManager::openMetaFile(int index) {
+  if (index < 0 || index >= m_ActiveDownloads.size()) {
+    reportError(tr("OpenMetaFile: invalid download index %1").arg(index));
+    return;
+  }
+
+  auto path = QDir(m_OutputDirectory);
+  auto metaPath = getFilePath(index) + ".meta";
+  if (path.exists(metaPath)) {
+    shell::Open(metaPath);
+    return;
+  }
+
+  auto info = m_ActiveDownloads[index];
+  info->m_FileInfo->repository = "Nexus";
+
+  if (path.exists(metaPath)) {
+    shell::Open(metaPath);
+  } else {
+    shell::Explore(m_OutputDirectory);
+  }
+}
+
 void DownloadManager::openInDownloadsFolder(int index)
 {
   if ((index < 0) || (index >= m_ActiveDownloads.size())) {

--- a/src/downloadmanager.cpp
+++ b/src/downloadmanager.cpp
@@ -1093,7 +1093,7 @@ void DownloadManager::openFile(int index)
 
 void DownloadManager::openMetaFile(int index) {
   if (index < 0 || index >= m_ActiveDownloads.size()) {
-    reportError(tr("OpenMetaFile: invalid download index %1").arg(index));
+    reportError("OpenMetaFile: invalid download index "+index);
     return;
   }
 

--- a/src/downloadmanager.cpp
+++ b/src/downloadmanager.cpp
@@ -1097,21 +1097,25 @@ void DownloadManager::openMetaFile(int index) {
     return;
   }
 
-  auto path = QDir(m_OutputDirectory);
-  auto metaPath = getFilePath(index) + ".meta";
+  const auto path = QDir(m_OutputDirectory);
+  const auto filePath = getFilePath(index);
+  const auto metaPath = filePath + ".meta";
+
+  if (path.exists(metaPath)) {
+    shell::Open(metaPath);
+    return;
+  }
+  else {
+    QSettings metaFile(metaPath, QSettings::IniFormat);
+    metaFile.setValue("removed", false);
+  }
+
   if (path.exists(metaPath)) {
     shell::Open(metaPath);
     return;
   }
 
-  auto info = m_ActiveDownloads[index];
-  info->m_FileInfo->repository = "Nexus";
-
-  if (path.exists(metaPath)) {
-    shell::Open(metaPath);
-  } else {
-    shell::Explore(m_OutputDirectory);
-  }
+  shell::Explore(filePath);
 }
 
 void DownloadManager::openInDownloadsFolder(int index)

--- a/src/downloadmanager.h
+++ b/src/downloadmanager.h
@@ -453,6 +453,8 @@ public slots:
 
   void openFile(int index);
 
+  void openMetaFile(int index);
+
   void openInDownloadsFolder(int index);
 
   void nxmDescriptionAvailable(QString gameName, int modID, QVariant userData, QVariant resultData, int requestID);

--- a/src/mainwindow.cpp
+++ b/src/mainwindow.cpp
@@ -5360,6 +5360,7 @@ void MainWindow::initDownloadView()
   connect(ui->downloadView, SIGNAL(queryInfoMd5(int)), m_OrganizerCore.downloadManager(), SLOT(queryInfoMd5(int)));
   connect(ui->downloadView, SIGNAL(visitOnNexus(int)), m_OrganizerCore.downloadManager(), SLOT(visitOnNexus(int)));
   connect(ui->downloadView, SIGNAL(openFile(int)), m_OrganizerCore.downloadManager(), SLOT(openFile(int)));
+  connect(ui->downloadView, SIGNAL(openMetaFile(int)), m_OrganizerCore.downloadManager(), SLOT(openMetaFile(int)));
   connect(ui->downloadView, SIGNAL(openInDownloadsFolder(int)), m_OrganizerCore.downloadManager(), SLOT(openInDownloadsFolder(int)));
   connect(ui->downloadView, SIGNAL(removeDownload(int, bool)), m_OrganizerCore.downloadManager(), SLOT(removeDownload(int, bool)));
   connect(ui->downloadView, SIGNAL(restoreDownload(int)), m_OrganizerCore.downloadManager(), SLOT(restoreDownload(int)));


### PR DESCRIPTION
Adds a new context action `Open Meta File` for quickly opening the meta file of a download or creating a new meta file and opening that.
This speeds up the process of creating Wabbajack modlists by a significant amount of time and a simple convenience feature because it takes forever manually downloading an archive from eg LoversLab, installing the mod, using the Reveal in Explorer action to then open the meta file.