### PR TITLE
Add a bulk-version of ModList::setActive.

### DIFF
--- a/src/modlist.cpp
+++ b/src/modlist.cpp
@@ -822,7 +822,7 @@ void ModList::modInfoChanged(ModInfo::Ptr info)
   if (info->name() == m_ChangeInfo.name) {
     IModList::ModStates newState = state(info->name());
     if (m_ChangeInfo.state != newState) {
-      m_ModStateChanged(info->name(), newState);
+      m_ModStateChanged({ {info->name(), newState} });
     }
 
     int row = ModInfo::getIndex(info->name());
@@ -1001,17 +1001,20 @@ bool ModList::setPriority(const QString &name, int newPriority)
   }
 }
 
-bool ModList::onModStateChanged(const std::function<void (const QString &, IModList::ModStates)> &func)
+bool ModList::onModStateChanged(const std::function<void(const std::map<QString, ModStates>&)>& func)
 {
   auto conn = m_ModStateChanged.connect(func);
   return conn.connected();
 }
 
-void ModList::notifyModStateChanged(QList<unsigned int> modIndices) const {
+void ModList::notifyModStateChanged(QList<unsigned int> modIndices) const 
+{
+  std::map<QString, ModStates> mods;
   for (auto modIndex : modIndices) {
     ModInfo::Ptr modInfo = ModInfo::getByIndex(modIndex);
-    m_ModStateChanged(modInfo->name(), state(modIndex));
+    mods.emplace(modInfo->name(), state(modIndex));
   }
+  m_ModStateChanged(mods);
 }
 
 bool ModList::onModMoved(const std::function<void (const QString &, int, int)> &func)

--- a/src/modlist.cpp
+++ b/src/modlist.cpp
@@ -952,6 +952,8 @@ bool ModList::setActive(const QString &name, bool active)
 {
   unsigned int modIndex = ModInfo::getIndex(name);
   if (modIndex == UINT_MAX) {
+    log::debug("Trying to {} mod {} which does not exist.",
+      active ? "enable" : "disable", name);
     return false;
   } else {
     m_Profile->setModEnabled(modIndex, active);
@@ -970,13 +972,11 @@ int ModList::setActive(const QStringList& names, bool active) {
   for (const auto& name : names) {
     auto modIndex = ModInfo::getIndex(name);
     if (modIndex != UINT_MAX) {
-
-      // This check is not done by the bulk Profile::setModsEnabled, so we
-      // do it here.
-      ModInfo::Ptr modInfo = ModInfo::getByIndex(modIndex);
-      if (!modInfo->alwaysEnabled()) {
-        indices.append(modIndex);
-      }
+      indices.append(modIndex);
+    }
+    else {
+      log::debug("Trying to {} mod {} which does not exist.", 
+        active ? "enable" : "disable", name);
     }
   }
 

--- a/src/modlist.h
+++ b/src/modlist.h
@@ -70,7 +70,7 @@ public:
     COL_LASTCOLUMN = COL_NOTES,
   };
 
-  typedef boost::signals2::signal<void (const QString &, ModStates)> SignalModStateChanged;
+  typedef boost::signals2::signal<void (const std::map<QString, ModStates>&)> SignalModStateChanged;
   typedef boost::signals2::signal<void (const QString &, int, int)> SignalModMoved;
 
 public:
@@ -156,7 +156,7 @@ public:
   virtual bool setPriority(const QString &name, int newPriority) override;
 
   /// \copydoc MOBase::IModList::onModStateChanged
-  virtual bool onModStateChanged(const std::function<void (const QString &, ModStates)> &func) override;
+  virtual bool onModStateChanged(const std::function<void(const std::map<QString, ModStates>&)>& func) override;
 
   /// \copydoc MOBase::IModList::onModMoved
   virtual bool onModMoved(const std::function<void (const QString &, int, int)> &func) override;

--- a/src/modlist.h
+++ b/src/modlist.h
@@ -125,7 +125,7 @@ public:
   void highlightMods(const QItemSelectionModel *selection, const MOShared::DirectoryEntry &directoryEntry);
 
   /**
-   * @brief Notify the most list that the state of the specified mods has changed. This is used
+   * @brief Notify the mod list that the state of the specified mods has changed. This is used
    * to notify the plugin that registered through onModStateChanged().
    *
    * @param modIndices Indices of the mods that changed.

--- a/src/modlist.h
+++ b/src/modlist.h
@@ -138,6 +138,9 @@ public:
   /// \copydoc MOBase::IModList::setActive
   virtual bool setActive(const QString &name, bool active) override;
 
+  /// \copydoc MOBase::IModList::setActive
+  int setActive(const QStringList& names, bool active) override;
+
   /// \copydoc MOBase::IModList::priority
   virtual int priority(const QString &name) const override;
 

--- a/src/modlist.h
+++ b/src/modlist.h
@@ -124,6 +124,14 @@ public:
 
   void highlightMods(const QItemSelectionModel *selection, const MOShared::DirectoryEntry &directoryEntry);
 
+  /**
+   * @brief Notify the most list that the state of the specified mods has changed. This is used
+   * to notify the plugin that registered through onModStateChanged().
+   *
+   * @param modIndices Indices of the mods that changed.
+   */
+  void notifyModStateChanged(QList<unsigned int> modIndices) const;
+
 public:
 
   /// \copydoc MOBase::IModList::displayName

--- a/src/organizercore.cpp
+++ b/src/organizercore.cpp
@@ -1552,6 +1552,9 @@ void OrganizerCore::modStatusChanged(unsigned int index)
     m_DirectoryStructure->getFileRegister()->sortOrigins();
 
     refreshLists();
+
+    m_ModList.notifyModStateChanged({ index });
+
   } catch (const std::exception &e) {
     reportError(tr("failed to update mod list: %1").arg(e.what()));
   }
@@ -1601,6 +1604,8 @@ void OrganizerCore::modStatusChanged(QList<unsigned int> index) {
     m_DirectoryStructure->getFileRegister()->sortOrigins();
 
     refreshLists();
+
+    m_ModList.notifyModStateChanged(index);
   } catch (const std::exception &e) {
     reportError(tr("failed to update mod list: %1").arg(e.what()));
   }


### PR DESCRIPTION
**Edit:** This does not work, keeping for future reference:

Following discussions on Discord:

- I moved `m_ModStateChanged` to `Profile` to centralize the notifications to plugins (currently, there are missing notifications, in particular due to `ModListSortProxy` enable/disable all visible).
- I had to move `state()` to `Profile` because it's required to use `m_ModStateChanged`.
- The implementation of `onModStateChanged` and `state` in `ModList` only calls the ones in `Profile` (avoid changing the plugin interface).
- I had to add a `notifyModStateChanged` for `modInfoChanged`, not sure if there is a way to avoid it.