### PR TITLE
Fix issue with global saves directory when setting files are availble for non-Bethesda games.

### DIFF
--- a/src/mainwindow.cpp
+++ b/src/mainwindow.cpp
@@ -1893,12 +1893,16 @@ QDir MainWindow::currentSavesDir() const
     iniPath += "/" + iniFiles[0];
 
     wchar_t path[MAX_PATH];
-    ::GetPrivateProfileStringW(
-          L"General", L"SLocalSavePath", L"Saves",
-          path, MAX_PATH,
-          iniPath.toStdWString().c_str()
-          );
-    savesDir.setPath(m_OrganizerCore.managedGame()->documentsDirectory().absoluteFilePath(QString::fromWCharArray(path)));
+    if (::GetPrivateProfileStringW(
+      L"General", L"SLocalSavePath", L"",
+      path, MAX_PATH,
+      iniPath.toStdWString().c_str()
+    )) {
+      savesDir.setPath(m_OrganizerCore.managedGame()->documentsDirectory().absoluteFilePath(QString::fromWCharArray(path)));
+    }
+    else {
+      savesDir = m_OrganizerCore.managedGame()->savesDirectory();
+    }
   }
 
   return savesDir;


### PR DESCRIPTION
This was discussed some times ago on Discord https://discordapp.com/channels/265929299490635777/265929879718068224/740259543032004658

There is some Bethesda-specific stuff in `currentSavesDir` which prevents display of save games (I think this is only used for this) when `iniFiles()` is specific for a game. I just added a test to not use the settings from the ini file if it's not found and fall back to the game default saves directory if it is not.

Ideally, this would go to the game plugin but `savesDirectory` is used in other places where this ini-stuff is not present so I don't want to break these.