### PR TITLE
Add IPluginList::setPriority implementation.

### DIFF
--- a/src/pluginlist.cpp
+++ b/src/pluginlist.cpp
@@ -766,6 +766,29 @@ int PluginList::priority(const QString &name) const
   }
 }
 
+bool PluginList::setPriority(const QString& name, int newPriority) {
+
+  if (newPriority < 0 || newPriority >= static_cast<int>(m_ESPsByPriority.size())) {
+    return false;
+  }
+
+  auto oldPriority = priority(name);
+  if (oldPriority == -1) {
+    return false;
+  }
+
+  int rowIndex = findPluginByPriority(oldPriority);
+
+  // We need to increment newPriority if its above the old one, otherwise the 
+  // plugin is place right below the new priority.
+  if (oldPriority < newPriority) {
+    newPriority += 1;
+  }
+  changePluginPriority({ rowIndex }, newPriority);
+
+  return true;
+}
+
 int PluginList::loadOrder(const QString &name) const
 {
   auto iter = m_ESPsByName.find(name.toLower());

--- a/src/pluginlist.h
+++ b/src/pluginlist.h
@@ -222,18 +222,19 @@ public:
 public:
 
   virtual QStringList pluginNames() const override;
-  virtual PluginStates state(const QString &name) const;
+  virtual PluginStates state(const QString &name) const override;
   virtual void setState(const QString &name, PluginStates state) override;
-  virtual int priority(const QString &name) const;
-  virtual int loadOrder(const QString &name) const;
+  virtual int priority(const QString &name) const override;
+  virtual int loadOrder(const QString &name) const override;
+  virtual bool setPriority(const QString& name, int newPriority) override;
   virtual bool onRefreshed(const std::function<void()> &callback);
-  virtual bool isMaster(const QString &name) const;
+  virtual bool isMaster(const QString &name) const override;
   virtual bool isLight(const QString &name) const;
   virtual bool isLightFlagged(const QString &name) const;
-  virtual QStringList masters(const QString &name) const;
-  virtual QString origin(const QString &name) const;
+  virtual QStringList masters(const QString &name) const override;
+  virtual QString origin(const QString &name) const override;
   virtual void setLoadOrder(const QStringList &pluginList) override;
-  virtual bool onPluginMoved(const std::function<void (const QString &, int, int)> &func);
+  virtual bool onPluginMoved(const std::function<void (const QString &, int, int)> &func) override;
   virtual bool onPluginStateChanged(const std::function<void (const QString &, PluginStates)> &func) override;
 
 public: // implementation of the QAbstractTableModel interface


### PR DESCRIPTION
I based the implementation on https://github.com/ModOrganizer2/modorganizer/blob/f0e94c26aebae6f86a59ed974e433f96e77faec7/src/pluginlist.cpp#L391-L405

But I noticed that when moving a plugin lower (e.g. from priority 4 to 10), the plugin is moved *below 10*, so at 9, which does not feel right, hence the +1 when required.