### PR TITLE
Show details for all releases from Github when updating.

### DIFF
--- a/src/selfupdater.cpp
+++ b/src/selfupdater.cpp
@@ -186,7 +186,7 @@ void SelfUpdater::startUpdate()
       includePreRelease = false;
     }
 
-    details += "\n# " + release["tag_name"].toString() + "\n";
+    details += "\n# " + release["tag_name"].toString() + "\n---\n";
     details += release["body"].toString();
   }
 

--- a/src/selfupdater.h
+++ b/src/selfupdater.h
@@ -20,6 +20,7 @@ along with Mod Organizer.  If not, see <http://www.gnu.org/licenses/>.
 #ifndef SELFUPDATER_H
 #define SELFUPDATER_H
 
+#include <map>
 
 #include <versioninfo.h>
 #include <github.h>
@@ -141,7 +142,10 @@ private:
   int m_Attempts;
 
   GitHub m_GitHub;
-  QJsonObject m_UpdateCandidate;
+
+  // Map from version to release, in decreasing order (first element is the latest release):
+  using CandidatesMap = std::map<MOBase::VersionInfo, QJsonObject, std::greater<>>;
+  CandidatesMap m_UpdateCandidates;
 
 };
 


### PR DESCRIPTION
The "Show details... " button on the update dialog (for MO2) now shows the changelog for all versions between the current MO2 version and the release to-be-installed:

- If pre-releases are enabled, this will only show changelogs from pre-release for which no release is available yet.
- Displaying Markdown in the `QMessageBox` detailed text requires a dirty hack... And the display is not that great due to the dialog not being resizable. This could be "fixed" by creating a custom dialog.

Closes #1205 