### PR TITLE
Add FOMOD C# installer link

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -70,6 +70,7 @@ Here is a complete list:
 * https://github.com/ModOrganizer2/modorganizer-installer_bain
 * https://github.com/ModOrganizer2/modorganizer-installer_bundle
 * https://github.com/ModOrganizer2/modorganizer-installer_fomod
+* https://github.com/ModOrganizer2/modorganizer-installer_fomod_csharp
 * https://github.com/ModOrganizer2/modorganizer-installer_manual
 * https://github.com/ModOrganizer2/modorganizer-installer_ncc
 * https://github.com/ModOrganizer2/modorganizer-installer_quick


### PR DESCRIPTION
Maybe we should add a CI step to check we've got links to all the MO2 repos (except the few that are deliberately not there).