### PR TITLE
Disable profile-specific game saves if not available from game plugin.

### DIFF
--- a/src/profilesdialog.cpp
+++ b/src/profilesdialog.cpp
@@ -29,6 +29,7 @@ along with Mod Organizer.  If not, see <http://www.gnu.org/licenses/>.
 #include "transfersavesdialog.h"
 #include "utility.h"
 #include "settings.h"
+#include "localsavegames.h"
 
 #include <QDir>
 #include <QDirIterator>
@@ -76,6 +77,11 @@ ProfilesDialog::ProfilesDialog(const QString &profileName, MOBase::IPluginGame c
   if (invalidation == nullptr) {
     ui->invalidationBox->setToolTip(tr("Archive invalidation isn't required for this game."));
     ui->invalidationBox->setEnabled(false);
+  }
+
+  if (!game->feature<LocalSavegames>()) {
+    ui->localSavesBox->setToolTip(tr("This game does not support profile-specific game saves."));
+    ui->localSavesBox->setEnabled(false);
   }
 }
 


### PR DESCRIPTION
Disables the *"Use profile-specific Save Games"* checkbox if the `LocalSavegames` feature is not present. The current way local saves is handled is by using a Bethesda-specific INI setting, which does not exist for other games.

This is mainly to avoid users trying local save games and not understanding why it does not work with most games.