### PR TITLE
Do not report a canceled install as failed

### DIFF
--- a/src/installationmanager.h
+++ b/src/installationmanager.h
@@ -185,7 +185,7 @@ public:
    * @param merge if this value is not null, the value will be set to whether the use chose to merge or replace
    * @return true if we can proceed with the installation, false if the user canceled or in case of an unrecoverable error
    */
-  virtual bool testOverwrite(MOBase::GuessedValue<QString> &modName, bool *merge = nullptr);
+  virtual MOBase::IPluginInstaller::EInstallResult testOverwrite(MOBase::GuessedValue<QString> &modName, bool *merge = nullptr);
 
   QString generateBackupName(const QString &directoryName) const;
 


### PR DESCRIPTION
When a mod install reached the point of checking for overwrites with
existing mods (i.e., new mod has the same name as an old mod), there
was no way to distinguish between a failure and a user cancellation.
Now, an explicit status is passed up the stack so the cancellation
can be safely ignored by error checking code.