### PR TITLE
Add getters for most meta-information in mod.

### DIFF
--- a/src/installationmanager.cpp
+++ b/src/installationmanager.cpp
@@ -410,7 +410,7 @@ IPluginInstaller::EInstallResult InstallationManager::testOverwrite(GuessedValue
         if (idx != UINT_MAX) {
           auto modInfo = ModInfo::getByIndex(idx);
           // mark the old install file as uninstalled
-          emit modReplaced(modInfo->getInstallationFile());
+          emit modReplaced(modInfo->installationFile());
         }
         // save original settings like categories. Because it makes sense
         QString metaFilename = targetDirectory + "/meta.ini";

--- a/src/mainwindow.cpp
+++ b/src/mainwindow.cpp
@@ -2577,7 +2577,7 @@ void MainWindow::modInstalled(const QString &modName)
   // force an update to happen
   std::multimap<QString, int> IDs;
   ModInfo::Ptr info = ModInfo::getByIndex(ModInfo::getIndex(modName));
-  IDs.insert(std::make_pair<QString, int>(info->getGameName(), info->getNexusID()));
+  IDs.insert(std::make_pair<QString, int>(info->gameName(), info->modId()));
   modUpdateCheck(IDs);
 }
 
@@ -2790,7 +2790,7 @@ void MainWindow::modRemoved(const QString &fileName)
 void MainWindow::reinstallMod_clicked()
 {
   ModInfo::Ptr modInfo = ModInfo::getByIndex(m_ContextRow);
-  QString installationFile = modInfo->getInstallationFile();
+  QString installationFile = modInfo->installationFile();
   if (installationFile.length() != 0) {
     QString fullInstallationFile;
     QFileInfo fileInfo(installationFile);
@@ -3254,8 +3254,8 @@ void MainWindow::visitOnNexus_clicked()
     for (QModelIndex idx : selection->selectedRows()) {
       row_idx = idx.data(Qt::UserRole + 1).toInt();
       info = ModInfo::getByIndex(row_idx);
-      int modID = info->getNexusID();
-      gameName = info->getGameName();
+      int modID = info->modId();
+      gameName = info->gameName();
       if (modID > 0)  {
         linkClicked(NexusInterface::instance(&m_PluginContainer)->getModURL(modID, gameName));
       } else {
@@ -3319,8 +3319,8 @@ void MainWindow::visitNexusOrWebPage(const QModelIndex& idx)
     return;
   }
 
-  int modID = info->getNexusID();
-  QString gameName = info->getGameName();
+  int modID = info->modId();
+  QString gameName = info->gameName();
   const auto url = info->parseCustomURL();
 
   if (modID > 0) {
@@ -3665,7 +3665,7 @@ void MainWindow::setColor_clicked()
   QColorDialog dialog(this);
   dialog.setOption(QColorDialog::ShowAlphaChannel);
 
-  QColor currentColor = modInfo->getColor();
+  QColor currentColor = modInfo->color();
   if (currentColor.isValid()) {
     dialog.setCurrentColor(currentColor);
   }
@@ -4240,8 +4240,8 @@ void MainWindow::changeVersioningScheme() {
     static VersionInfo::VersionScheme schemes[] = { VersionInfo::SCHEME_REGULAR, VersionInfo::SCHEME_DECIMALMARK, VersionInfo::SCHEME_NUMBERSANDLETTERS };
 
     for (int i = 0; i < sizeof(schemes) / sizeof(VersionInfo::VersionScheme) && !success; ++i) {
-      VersionInfo verOld(info->getVersion().canonicalString(), schemes[i]);
-      VersionInfo verNew(info->getNewestVersion().canonicalString(), schemes[i]);
+      VersionInfo verOld(info->version().canonicalString(), schemes[i]);
+      VersionInfo verNew(info->newestVersion().canonicalString(), schemes[i]);
       if (verOld < verNew) {
         info->setVersion(verOld);
         info->setNewestVersion(verNew);
@@ -4250,7 +4250,7 @@ void MainWindow::changeVersioningScheme() {
     }
     if (!success) {
       QMessageBox::information(this, tr("Sorry"),
-          tr("I don't know a versioning scheme where %1 is newer than %2.").arg(info->getNewestVersion().canonicalString()).arg(info->getVersion().canonicalString()),
+          tr("I don't know a versioning scheme where %1 is newer than %2.").arg(info->newestVersion().canonicalString()).arg(info->version().canonicalString()),
           QMessageBox::Ok);
     }
   }
@@ -4279,11 +4279,11 @@ void MainWindow::checkModUpdates_clicked()
   if (selection->hasSelection() && selection->selectedRows().count() > 1) {
     for (QModelIndex idx : selection->selectedRows()) {
       ModInfo::Ptr info = ModInfo::getByIndex(idx.data(Qt::UserRole + 1).toInt());
-      IDs.insert(std::make_pair<QString, int>(info->getGameName(), info->getNexusID()));
+      IDs.insert(std::make_pair<QString, int>(info->gameName(), info->modId()));
     }
   } else {
     ModInfo::Ptr info = ModInfo::getByIndex(m_ContextRow);
-    IDs.insert(std::make_pair<QString, int>(info->getGameName(), info->getNexusID()));
+    IDs.insert(std::make_pair<QString, int>(info->gameName(), info->modId()));
   }
   modUpdateCheck(IDs);
 }
@@ -4320,7 +4320,7 @@ void MainWindow::addPrimaryCategoryCandidates(QMenu *primaryCategoryMenu,
           info->setPrimaryCategory(categoryID);
         }
       });
-      categoryBox->setChecked(categoryID == info->getPrimaryCategory());
+      categoryBox->setChecked(categoryID == info->primaryCategory());
       action->setDefaultWidget(categoryBox);
     } catch (const std::exception &e) {
       log::error("failed to create category checkbox: {}", e.what());
@@ -4568,17 +4568,17 @@ void MainWindow::exportModListCSV()
           if (mod_Note->isChecked())
             builder.setRowField("#Note", QString("%1").arg(info->comments().remove(',')));
 					if (primary_Category->isChecked())
-						builder.setRowField("#Primary_Category", (m_CategoryFactory.categoryExists(info->getPrimaryCategory())) ? m_CategoryFactory.getCategoryNameByID(info->getPrimaryCategory()) : "");
+						builder.setRowField("#Primary_Category", (m_CategoryFactory.categoryExists(info->primaryCategory())) ? m_CategoryFactory.getCategoryNameByID(info->primaryCategory()) : "");
 					if (nexus_ID->isChecked())
-						builder.setRowField("#Nexus_ID", info->getNexusID());
+						builder.setRowField("#Nexus_ID", info->modId());
 					if (mod_Nexus_URL->isChecked())
-						builder.setRowField("#Mod_Nexus_URL",(info->getNexusID()>0)? NexusInterface::instance(&m_PluginContainer)->getModURL(info->getNexusID(), info->getGameName()) : "");
+						builder.setRowField("#Mod_Nexus_URL",(info->modId()>0)? NexusInterface::instance(&m_PluginContainer)->getModURL(info->modId(), info->gameName()) : "");
 					if (mod_Version->isChecked())
-						builder.setRowField("#Mod_Version", info->getVersion().canonicalString());
+						builder.setRowField("#Mod_Version", info->version().canonicalString());
 					if (install_Date->isChecked())
 						builder.setRowField("#Install_Date", info->creationTime().toString("yyyy/MM/dd HH:mm:ss"));
 					if (download_File_Name->isChecked())
-						builder.setRowField("#Download_File_Name", info->getInstallationFile());
+						builder.setRowField("#Download_File_Name", info->installationFile());
 
 					builder.writeRow();
 				}
@@ -4726,7 +4726,7 @@ void MainWindow::on_modList_customContextMenuRequested(const QPoint &pos)
             menu.addAction(tr("Mark as converted/working"), this, SLOT(markConverted_clicked()));
           }
           menu.addSeparator();
-          if (info->getNexusID() > 0) {
+          if (info->modId() > 0) {
             menu.addAction(tr("Visit on Nexus"), this, SLOT(visitOnNexus_clicked()));
           }
 
@@ -4755,7 +4755,7 @@ void MainWindow::on_modList_customContextMenuRequested(const QPoint &pos)
         addModSendToContextMenu(&menu);
         menu.addAction(tr("Select Color..."), this, SLOT(setColor_clicked()));
 
-        if(info->getColor().isValid())
+        if(info->color().isValid())
           menu.addAction(tr("Reset Color"), this, SLOT(resetColor_clicked()));
 
         menu.addSeparator();
@@ -4779,7 +4779,7 @@ void MainWindow::on_modList_customContextMenuRequested(const QPoint &pos)
           menu.addAction(tr("Change versioning scheme"), this, SLOT(changeVersioningScheme()));
         }
 
-        if (info->getNexusID() > 0)
+        if (info->modId() > 0)
           menu.addAction(tr("Force-check updates"), this, SLOT(checkModUpdates_clicked()));
         if (info->updateIgnored()) {
           menu.addAction(tr("Un-ignore update"), this, SLOT(unignoreUpdate()));
@@ -4811,22 +4811,22 @@ void MainWindow::on_modList_customContextMenuRequested(const QPoint &pos)
         if (contextColumn == ModList::COL_NOTES) {
           menu.addAction(tr("Select Color..."), this, SLOT(setColor_clicked()));
 
-          if (info->getColor().isValid())
+          if (info->color().isValid())
             menu.addAction(tr("Reset Color"), this, SLOT(resetColor_clicked()));
 
           menu.addSeparator();
         }
 
-        if (info->getNexusID() > 0 && Settings::instance().nexus().endorsementIntegration()) {
+        if (info->modId() > 0 && Settings::instance().nexus().endorsementIntegration()) {
           switch (info->endorsedState()) {
-            case ModInfo::ENDORSED_TRUE: {
+            case EndorsedState::ENDORSED_TRUE: {
               menu.addAction(tr("Un-Endorse"), this, SLOT(unendorse_clicked()));
             } break;
-            case ModInfo::ENDORSED_FALSE: {
+            case EndorsedState::ENDORSED_FALSE: {
               menu.addAction(tr("Endorse"), this, SLOT(endorse_clicked()));
               menu.addAction(tr("Won't endorse"), this, SLOT(dontendorse_clicked()));
             } break;
-            case ModInfo::ENDORSED_NEVER: {
+            case EndorsedState::ENDORSED_NEVER: {
               menu.addAction(tr("Endorse"), this, SLOT(endorse_clicked()));
             } break;
             default: {
@@ -4837,12 +4837,12 @@ void MainWindow::on_modList_customContextMenuRequested(const QPoint &pos)
           }
         }
 
-        if (info->getNexusID() > 0) {
+        if (info->modId() > 0) {
           switch (info->trackedState()) {
-            case ModInfo::TRACKED_FALSE: {
+            case TrackedState::TRACKED_FALSE: {
               menu.addAction(tr("Start tracking"), this, SLOT(track_clicked()));
             } break;
-            case ModInfo::TRACKED_TRUE: {
+            case TrackedState::TRACKED_TRUE: {
               menu.addAction(tr("Stop tracking"), this, SLOT(untrack_clicked()));
             } break;
             default: {
@@ -4866,7 +4866,7 @@ void MainWindow::on_modList_customContextMenuRequested(const QPoint &pos)
 
         menu.addSeparator();
 
-        if (info->getNexusID() > 0)  {
+        if (info->modId() > 0)  {
           menu.addAction(tr("Visit on Nexus"), this, SLOT(visitOnNexus_clicked()));
         }
 
@@ -5548,7 +5548,7 @@ void MainWindow::finishUpdateInfo()
   std::set<std::pair<QString, int>> organizedGames;
   for (auto mod : finalMods) {
     if (mod->canBeUpdated()) {
-      organizedGames.insert(std::make_pair<QString, int>(mod->getGameName().toLower(), mod->getNexusID()));
+      organizedGames.insert(std::make_pair<QString, int>(mod->gameName().toLower(), mod->modId()));
     }
   }
 
@@ -5580,7 +5580,7 @@ void MainWindow::nxmUpdatesAvailable(QString gameName, int modID, QVariant userD
   for (auto mod : modsList) {
     bool foundUpdate = false;
     bool oldFile = false;
-    QString installedFile = mod->getInstallationFile();
+    QString installedFile = mod->installationFile();
     if (!installedFile.isEmpty()) {
       QVariantMap foundFile;
       for (auto file : files) {
@@ -5672,7 +5672,7 @@ void MainWindow::nxmModInfoAvailable(QString gameName, int modID, QVariant userD
       mod->setLastNexusUpdate(QDateTime::currentDateTimeUtc());
     }
     mod->setNexusDescription(result["description"].toString());
-    if ((mod->endorsedState() != ModInfo::ENDORSED_NEVER) && (result.contains("endorsement"))) {
+    if ((mod->endorsedState() != EndorsedState::ENDORSED_NEVER) && (result.contains("endorsement"))) {
       QVariantMap endorsement = result["endorsement"].toMap();
       QString endorsementStatus = endorsement["endorse_status"].toString();
       if (endorsementStatus.compare("Endorsed") == 00)
@@ -5742,15 +5742,15 @@ void MainWindow::nxmTrackedModsAvailable(QVariant userData, QVariant resultData,
 
   for (unsigned int i = 0; i < ModInfo::getNumMods(); i++) {
     auto modInfo = ModInfo::getByIndex(i);
-    if (modInfo->getNexusID() <= 0)
+    if (modInfo->modId() <= 0)
       continue;
 
     bool found = false;
     auto resultsList = resultData.toList();
     for (auto item : resultsList) {
       auto results = item.toMap();
-      if ((gameNames[results["domain_name"].toString()].compare(modInfo->getGameName(), Qt::CaseInsensitive) == 0) &&
-          (results["mod_id"].toInt() == modInfo->getNexusID())) {
+      if ((gameNames[results["domain_name"].toString()].compare(modInfo->gameName(), Qt::CaseInsensitive) == 0) &&
+          (results["mod_id"].toInt() == modInfo->modId())) {
         found = true;
         break;
       }

--- a/src/mainwindow.cpp
+++ b/src/mainwindow.cpp
@@ -2577,7 +2577,7 @@ void MainWindow::modInstalled(const QString &modName)
   // force an update to happen
   std::multimap<QString, int> IDs;
   ModInfo::Ptr info = ModInfo::getByIndex(ModInfo::getIndex(modName));
-  IDs.insert(std::make_pair<QString, int>(info->gameName(), info->modId()));
+  IDs.insert(std::make_pair<QString, int>(info->gameName(), info->nexusId()));
   modUpdateCheck(IDs);
 }
 
@@ -3254,7 +3254,7 @@ void MainWindow::visitOnNexus_clicked()
     for (QModelIndex idx : selection->selectedRows()) {
       row_idx = idx.data(Qt::UserRole + 1).toInt();
       info = ModInfo::getByIndex(row_idx);
-      int modID = info->modId();
+      int modID = info->nexusId();
       gameName = info->gameName();
       if (modID > 0)  {
         linkClicked(NexusInterface::instance(&m_PluginContainer)->getModURL(modID, gameName));
@@ -3319,7 +3319,7 @@ void MainWindow::visitNexusOrWebPage(const QModelIndex& idx)
     return;
   }
 
-  int modID = info->modId();
+  int modID = info->nexusId();
   QString gameName = info->gameName();
   const auto url = info->parseCustomURL();
 
@@ -4279,11 +4279,11 @@ void MainWindow::checkModUpdates_clicked()
   if (selection->hasSelection() && selection->selectedRows().count() > 1) {
     for (QModelIndex idx : selection->selectedRows()) {
       ModInfo::Ptr info = ModInfo::getByIndex(idx.data(Qt::UserRole + 1).toInt());
-      IDs.insert(std::make_pair<QString, int>(info->gameName(), info->modId()));
+      IDs.insert(std::make_pair<QString, int>(info->gameName(), info->nexusId()));
     }
   } else {
     ModInfo::Ptr info = ModInfo::getByIndex(m_ContextRow);
-    IDs.insert(std::make_pair<QString, int>(info->gameName(), info->modId()));
+    IDs.insert(std::make_pair<QString, int>(info->gameName(), info->nexusId()));
   }
   modUpdateCheck(IDs);
 }
@@ -4570,9 +4570,9 @@ void MainWindow::exportModListCSV()
 					if (primary_Category->isChecked())
 						builder.setRowField("#Primary_Category", (m_CategoryFactory.categoryExists(info->primaryCategory())) ? m_CategoryFactory.getCategoryNameByID(info->primaryCategory()) : "");
 					if (nexus_ID->isChecked())
-						builder.setRowField("#Nexus_ID", info->modId());
+						builder.setRowField("#Nexus_ID", info->nexusId());
 					if (mod_Nexus_URL->isChecked())
-						builder.setRowField("#Mod_Nexus_URL",(info->modId()>0)? NexusInterface::instance(&m_PluginContainer)->getModURL(info->modId(), info->gameName()) : "");
+						builder.setRowField("#Mod_Nexus_URL",(info->nexusId()>0)? NexusInterface::instance(&m_PluginContainer)->getModURL(info->nexusId(), info->gameName()) : "");
 					if (mod_Version->isChecked())
 						builder.setRowField("#Mod_Version", info->version().canonicalString());
 					if (install_Date->isChecked())
@@ -4726,7 +4726,7 @@ void MainWindow::on_modList_customContextMenuRequested(const QPoint &pos)
             menu.addAction(tr("Mark as converted/working"), this, SLOT(markConverted_clicked()));
           }
           menu.addSeparator();
-          if (info->modId() > 0) {
+          if (info->nexusId() > 0) {
             menu.addAction(tr("Visit on Nexus"), this, SLOT(visitOnNexus_clicked()));
           }
 
@@ -4779,7 +4779,7 @@ void MainWindow::on_modList_customContextMenuRequested(const QPoint &pos)
           menu.addAction(tr("Change versioning scheme"), this, SLOT(changeVersioningScheme()));
         }
 
-        if (info->modId() > 0)
+        if (info->nexusId() > 0)
           menu.addAction(tr("Force-check updates"), this, SLOT(checkModUpdates_clicked()));
         if (info->updateIgnored()) {
           menu.addAction(tr("Un-ignore update"), this, SLOT(unignoreUpdate()));
@@ -4817,7 +4817,7 @@ void MainWindow::on_modList_customContextMenuRequested(const QPoint &pos)
           menu.addSeparator();
         }
 
-        if (info->modId() > 0 && Settings::instance().nexus().endorsementIntegration()) {
+        if (info->nexusId() > 0 && Settings::instance().nexus().endorsementIntegration()) {
           switch (info->endorsedState()) {
             case EndorsedState::ENDORSED_TRUE: {
               menu.addAction(tr("Un-Endorse"), this, SLOT(unendorse_clicked()));
@@ -4837,7 +4837,7 @@ void MainWindow::on_modList_customContextMenuRequested(const QPoint &pos)
           }
         }
 
-        if (info->modId() > 0) {
+        if (info->nexusId() > 0) {
           switch (info->trackedState()) {
             case TrackedState::TRACKED_FALSE: {
               menu.addAction(tr("Start tracking"), this, SLOT(track_clicked()));
@@ -4866,7 +4866,7 @@ void MainWindow::on_modList_customContextMenuRequested(const QPoint &pos)
 
         menu.addSeparator();
 
-        if (info->modId() > 0)  {
+        if (info->nexusId() > 0)  {
           menu.addAction(tr("Visit on Nexus"), this, SLOT(visitOnNexus_clicked()));
         }
 
@@ -5548,7 +5548,7 @@ void MainWindow::finishUpdateInfo()
   std::set<std::pair<QString, int>> organizedGames;
   for (auto mod : finalMods) {
     if (mod->canBeUpdated()) {
-      organizedGames.insert(std::make_pair<QString, int>(mod->gameName().toLower(), mod->modId()));
+      organizedGames.insert(std::make_pair<QString, int>(mod->gameName().toLower(), mod->nexusId()));
     }
   }
 
@@ -5742,7 +5742,7 @@ void MainWindow::nxmTrackedModsAvailable(QVariant userData, QVariant resultData,
 
   for (unsigned int i = 0; i < ModInfo::getNumMods(); i++) {
     auto modInfo = ModInfo::getByIndex(i);
-    if (modInfo->modId() <= 0)
+    if (modInfo->nexusId() <= 0)
       continue;
 
     bool found = false;
@@ -5750,7 +5750,7 @@ void MainWindow::nxmTrackedModsAvailable(QVariant userData, QVariant resultData,
     for (auto item : resultsList) {
       auto results = item.toMap();
       if ((gameNames[results["domain_name"].toString()].compare(modInfo->gameName(), Qt::CaseInsensitive) == 0) &&
-          (results["mod_id"].toInt() == modInfo->modId())) {
+          (results["mod_id"].toInt() == modInfo->nexusId())) {
         found = true;
         break;
       }

--- a/src/modinfo.cpp
+++ b/src/modinfo.cpp
@@ -180,11 +180,11 @@ bool ModInfo::removeMod(unsigned int index)
   ModInfo::Ptr modInfo = s_Collection[index];
   s_ModsByName.erase(s_ModsByName.find(modInfo->name()));
 
-  auto iter = s_ModsByModID.find(std::pair<QString, int>(modInfo->getGameName(), modInfo->getNexusID()));
+  auto iter = s_ModsByModID.find(std::pair<QString, int>(modInfo->gameName(), modInfo->modId()));
   if (iter != s_ModsByModID.end()) {
     std::vector<unsigned int> indices = iter->second;
     indices.erase(std::remove(indices.begin(), indices.end(), index), indices.end());
-    s_ModsByModID[std::pair<QString, int>(modInfo->getGameName(), modInfo->getNexusID())] = indices;
+    s_ModsByModID[std::pair<QString, int>(modInfo->gameName(), modInfo->modId())] = indices;
   }
 
   // physically remove the mod directory
@@ -281,8 +281,8 @@ void ModInfo::updateIndices()
 
   for (unsigned int i = 0; i < s_Collection.size(); ++i) {
     QString modName = s_Collection[i]->internalName();
-    QString game = s_Collection[i]->getGameName();
-    int modID = s_Collection[i]->getNexusID();
+    QString game = s_Collection[i]->gameName();
+    int modID = s_Collection[i]->modId();
     s_ModsByName[modName] = i;
     s_ModsByModID[std::pair<QString, int>(game, modID)].push_back(i);
   }
@@ -308,7 +308,7 @@ bool ModInfo::checkAllForUpdate(PluginContainer *pluginContainer, QObject *recei
         earliest = mod->getLastNexusUpdate();
       if (mod->getLastNexusUpdate() > latest)
         latest = mod->getLastNexusUpdate();
-      games.insert(mod->getGameName().toLower());
+      games.insert(mod->gameName().toLower());
     }
   }
 
@@ -334,7 +334,7 @@ bool ModInfo::checkAllForUpdate(PluginContainer *pluginContainer, QObject *recei
     std::set<std::pair<QString, int>> organizedGames;
     for (auto mod : s_Collection) {
       if (mod->canBeUpdated() && mod->getLastNexusUpdate() < QDateTime::currentDateTimeUtc().addMonths(-1)) {
-        organizedGames.insert(std::make_pair<QString, int>(mod->getGameName().toLower(), mod->getNexusID()));
+        organizedGames.insert(std::make_pair<QString, int>(mod->gameName().toLower(), mod->modId()));
       }
     }
 
@@ -372,7 +372,7 @@ std::set<QSharedPointer<ModInfo>> ModInfo::filteredMods(QString gameName, QVaria
   for (QVariant result : updateData) {
     QVariantMap update = result.toMap();
     std::copy_if(s_Collection.begin(), s_Collection.end(), std::inserter(finalMods, finalMods.end()), [=](QSharedPointer<ModInfo> info) -> bool {
-      if (info->getNexusID() == update["mod_id"].toInt() && info->getGameName().compare(gameName, Qt::CaseInsensitive) == 0)
+      if (info->modId() == update["mod_id"].toInt() && info->gameName().compare(gameName, Qt::CaseInsensitive) == 0)
         if (info->getLastNexusUpdate().addSecs(-3600) < QDateTime::fromSecsSinceEpoch(update["latest_file_update"].toInt(), Qt::UTC))
           return true;
       return false;
@@ -381,13 +381,13 @@ std::set<QSharedPointer<ModInfo>> ModInfo::filteredMods(QString gameName, QVaria
 
   if (addOldMods)
     for (auto mod : s_Collection)
-      if (mod->getLastNexusUpdate() < QDateTime::currentDateTimeUtc().addMonths(-1) && mod->getGameName().compare(gameName, Qt::CaseInsensitive) == 0)
+      if (mod->getLastNexusUpdate() < QDateTime::currentDateTimeUtc().addMonths(-1) && mod->gameName().compare(gameName, Qt::CaseInsensitive) == 0)
         finalMods.insert(mod);
 
   if (markUpdated) {
     std::set<QSharedPointer<ModInfo>> updates;
     std::copy_if(s_Collection.begin(), s_Collection.end(), std::inserter(updates, updates.end()), [=](QSharedPointer<ModInfo> info) -> bool {
-      if (info->getGameName().compare(gameName, Qt::CaseInsensitive) == 0 && info->canBeUpdated())
+      if (info->gameName().compare(gameName, Qt::CaseInsensitive) == 0 && info->canBeUpdated())
         return true;
       return false;
     });
@@ -419,7 +419,7 @@ void ModInfo::manualUpdateCheck(PluginContainer *pluginContainer, QObject *recei
     }
   }
   mods.erase(
-    std::remove_if(mods.begin(), mods.end(), [](ModInfo::Ptr mod) -> bool { return mod->getNexusID() <= 0; }),
+    std::remove_if(mods.begin(), mods.end(), [](ModInfo::Ptr mod) -> bool { return mod->modId() <= 0; }),
     mods.end()
   );
   for (auto mod : mods) {
@@ -434,7 +434,7 @@ void ModInfo::manualUpdateCheck(PluginContainer *pluginContainer, QObject *recei
     log::info("Checking updates for {} mods...", mods.size());
 
     for (auto mod : mods) {
-      organizedGames.insert(std::make_pair<QString, int>(mod->getGameName().toLower(), mod->getNexusID()));
+      organizedGames.insert(std::make_pair<QString, int>(mod->gameName().toLower(), mod->modId()));
     }
 
     for (auto game : organizedGames) {
@@ -526,14 +526,14 @@ bool ModInfo::categorySet(int categoryID) const
 
 QUrl ModInfo::parseCustomURL() const
 {
-  if (!hasCustomURL() || getCustomURL().isEmpty()) {
+  if (!hasCustomURL() || url().isEmpty()) {
     return {};
   }
 
-  const auto url = QUrl::fromUserInput(getCustomURL());
+  const auto url = QUrl::fromUserInput(this->url());
 
   if (!url.isValid()) {
-    log::error("mod '{}' has an invalid custom url '{}'", name(), getCustomURL());
+    log::error("mod '{}' has an invalid custom url '{}'", name(), this->url());
     return {};
   }
 

--- a/src/modinfo.h
+++ b/src/modinfo.h
@@ -95,19 +95,6 @@ public:
     HIGHLIGHT_PLUGIN = 8
   };
 
-  enum EEndorsedState {
-    ENDORSED_FALSE,
-    ENDORSED_TRUE,
-    ENDORSED_UNKNOWN,
-    ENDORSED_NEVER
-  };
-
-  enum ETrackedState {
-    TRACKED_FALSE,
-    TRACKED_TRUE,
-    TRACKED_UNKNOWN,
-  };
-
   enum EModType {
     MOD_DEFAULT,
     MOD_DLC,
@@ -371,6 +358,7 @@ public:
 
   virtual void addCategory(const QString &categoryName) override;
   virtual bool removeCategory(const QString &categoryName) override;
+
   virtual QStringList categories() const override;
 
   /**
@@ -439,47 +427,19 @@ public:
   virtual QString absolutePath() const = 0;
 
   /**
-   * @brief getter for the installation file
-   *
-   * @return file used to install this mod from
-   */
-  virtual QString getInstallationFile() const = 0;
-
-  /**
    * @return version object for machine based comparisons
    **/
-  virtual MOBase::VersionInfo getVersion() const { return m_Version; }
-
-  /**
-   * @brief getter for the newest version number of this mod
-   *
-   * @return newest version of the mod
-   **/
-  virtual MOBase::VersionInfo getNewestVersion() const = 0;
+  virtual MOBase::VersionInfo version() const { return m_Version; }
 
   /**
    * @return the repository from which the file was downloaded. Only relevant regular mods
    */
-  virtual QString repository() const { return ""; }
+  virtual QString repository() const override { return ""; }
 
   /**
    * @brief ignore the newest version for updates
    */
   virtual void ignoreUpdate(bool ignore) = 0;
-
-  /**
-   * @brief getter for the nexus mod id
-   *
-   * @return the nexus mod id. may be 0 if the mod id isn't known or doesn't exist
-   **/
-  virtual int getNexusID() const = 0;
-
-  /**
-  * @brief getter for the source game repository
-  *
-  * @return the source game repository. should default to the active game.
-  **/
-  virtual QString getGameName() const = 0;
 
   /**
    * @return the fixed priority of mods of this type or INT_MIN if the priority of mods
@@ -574,16 +534,6 @@ public:
   virtual void setNexusFileStatus(int status) = 0;
 
   /**
-   * @return comments for this mod
-   */
-  virtual QString comments() const = 0;
-
-  /**
-   * @return notes for this mod
-   */
-  virtual QString notes() const = 0;
-
-  /**
    * @return creation time of this mod
    */
   virtual QDateTime creationTime() const = 0;
@@ -633,13 +583,13 @@ public:
    */
   virtual QStringList archives(bool checkOnDisk = false) = 0;
 
-  /*
-   *@return the color choosen by the user for the mod/separator
+  /**
+   * @return the color choosen by the user for the mod/separator
    */
-  virtual QColor getColor() const { return QColor(); }
+  virtual QColor color() const override { return QColor(); }
 
-  /*
-   *@return true if the color has been set successfully.
+  /**
+   * 
    */
   virtual void setColor(QColor) { }
 
@@ -669,7 +619,7 @@ public:
   /**
    * @return id of the primary category of this mod
    */
-  int getPrimaryCategory() const { return m_PrimaryCategory; }
+  int primaryCategory() const override { return m_PrimaryCategory; }
 
   /**
    * @brief sets the new primary category of the mod
@@ -685,12 +635,12 @@ public:
   /**
    * @return true if the file has been endorsed on nexus
    */
-  virtual EEndorsedState endorsedState() const { return ENDORSED_NEVER; }
+  virtual MOBase::EndorsedState endorsedState() const override { return MOBase::EndorsedState::ENDORSED_NEVER; }
 
   /**
    * @return true if the file is being tracked on nexus
    */
-  virtual ETrackedState trackedState() const { return TRACKED_FALSE; }
+  virtual MOBase::TrackedState trackedState() const override { return MOBase::TrackedState::TRACKED_FALSE; }
 
   /**
    * @brief updates the mod to flag it as converted in order to ignore the alternate game warning
@@ -765,7 +715,7 @@ public:
   /**
    * @brief returns the custom url
    **/
-  virtual QString getCustomURL() const { return ""; }
+  virtual QString url() const override { return ""; }
 
   /**
    * If hasCustomURL() is true and getCustomURL() is not empty, tries to parse

--- a/src/modinfo.h
+++ b/src/modinfo.h
@@ -48,13 +48,13 @@ namespace MOShared { class DirectoryEntry; }
  * Represents meta information about a single mod. The class interface is used
  * to manage the mod collection
  *
- **/
+ */
 class ModInfo : public QObject, public MOBase::IModInterface
 {
 
   Q_OBJECT
 
-public:
+public: // Type definitions:
 
   typedef QSharedPointer<ModInfo> Ptr;
 
@@ -102,11 +102,11 @@ public:
   };
 
 
-public:
+public: // Static functions:
 
   /**
-   * @brief read the mod directory and Mod ModInfo objects for all subdirectories
-   **/
+   * @brief Read the mod directory and Mod ModInfo objects for all subdirectories.
+   */
   static void updateFromDisc(const QString &modDirectory,
                              MOShared::DirectoryEntry **directoryStructure,
                              PluginContainer *pluginContainer,
@@ -117,388 +117,556 @@ public:
   static void clear() { s_Collection.clear(); s_ModsByName.clear(); s_ModsByModID.clear(); }
 
   /**
-   * @brief retrieve the number of mods
+   * @brief Retrieve the number of mods.
    *
-   * @return number of mods
-   **/
+   * @return the number of mods.
+   */
   static unsigned int getNumMods();
 
   /**
-   * @brief retrieve a ModInfo object based on its index
+   * @brief Retrieve a ModInfo object based on its index.
    *
-   * @param index the index to look up. the maximum is getNumMods() - 1
+   * @param index The index to look up. The maximum value is getNumMods() - 1.
+   *
    * @return a reference counting pointer to the mod info.
-   * @note since the pointer is reference counting, the pointer remains valid even if the collection is refreshed in a different thread
-   **/
+   *
+   * @note since the pointer is reference counting, the pointer remains valid even if the
+   *     collection is refreshed in a different thread.
+   */
   static ModInfo::Ptr getByIndex(unsigned int index);
 
   /**
-   * @brief retrieve a ModInfo object based on its nexus mod id
+   * @brief Retrieve ModInfo objects based on mod id.
    *
-   * @param modID the nexus mod id to look up
-   * @return a reference counting pointer to the mod info
-   * @todo in its current form, this function is broken! There may be multiple mods with the same nexus id,
-   *       this function will return only one of them
-   **/
+   * @param modID The mod id to look up.
+   *
+   * @return a vector of reference counting pointer to the mod info objects with the given mod ID.
+   */
   static std::vector<ModInfo::Ptr> getByModID(QString game, int modID);
 
   /**
-   * @brief retrieve a ModInfo object based on its name
+   * @brief Retrieve a ModInfo object based on its name.
    *
-   * @param name the name to look up
-   * @return a reference counting pointer to the mod info
-   * @note since the pointer is reference counter, the pointer remains valid even if the collection is refreshed in a different thread
-   **/
+   * @param name The name to look up.
+   *
+   * @return a reference counting pointer to the mod info.
+   *
+   * @note Since the pointer is reference counter, the pointer remains valid even if the
+   *     collection is refreshed in a different thread.
+   */
   static ModInfo::Ptr getByName(const QString &name);
 
   /**
-   * @brief remove a mod by index
+   * @brief Remove a mod by index.
    *
-   * this physically deletes the specified mod from the disc and updates the ModInfo collection
-   * but not other structures that reference mods
-   * @param index index of the mod to delete
-   * @return true if removal was successful, fals otherwise
-   **/
+   * This physically deletes the specified mod from the disc and updates the ModInfo collection
+   * but not other structures that reference mods.
+   *
+   * @param index Index of the mod to delete.
+   *
+   * @return true if removal was successful, false otherwise.
+   */
   static bool removeMod(unsigned int index);
 
   /**
-   * @brief retrieve the mod index by the mod name
+   * @brief Retrieve the mod index by the mod name.
    *
-   * @param name name of the mod to look up
-   * @return the index of the mod. If the mod doesn't exist, UINT_MAX is returned
-   **/
+   * @param name Name of the mod to look up.
+   *
+   * @return The index of the mod. If the mod doesn't exist, UINT_MAX is returned.
+   */
   static unsigned int getIndex(const QString &name);
 
   /**
-   * @brief find the first mod that fulfills the filter function (after no particular order)
-   * @param filter a function to filter by. should return true for a match
-   * @return index of the matching mod or UINT_MAX if there wasn't a match
+   * @brief Find the first mod that fulfills the filter function (after no particular order).
+   *
+   * @param filter A function to filter mods by. Should return true for a match.
+   *
+   * @return index of the matching mod or UINT_MAX if there was no match.
    */
   static unsigned int findMod(const boost::function<bool (ModInfo::Ptr)> &filter);
 
   /**
-   * @brief run a limited batch of mod update checks for "newest version" information
+   * @brief Run a limited batch of mod update checks for "newest version" information.
+   *
    */
-  static void manualUpdateCheck(PluginContainer *pluginContainer, QObject *receiver, std::multimap<QString, int> IDs);
+  static void manualUpdateCheck(
+    PluginContainer *pluginContainer, QObject *receiver, std::multimap<QString, int> IDs);
 
   /**
-   * @brief query nexus information for every mod and update the "newest version" information
-   * @return true if any mods are checked for update
-   **/
+   * @brief Query nexus information for every mod and update the "newest version" information.
+   *
+   * @return true if any mods are checked for update.
+   */
   static bool checkAllForUpdate(PluginContainer *pluginContainer, QObject *receiver);
 
-  static std::set<QSharedPointer<ModInfo>> filteredMods(QString gameName, QVariantList updateData, bool addOldMods = false, bool markUpdated = false);
+  /**
+   *
+   */
+  static std::set<ModInfo::Ptr> filteredMods(
+    QString gameName, QVariantList updateData, bool addOldMods = false, bool markUpdated = false);
 
   /**
-   * @brief create a new mod from the specified directory and add it to the collection
-   * @param dir directory to create from
-   * @return pointer to the info-structure of the newly created/added mod
+   * @brief Create a new mod from the specified directory and add it to the collection.
+   *
+   * @param dir Directory to create from.
+   *
+   * @return pointer to the info-structure of the newly created/added mod.
    */
-  static ModInfo::Ptr createFrom(PluginContainer *pluginContainer, const MOBase::IPluginGame *game, const QDir &dir, MOShared::DirectoryEntry **directoryStructure);
+  static ModInfo::Ptr createFrom(
+    PluginContainer *pluginContainer, const MOBase::IPluginGame *game,
+    const QDir &dir, MOShared::DirectoryEntry **directoryStructure);
 
   /**
-   * @brief create a new "foreign-managed" mod from a tuple of plugin and archives
-   * @param espName name of the plugin
-   * @param bsaNames names of archives
-   * @return a new mod
+   * @brief Create a new "foreign-managed" mod from a tuple of plugin and archives.
+   *
+   * @param espName Name of the plugin.
+   * @param bsaNames Names of archives.
+   *
+   * @return a new mod.
    */
-  static ModInfo::Ptr createFromPlugin(const QString &modName, const QString &espName, const QStringList &bsaNames, ModInfo::EModType modType, 
-    const MOBase::IPluginGame* game, MOShared::DirectoryEntry **directoryStructure, PluginContainer *pluginContainer);
+  static ModInfo::Ptr createFromPlugin(
+    const QString &modName, const QString &espName, const QStringList &bsaNames,
+    ModInfo::EModType modType, const MOBase::IPluginGame* game,
+    MOShared::DirectoryEntry **directoryStructure, PluginContainer *pluginContainer);
 
-  // whether the given name is used for separators
-  //
+  /**
+   * @brief Check wheter a name corresponds to a separator or not,
+   *
+   * @return whether the given name is used for separators.
+   */
   static bool isSeparatorName(const QString& name);
 
-  // whether the given name is used for backups
-  //
+  /**
+   * @brief Check wheter a name corresponds to a backup or not,
+   *
+   * @return whether the given name is used for backups.
+   */
   static bool isBackupName(const QString& name);
 
-  // whether the given name is used for regular mods
-  //
+  /**
+   * @brief Check wheter a name corresponds to a regular mod or not,
+   *
+   * @return whether the given name corresponds to a regular mod.
+   */
   static bool isRegularName(const QString& name);
 
-  virtual bool isRegular() const { return false; }
+public: // IModInterface implementations / Re-declaration
 
-  virtual bool isEmpty() const { return false; }
-
-  /**
-   * @brief test if there is a newer version of the mod
-   *
-   * test if there is a newer version of the mod. This does NOT cause
-   * information to be retrieved from the nexus, it will only test version information already
-   * available locally. Use checkAllForUpdate() to update this version information
-   *
-   * @return true if there is a newer version
-   **/
-  virtual bool updateAvailable() const = 0;
+  // Note: This section contains default-implementation for some of the virtual methods from
+  // IModInterface, but also redeclaration of all the pure-virtual methods to centralize all
+  // of them in a single place.
 
   /**
-   * @return true if the update currently available is ignored
+   * @return the name of the mod.
    */
-  virtual bool updateIgnored() const = 0;
-
-  /**
-   * @brief test if the "newest" version of the mod is older than the installed version
-   *
-   * test if there is a newer version of the mod. This does NOT cause
-   * information to be retrieved from the nexus, it will only test version information already
-   * available locally. Use checkAllForUpdate() to update this version information
-   *
-   * @return true if the newest version is older than the installed one
-   **/
-  virtual bool downgradeAvailable() const = 0;
-
-  /**
-   * @brief request an update of nexus description for this mod.
-   *
-   * This requests mod information from the nexus. This is an asynchronous request,
-   * so there is no immediate effect of this call.
-   * Right now, Mod Organizer interprets the "newest version" and "description" from the
-   * response, though the description is only stored in memory
-   *
-   **/
-  virtual bool updateNXMInfo() = 0;
-
-  /**
-   * @brief assign or unassign the specified category
-   *
-   * Every mod can have an arbitrary number of categories assigned to it
-   *
-   * @param categoryID id of the category to set
-   * @param active determines wheter the category is assigned or unassigned
-   * @note this function does not test whether categoryID actually identifies a valid category
-   **/
-  virtual void setCategory(int categoryID, bool active) = 0;
-
-  /**
-   * @brief changes the comments (manually set information displayed in the mod list) for this mod
-   * @param comments new comments
-   */
-  virtual void setComments(const QString &comments) = 0;
-
-  /**
-   * @brief change the notes (manually set information) for this mod
-   * @param notes new notes
-   */
-  virtual void setNotes(const QString &notes) = 0;
-
-  /**
-   * @brief set/change the source game of this mod
-   *
-   * @param gameName the source game shortName
-   */
-  virtual void setGameName(const QString& gameName) = 0;
-
-  /**
-   * @brief set the name of this mod
-   *
-   * set the name of this mod. This will also update the name of the
-   * directory that contains this mod
-   *
-   * @param name new name of the mod
-   * @return true on success, false if the new name can't be used (i.e. because the new
-   *         directory name wouldn't be valid)
-   **/
-  virtual bool setName(const QString& name) = 0;
-
-  /**
-   * @brief set/change the nexus mod id of this mod
-   *
-   * @param modID the nexus mod id
-   **/
-  virtual void setNexusID(int modID) = 0;
-
-  /**
-   * @brief set/change the version of this mod
-   * @param version new version of the mod
-   */
-  virtual void setVersion(const MOBase::VersionInfo &version) override;
-
-  /**
-  * @brief Controls if mod should be highlighted based on plugin selection
-  * @param isSelected whether or not the plugin has a selected mod
-  **/
-  virtual void setPluginSelected(const bool &isSelected);
-
-  /**
-   * @brief set the newest version of this mod on the nexus
-   *
-   * this can be used to overwrite the version of a mod without actually
-   * updating the mod
-   *
-   * @param version the new version to use
-   * @todo this function should be made obsolete. All queries for mod information should go through
-   *       this class so no public function for this change is required
-   **/
-  virtual void setNewestVersion(const MOBase::VersionInfo &version) = 0;
-
-  /**
-   * @brief sets the repository that was used to download the mod
-   */
-  virtual void setRepository(const QString &) {}
-
-  /**
-   * @brief changes/updates the nexus description text
-   * @param description the current description text
-   */
-  virtual void setNexusDescription(const QString &description) = 0;
-
-  /**
-   * @brief sets the file this mod was installed from
-   * @param fileName name of the file
-   */
-  virtual void setInstallationFile(const QString &fileName) = 0;
-
-  /**
-   * @brief sets the category id from a nexus category id. Conversion to MO id happens internally
-   * @param categoryID the nexus category id
-   * @note if a mapping is not possible, the category is set to the default value
-   */
-  virtual void addNexusCategory(int categoryID) = 0;
-
-  virtual void addCategory(const QString &categoryName) override;
-  virtual bool removeCategory(const QString &categoryName) override;
-
-  virtual QStringList categories() const override;
-
-  /**
-   * update the endorsement state for the mod. This only changes the
-   * buffered state, it does not sync with Nexus
-   * @param endorsed the new endorsement state
-   */
-  virtual void setIsEndorsed(bool endorsed) = 0;
-
-  /**
-   * set the mod to "i don't intend to endorse". The mod will not show as unendorsed but can still be endorsed
-   */
-  virtual void setNeverEndorse() = 0;
-
-  /**
-   * update the tracked state for the mod.  This only changes the
-   * buffered state, it does not sync with Nexus
-   * @param tracked the new tracked state
-   */
-  virtual void setIsTracked(bool tracked) = 0;
-
-  /**
-   * @brief delete the mod from the disc. This does not update the global ModInfo structure or indices
-   * @return true if the mod was successfully removed
-   **/
-  virtual bool remove() = 0;
-
-  /**
-   * @brief endorse or un-endorse the mod. This will sync with nexus!
-   * @param doEndorse if true, the mod is endorsed, if false, it's un-endorsed.
-   * @note if doEndorse doesn't differ from the current value, nothing happens.
-   */
-  virtual void endorse(bool doEndorse) = 0;
-
-  /**
-   * @brief track or untrack the mod.  This will sync with nexus!
-   * @param doTrack if true, the mod is tracked, if false, it's untracked.
-   * @note if doTrack doesn't differ from the current value, nothing happens.
-   */
-  virtual void track(bool doTrack) = 0;
-
-  /**
-   * @brief clear all caches held for this mod
-   */
-  virtual void clearCaches() {}
-
-  /**
-   * @brief getter for the mod name
-   *
-   * @return the mod name
-   **/
   virtual QString name() const = 0;
 
   /**
-   * @brief getter for an internal name. This is usually the same as the regular name, but with special mod types it might be
-   *        this is used to distinguish between mods that have the same visible name
-   * @return internal mod name
+   * @return the absolute path to the mod to be used in file system operations.
    */
-  virtual QString internalName() const { return name(); }
-
-  /**
-   * @brief getter for the mod path
-   *
-   * @return the (absolute) path to the mod
-   **/
   virtual QString absolutePath() const = 0;
 
   /**
-   * @return version object for machine based comparisons
-   **/
-  virtual MOBase::VersionInfo version() const { return m_Version; }
+   * @return the comments for this mod, if any.
+   */
+  virtual QString comments() const = 0;
 
   /**
-   * @return the repository from which the file was downloaded. Only relevant regular mods
+   * @return the notes for this mod, if any.
+   */
+  virtual QString notes() const = 0;
+
+  /**
+   * @brief Retrieve the short name of the game associated with this mod. This may differ
+   *     from the current game plugin (e.g. you can install a Skyrim LE game in a SSE
+   *     installation).
+   *
+   * @return the name of the game associated with this mod.
+   */
+  virtual QString gameName() const = 0;
+
+  /**
+   * @return the name of the repository from which this mod was installed.
    */
   virtual QString repository() const override { return ""; }
 
   /**
-   * @brief ignore the newest version for updates
+   * @return the ID of this mod on the repository.
+   *
+   * @note For Nexus, this is the Nexus ID of the mod.
+   */
+  virtual int modId() const = 0;
+
+  /**
+   * @return the current version of this mod.
+   */
+  virtual MOBase::VersionInfo version() const override { return m_Version; }
+
+  /**
+   * @return the newest version of thid mod (as known by MO2). If this matches version(),
+   *     then the mod is up-to-date.
+   */
+  virtual MOBase::VersionInfo newestVersion() const = 0;
+
+  /**
+   * @return the ignored version of this mod (for update), or an invalid version if the user
+   *     did not ignore version for this mod.
+   */
+  virtual MOBase::VersionInfo ignoredVersion() const = 0;
+
+  /**
+   * @return the absolute path to the file that was used to install this mod.
+   */
+  virtual QString installationFile() const = 0;
+
+  virtual std::set<std::pair<int, int>> installedFiles() const = 0;
+
+  /**
+   * @return true if this mod was marked as converted by the user.
+   *
+   * @note When a mod is for a different game, a flag is shown to users to warn them, but
+   *     they can mark mods as converted to remove this flag.
+   */
+  virtual bool converted() const = 0;
+
+  /**
+   * @return true if th is mod was marked as containing valid game data.
+   *
+   * @note MO2 uses ModDataChecker to check the content of mods, but sometimes these fail, in
+   *     which case mods are incorrectly marked as 'not containing valid games data'. Users can
+   *     choose to mark these mods as valid to hide the warning / flag.
+   */
+  virtual bool validated() const = 0;
+
+  /**
+   * @return the color of the 'Notes' column chosen by the user.
+   */
+  virtual QColor color() const override { return QColor(); }
+
+  /**
+   * @return the URL of this mod, or an empty QString() if no URL is associated
+   *     with this mod.
+   */
+  virtual QString url() const override { return ""; }
+
+  /**
+   * @return the ID of the primary category of this mod.
+   */
+  int primaryCategory() const override { return m_PrimaryCategory; }
+
+  /**
+   * @return the list of categories this mod belongs to.
+   */
+  virtual QStringList categories() const override;
+
+  /**
+   * @return the tracked state of this mod.
+   */
+  virtual MOBase::TrackedState trackedState() const override { return MOBase::TrackedState::TRACKED_FALSE; }
+
+  /**
+   * @return the endorsement state of this mod.
+   */
+  virtual MOBase::EndorsedState endorsedState() const override { return MOBase::EndorsedState::ENDORSED_NEVER; }
+
+public: // Mutable operations:
+
+  /**
+   * @brief Sets or changes the version of this mod.
+   *
+   * @param version New version of the mod.
+   */
+  virtual void setVersion(const MOBase::VersionInfo& version) override;
+
+  /**
+   * @brief Sets the installation file for this mod.
+   *
+   * @param fileName archive file name.
+   */
+  virtual void setInstallationFile(const QString& fileName) = 0;
+
+  /**
+   * @brief Sets or changes the latest known version of this mod.
+   *
+   * @param version Newest known version of the mod.
+   */
+  virtual void setNewestVersion(const MOBase::VersionInfo& version) = 0;
+
+  /**
+   * @brief Sets endorsement state of the mod.
+   *
+   * @param endorsed New endorsement state.
+   */
+  virtual void setIsEndorsed(bool endorsed) = 0;
+
+  /**
+   * @brief Sets the mod id on nexus for this mod.
+   *
+   * @param nexusID The new Nexus id to set.
+   */
+  virtual void setNexusID(int nexusID) = 0;
+
+  /**
+   * @brief Sets the category id from a nexus category id. Conversion to MO id happens
+   *     internally.
+   *
+   * @param categoryID The nexus category id.
+   *
+   * @note If a mapping is not possible, the category is set to the default value.
+   */
+  virtual void addNexusCategory(int categoryID) = 0;
+
+  /**
+   * @brief Assigns a category to the mod. If the named category does not exist it is created.
+   *
+   * @param categoryName Name of the new category.
+   */
+  virtual void addCategory(const QString& categoryName) override;
+
+  /**
+   * @brief Unassigns a category from this mod.
+   *
+   * @param categoryName Name of the category to be removed.
+   *
+   * @return true if the category was removed successfully, false if no such category
+   *    was assigned.
+   */
+  virtual bool removeCategory(const QString& categoryName) override;
+
+  /**
+   * @brief Sets or changes the source game of this mod.
+   *
+   * @param gameName The source game short name.
+   */
+  virtual void setGameName(const QString& gameName) = 0;
+
+  /**
+   * @brief Sets the name of this mod.
+   *
+   * This will also update the name of the directory that contains this mod.
+   *
+   * @param name New name of the mod.
+   *
+   * @return true on success, false if the new name can't be used (i.e. because the new
+   *     directory name wouldn't be valid).
+   */
+  virtual bool setName(const QString& name) = 0;
+
+  /**
+   * @brief Deletes the mod from the disc. This does not update the global ModInfo structure or
+   *     indices.
+   *
+   * @return true on success, false otherwise.
+   */
+  virtual bool remove() = 0;
+
+public: // Methods after this do not come from IModInterface:
+
+  /**
+   * @return true if this mod is a regular mod, false otherwise.
+   */
+  virtual bool isRegular() const { return false; }
+
+  /**
+   * @return true if this mod is empty, false otherwise.
+   */
+  virtual bool isEmpty() const { return false; }
+
+  /**
+   * @brief Check if there is a newer version of the mod.
+   *
+   * Check if there is a newer version of the mod. This does NOT cause information
+   * to be retrieved from the nexus, it will only test version information already
+   * available locally. Use checkAllForUpdate() to update this version information.
+   *
+   * @return true if there is a newer version, false otherwise.
+   */
+  virtual bool updateAvailable() const = 0;
+
+  /**
+   * @return true if the update currently available is ignored.
+   */
+  virtual bool updateIgnored() const = 0;
+
+  /**
+   * @brief Check if the "newest" version of the mod is older than the installed version.
+   *
+   * Check if there is a newer version of the mod. This does NOT cause information to be
+   * retrieved from the nexus, it will only test version information already available
+   * locally. Use checkAllForUpdate() to update this version information.
+   *
+   * @return true if the newest version is older than the installed one.
+   */
+  virtual bool downgradeAvailable() const = 0;
+
+  /**
+   * @brief Request an update of nexus description for this mod.
+   *
+   * This requests mod information from the nexus. This is an asynchronous request,
+   * so there is no immediate effect of this call. Right now, Mod Organizer interprets the
+   * "newest version" and "description" from the response, though the description is only
+   * stored in memory.
+   *
+   */
+  virtual bool updateNXMInfo() = 0;
+
+  /**
+   * @brief Assigns or unassigns the specified category/
+   *
+   * Every mod can have an arbitrary number of categories assigned to it.
+   *
+   * @param categoryID ID of the category to set.
+   * @param active Determines whether the category is assigned or unassigned.
+   *
+   * @note This function does not test whether categoryID actually identifies a valid category.
+   */
+  virtual void setCategory(int categoryID, bool active) = 0;
+
+  /**
+   * @brief Changes the comments (manually set information displayed in the mod list) for this mod.
+   *
+   * @param comments The new comments.
+   */
+  virtual void setComments(const QString &comments) = 0;
+
+  /**
+   * @brief Change the notes (manually set information) for this mod.
+   *
+   * @param notes The new notes.
+   */
+  virtual void setNotes(const QString &notes) = 0;
+
+  /**
+  * @brief Controls if mod should be highlighted based on plugin selection.
+  *
+  * @param isSelected Whether or not the plugin has a selected mod.
+  */
+  virtual void setPluginSelected(const bool &isSelected);
+
+  /**
+   * @brief Sets the repository that was used to download the mod.
+   */
+  virtual void setRepository(const QString &) {}
+
+  /**
+   * @brief Set the mod to "I do not intend to endorse.". The mod will not show as unendorsed
+   *     but can still be endorsed.
+   */
+  virtual void setNeverEndorse() = 0;
+
+  /**
+   * @brief Updates the tracked state for the mod. This only changes the buffered state,
+   *     it does not sync with Nexus.
+   *
+   * @param tracked The new tracked state.
+   *
+   * @see track(bool)
+   */
+  virtual void setIsTracked(bool tracked) = 0;
+
+  /**
+   * @brief Endorses or un-endorses the mod. This will sync with nexus!
+   *
+   * @param doEndorse If true, the mod is endorsed, if false, it's un-endorsed.
+   *
+   * @note If doEndorse does not differ from the current value, nothing happens.
+   */
+  virtual void endorse(bool doEndorse) = 0;
+
+  /**
+   * @brief Tracks or untracks the mod.  This will sync with nexus!
+   *
+   * @param doTrack If true, the mod is tracked, if false, it's untracked.
+   *
+   * @note If doTrack does not differ from the current value, nothing happens.
+   */
+  virtual void track(bool doTrack) = 0;
+
+  /**
+   * @brief Clear all caches held for this mod.
+   */
+  virtual void clearCaches() {}
+
+  /**
+   * @brief Retrieve the internal name of the mod. This is usually the same as the regular name,
+   *     but with special mod types it might be used to distinguish between mods that have the same
+   *     visible name.
+   *
+   * @return the internal mod name.
+   */
+  virtual QString internalName() const { return name(); }
+
+  /**
+   * @brief Ignores the newest version for updates.
    */
   virtual void ignoreUpdate(bool ignore) = 0;
 
   /**
    * @return the fixed priority of mods of this type or INT_MIN if the priority of mods
-   *         needs to be user-modifiable. Can be < 0 to force a priority below user-modifable mods
-   *         or INT_MAX to force priority above all user-modifiables
+   *     needs to be user-modifiable. Can be < 0 to force a priority below user-modifable mods
+   *     or INT_MAX to force priority above all user-modifiables.
    */
   virtual int getFixedPriority() const = 0;
 
   /**
-   * @return true if the mod is always enabled
+   * @return true if the mod is always enabled.
    */
   virtual bool alwaysEnabled() const { return false; }
 
   /**
-   * @return true if the mod can be updated
+   * @return true if the mod can be updated.
    */
   virtual bool canBeUpdated() const { return false; }
 
   /**
-   * @return the mod update check expiration date
+   * @return the mod update check expiration date.
    */
   virtual QDateTime getExpires() const = 0;
 
   /**
-   * @return true if the mod can be enabled/disabled
+   * @return true if the mod can be enabled/disabled.
    */
   virtual bool canBeEnabled() const { return false; }
 
   /**
-   * @return a list of flags for this mod
+   * @return a list of flags for this mod.
    */
   virtual std::vector<EFlag> getFlags() const = 0;
 
   /**
-   * @return a list of conflict flags for this mod
+   * @return a list of conflict flags for this mod.
    */
   virtual std::vector<EConflictFlag> getConflictFlags() const = 0;
 
   /**
-   * @return a list of content types contained in a mod
+   * @return a list of content types contained in a mod.
+   *
+   * @note The IDs of the content are game-dependent. See the ModDataContent game feature
+   *     for more details on this.
    */
   virtual const std::set<int>& getContents() const = 0;
 
   /**
-   * @brief test if the specified flag is set for this mod
-   * @param flag the flag to test
-   * @return true if the flag is set, false otherwise
+   * @brief Check if the specified flag is set for this mod.
+   *
+   * @param flag The flag to test.
+   *
+   * @return true if the flag is set, false otherwise.
    */
   bool hasFlag(EFlag flag) const;
 
   /**
-   * @brief test if any of the provided flags are set for this mod
-   * @param flags the flags to test
-   * @return true if any of the flags are set, false otherwise
+   * @brief Check if any of the provided flags are set for this mod.
+   *
+   * @param flags The flags to test.
+   *
+   * @return true if any of the flags are set, false otherwise.
    */
   bool hasAnyOfTheseFlags(std::vector<ModInfo::EFlag> flags) const;
 
   /**
-   * @brief Test if the mod contains the specified content.
+   * @brief Check if this mod contains the specified content.
    *
    * @param content ID of the content to test.
    *
@@ -507,222 +675,232 @@ public:
   virtual bool hasContent(int content) const = 0;
 
   /**
-   * @return an indicator if and how this mod should be highlighted by the UI
+   * @return an indicator if and how this mod should be highlighted in the UI.
    */
   virtual int getHighlight() const { return HIGHLIGHT_NONE; }
 
   /**
-   * @return list of names of ini tweaks
-   **/
+   * @return the list of INI tweaks in this mod.
+   */
   virtual std::vector<QString> getIniTweaks() const = 0;
 
   /**
-   * @return a description about the mod, to be displayed in the ui
+   * @return the description of the mod, to display in the UI.
    */
   virtual QString getDescription() const = 0;
 
   /**
-   * @return the nexus file status (aka category ID)
-   */
-  virtual int getNexusFileStatus() const = 0;
-
-
-  /**
-   * @brief sets the file status (category ID) from Nexus
-   * @param status the status id of the installed file
-   */
-  virtual void setNexusFileStatus(int status) = 0;
-
-  /**
-   * @return creation time of this mod
+   * @return the creation time of this mod.
    */
   virtual QDateTime creationTime() const = 0;
 
   /**
-   * @return nexus description of the mod (html)
-   */
-  virtual QString getNexusDescription() const = 0;
-
-  /**
-   * @brief get the last time nexus was checked for file updates on this mod
-   */
-  virtual QDateTime getLastNexusUpdate() const = 0;
-
-  /**
-   * @brief set the last time nexus was checked for file updates on this mod
-   */
-  virtual void setLastNexusUpdate(QDateTime time) = 0;
-
-  /**
-   * @return last time nexus was queried for infos on this mod
-   */
-  virtual QDateTime getLastNexusQuery() const = 0;
-
-  /**
-   * @brief set the last time nexus was queried for info on this mod
-   */
-  virtual void setLastNexusQuery(QDateTime time) = 0;
-
-  /**
-   * @return last time the mod was updated on Nexus
-   */
-  virtual QDateTime getNexusLastModified() const = 0;
-
-  /**
-   * @brief set the last time the mod was updated on Nexus
-   */
-  virtual void setNexusLastModified(QDateTime time) = 0;
-
-  /**
-   * @return a list of files that, if they exist in the data directory are treated as files in THIS mod
+   * @return the list of files that, if they exist in the data directory are treated as files in
+   *     THIS mod.
    */
   virtual QStringList stealFiles() const { return QStringList(); }
 
   /**
-   * @return a list of archives belonging to this mod (as absolute file paths)
+   * @return the list of archives belonging to this mod (as absolute file paths).
    */
   virtual QStringList archives(bool checkOnDisk = false) = 0;
 
   /**
-   * @return the color choosen by the user for the mod/separator
+   * @brief Set the color of this mod for display.
+   *
+   * @param color New color of this mod.
+   *
+   * @note Currently, this changes the color of the cell under the "Notes" column.
    */
-  virtual QColor color() const override { return QColor(); }
+  virtual void setColor(QColor color) { }
 
   /**
-   * 
-   */
-  virtual void setColor(QColor) { }
-
-  /**
-   * @brief adds the information that a file has been installed into this mod
-   * @param modId id of the mod installed
-   * @param fileId id of the file installed
+   * @brief Adds the information that a file has been installed into this mod.
+   *
+   * @param modId ID of the mod installed.
+   * @param fileId ID of the file installed.
    */
   virtual void addInstalledFile(int modId, int fileId) = 0;
 
   /**
-   * @brief test if the mod belongs to the specified category
+   * @brief Check if the mod belongs to the specified category.
    *
-   * @param categoryID the category to test for.
-   * @return true if the mod belongs to the specified category
-   * @note this does not verify the id actually identifies a category
-   **/
+   * @param categoryID ID of the category to test for.
+   *
+   * @return true if the mod belongs to the specified category.
+   *
+   * @note This does not verify the id actually identifies a category.
+   */
   bool categorySet(int categoryID) const;
 
   /**
-   * @brief retrive the whole list of categories (as ids) this mod belongs to
+   * @brief Retrieves the whole list of categories (as ids) this mod belongs to.
    *
-   * @return list of categories
-   **/
+   * @return the IDs of categories this mod belongs to.
+   */
   const std::set<int> &getCategories() const { return m_Categories; }
 
   /**
-   * @return id of the primary category of this mod
-   */
-  int primaryCategory() const override { return m_PrimaryCategory; }
-
-  /**
-   * @brief sets the new primary category of the mod
-   * @param categoryID the category to set
+   * @brief Sets the new primary category of the mod.
+   *
+   * @param categoryID ID of the primary category to set.
    */
   virtual void setPrimaryCategory(int categoryID) { m_PrimaryCategory = categoryID; }
 
   /**
-   * @return true if this mod is considered "valid", that is: it contains data used by the game
-   **/
+   * @return true if this mod is considered "valid", that is it contains data used by the game.
+   */
   virtual bool isValid() const = 0;
 
   /**
-   * @return true if the file has been endorsed on nexus
-   */
-  virtual MOBase::EndorsedState endorsedState() const override { return MOBase::EndorsedState::ENDORSED_NEVER; }
-
-  /**
-   * @return true if the file is being tracked on nexus
-   */
-  virtual MOBase::TrackedState trackedState() const override { return MOBase::TrackedState::TRACKED_FALSE; }
-
-  /**
-   * @brief updates the mod to flag it as converted in order to ignore the alternate game warning
+   * @brief Updates the mod to flag it as converted in order to ignore the alternate game
+   *     warning.
    */
   virtual void markConverted(bool) {}
 
   /**
-  * @brief updates the mod to flag it as valid in order to ignore the invalid game data flag
+  * @brief Updates the mod to flag it as valid in order to ignore the invalid game data
+  *     flag.
   */
   virtual void markValidated(bool) {}
 
   /**
-   * @brief reads meta information from disk
+   * @brief Reads meta information from disk.
    */
   virtual void readMeta() {}
 
   /**
-   * @brief stores meta information back to disk
+   * @brief Stores meta information back to disk.
    */
   virtual void saveMeta() {}
 
   /**
-   * @return retrieve list of mods (as mod index) that are overwritten by this one. Updates may be delayed
+   * @brief Sets whether this mod uses a custom url.
    */
-  virtual std::set<unsigned int> getModOverwrite() const { return std::set<unsigned int>(); }
-
-  /**
-   * @return list of mods (as mod index) that overwrite this one. Updates may be delayed
-   */
-  virtual std::set<unsigned int> getModOverwritten() const { return std::set<unsigned int>(); }
-
-  /**
-   * @return retrieve list of mods (as mod index) with archives that are overwritten by this one. Updates may be delayed
-  */
-  virtual std::set<unsigned int> getModArchiveOverwrite() const { return std::set<unsigned int>(); }
-
-  /**
-  * @return list of mods (as mod index) with archives that overwrite this one. Updates may be delayed
-  */
-  virtual std::set<unsigned int> getModArchiveOverwritten() const { return std::set<unsigned int>(); }
-
-  /**
-  * @return retrieve list of mods (as mod index) with archives that are overwritten by thos mod's loose files. Updates may be delayed
-  */
-  virtual std::set<unsigned int> getModArchiveLooseOverwrite() const { return std::set<unsigned int>(); }
-
-  /**
-  * @return list of mods (as mod index) with loose files that overwrite this one's archive files. Updates may be delayed
-  */
-  virtual std::set<unsigned int> getModArchiveLooseOverwritten() const { return std::set<unsigned int>(); }
-
-  /**
-   * @brief update conflict information
-   */
-  virtual void doConflictCheck() const {}
-
-  /**
-   * @brief sets whether this mod uses a custom url
-   **/
   virtual void setHasCustomURL(bool) {}
 
   /**
-   * @brief returns whether this mod uses a custom url
-   **/
+   * @brief Check whether this mod uses a custom url.
+   *
+   * @return true if this mod has a custom URL, false otherwise.
+   */
   virtual bool hasCustomURL() const { return false; }
 
   /**
-   * @brief sets the custom url
-   **/
-  virtual void setCustomURL(QString const &) {}
-
-  /**
-   * @brief returns the custom url
-   **/
-  virtual QString url() const override { return ""; }
+   * @brief Sets the custom url.
+   */
+  virtual void setCustomURL(QString const&) {}
 
   /**
    * If hasCustomURL() is true and getCustomURL() is not empty, tries to parse
    * the url using QUrl::fromUserInput() and returns it. Otherwise, returns an
    * empty QUrl.
-   **/
+   */
   QUrl parseCustomURL() const;
+
+public: // Nexus stuff
+
+  /**
+   * @brief Changes the nexus description text.
+   *
+   * @param description The current description text.
+   */
+  virtual void setNexusDescription(const QString& description) = 0;
+
+  /**
+   * @return the nexus file status (aka category ID).
+   */
+  virtual int getNexusFileStatus() const = 0;
+
+  /**
+   * @brief Sets the file status (category ID) from Nexus.
+   *
+   * @param status The status id of the installed file.
+   */
+  virtual void setNexusFileStatus(int status) = 0;
+
+  /**
+   * @return the nexus description of the mod (html).
+   */
+  virtual QString getNexusDescription() const = 0;
+
+  /**
+   * @brief Get the last time nexus was checked for file updates on this mod.
+   */
+  virtual QDateTime getLastNexusUpdate() const = 0;
+
+  /**
+   * @brief Sets the last time nexus was checked for file updates on this mod.
+   */
+  virtual void setLastNexusUpdate(QDateTime time) = 0;
+
+  /**
+   * @return the last time nexus was queried for infos on this mod.
+   */
+  virtual QDateTime getLastNexusQuery() const = 0;
+
+  /**
+   * @brief Sets the last time nexus was queried for info on this mod.
+   */
+  virtual void setLastNexusQuery(QDateTime time) = 0;
+
+  /**
+   * @return the last time the mod was updated on Nexus.
+   */
+  virtual QDateTime getNexusLastModified() const = 0;
+
+  /**
+   * @brief Set the last time the mod was updated on Nexus.
+   */
+  virtual void setNexusLastModified(QDateTime time) = 0;
+
+public: // Conflicts
+
+  /**
+   * @return retrieve list of mods (as mod index) that are overwritten by this one.
+   *    Updates may be delayed.
+   */
+  virtual std::set<unsigned int> getModOverwrite() const {
+    return std::set<unsigned int>(); }
+
+  /**
+   * @return list of mods (as mod index) that overwrite this one. Updates may be delayed.
+   */
+  virtual std::set<unsigned int> getModOverwritten() const {
+    return std::set<unsigned int>(); }
+
+  /**
+   * @return retrieve list of mods (as mod index) with archives that are overwritten by
+   *     this one. Updates may be delayed
+   */
+  virtual std::set<unsigned int> getModArchiveOverwrite() const {
+    return std::set<unsigned int>(); }
+
+  /**
+   * @return list of mods (as mod index) with archives that overwrite this one. Updates
+   *     may be delayed.
+   */
+  virtual std::set<unsigned int> getModArchiveOverwritten() const {
+    return std::set<unsigned int>(); }
+
+  /**
+   * @return the list of mods (as mod index) with archives that are overwritten by loose
+   *     files of this mod. Updates may be delayed.
+   */
+  virtual std::set<unsigned int> getModArchiveLooseOverwrite() const {
+    return std::set<unsigned int>(); }
+
+  /**
+   * @return the list of mods (as mod index) with loose files that overwrite this one's
+   *     archive files. Updates may be delayed.
+   */
+  virtual std::set<unsigned int> getModArchiveLooseOverwritten() const {
+    return std::set<unsigned int>(); }
+
+  /**
+   * @brief Update conflict information.
+   */
+  virtual void doConflictCheck() const {}
 
 public slots:
 
@@ -734,10 +912,10 @@ public slots:
 signals:
 
   /**
-   * @brief emitted whenever the information of a mod changes
+   * @brief Emitted whenever the information of a mod changes.
    *
-   * @param success true if the mod details were updated successfully, false if not
-   **/
+   * @param success true if the mod details were updated successfully, false if not.
+   */
   void modDetailsUpdated(bool success);
 
 protected:
@@ -759,12 +937,6 @@ protected:
   static void updateIndices();
   static bool ByName(const ModInfo::Ptr &LHS, const ModInfo::Ptr &RHS);
 
-private:
-
-  static void createFromOverwrite(PluginContainer *pluginContainer,
-                                  const MOBase::IPluginGame* game,
-                                  MOShared::DirectoryEntry **directoryStructure);
-
 protected:
 
   static std::vector<ModInfo::Ptr> s_Collection;
@@ -776,6 +948,12 @@ protected:
   MOBase::VersionInfo m_Version;
 
   bool m_PluginSelected = false;
+
+private:
+
+  static void createFromOverwrite(PluginContainer* pluginContainer,
+    const MOBase::IPluginGame* game,
+    MOShared::DirectoryEntry** directoryStructure);
 
 private:
 

--- a/src/modinfo.h
+++ b/src/modinfo.h
@@ -292,11 +292,9 @@ public: // IModInterface implementations / Re-declaration
   virtual QString repository() const override { return ""; }
 
   /**
-   * @return the ID of this mod on the repository.
-   *
-   * @note For Nexus, this is the Nexus ID of the mod.
+   * @return the nexus ID of this mod on the repository.
    */
-  virtual int modId() const = 0;
+  virtual int nexusId() const = 0;
 
   /**
    * @return the current version of this mod.

--- a/src/modinfodialogcategories.cpp
+++ b/src/modinfodialogcategories.cpp
@@ -79,7 +79,7 @@ void CategoriesTab::updatePrimary()
 {
   ui->primaryCategories->clear();
 
-  int primaryCategory = mod().getPrimaryCategory();
+  int primaryCategory = mod().primaryCategory();
 
   addChecked(ui->categories->invisibleRootItem());
 

--- a/src/modinfodialognexus.cpp
+++ b/src/modinfodialognexus.cpp
@@ -68,9 +68,9 @@ void NexusTab::update()
 
   clear();
 
-  ui->modID->setText(QString("%1").arg(mod().getNexusID()));
+  ui->modID->setText(QString("%1").arg(mod().modId()));
 
-  QString gameName = mod().getGameName();
+  QString gameName = mod().gameName();
   ui->sourceGame->addItem(
     core().managedGame()->gameName(),
     core().managedGame()->gameShortName());
@@ -98,10 +98,10 @@ void NexusTab::update()
     [&](const QUrl& url){ shell::Open(url); });
 
   ui->endorse->setEnabled(
-    (mod().endorsedState() == ModInfo::ENDORSED_FALSE) ||
-    (mod().endorsedState() == ModInfo::ENDORSED_NEVER));
+    (mod().endorsedState() == EndorsedState::ENDORSED_FALSE) ||
+    (mod().endorsedState() == EndorsedState::ENDORSED_NEVER));
 
-  setHasData(mod().getNexusID() >= 0);
+  setHasData(mod().modId() >= 0);
 }
 
 void NexusTab::firstActivation()
@@ -126,10 +126,10 @@ bool NexusTab::usesOriginFiles() const
 
 void NexusTab::updateVersionColor()
 {
-  if (mod().getVersion() != mod().getNewestVersion()) {
+  if (mod().version() != mod().newestVersion()) {
     ui->version->setStyleSheet("color: red");
     ui->version->setToolTip(tr("Current Version: %1").arg(
-      mod().getNewestVersion().canonicalString()));
+      mod().newestVersion().canonicalString()));
   } else {
     ui->version->setStyleSheet("color: green");
     ui->version->setToolTip(tr("No update available"));
@@ -138,11 +138,11 @@ void NexusTab::updateVersionColor()
 
 void NexusTab::updateWebpage()
 {
-  const int modID = mod().getNexusID();
+  const int modID = mod().modId();
 
   if (isValidModID(modID)) {
     const QString nexusLink = NexusInterface::instance(&plugin())
-      ->getModURL(modID, mod().getGameName());
+      ->getModURL(modID, mod().gameName());
 
     ui->visitNexus->setToolTip(nexusLink);
     refreshData(modID);
@@ -150,9 +150,9 @@ void NexusTab::updateWebpage()
     onModChanged();
   }
 
-  ui->version->setText(mod().getVersion().displayString());
+  ui->version->setText(mod().version().displayString());
   ui->hasCustomURL->setChecked(mod().hasCustomURL());
-  ui->customURL->setText(mod().getCustomURL());
+  ui->customURL->setText(mod().url());
   ui->customURL->setEnabled(mod().hasCustomURL());
   ui->visitCustomURL->setEnabled(mod().hasCustomURL());
   ui->visitCustomURL->setToolTip(mod().parseCustomURL().toString());
@@ -162,7 +162,7 @@ void NexusTab::updateWebpage()
 
 void NexusTab::updateTracking()
 {
-  if (mod().trackedState() == ModInfo::TRACKED_TRUE) {
+  if (mod().trackedState() == TrackedState::TRACKED_TRUE) {
     ui->track->setChecked(true);
     ui->track->setText(tr("Tracked"));
   } else {
@@ -301,7 +301,7 @@ void NexusTab::onModIDChanged()
     return;
   }
 
-  const int oldID = mod().getNexusID();
+  const int oldID = mod().modId();
   const int newID = ui->modID->text().toInt();
 
   if (oldID != newID){
@@ -326,7 +326,7 @@ void NexusTab::onSourceGameChanged()
     if (game->gameName() == ui->sourceGame->currentText()) {
       mod().setGameName(game->gameShortName()); 
       mod().setLastNexusQuery(QDateTime::fromSecsSinceEpoch(0));
-      refreshData(mod().getNexusID());
+      refreshData(mod().modId());
       return;
     }
   }
@@ -345,7 +345,7 @@ void NexusTab::onVersionChanged()
 
 void NexusTab::onRefreshBrowser()
 {
-  const auto modID = mod().getNexusID();
+  const auto modID = mod().modId();
 
   if (isValidModID(modID)) {
     mod().setLastNexusQuery(QDateTime::fromSecsSinceEpoch(0));
@@ -357,11 +357,11 @@ void NexusTab::onRefreshBrowser()
 
 void NexusTab::onVisitNexus()
 {
-  const int modID = mod().getNexusID();
+  const int modID = mod().modId();
 
   if (isValidModID(modID)) {
     const QString nexusLink = NexusInterface::instance(&plugin())
-      ->getModURL(modID, mod().getGameName());
+      ->getModURL(modID, mod().gameName());
 
     shell::Open(QUrl(nexusLink));
   }
@@ -379,7 +379,7 @@ void NexusTab::onTrack()
   // use modPtr() instead of mod() or this because the callback may be
   // executed after the dialog is closed
   core().loggedInAction(parentWidget(), [m=modPtr()] {
-    if (m->trackedState() == ModInfo::TRACKED_TRUE) {
+    if (m->trackedState() == TrackedState::TRACKED_TRUE) {
       m->track(false);
     } else {
       m->track(true);

--- a/src/modinfodialognexus.cpp
+++ b/src/modinfodialognexus.cpp
@@ -68,7 +68,7 @@ void NexusTab::update()
 
   clear();
 
-  ui->modID->setText(QString("%1").arg(mod().modId()));
+  ui->modID->setText(QString("%1").arg(mod().nexusId()));
 
   QString gameName = mod().gameName();
   ui->sourceGame->addItem(
@@ -101,7 +101,7 @@ void NexusTab::update()
     (mod().endorsedState() == EndorsedState::ENDORSED_FALSE) ||
     (mod().endorsedState() == EndorsedState::ENDORSED_NEVER));
 
-  setHasData(mod().modId() >= 0);
+  setHasData(mod().nexusId() >= 0);
 }
 
 void NexusTab::firstActivation()
@@ -138,7 +138,7 @@ void NexusTab::updateVersionColor()
 
 void NexusTab::updateWebpage()
 {
-  const int modID = mod().modId();
+  const int modID = mod().nexusId();
 
   if (isValidModID(modID)) {
     const QString nexusLink = NexusInterface::instance(&plugin())
@@ -301,7 +301,7 @@ void NexusTab::onModIDChanged()
     return;
   }
 
-  const int oldID = mod().modId();
+  const int oldID = mod().nexusId();
   const int newID = ui->modID->text().toInt();
 
   if (oldID != newID){
@@ -326,7 +326,7 @@ void NexusTab::onSourceGameChanged()
     if (game->gameName() == ui->sourceGame->currentText()) {
       mod().setGameName(game->gameShortName()); 
       mod().setLastNexusQuery(QDateTime::fromSecsSinceEpoch(0));
-      refreshData(mod().modId());
+      refreshData(mod().nexusId());
       return;
     }
   }
@@ -345,7 +345,7 @@ void NexusTab::onVersionChanged()
 
 void NexusTab::onRefreshBrowser()
 {
-  const auto modID = mod().modId();
+  const auto modID = mod().nexusId();
 
   if (isValidModID(modID)) {
     mod().setLastNexusQuery(QDateTime::fromSecsSinceEpoch(0));
@@ -357,7 +357,7 @@ void NexusTab::onRefreshBrowser()
 
 void NexusTab::onVisitNexus()
 {
-  const int modID = mod().modId();
+  const int modID = mod().nexusId();
 
   if (isValidModID(modID)) {
     const QString nexusLink = NexusInterface::instance(&plugin())

--- a/src/modinfodialogtab.cpp
+++ b/src/modinfodialogtab.cpp
@@ -163,7 +163,7 @@ void NotesTab::updateCommentsColor(bool clear)
   QPalette commentPalette = QPalette();
   
   if (!clear) {
-    auto modColor = mod().getColor();
+    auto modColor = mod().color();
     if (modColor.isValid()) {
       commentPalette.setColor(QPalette::Base, modColor);
       commentPalette.setColor(QPalette::Text, ColorSettings::idealTextColor(modColor));
@@ -219,7 +219,7 @@ void NotesTab::onSetColor()
   QColorDialog dialog(m_parent);
   dialog.setOption(QColorDialog::ShowAlphaChannel);
 
-  QColor currentColor = mod().getColor();
+  QColor currentColor = mod().color();
   
   if (currentColor.isValid()) {
     dialog.setCurrentColor(currentColor);
@@ -256,5 +256,5 @@ void NotesTab::checkHasData()
   setHasData(
     !ui->comments->text().isEmpty() ||
     !ui->notes->toPlainText().isEmpty() ||
-    mod().getColor().isValid());
+    mod().color().isValid());
 }

--- a/src/modinfoforeign.h
+++ b/src/modinfoforeign.h
@@ -42,10 +42,11 @@ public:
   virtual QString notes() const override { return ""; }
   virtual QDateTime creationTime() const override;
   virtual QString absolutePath() const override;
-  virtual MOBase::VersionInfo getNewestVersion() const override { return QString(); }
-  virtual QString getInstallationFile() const override { return ""; }
-  virtual QString getGameName() const override { return ""; }
-  virtual int getNexusID() const override { return -1; }
+  virtual MOBase::VersionInfo newestVersion() const override { return QString(); }
+  virtual MOBase::VersionInfo ignoredVersion() const override { return QString(); }
+  virtual QString installationFile() const override { return ""; }
+  virtual QString gameName() const override { return ""; }
+  virtual int modId() const override { return -1; }
   virtual QDateTime getExpires() const override { return QDateTime(); }
   virtual std::vector<QString> getIniTweaks() const override { return std::vector<QString>(); }
   virtual std::vector<ModInfo::EFlag> getFlags() const override;
@@ -65,6 +66,7 @@ public:
   virtual QStringList stealFiles() const override { return m_Archives + QStringList(m_ReferenceFile); }
   virtual bool alwaysEnabled() const override { return true; }
   virtual void addInstalledFile(int, int) override {}
+  virtual std::set<std::pair<int, int>> installedFiles() const override { return {}; }
 
   ModInfo::EModType modType() const { return m_ModType; }
 

--- a/src/modinfoforeign.h
+++ b/src/modinfoforeign.h
@@ -48,7 +48,7 @@ public:
   virtual bool converted() const override { return false; }
   virtual bool validated() const override { return false; }
   virtual QString gameName() const override { return ""; }
-  virtual int modId() const override { return -1; }
+  virtual int nexusId() const override { return -1; }
   virtual QDateTime getExpires() const override { return QDateTime(); }
   virtual std::vector<QString> getIniTweaks() const override { return std::vector<QString>(); }
   virtual std::vector<ModInfo::EFlag> getFlags() const override;

--- a/src/modinfoforeign.h
+++ b/src/modinfoforeign.h
@@ -45,6 +45,8 @@ public:
   virtual MOBase::VersionInfo newestVersion() const override { return QString(); }
   virtual MOBase::VersionInfo ignoredVersion() const override { return QString(); }
   virtual QString installationFile() const override { return ""; }
+  virtual bool converted() const override { return false; }
+  virtual bool validated() const override { return false; }
   virtual QString gameName() const override { return ""; }
   virtual int modId() const override { return -1; }
   virtual QDateTime getExpires() const override { return QDateTime(); }

--- a/src/modinfooverwrite.h
+++ b/src/modinfooverwrite.h
@@ -51,7 +51,7 @@ public:
   virtual bool validated() const override { return false; }
   virtual int getFixedPriority() const override { return std::numeric_limits<int>::max(); }
   virtual QString gameName() const override { return ""; }
-  virtual int modId() const override { return -1; }
+  virtual int nexusId() const override { return -1; }
   virtual QDateTime getExpires() const override { return QDateTime(); }
   virtual std::vector<QString> getIniTweaks() const override { return std::vector<QString>(); }
   virtual std::vector<ModInfo::EFlag> getFlags() const override;

--- a/src/modinfooverwrite.h
+++ b/src/modinfooverwrite.h
@@ -44,11 +44,12 @@ public:
   virtual QString notes() const override { return ""; }
   virtual QDateTime creationTime() const override { return QDateTime(); }
   virtual QString absolutePath() const override;
-  virtual MOBase::VersionInfo getNewestVersion() const override { return QString(); }
-  virtual QString getInstallationFile() const override { return ""; }
+  virtual MOBase::VersionInfo newestVersion() const override { return QString(); }
+  virtual MOBase::VersionInfo ignoredVersion() const override { return QString(); }
+  virtual QString installationFile() const override { return ""; }
   virtual int getFixedPriority() const override { return std::numeric_limits<int>::max(); }
-  virtual QString getGameName() const override { return ""; }
-  virtual int getNexusID() const override { return -1; }
+  virtual QString gameName() const override { return ""; }
+  virtual int modId() const override { return -1; }
   virtual QDateTime getExpires() const override { return QDateTime(); }
   virtual std::vector<QString> getIniTweaks() const override { return std::vector<QString>(); }
   virtual std::vector<ModInfo::EFlag> getFlags() const override;
@@ -66,6 +67,7 @@ public:
   virtual QString getNexusDescription() const override { return QString(); }
   virtual QStringList archives(bool checkOnDisk = false) override;
   virtual void addInstalledFile(int, int) override {}
+  virtual std::set<std::pair<int, int>> installedFiles() const override { return {}; }
 
 private:
   ModInfoOverwrite(PluginContainer *pluginContainer, const MOBase::IPluginGame* game, MOShared::DirectoryEntry **directoryStructure);

--- a/src/modinfooverwrite.h
+++ b/src/modinfooverwrite.h
@@ -47,6 +47,8 @@ public:
   virtual MOBase::VersionInfo newestVersion() const override { return QString(); }
   virtual MOBase::VersionInfo ignoredVersion() const override { return QString(); }
   virtual QString installationFile() const override { return ""; }
+  virtual bool converted() const override { return false; }
+  virtual bool validated() const override { return false; }
   virtual int getFixedPriority() const override { return std::numeric_limits<int>::max(); }
   virtual QString gameName() const override { return ""; }
   virtual int modId() const override { return -1; }

--- a/src/modinforegular.cpp
+++ b/src/modinforegular.cpp
@@ -570,14 +570,14 @@ bool ModInfoRegular::remove()
 void ModInfoRegular::endorse(bool doEndorse)
 {
   if (doEndorse != (m_EndorsedState == EndorsedState::ENDORSED_TRUE)) {
-    m_NexusBridge.requestToggleEndorsement(m_GameName, modId(), m_Version.canonicalString(), doEndorse, QVariant(1));
+    m_NexusBridge.requestToggleEndorsement(m_GameName, nexusId(), m_Version.canonicalString(), doEndorse, QVariant(1));
   }
 }
 
 void ModInfoRegular::track(bool doTrack)
 {
   if (doTrack != (m_TrackedState == TrackedState::TRACKED_TRUE)) {
-    m_NexusBridge.requestToggleTracking(m_GameName, modId(), doTrack, QVariant(1));
+    m_NexusBridge.requestToggleTracking(m_GameName, nexusId(), doTrack, QVariant(1));
   }
 }
 

--- a/src/modinforegular.h
+++ b/src/modinforegular.h
@@ -397,6 +397,8 @@ public:
 
   virtual QString gameName() const override { return m_GameName; }
   virtual QString installationFile() const override { return m_InstallationFile; }
+  virtual bool converted() const override { return m_Converted; }
+  virtual bool validated() const override { return m_Validated; }
   virtual std::set<std::pair<int, int>> installedFiles() const override { return m_InstalledFileIDs; }
 
 private:

--- a/src/modinforegular.h
+++ b/src/modinforegular.h
@@ -254,7 +254,7 @@ public:
    *
    * @return the nexus mod id. may be 0 if the mod id isn't known or doesn't exist
    **/
-  int modId() const override { return m_NexusID; }
+  int nexusId() const override { return m_NexusID; }
 
   /**
    * @return the fixed priority of mods of this type or INT_MIN if the priority of mods

--- a/src/modinforegular.h
+++ b/src/modinforegular.h
@@ -235,7 +235,14 @@ public:
    *
    * @return newest version of the mod
    **/
-  MOBase::VersionInfo getNewestVersion() const override { return m_NewestVersion; }
+  MOBase::VersionInfo newestVersion() const override { return m_NewestVersion; }
+
+  /**
+   * @brief getter for the newest version number of this mod
+   *
+   * @return newest version of the mod
+   **/
+  MOBase::VersionInfo ignoredVersion() const override { return m_IgnoredVersion; }
 
   /**
    * @brief ignore the newest version for updates
@@ -243,25 +250,11 @@ public:
   void ignoreUpdate(bool ignore) override;
 
   /**
-   * @brief getter for the installation file
-   *
-   * @return file used to install this mod from
-   */
-  virtual QString getInstallationFile() const override { return m_InstallationFile; }
-
-  /**
-   * @brief getter for the source game repository
-   *
-   * @return the source game repository. should default to the active game.
-   **/
-  QString getGameName() const override { return m_GameName; }
-
-  /**
    * @brief getter for the nexus mod id
    *
    * @return the nexus mod id. may be 0 if the mod id isn't known or doesn't exist
    **/
-  int getNexusID() const override { return m_NexusID; }
+  int modId() const override { return m_NexusID; }
 
   /**
    * @return the fixed priority of mods of this type or INT_MIN if the priority of mods
@@ -345,12 +338,12 @@ public:
   /**
    * @return true if the file has been endorsed on nexus
    */
-  virtual EEndorsedState endorsedState() const override;
+  virtual MOBase::EndorsedState endorsedState() const override;
 
   /**
    * @return true if the file is being tracked on nexus
    */
-  virtual ETrackedState trackedState() const override;
+  virtual MOBase::TrackedState trackedState() const override;
 
   /**
    * @brief get the last time nexus was checked for file updates on this mod
@@ -386,7 +379,7 @@ public:
 
   virtual void setColor(QColor color) override;
 
-  virtual QColor getColor() const override;
+  virtual QColor color() const override;
 
   virtual void addInstalledFile(int modId, int fileId) override;
 
@@ -400,12 +393,16 @@ public:
   virtual void setHasCustomURL(bool b) override;
   virtual bool hasCustomURL() const override;
   virtual void setCustomURL(QString const &) override;
-  virtual QString getCustomURL() const override;
+  virtual QString url() const override;
+
+  virtual QString gameName() const override { return m_GameName; }
+  virtual QString installationFile() const override { return m_InstallationFile; }
+  virtual std::set<std::pair<int, int>> installedFiles() const override { return m_InstalledFileIDs; }
 
 private:
 
-  void setEndorsedState(EEndorsedState endorsedState);
-  void setTrackedState(ETrackedState trackedState);
+  void setEndorsedState(MOBase::EndorsedState endorsedState);
+  void setTrackedState(MOBase::TrackedState trackedState);
 
 private slots:
 
@@ -457,8 +454,8 @@ private:
   MOBase::VersionInfo m_NewestVersion;
   MOBase::VersionInfo m_IgnoredVersion;
 
-  EEndorsedState m_EndorsedState;
-  ETrackedState m_TrackedState;
+  MOBase::EndorsedState m_EndorsedState;
+  MOBase::TrackedState m_TrackedState;
 
   NexusBridge m_NexusBridge;
 

--- a/src/modinfoseparator.h
+++ b/src/modinfoseparator.h
@@ -20,7 +20,7 @@ public:
   //TODO: Fix renaming method to avoid priority reset
   virtual bool setName(const QString& name);
 
-  virtual int modId() const override { return -1; }
+  virtual int nexusId() const override { return -1; }
   virtual void setGameName(const QString& gameName) override {}
   virtual void setNexusID(int /*modID*/) override {}
   virtual void endorse(bool /*doEndorse*/) override {}

--- a/src/modinfoseparator.h
+++ b/src/modinfoseparator.h
@@ -20,7 +20,7 @@ public:
   //TODO: Fix renaming method to avoid priority reset
   virtual bool setName(const QString& name);
 
-  virtual int getNexusID() const override { return -1; }
+  virtual int modId() const override { return -1; }
   virtual void setGameName(const QString& gameName) override {}
   virtual void setNexusID(int /*modID*/) override {}
   virtual void endorse(bool /*doEndorse*/) override {}
@@ -33,8 +33,8 @@ public:
   virtual int getHighlight() const override;
   virtual QString getDescription() const override;
   virtual QString name() const override;
-  virtual QString getGameName() const override { return ""; }
-  virtual QString getInstallationFile() const override { return ""; }
+  virtual QString gameName() const override { return ""; }
+  virtual QString installationFile() const override { return ""; }
   virtual QString repository() const override { return ""; }
   virtual int getNexusFileStatus() const override { return 0; }
   virtual void setNexusFileStatus(int) override {}

--- a/src/modinfowithconflictinfo.cpp
+++ b/src/modinfowithconflictinfo.cpp
@@ -5,6 +5,7 @@
 #include "shared/fileentry.h"
 #include <filesystem>
 
+#include "iplugingame.h"
 #include "moddatachecker.h"
 #include "qdirfiletree.h"
 

--- a/src/modlist.cpp
+++ b/src/modlist.cpp
@@ -224,7 +224,7 @@ QVariant ModList::data(const QModelIndex &modelIndex, int role) const
       else
         return modInfo->name();
     } else if (column == COL_VERSION) {
-      VersionInfo verInfo = modInfo->getVersion();
+      VersionInfo verInfo = modInfo->version();
       QString version = verInfo.displayString();
       if (role != Qt::EditRole) {
         if (version.isEmpty() && modInfo->canBeUpdated()) {
@@ -240,7 +240,7 @@ QVariant ModList::data(const QModelIndex &modelIndex, int role) const
         return m_Profile->getModPriority(modIndex);
       }
     } else if (column == COL_MODID) {
-      int modID = modInfo->getNexusID();
+      int modID = modInfo->modId();
       if (modID > 0) {
         return modID;
       }
@@ -250,16 +250,16 @@ QVariant ModList::data(const QModelIndex &modelIndex, int role) const
     } else if (column == COL_GAME) {
       if (m_PluginContainer != nullptr) {
         for (auto game : m_PluginContainer->plugins<IPluginGame>()) {
-          if (game->gameShortName().compare(modInfo->getGameName(), Qt::CaseInsensitive) == 0)
+          if (game->gameShortName().compare(modInfo->gameName(), Qt::CaseInsensitive) == 0)
             return game->gameName();
         }
       }
-      return modInfo->getGameName();
+      return modInfo->gameName();
     } else if (column == COL_CATEGORY) {
       if (modInfo->hasFlag(ModInfo::FLAG_FOREIGN)) {
         return tr("Non-MO");
       } else {
-        int category = modInfo->getPrimaryCategory();
+        int category = modInfo->primaryCategory();
         if (category != -1) {
           CategoryFactory &categoryFactory = CategoryFactory::instance();
           if (categoryFactory.categoryExists(category)) {
@@ -333,7 +333,7 @@ QVariant ModList::data(const QModelIndex &modelIndex, int role) const
         return m_Profile->getModPriority(modIndex);
       }
     } else {
-      return modInfo->getNexusID();
+      return modInfo->modId();
     }
   } else if (role == Qt::UserRole + 1) {
     return modIndex;
@@ -348,7 +348,7 @@ QVariant ModList::data(const QModelIndex &modelIndex, int role) const
   } else if (role == Qt::UserRole + 3) {
     return contentsToIcons(modInfo->getContents());
   } else if (role == Qt::UserRole + 4) {
-    return modInfo->getGameName();
+    return modInfo->gameName();
   } else if (role == Qt::FontRole) {
     QFont result;
     auto flags = modInfo->getFlags();
@@ -379,14 +379,14 @@ QVariant ModList::data(const QModelIndex &modelIndex, int role) const
         return QIcon(":/MO/gui/update_available");
       } else if (modInfo->downgradeAvailable()) {
         return QIcon(":/MO/gui/warning");
-      } else if (modInfo->getVersion().scheme() == VersionInfo::SCHEME_DATE) {
+      } else if (modInfo->version().scheme() == VersionInfo::SCHEME_DATE) {
         return QIcon(":/MO/gui/version_date");
       }
     }
     return QVariant();
   } else if (role == Qt::ForegroundRole) {
-    if ((modInfo->hasFlag(ModInfo::FLAG_SEPARATOR) || (column == COL_NOTES)) && modInfo->getColor().isValid()) {
-      return ColorSettings::idealTextColor(modInfo->getColor());
+    if ((modInfo->hasFlag(ModInfo::FLAG_SEPARATOR) || (column == COL_NOTES)) && modInfo->color().isValid()) {
+      return ColorSettings::idealTextColor(modInfo->color());
     } else if (column == COL_NAME) {
       int highlight = modInfo->getHighlight();
       if (highlight & ModInfo::HIGHLIGHT_IMPORTANT)
@@ -394,7 +394,7 @@ QVariant ModList::data(const QModelIndex &modelIndex, int role) const
       else if (highlight & ModInfo::HIGHLIGHT_INVALID)
         return QBrush(Qt::darkGray);
     } else if (column == COL_VERSION) {
-      if (!modInfo->getNewestVersion().isValid()) {
+      if (!modInfo->newestVersion().isValid()) {
         return QVariant();
       } else if (modInfo->updateAvailable() || modInfo->downgradeAvailable()) {
         return QBrush(Qt::red);
@@ -411,8 +411,8 @@ QVariant ModList::data(const QModelIndex &modelIndex, int role) const
     bool overwritten = m_Overwritten.find(modIndex) != m_Overwritten.end();
     bool archiveOverwritten = m_ArchiveOverwritten.find(modIndex) != m_ArchiveOverwritten.end();
     bool archiveLooseOverwritten = m_ArchiveLooseOverwritten.find(modIndex) != m_ArchiveLooseOverwritten.end();
-    if (column == COL_NOTES && modInfo->getColor().isValid()) {
-      return modInfo->getColor();
+    if (column == COL_NOTES && modInfo->color().isValid()) {
+      return modInfo->color();
     } else if (modInfo->getHighlight() & ModInfo::HIGHLIGHT_PLUGIN) {
       return Settings::instance().colors().modlistContainsPlugin();
     } else if (overwritten || archiveLooseOverwritten) {
@@ -424,10 +424,10 @@ QVariant ModList::data(const QModelIndex &modelIndex, int role) const
     } else if (archiveOverwrite) {
       return Settings::instance().colors().modlistOverwrittenArchive();
     } else if (modInfo->hasFlag(ModInfo::FLAG_SEPARATOR)
-               && modInfo->getColor().isValid()
+               && modInfo->color().isValid()
                && ((role != ViewMarkingScrollBar::DEFAULT_ROLE)
                     || Settings::instance().colors().colorSeparatorScrollbar())) {
-      return modInfo->getColor();
+      return modInfo->color();
     } else {
       return QVariant();
     }
@@ -460,7 +460,7 @@ QVariant ModList::data(const QModelIndex &modelIndex, int role) const
         return QString();
       }
     } else if (column == COL_VERSION) {
-      QString text = tr("installed version: \"%1\", newest version: \"%2\"").arg(modInfo->getVersion().displayString(3)).arg(modInfo->getNewestVersion().displayString(3));
+      QString text = tr("installed version: \"%1\", newest version: \"%2\"").arg(modInfo->version().displayString(3)).arg(modInfo->newestVersion().displayString(3));
       if (modInfo->downgradeAvailable()) {
         text += "<br>" + tr("The newest version on Nexus seems to be older than the one you have installed. This could either mean the version you have has been withdrawn "
                           "(i.e. due to a bug) or the author uses a non-standard versioning scheme and that newest version is actually newer. "
@@ -471,7 +471,7 @@ QVariant ModList::data(const QModelIndex &modelIndex, int role) const
       } else if (modInfo->getNexusFileStatus() == 6) {
         text += "<br>" + tr("This file has been marked as \"Deleted\"! You may want to check for an update or remove the nexus ID from this mod!");
       }
-      if (modInfo->getNexusID() > 0) {
+      if (modInfo->modId() > 0) {
         if (!modInfo->canBeUpdated()) {
           qint64 remains = QDateTime::currentDateTimeUtc().secsTo(modInfo->getExpires());
           qint64 minutes = remains / 60;
@@ -611,7 +611,7 @@ bool ModList::setData(const QModelIndex &index, const QVariant &value, int role)
         }
       } break;
       case COL_VERSION: {
-        VersionInfo::VersionScheme scheme = info->getVersion().scheme();
+        VersionInfo::VersionScheme scheme = info->version().scheme();
         VersionInfo version(value.toString(), scheme, true);
         if (version.isValid()) {
           info->setVersion(version);
@@ -885,7 +885,7 @@ IModList::ModStates ModList::state(unsigned int modIndex) const
     if (modInfo->isEmpty()) {
       result |= IModList::STATE_EMPTY;
     }
-    if (modInfo->endorsedState() == ModInfo::ENDORSED_TRUE) {
+    if (modInfo->endorsedState() == EndorsedState::ENDORSED_TRUE) {
       result |= IModList::STATE_ENDORSED;
     }
     if (modInfo->isValid()) {
@@ -1181,7 +1181,7 @@ void ModList::removeRowForce(int row, const QModelIndex &parent)
   }
   auto flags = modInfo->getFlags();
   if (std::find(flags.begin(), flags.end(), ModInfo::FLAG_BACKUP) == flags.end()) {
-    emit modUninstalled(modInfo->getInstallationFile());
+    emit modUninstalled(modInfo->installationFile());
   }
 }
 

--- a/src/modlist.cpp
+++ b/src/modlist.cpp
@@ -240,7 +240,7 @@ QVariant ModList::data(const QModelIndex &modelIndex, int role) const
         return m_Profile->getModPriority(modIndex);
       }
     } else if (column == COL_MODID) {
-      int modID = modInfo->modId();
+      int modID = modInfo->nexusId();
       if (modID > 0) {
         return modID;
       }
@@ -333,7 +333,7 @@ QVariant ModList::data(const QModelIndex &modelIndex, int role) const
         return m_Profile->getModPriority(modIndex);
       }
     } else {
-      return modInfo->modId();
+      return modInfo->nexusId();
     }
   } else if (role == Qt::UserRole + 1) {
     return modIndex;
@@ -471,7 +471,7 @@ QVariant ModList::data(const QModelIndex &modelIndex, int role) const
       } else if (modInfo->getNexusFileStatus() == 6) {
         text += "<br>" + tr("This file has been marked as \"Deleted\"! You may want to check for an update or remove the nexus ID from this mod!");
       }
-      if (modInfo->modId() > 0) {
+      if (modInfo->nexusId() > 0) {
         if (!modInfo->canBeUpdated()) {
           qint64 remains = QDateTime::currentDateTimeUtc().secsTo(modInfo->getExpires());
           qint64 minutes = remains / 60;

--- a/src/modlistsortproxy.cpp
+++ b/src/modlistsortproxy.cpp
@@ -198,14 +198,14 @@ bool ModListSortProxy::lessThan(const QModelIndex &left,
         lt = comp < 0;
     } break;
     case ModList::COL_CATEGORY: {
-      if (leftMod->getPrimaryCategory() != rightMod->getPrimaryCategory()) {
-        if (leftMod->getPrimaryCategory() < 0) lt = false;
-        else if (rightMod->getPrimaryCategory() < 0) lt = true;
+      if (leftMod->primaryCategory() != rightMod->primaryCategory()) {
+        if (leftMod->primaryCategory() < 0) lt = false;
+        else if (rightMod->primaryCategory() < 0) lt = true;
         else {
           try {
             CategoryFactory &categories = CategoryFactory::instance();
-            QString leftCatName = categories.getCategoryName(categories.getCategoryIndex(leftMod->getPrimaryCategory()));
-            QString rightCatName = categories.getCategoryName(categories.getCategoryIndex(rightMod->getPrimaryCategory()));
+            QString leftCatName = categories.getCategoryName(categories.getCategoryIndex(leftMod->primaryCategory()));
+            QString rightCatName = categories.getCategoryName(categories.getCategoryIndex(rightMod->primaryCategory()));
             lt = leftCatName < rightCatName;
           } catch (const std::exception &e) {
             log::error("failed to compare categories: {}", e.what());
@@ -214,12 +214,12 @@ bool ModListSortProxy::lessThan(const QModelIndex &left,
       }
     } break;
     case ModList::COL_MODID: {
-      if (leftMod->getNexusID() != rightMod->getNexusID())
-        lt = leftMod->getNexusID() < rightMod->getNexusID();
+      if (leftMod->modId() != rightMod->modId())
+        lt = leftMod->modId() < rightMod->modId();
     } break;
     case ModList::COL_VERSION: {
-      if (leftMod->getVersion() != rightMod->getVersion())
-        lt = leftMod->getVersion() < rightMod->getVersion();
+      if (leftMod->version() != rightMod->version())
+        lt = leftMod->version() < rightMod->version();
     } break;
     case ModList::COL_INSTALLTIME: {
       QDateTime leftTime = left.data().toDateTime();
@@ -228,8 +228,8 @@ bool ModListSortProxy::lessThan(const QModelIndex &left,
         return leftTime < rightTime;
     } break;
     case ModList::COL_GAME: {
-      if (leftMod->getGameName() != rightMod->getGameName()) {
-        lt = leftMod->getGameName() < rightMod->getGameName();
+      if (leftMod->gameName() != rightMod->gameName()) {
+        lt = leftMod->gameName() < rightMod->gameName();
       }
       else {
         int comp = QString::compare(leftMod->name(), rightMod->name(), Qt::CaseInsensitive);
@@ -392,7 +392,7 @@ bool ModListSortProxy::categoryMatchesMod(
 
     case CategoryFactory::Endorsed:
     {
-      b = (info->endorsedState() == ModInfo::ENDORSED_TRUE);
+      b = (info->endorsedState() == EndorsedState::ENDORSED_TRUE);
       break;
     }
 
@@ -425,13 +425,13 @@ bool ModListSortProxy::categoryMatchesMod(
         return false;
       }
 
-      b = (info->getNexusID() > 0);
+      b = (info->modId() > 0);
       break;
     }
 
     case CategoryFactory::Tracked:
     {
-      b = (info->trackedState() == ModInfo::TRACKED_TRUE);
+      b = (info->trackedState() == TrackedState::TRACKED_TRUE);
       break;
     }
 
@@ -531,7 +531,7 @@ bool ModListSortProxy::filterMatchesMod(ModInfo::Ptr info, bool enabled) const
           bool ok;
           int filterID = currentKeyword.toInt(&ok);
           if (ok) {
-            int modID = info->getNexusID();
+            int modID = info->modId();
             while (modID > 0) {
               if (modID == filterID) {
                 foundKeyword = true;

--- a/src/modlistsortproxy.cpp
+++ b/src/modlistsortproxy.cpp
@@ -214,8 +214,8 @@ bool ModListSortProxy::lessThan(const QModelIndex &left,
       }
     } break;
     case ModList::COL_MODID: {
-      if (leftMod->modId() != rightMod->modId())
-        lt = leftMod->modId() < rightMod->modId();
+      if (leftMod->nexusId() != rightMod->nexusId())
+        lt = leftMod->nexusId() < rightMod->nexusId();
     } break;
     case ModList::COL_VERSION: {
       if (leftMod->version() != rightMod->version())
@@ -425,7 +425,7 @@ bool ModListSortProxy::categoryMatchesMod(
         return false;
       }
 
-      b = (info->modId() > 0);
+      b = (info->nexusId() > 0);
       break;
     }
 
@@ -531,7 +531,7 @@ bool ModListSortProxy::filterMatchesMod(ModInfo::Ptr info, bool enabled) const
           bool ok;
           int filterID = currentKeyword.toInt(&ok);
           if (ok) {
-            int modID = info->modId();
+            int modID = info->nexusId();
             while (modID > 0) {
               if (modID == filterID) {
                 foundKeyword = true;


### PR DESCRIPTION
Fixes point 1 of https://github.com/ModOrganizer2/modorganizer/issues/1139

Related `uibase` PR: https://github.com/ModOrganizer2/modorganizer-uibase/pull/83

There are lots of changes but nothing major:

- I renamed a lots of `getX` function to simply `x` to be consistent with other stuffs.
- I moved two `enum`s to `uibase` to be able to access them through `IModInterface`.
- I switch `getCustomUrl()` for `url()` since I don't think the `hasCustomUrl()` is relevant for plugins. Correct me if wrong.