### PR TITLE
Mark downloads of replaced mods as uninstalled

### DIFF
--- a/src/installationmanager.cpp
+++ b/src/installationmanager.cpp
@@ -369,7 +369,7 @@ QString InstallationManager::generateBackupName(const QString &directoryName) co
 }
 
 
-bool InstallationManager::testOverwrite(GuessedValue<QString> &modName, bool *merge) const
+bool InstallationManager::testOverwrite(GuessedValue<QString> &modName, bool *merge)
 {
   QString targetDirectory = QDir::fromNativeSeparators(m_ModsDirectory + "\\" + modName);
 
@@ -406,6 +406,12 @@ bool InstallationManager::testOverwrite(GuessedValue<QString> &modName, bool *me
           targetDirectory = QDir::fromNativeSeparators(m_ModsDirectory) + "/" + modName;
         }
       } else if (overwriteDialog.action() == QueryOverwriteDialog::ACT_REPLACE) {
+        unsigned int idx = ModInfo::getIndex(modName);
+        if (idx != UINT_MAX) {
+          auto modInfo = ModInfo::getByIndex(idx);
+          // mark the old install file as uninstalled
+          emit modReplaced(modInfo->getInstallationFile());
+        }
         // save original settings like categories. Because it makes sense
         QString metaFilename = targetDirectory + "/meta.ini";
         QFile settingsFile(metaFilename);

--- a/src/installationmanager.h
+++ b/src/installationmanager.h
@@ -185,7 +185,7 @@ public:
    * @param merge if this value is not null, the value will be set to whether the use chose to merge or replace
    * @return true if we can proceed with the installation, false if the user canceled or in case of an unrecoverable error
    */
-  virtual bool testOverwrite(MOBase::GuessedValue<QString> &modName, bool *merge = nullptr) const;
+  virtual bool testOverwrite(MOBase::GuessedValue<QString> &modName, bool *merge = nullptr);
 
   QString generateBackupName(const QString &directoryName) const;
 
@@ -224,6 +224,11 @@ signals:
    * @brief Progress update from the extraction.
    */
   void progressUpdate();
+
+  /**
+ * @brief An existing mod has been replaced with a newly installed one.
+ */
+  void modReplaced(const QString fileName);
 
 private:
 

--- a/src/organizercore.cpp
+++ b/src/organizercore.cpp
@@ -247,6 +247,8 @@ void OrganizerCore::setUserInterface(IUserInterface* ui)
             SLOT(modRenamed(QString, QString)));
     connect(&m_ModList, SIGNAL(modUninstalled(QString)), w,
             SLOT(modRemoved(QString)));
+    connect(&m_InstallationManager, SIGNAL(modReplaced(QString)), w,
+            SLOT(modRemoved(QString)));
     connect(&m_ModList, SIGNAL(removeSelectedMods()), w,
             SLOT(removeMod_clicked()));
     connect(&m_ModList, SIGNAL(clearOverwrite()), w,


### PR DESCRIPTION
Fix #1130 
If the replaced mod is being reinstalled using the same archive then it gets still marked as uninstalled but the code later marks it as installed again anyways.