### PR TITLE
Remove potential early return in forEachEntry()

### DIFF
--- a/src/envfs.cpp
+++ b/src/envfs.cpp
@@ -315,12 +315,6 @@ void forEachEntryImpl(
         break;
       }
     }
-    
-    // This might be returning early in some unknown cases! Testing
-    //if (AllocSize - iosb.Information > (ULONG)FIELD_OFFSET(FILE_DIRECTORY_INFORMATION, FileName[256])) {
-    //  // NO_MORE_FILES
-    //  break;
-    //}
   }
 }
 

--- a/src/envfs.cpp
+++ b/src/envfs.cpp
@@ -315,11 +315,12 @@ void forEachEntryImpl(
         break;
       }
     }
-
-    if (AllocSize - iosb.Information > (ULONG)FIELD_OFFSET(FILE_DIRECTORY_INFORMATION, FileName[256])) {
-      // NO_MORE_FILES
-      break;
-    }
+    
+    // This might be returning early in some unknown cases! Testing
+    //if (AllocSize - iosb.Information > (ULONG)FIELD_OFFSET(FILE_DIRECTORY_INFORMATION, FileName[256])) {
+    //  // NO_MORE_FILES
+    //  break;
+    //}
   }
 }
 


### PR DESCRIPTION
This caused the refresher to skip files inside mods due to breaking early. We only have one report of this but potentially it was a more widespread problem that people didn't notice about.

