### PR TITLE
Allow MO2 to find game saves into subdirectories / Hide 'Enable Mods... ' when SaveGameInfo does not exist.

### DIFF
--- a/src/mainwindow.cpp
+++ b/src/mainwindow.cpp
@@ -4973,25 +4973,25 @@ void MainWindow::fixMods_clicked(SaveGameInfo::MissingAssets const &missingAsset
 }
 
 
-void MainWindow::on_savegameList_customContextMenuRequested(const QPoint &pos)
+void MainWindow::on_savegameList_customContextMenuRequested(const QPoint& pos)
 {
-  QItemSelectionModel *selection = ui->savegameList->selectionModel();
+  QItemSelectionModel* selection = ui->savegameList->selectionModel();
 
   if (!selection->hasSelection()) {
     return;
   }
 
   QMenu menu;
-  QAction *action = menu.addAction(tr("Enable Mods..."));
-  action->setEnabled(false);
 
-  if (selection->selectedIndexes().count() == 1) {
-    SaveGameInfo const *info = this->m_OrganizerCore.managedGame()->feature<SaveGameInfo>();
-    if (info != nullptr) {
+  SaveGameInfo const* info = this->m_OrganizerCore.managedGame()->feature<SaveGameInfo>();
+  if (info != nullptr) {
+    QAction* action = menu.addAction(tr("Enable Mods..."));
+    action->setEnabled(false);
+    if (selection->selectedIndexes().count() == 1) {
       QString save = ui->savegameList->currentItem()->data(Qt::UserRole).toString();
       SaveGameInfo::MissingAssets missing = info->getMissingAssets(save);
       if (missing.size() != 0) {
-        connect(action, &QAction::triggered, this, [this, missing]{ fixMods_clicked(missing); });
+        connect(action, &QAction::triggered, this, [this, missing] { fixMods_clicked(missing); });
         action->setEnabled(true);
       }
     }

--- a/src/mainwindow.cpp
+++ b/src/mainwindow.cpp
@@ -1932,11 +1932,21 @@ void MainWindow::refreshSaveList()
 
   QDir savesDir = currentSavesDir();
   savesDir.setNameFilters(filters);
+  savesDir.setFilter(QDir::Files);
+  QDirIterator it(savesDir, QDirIterator::Subdirectories);
   log::debug("reading save games from {}", savesDir.absolutePath());
 
-  QFileInfoList files = savesDir.entryInfoList(QDir::Files, QDir::Time);
+  QFileInfoList files;
+  while (it.hasNext()) {
+    it.next();
+    files.append(it.fileInfo());
+  }
+  std::sort(files.begin(), files.end(), [](auto const& lhs, auto const& rhs) { 
+    return lhs.fileTime(QFileDevice::FileModificationTime) < rhs.fileTime(QFileDevice::FileModificationTime); 
+  });
+
   for (const QFileInfo &file : files) {
-    QListWidgetItem *item = new QListWidgetItem(file.fileName());
+    QListWidgetItem *item = new QListWidgetItem(savesDir.relativeFilePath(file.absoluteFilePath()));
     item->setData(Qt::UserRole, file.absoluteFilePath());
     ui->savegameList->addItem(item);
   }

--- a/src/transfersavesdialog.h
+++ b/src/transfersavesdialog.h
@@ -92,8 +92,9 @@ private:
                          QPushButton *move);
 
   bool transferCharacters(
-      QString const &character, char const *message, SaveList &saves,
-      QString const &dest,
+      QString const &character, char const *message,
+      QDir const& sourceDirectory, SaveList &saves,
+      QDir const& dest,
       const std::function<bool(const QString &, const QString &)> &method,
       char const *errmsg);
 };


### PR DESCRIPTION
Some games have saves in subfolder, e.g. Dungeon Siege II has saves in `SinglePlayer/$PCName/...`. This basically recurse in the save folder when needed. 

For display, I simply display the relative path to the save folder. 