### PR TITLE
Better display of MO2 plugins

### DIFF
--- a/src/plugincontainer.cpp
+++ b/src/plugincontainer.cpp
@@ -34,58 +34,22 @@ template <> struct PluginTypeName<MOBase::IPluginTool> { static QString value() 
 template <> struct PluginTypeName<MOBase::IPluginProxy> { static QString value() { return QT_TR_NOOP("Proxy"); } };
 template <> struct PluginTypeName<MOBase::IPluginFileMapper> { static QString value() { return QT_TR_NOOP("File Mapper"); } };
 
-QStringList PluginContainer::implementedInterfaces(IPlugin* plugin) const
+
+QStringList PluginContainer::pluginInterfaces()
 {
-  // We need a QObject to be able to qobject_cast<> to the plugin types:
-  QObject* oPlugin = as_qobject(plugin);
-
-  if (!oPlugin) {
-    return {};
-  }
-
   // Find all the names:
   QStringList names;
-  boost::mp11::mp_for_each<PluginTypeOrder>([oPlugin, &names](const auto *p) {
+  boost::mp11::mp_for_each<PluginTypeOrder>([&names](const auto* p) {
     using plugin_type = std::decay_t<decltype(*p)>;
-    if (qobject_cast<plugin_type*>(oPlugin)) {
-      auto name = PluginTypeName<plugin_type>::value();
-      if (!name.isEmpty()) {
-        names.append(name);
-      }
+    auto name = PluginTypeName<plugin_type>::value();
+    if (!name.isEmpty()) {
+      names.append(name);
     }
   });
-
-  // If the plugin implements at least one interface other than IPlugin, remove IPlugin:
-  if (names.size() > 1) {
-    names.removeAll(PluginTypeName<IPlugin>::value());
-  }
 
   return names;
 }
 
-QString PluginContainer::topImplementedInterface(IPlugin* plugin) const
-{
-  // We need a QObject to be able to qobject_cast<> to the plugin types:
-  QObject* oPlugin = as_qobject(plugin);
-
-  if (!oPlugin) {
-    return {};
-  }
-
-  // Find all the names:
-  QString name;
-  boost::mp11::mp_for_each<PluginTypeOrder>([oPlugin, &name](auto *p) {
-    using plugin_type = std::decay_t<decltype(*p)>;
-    if (name.isEmpty() && qobject_cast<plugin_type*>(oPlugin)) {
-      auto tname = PluginTypeName<plugin_type>::value();
-      if (!tname.isEmpty()) {
-        name = tname;
-      }
-    }
-  });
-
-  return name;
-}
 
 PluginContainer::PluginContainer(OrganizerCore *organizer)
   : m_Organizer(organizer)
@@ -116,6 +80,61 @@ void PluginContainer::setUserInterface(IUserInterface *userInterface, QWidget *w
   }
 
   m_UserInterface = userInterface;
+}
+
+
+QStringList PluginContainer::implementedInterfaces(IPlugin* plugin) const
+{
+  // We need a QObject to be able to qobject_cast<> to the plugin types:
+  QObject* oPlugin = as_qobject(plugin);
+
+  if (!oPlugin) {
+    return {};
+  }
+
+  // Find all the names:
+  QStringList names;
+  boost::mp11::mp_for_each<PluginTypeOrder>([oPlugin, &names](const auto* p) {
+    using plugin_type = std::decay_t<decltype(*p)>;
+    if (qobject_cast<plugin_type*>(oPlugin)) {
+      auto name = PluginTypeName<plugin_type>::value();
+      if (!name.isEmpty()) {
+        names.append(name);
+      }
+    }
+    });
+
+  // If the plugin implements at least one interface other than IPlugin, remove IPlugin:
+  if (names.size() > 1) {
+    names.removeAll(PluginTypeName<IPlugin>::value());
+  }
+
+  return names;
+}
+
+
+QString PluginContainer::topImplementedInterface(IPlugin* plugin) const
+{
+  // We need a QObject to be able to qobject_cast<> to the plugin types:
+  QObject* oPlugin = as_qobject(plugin);
+
+  if (!oPlugin) {
+    return {};
+  }
+
+  // Find all the names:
+  QString name;
+  boost::mp11::mp_for_each<PluginTypeOrder>([oPlugin, &name](auto* p) {
+    using plugin_type = std::decay_t<decltype(*p)>;
+    if (name.isEmpty() && qobject_cast<plugin_type*>(oPlugin)) {
+      auto tname = PluginTypeName<plugin_type>::value();
+      if (!tname.isEmpty()) {
+        name = tname;
+      }
+    }
+    });
+
+  return name;
 }
 
 

--- a/src/plugincontainer.cpp
+++ b/src/plugincontainer.cpp
@@ -24,57 +24,16 @@ namespace bf = boost::fusion;
 template <class T>
 struct PluginTypeName;
 
-template <> struct PluginTypeName<QObject> { static QString get() { return {}; } };
-template <> struct PluginTypeName<MOBase::IPlugin> { static QString get() { return QT_TR_NOOP("Plugin"); } };
-template <> struct PluginTypeName<MOBase::IPluginDiagnose> { static QString get() { return QT_TR_NOOP("Diagnose"); } };
-template <> struct PluginTypeName<MOBase::IPluginGame> { static QString get() { return QT_TR_NOOP("Game"); } };
-template <> struct PluginTypeName<MOBase::IPluginInstaller> { static QString get() { return QT_TR_NOOP("Installer"); } };
-template <> struct PluginTypeName<MOBase::IPluginModPage> { static QString get() { return QT_TR_NOOP("Mod Page"); } };
-template <> struct PluginTypeName<MOBase::IPluginPreview> { static QString get() { return QT_TR_NOOP("Preview"); } };
-template <> struct PluginTypeName<MOBase::IPluginTool> { static QString get() { return QT_TR_NOOP("Tool"); } };
-template <> struct PluginTypeName<MOBase::IPluginProxy> { static QString get() { return QT_TR_NOOP("Proxy"); } };
-template <> struct PluginTypeName<MOBase::IPluginFileMapper> { static QString get() { return QT_TR_NOOP("File Mapper"); } };
-
-template <class Reducer, template <class> class Mapper, class BfMap>
-struct plugin_map_iterate_impl;
-
-template <class Reducer, template <class> class Mapper>
-struct plugin_map_iterate_impl<Reducer, Mapper, bf::map<>>
-{
-  template <class U, class... Args>
-  static auto apply(Reducer const& r, U &&u, Args const&... args) {
-    return std::forward<U>(u);
-  }
-};
-
-template <
-  class Reducer,
-  template <class> class Mapper, 
-  class K, class V, class... Ps
->
-struct plugin_map_iterate_impl<Reducer, Mapper, bf::map<bf::pair<K, V>, Ps... >>
-{
-  template <class U, class... Args>
-  static auto apply(Reducer const& r, U&& u, Args const&... args) {
-    return plugin_map_iterate_impl<Reducer, Mapper, bf::map<Ps... >>::apply(r, r(Mapper<K>::get(args... ), u), args... );
-  }
-};
-
-template <template <class> class M, class B, class R, class U, class... Args>
-auto plugin_map_iterate(R const& r, U &&init, Args const&... args) {
-  return plugin_map_iterate_impl<R, M, B>::apply(r, std::forward<U>(init), args... );
-}
-
-template <class T>
-struct PluginTypeNameIf {
-  static QString get(QObject* plugin) {
-    if (qobject_cast<T*>(plugin)) {
-      return PluginTypeName<T>::get();
-    }
-    return {};
-  }
-};
-
+template <> struct PluginTypeName<QObject> { static QString value() { return {}; } };
+template <> struct PluginTypeName<MOBase::IPlugin> { static QString value() { return QT_TR_NOOP("Plugin"); } };
+template <> struct PluginTypeName<MOBase::IPluginDiagnose> { static QString value() { return QT_TR_NOOP("Diagnose"); } };
+template <> struct PluginTypeName<MOBase::IPluginGame> { static QString value() { return QT_TR_NOOP("Game"); } };
+template <> struct PluginTypeName<MOBase::IPluginInstaller> { static QString value() { return QT_TR_NOOP("Installer"); } };
+template <> struct PluginTypeName<MOBase::IPluginModPage> { static QString value() { return QT_TR_NOOP("Mod Page"); } };
+template <> struct PluginTypeName<MOBase::IPluginPreview> { static QString value() { return QT_TR_NOOP("Preview"); } };
+template <> struct PluginTypeName<MOBase::IPluginTool> { static QString value() { return QT_TR_NOOP("Tool"); } };
+template <> struct PluginTypeName<MOBase::IPluginProxy> { static QString value() { return QT_TR_NOOP("Proxy"); } };
+template <> struct PluginTypeName<MOBase::IPluginFileMapper> { static QString value() { return QT_TR_NOOP("File Mapper"); } };
 
 QStringList PluginContainer::implementedInterfaces(const IPlugin* plugin) const
 {
@@ -88,17 +47,22 @@ QStringList PluginContainer::implementedInterfaces(const IPlugin* plugin) const
     return {};
   }
 
+  // We need a QObject to be able to qobject_cast<> to the plugin types:
+  const QObject* oPlugin = *it;
+
   // Find all the names:
-  auto names = plugin_map_iterate<PluginTypeNameIf, PluginMap>([](QString name, QStringList value) {
-    if (name.isEmpty()) {
-      return value;
+  QStringList names;
+  bf::for_each(m_Plugins, [oPlugin, &names](auto const& p) {
+    using key_type = typename std::decay_t<decltype(p)>::first_type;
+    auto name = PluginTypeName<key_type>::value();
+    if (!name.isEmpty()) {
+      names.append(name);
     }
-    return value << name;
-  }, QStringList(), *it);
+  });
 
   // If the plugin implements at least one interface other than IPlugin, remove IPlugin:
   if (names.size() > 1) {
-    names.removeAll(PluginTypeName<IPlugin>::get());
+    names.removeAll(PluginTypeName<IPlugin>::value());
   }
 
   return names;

--- a/src/plugincontainer.h
+++ b/src/plugincontainer.h
@@ -72,26 +72,13 @@ private:
 public:
 
   /**
-   * @brief Retrieved the (localized) names of interfaces implemented by the given
-   *     plugin.
+   * @brief Retrieved the (localized) names of the various plugin interfaces.
    *
-   * @param plugin The plugin to retrieve interface for.
-   *
-   * @return the (localized) names of interfaces implemented by this plugin.
+   * @return the (localized) names of the various plugin interfaces.
    */
-  QStringList implementedInterfaces(MOBase::IPlugin *plugin) const;
+  static QStringList pluginInterfaces();
 
-  /**
-   * @brief Return the (localized) name of the most important interface implemented by
-   *     the given plugin.
-   *
-   * The order of interfaces is defined in X.
-   *
-   * @param plugin The plugin to retrieve the interface for.
-   *
-   * @return the (localized) name of the most important interface implemented by this plugin.
-   */
-  QString topImplementedInterface(MOBase::IPlugin* plugin) const;
+public:
 
   PluginContainer(OrganizerCore *organizer);
   virtual ~PluginContainer();
@@ -124,6 +111,28 @@ public:
     typename boost::fusion::result_of::at_key<const PluginMap, T>::type temp = boost::fusion::at_key<T>(m_Plugins);
     return temp;
   }
+
+  /**
+   * @brief Retrieved the (localized) names of interfaces implemented by the given
+   *     plugin.
+   *
+   * @param plugin The plugin to retrieve interface for.
+   *
+   * @return the (localized) names of interfaces implemented by this plugin.
+   */
+  QStringList implementedInterfaces(MOBase::IPlugin* plugin) const;
+
+  /**
+   * @brief Return the (localized) name of the most important interface implemented by
+   *     the given plugin.
+   *
+   * The order of interfaces is defined in X.
+   *
+   * @param plugin The plugin to retrieve the interface for.
+   *
+   * @return the (localized) name of the most important interface implemented by this plugin.
+   */
+  QString topImplementedInterface(MOBase::IPlugin* plugin) const;
 
   /**
    * @return the preview generator.

--- a/src/plugincontainer.h
+++ b/src/plugincontainer.h
@@ -48,6 +48,16 @@ private:
 
 public:
 
+  /**
+   * @brief Retrieved the (localized) names of interfaces implemented by the given
+   *     plugin.
+   *
+   * @param plugin The plugin to retrieve interface for.
+   *
+   * @return the (localized) names of interfaces implemented by this plugin.
+   */
+  QStringList implementedInterfaces(const MOBase::IPlugin *plugin) const;
+
   PluginContainer(OrganizerCore *organizer);
   virtual ~PluginContainer();
 
@@ -56,16 +66,38 @@ public:
   void loadPlugins();
   void unloadPlugins();
 
+  /**
+   * @brief Find the game plugin corresponding to the given name.
+   *
+   * @param name The name of the game to find a plugin for (as returned by
+   *     IPluginGame::gameName()).
+   *
+   * @return the game plugin for the given name, or a null pointer if no
+   *     plugin exists for this game.
+   */
   MOBase::IPluginGame *managedGame(const QString &name) const;
 
+  /**
+   * @brief Retrieve the list of plugins of the given type.
+   *
+   * @return the list of plugins of the specified type.
+   *
+   * @tparam T The type of plugin to retrieve.
+   */
   template <typename T>
   const std::vector<T*> &plugins() const {
     typename boost::fusion::result_of::at_key<const PluginMap, T>::type temp = boost::fusion::at_key<T>(m_Plugins);
     return temp;
   }
 
+  /**
+   * @return the preview generator.
+   */
   const PreviewGenerator &previewGenerator() const;
 
+  /**
+   * @return the list of plugin file names, including proxied plugins.
+   */
   QStringList pluginFileNames() const;
 
 public: // IPluginDiagnose interface

--- a/src/settingsdialog.cpp
+++ b/src/settingsdialog.cpp
@@ -43,7 +43,7 @@ SettingsDialog::SettingsDialog(PluginContainer *pluginContainer, Settings& setti
   m_tabs.push_back(std::unique_ptr<SettingsTab>(new DiagnosticsSettingsTab(settings, *this)));
   m_tabs.push_back(std::unique_ptr<SettingsTab>(new NexusSettingsTab(settings, *this)));
   m_tabs.push_back(std::unique_ptr<SettingsTab>(new SteamSettingsTab(settings, *this)));
-  m_tabs.push_back(std::unique_ptr<SettingsTab>(new PluginsSettingsTab(settings, *this)));
+  m_tabs.push_back(std::unique_ptr<SettingsTab>(new PluginsSettingsTab(settings, m_pluginContainer, *this)));
   m_tabs.push_back(std::unique_ptr<SettingsTab>(new WorkaroundsSettingsTab(settings, *this)));
 }
 

--- a/src/settingsdialog.ui
+++ b/src/settingsdialog.ui
@@ -17,7 +17,7 @@
    <item>
     <widget class="QTabWidget" name="tabWidget">
      <property name="currentIndex">
-      <number>4</number>
+      <number>0</number>
      </property>
      <widget class="QWidget" name="generalTab">
       <attribute name="title">
@@ -1047,7 +1047,7 @@
          <property name="handleWidth">
           <number>2</number>
          </property>
-         <widget class="QWidget" name="" native="true">
+         <widget class="QWidget" name="widget" native="true">
           <property name="sizePolicy">
            <sizepolicy hsizetype="Preferred" vsizetype="Preferred">
             <horstretch>0</horstretch>
@@ -1069,7 +1069,7 @@
              <property name="handleWidth">
               <number>2</number>
              </property>
-             <widget class="QWidget" name="" native="true">
+             <widget class="QWidget" name="widget" native="true">
               <layout class="QVBoxLayout" name="verticalLayout_15">
                <item>
                 <widget class="QTreeWidget" name="pluginsList">
@@ -1093,7 +1093,7 @@
                </item>
               </layout>
              </widget>
-             <widget class="QWidget" name="" native="true">
+             <widget class="QWidget" name="widget" native="true">
               <layout class="QVBoxLayout" name="verticalLayout_7" stretch="0,1">
                <item>
                 <layout class="QFormLayout" name="formLayout_2">

--- a/src/settingsdialog.ui
+++ b/src/settingsdialog.ui
@@ -17,7 +17,7 @@
    <item>
     <widget class="QTabWidget" name="tabWidget">
      <property name="currentIndex">
-      <number>0</number>
+      <number>4</number>
      </property>
      <widget class="QWidget" name="generalTab">
       <attribute name="title">
@@ -1042,16 +1042,18 @@
        <item>
         <layout class="QHBoxLayout" name="horizontalLayout_9">
          <item>
-          <widget class="QListWidget" name="pluginsList">
+          <widget class="QTreeWidget" name="pluginsList">
            <property name="sizePolicy">
             <sizepolicy hsizetype="Fixed" vsizetype="Expanding">
              <horstretch>0</horstretch>
              <verstretch>0</verstretch>
             </sizepolicy>
            </property>
-           <property name="sortingEnabled">
-            <bool>true</bool>
-           </property>
+           <column>
+            <property name="text">
+             <string notr="true">1</string>
+            </property>
+           </column>
           </widget>
          </item>
          <item>

--- a/src/settingsdialog.ui
+++ b/src/settingsdialog.ui
@@ -1042,19 +1042,28 @@
        <item>
         <layout class="QHBoxLayout" name="horizontalLayout_9">
          <item>
-          <widget class="QTreeWidget" name="pluginsList">
-           <property name="sizePolicy">
-            <sizepolicy hsizetype="Fixed" vsizetype="Expanding">
-             <horstretch>0</horstretch>
-             <verstretch>0</verstretch>
-            </sizepolicy>
-           </property>
-           <column>
-            <property name="text">
-             <string notr="true">1</string>
-            </property>
-           </column>
-          </widget>
+          <layout class="QVBoxLayout" name="verticalLayout_15">
+           <item>
+            <widget class="QTreeWidget" name="pluginsList">
+             <column>
+              <property name="text">
+               <string notr="true">1</string>
+              </property>
+             </column>
+            </widget>
+           </item>
+           <item>
+            <layout class="QHBoxLayout" name="horizontalLayout_4">
+             <item>
+              <widget class="QLineEdit" name="pluginFilterEdit">
+               <property name="placeholderText">
+                <string/>
+               </property>
+              </widget>
+             </item>
+            </layout>
+           </item>
+          </layout>
          </item>
          <item>
           <layout class="QVBoxLayout" name="verticalLayout_7" stretch="0,1">
@@ -1615,7 +1624,6 @@ programs you are intentionally running.</string>
   <tabstop>preferredServersList</tabstop>
   <tabstop>steamUserEdit</tabstop>
   <tabstop>steamPassEdit</tabstop>
-  <tabstop>pluginsList</tabstop>
   <tabstop>pluginSettingsList</tabstop>
   <tabstop>pluginBlacklist</tabstop>
   <tabstop>appIDEdit</tabstop>

--- a/src/settingsdialog.ui
+++ b/src/settingsdialog.ui
@@ -6,8 +6,8 @@
    <rect>
     <x>0</x>
     <y>0</y>
-    <width>586</width>
-    <height>491</height>
+    <width>820</width>
+    <height>652</height>
    </rect>
   </property>
   <property name="windowTitle">
@@ -1038,129 +1038,171 @@
       <attribute name="title">
        <string>Plugins</string>
       </attribute>
-      <layout class="QVBoxLayout" name="verticalLayout_9" stretch="0,0,0">
+      <layout class="QVBoxLayout" name="verticalLayout_9">
        <item>
-        <layout class="QHBoxLayout" name="horizontalLayout_9">
-         <item>
-          <layout class="QVBoxLayout" name="verticalLayout_15">
-           <item>
-            <widget class="QTreeWidget" name="pluginsList">
-             <column>
-              <property name="text">
-               <string notr="true">1</string>
-              </property>
-             </column>
-            </widget>
-           </item>
-           <item>
-            <layout class="QHBoxLayout" name="horizontalLayout_4">
-             <item>
-              <widget class="QLineEdit" name="pluginFilterEdit">
-               <property name="placeholderText">
-                <string/>
-               </property>
-              </widget>
-             </item>
-            </layout>
-           </item>
-          </layout>
-         </item>
-         <item>
-          <layout class="QVBoxLayout" name="verticalLayout_7" stretch="0,1">
-           <item>
-            <layout class="QFormLayout" name="formLayout_2">
-             <item row="0" column="0">
-              <widget class="QLabel" name="label_13">
-               <property name="text">
-                <string>Author:</string>
-               </property>
-              </widget>
-             </item>
-             <item row="0" column="1">
-              <widget class="QLabel" name="authorLabel">
-               <property name="text">
-                <string/>
-               </property>
-              </widget>
-             </item>
-             <item row="1" column="0">
-              <widget class="QLabel" name="label_15">
-               <property name="text">
-                <string>Version:</string>
-               </property>
-              </widget>
-             </item>
-             <item row="1" column="1">
-              <widget class="QLabel" name="versionLabel">
-               <property name="text">
-                <string/>
-               </property>
-              </widget>
-             </item>
-             <item row="2" column="0">
-              <widget class="QLabel" name="label_14">
-               <property name="text">
-                <string>Description:</string>
-               </property>
-              </widget>
-             </item>
-             <item row="2" column="1">
-              <widget class="QLabel" name="descriptionLabel">
-               <property name="text">
-                <string/>
-               </property>
-               <property name="wordWrap">
-                <bool>true</bool>
-               </property>
-              </widget>
-             </item>
-            </layout>
-           </item>
-           <item>
-            <widget class="QTreeWidget" name="pluginSettingsList">
-             <property name="indentation">
-              <number>0</number>
-             </property>
-             <property name="rootIsDecorated">
-              <bool>false</bool>
-             </property>
-             <property name="itemsExpandable">
-              <bool>false</bool>
-             </property>
-             <property name="expandsOnDoubleClick">
-              <bool>false</bool>
-             </property>
-             <attribute name="headerVisible">
-              <bool>false</bool>
-             </attribute>
-             <attribute name="headerDefaultSectionSize">
-              <number>170</number>
-             </attribute>
-             <column>
-              <property name="text">
-               <string>Key</string>
-              </property>
-             </column>
-             <column>
-              <property name="text">
-               <string>Value</string>
-              </property>
-             </column>
-            </widget>
-           </item>
-          </layout>
-         </item>
-        </layout>
-       </item>
-       <item>
-        <widget class="QLabel" name="label_18">
-         <property name="text">
-          <string>Blacklisted Plugins (use &lt;del&gt; to remove):</string>
+        <widget class="QSplitter" name="splitter">
+         <property name="orientation">
+          <enum>Qt::Vertical</enum>
          </property>
+         <property name="handleWidth">
+          <number>2</number>
+         </property>
+         <widget class="QWidget" name="" native="true">
+          <property name="sizePolicy">
+           <sizepolicy hsizetype="Preferred" vsizetype="Preferred">
+            <horstretch>0</horstretch>
+            <verstretch>4</verstretch>
+           </sizepolicy>
+          </property>
+          <layout class="QHBoxLayout" name="horizontalLayout_6">
+           <item>
+            <widget class="QSplitter" name="splitter_2">
+             <property name="sizePolicy">
+              <sizepolicy hsizetype="Expanding" vsizetype="Preferred">
+               <horstretch>0</horstretch>
+               <verstretch>0</verstretch>
+              </sizepolicy>
+             </property>
+             <property name="orientation">
+              <enum>Qt::Horizontal</enum>
+             </property>
+             <property name="handleWidth">
+              <number>2</number>
+             </property>
+             <widget class="QWidget" name="" native="true">
+              <layout class="QVBoxLayout" name="verticalLayout_15">
+               <item>
+                <widget class="QTreeWidget" name="pluginsList">
+                 <column>
+                  <property name="text">
+                   <string notr="true">1</string>
+                  </property>
+                 </column>
+                </widget>
+               </item>
+               <item>
+                <layout class="QHBoxLayout" name="horizontalLayout_4">
+                 <item>
+                  <widget class="QLineEdit" name="pluginFilterEdit">
+                   <property name="placeholderText">
+                    <string/>
+                   </property>
+                  </widget>
+                 </item>
+                </layout>
+               </item>
+              </layout>
+             </widget>
+             <widget class="QWidget" name="" native="true">
+              <layout class="QVBoxLayout" name="verticalLayout_7" stretch="0,1">
+               <item>
+                <layout class="QFormLayout" name="formLayout_2">
+                 <item row="0" column="0">
+                  <widget class="QLabel" name="label_13">
+                   <property name="text">
+                    <string>Author:</string>
+                   </property>
+                  </widget>
+                 </item>
+                 <item row="0" column="1">
+                  <widget class="QLabel" name="authorLabel">
+                   <property name="text">
+                    <string/>
+                   </property>
+                  </widget>
+                 </item>
+                 <item row="1" column="0">
+                  <widget class="QLabel" name="label_15">
+                   <property name="text">
+                    <string>Version:</string>
+                   </property>
+                  </widget>
+                 </item>
+                 <item row="1" column="1">
+                  <widget class="QLabel" name="versionLabel">
+                   <property name="text">
+                    <string/>
+                   </property>
+                  </widget>
+                 </item>
+                 <item row="2" column="1">
+                  <widget class="QLabel" name="descriptionLabel">
+                   <property name="text">
+                    <string/>
+                   </property>
+                   <property name="wordWrap">
+                    <bool>true</bool>
+                   </property>
+                  </widget>
+                 </item>
+                 <item row="2" column="0">
+                  <widget class="QLabel" name="label_14">
+                   <property name="text">
+                    <string>Description:</string>
+                   </property>
+                  </widget>
+                 </item>
+                </layout>
+               </item>
+               <item>
+                <widget class="QTreeWidget" name="pluginSettingsList">
+                 <property name="indentation">
+                  <number>0</number>
+                 </property>
+                 <property name="rootIsDecorated">
+                  <bool>false</bool>
+                 </property>
+                 <property name="itemsExpandable">
+                  <bool>false</bool>
+                 </property>
+                 <property name="expandsOnDoubleClick">
+                  <bool>false</bool>
+                 </property>
+                 <attribute name="headerVisible">
+                  <bool>false</bool>
+                 </attribute>
+                 <attribute name="headerDefaultSectionSize">
+                  <number>170</number>
+                 </attribute>
+                 <column>
+                  <property name="text">
+                   <string>Key</string>
+                  </property>
+                 </column>
+                 <column>
+                  <property name="text">
+                   <string>Value</string>
+                  </property>
+                 </column>
+                </widget>
+               </item>
+              </layout>
+             </widget>
+            </widget>
+           </item>
+          </layout>
+         </widget>
+         <widget class="QWidget" name="verticalWidget" native="true">
+          <property name="sizePolicy">
+           <sizepolicy hsizetype="Preferred" vsizetype="Preferred">
+            <horstretch>0</horstretch>
+            <verstretch>1</verstretch>
+           </sizepolicy>
+          </property>
+          <layout class="QVBoxLayout" name="verticalLayout_16">
+           <item>
+            <widget class="QLabel" name="label_18">
+             <property name="text">
+              <string>Blacklisted Plugins (use &lt;del&gt; to remove):</string>
+             </property>
+            </widget>
+           </item>
+           <item>
+            <widget class="QListWidget" name="pluginBlacklist"/>
+           </item>
+          </layout>
+         </widget>
         </widget>
-       </item>
-       <item>
-        <widget class="QListWidget" name="pluginBlacklist"/>
        </item>
       </layout>
      </widget>
@@ -1625,7 +1667,6 @@ programs you are intentionally running.</string>
   <tabstop>steamUserEdit</tabstop>
   <tabstop>steamPassEdit</tabstop>
   <tabstop>pluginSettingsList</tabstop>
-  <tabstop>pluginBlacklist</tabstop>
   <tabstop>appIDEdit</tabstop>
   <tabstop>mechanismBox</tabstop>
   <tabstop>hideUncheckedBox</tabstop>

--- a/src/settingsdialogplugins.cpp
+++ b/src/settingsdialogplugins.cpp
@@ -33,7 +33,8 @@ PluginsSettingsTab::PluginsSettingsTab(Settings& s, PluginContainer* pluginConta
     if (handledNames.contains(plugin->name()))
       continue;
     QTreeWidgetItem* listItem = new QTreeWidgetItem(
-      topItems.at(pluginContainer->topImplementedInterface(plugin)), { plugin->localizedName() });
+      topItems.at(pluginContainer->topImplementedInterface(plugin)));
+    listItem->setData(0, Qt::DisplayRole, plugin->localizedName());
     listItem->setData(0, ROLE_PLUGIN, QVariant::fromValue((void*)plugin));
     listItem->setData(0, ROLE_SETTINGS, settings().plugins().settings(plugin->name()));
     listItem->setData(0, ROLE_DESCRIPTIONS, settings().plugins().descriptions(plugin->name()));
@@ -51,6 +52,9 @@ PluginsSettingsTab::PluginsSettingsTab(Settings& s, PluginContainer* pluginConta
   for (const QString &pluginName : settings().plugins().blacklist()) {
     ui->pluginBlacklist->addItem(pluginName);
   }
+
+  m_filter.setEdit(ui->pluginFilterEdit);
+  m_filter.setList(ui->pluginsList);
 
   QObject::connect(
     ui->pluginsList, &QTreeWidget::currentItemChanged,

--- a/src/settingsdialogplugins.cpp
+++ b/src/settingsdialogplugins.cpp
@@ -3,25 +3,49 @@
 #include "noeditdelegate.h"
 #include <iplugin.h>
 
+#include "plugincontainer.h"
+
 using MOBase::IPlugin;
 
-PluginsSettingsTab::PluginsSettingsTab(Settings& s, SettingsDialog& d)
+PluginsSettingsTab::PluginsSettingsTab(Settings& s, PluginContainer* pluginContainer, SettingsDialog& d)
   : SettingsTab(s, d)
 {
   ui->pluginSettingsList->setStyleSheet("QTreeWidget::item {padding-right: 10px;}");
+
+  // Create top-level tree widget:
+  QStringList pluginInterfaces = pluginContainer->pluginInterfaces();
+  pluginInterfaces.sort(Qt::CaseInsensitive);
+  std::map<QString, QTreeWidgetItem*> topItems;
+  for (QString interfaceName : pluginInterfaces) {
+    auto *item = new QTreeWidgetItem(ui->pluginsList, { interfaceName });
+    item->setFlags(item->flags() & ~Qt::ItemIsSelectable);
+    auto font = item->font(0);
+    font.setBold(true);
+    item->setFont(0, font);
+    topItems[interfaceName] = item;
+    item->setExpanded(true);
+  }
+  ui->pluginsList->setHeaderHidden(true);
 
   // display plugin settings
   QSet<QString> handledNames;
   for (IPlugin *plugin : settings().plugins().plugins()) {
     if (handledNames.contains(plugin->name()))
       continue;
-    QListWidgetItem *listItem = new QListWidgetItem(plugin->localizedName(), ui->pluginsList);
-    listItem->setData(ROLE_PLUGIN, QVariant::fromValue((void*)plugin));
-    listItem->setData(ROLE_SETTINGS, settings().plugins().settings(plugin->name()));
-    listItem->setData(ROLE_DESCRIPTIONS, settings().plugins().descriptions(plugin->name()));
-    ui->pluginsList->addItem(listItem);
+    QTreeWidgetItem* listItem = new QTreeWidgetItem(
+      topItems.at(pluginContainer->topImplementedInterface(plugin)), { plugin->localizedName() });
+    listItem->setData(0, ROLE_PLUGIN, QVariant::fromValue((void*)plugin));
+    listItem->setData(0, ROLE_SETTINGS, settings().plugins().settings(plugin->name()));
+    listItem->setData(0, ROLE_DESCRIPTIONS, settings().plugins().descriptions(plugin->name()));
+
+    if (handledNames.isEmpty()) {
+      listItem->setSelected(true);
+    }
+
     handledNames.insert(plugin->name());
   }
+
+  ui->pluginsList->sortByColumn(0, Qt::AscendingOrder);
 
   // display plugin blacklist
   for (const QString &pluginName : settings().plugins().blacklist()) {
@@ -29,7 +53,7 @@ PluginsSettingsTab::PluginsSettingsTab(Settings& s, SettingsDialog& d)
   }
 
   QObject::connect(
-    ui->pluginsList, &QListWidget::currentItemChanged,
+    ui->pluginsList, &QTreeWidget::currentItemChanged,
     [&](auto* current, auto* previous) { on_pluginsList_currentItemChanged(current, previous); });
 
   QShortcut *delShortcut = new QShortcut(
@@ -37,18 +61,21 @@ PluginsSettingsTab::PluginsSettingsTab(Settings& s, SettingsDialog& d)
   QObject::connect(delShortcut, &QShortcut::activated, &dialog(), [&]{ deleteBlacklistItem(); });
 }
 
-IPlugin* PluginsSettingsTab::plugin(QListWidgetItem* pluginItem) const
+IPlugin* PluginsSettingsTab::plugin(QTreeWidgetItem* pluginItem) const
 {
-  return static_cast<IPlugin*>(qvariant_cast<void*>(pluginItem->data(ROLE_PLUGIN)));
+  return static_cast<IPlugin*>(qvariant_cast<void*>(pluginItem->data(0, ROLE_PLUGIN)));
 }
 
 void PluginsSettingsTab::update()
 {
   // transfer plugin settings to in-memory structure
-  for (int i = 0; i < ui->pluginsList->count(); ++i) {
-    QListWidgetItem *item = ui->pluginsList->item(i);
-    settings().plugins().setSettings(
-      plugin(item)->name(), item->data(ROLE_SETTINGS).toMap());
+  for (int i = 0; i < ui->pluginsList->topLevelItemCount(); ++i) {
+    auto *topLevelItem = ui->pluginsList->topLevelItem(i);
+    for (int j = 0; j < topLevelItem->childCount(); ++j) {
+      auto* item = topLevelItem->child(j);
+      settings().plugins().setSettings(
+        plugin(item)->name(), item->data(0, ROLE_SETTINGS).toMap());
+    }
   }
 
   // set plugin blacklist
@@ -67,18 +94,22 @@ void PluginsSettingsTab::closing()
   storeSettings(ui->pluginsList->currentItem());
 }
 
-void PluginsSettingsTab::on_pluginsList_currentItemChanged(QListWidgetItem *current, QListWidgetItem *previous)
+void PluginsSettingsTab::on_pluginsList_currentItemChanged(QTreeWidgetItem *current, QTreeWidgetItem *previous)
 {
   storeSettings(previous);
 
+  if (!current->data(0, ROLE_PLUGIN).isValid()) {
+    return;
+  }
+
   ui->pluginSettingsList->clear();
-  IPlugin *plugin = static_cast<IPlugin*>(current->data(Qt::UserRole).value<void*>());
+  IPlugin* plugin = this->plugin(current);
   ui->authorLabel->setText(plugin->author());
   ui->versionLabel->setText(plugin->version().canonicalString());
   ui->descriptionLabel->setText(plugin->description());
 
-  QVariantMap settings = current->data(ROLE_SETTINGS).toMap();
-  QVariantMap descriptions = current->data(ROLE_DESCRIPTIONS).toMap();
+  QVariantMap settings = current->data(0, ROLE_SETTINGS).toMap();
+  QVariantMap descriptions = current->data(0, ROLE_DESCRIPTIONS).toMap();
   ui->pluginSettingsList->setEnabled(settings.count() != 0);
   for (auto iter = settings.begin(); iter != settings.end(); ++iter) {
     QTreeWidgetItem *newItem = new QTreeWidgetItem(QStringList(iter.key()));
@@ -109,16 +140,16 @@ void PluginsSettingsTab::deleteBlacklistItem()
   ui->pluginBlacklist->takeItem(ui->pluginBlacklist->currentIndex().row());
 }
 
-void PluginsSettingsTab::storeSettings(QListWidgetItem *pluginItem)
+void PluginsSettingsTab::storeSettings(QTreeWidgetItem *pluginItem)
 {
-  if (pluginItem != nullptr) {
-    QVariantMap settings = pluginItem->data(ROLE_SETTINGS).toMap();
+  if (pluginItem != nullptr && pluginItem->data(0, ROLE_PLUGIN).isValid()) {
+    QVariantMap settings = pluginItem->data(0, ROLE_SETTINGS).toMap();
 
     for (int i = 0; i < ui->pluginSettingsList->topLevelItemCount(); ++i) {
       const QTreeWidgetItem *item = ui->pluginSettingsList->topLevelItem(i);
       settings[item->text(0)] = item->data(1, Qt::DisplayRole);
     }
 
-    pluginItem->setData(ROLE_SETTINGS, settings);
+    pluginItem->setData(0, ROLE_SETTINGS, settings);
   }
 }

--- a/src/settingsdialogplugins.h
+++ b/src/settingsdialogplugins.h
@@ -19,6 +19,13 @@ private:
   void deleteBlacklistItem();
   void storeSettings(QTreeWidgetItem *pluginItem);
 
+private slots:
+  /**
+   * @brief Clear and repopulate the plugin list.
+   *
+   */
+  void populatePluginList();
+
   /**
    * @brief Retrieve the plugin associated to the given item in the list.
    *
@@ -30,6 +37,8 @@ private:
   constexpr static int ROLE_DESCRIPTIONS = Qt::UserRole + 2;
 
 private:
+
+  PluginContainer* m_pluginContainer;
 
   MOBase::FilterWidget m_filter;
 };

--- a/src/settingsdialogplugins.h
+++ b/src/settingsdialogplugins.h
@@ -7,21 +7,21 @@
 class PluginsSettingsTab : public SettingsTab
 {
 public:
-  PluginsSettingsTab(Settings& settings, SettingsDialog& dialog);
+  PluginsSettingsTab(Settings& settings, PluginContainer* pluginContainer, SettingsDialog& dialog);
 
   void update();
   void closing() override;
 
 private:
-  void on_pluginsList_currentItemChanged(QListWidgetItem *current, QListWidgetItem *previous);
+  void on_pluginsList_currentItemChanged(QTreeWidgetItem *current, QTreeWidgetItem *previous);
   void deleteBlacklistItem();
-  void storeSettings(QListWidgetItem *pluginItem);
+  void storeSettings(QTreeWidgetItem *pluginItem);
 
   /**
    * @brief Retrieve the plugin associated to the given item in the list.
    *
    */
-  MOBase::IPlugin* plugin(QListWidgetItem *pluginItem) const;
+  MOBase::IPlugin* plugin(QTreeWidgetItem *pluginItem) const;
 
   constexpr static int ROLE_PLUGIN = Qt::UserRole;
   constexpr static int ROLE_SETTINGS = Qt::UserRole + 1;

--- a/src/settingsdialogplugins.h
+++ b/src/settingsdialogplugins.h
@@ -16,6 +16,16 @@ private:
   void on_pluginsList_currentItemChanged(QListWidgetItem *current, QListWidgetItem *previous);
   void deleteBlacklistItem();
   void storeSettings(QListWidgetItem *pluginItem);
+
+  /**
+   * @brief Retrieve the plugin associated to the given item in the list.
+   *
+   */
+  MOBase::IPlugin* plugin(QListWidgetItem *pluginItem) const;
+
+  constexpr static int ROLE_PLUGIN = Qt::UserRole;
+  constexpr static int ROLE_SETTINGS = Qt::UserRole + 1;
+  constexpr static int ROLE_DESCRIPTIONS = Qt::UserRole + 2;
 };
 
 #endif // SETTINGSDIALOGPLUGINS_H

--- a/src/settingsdialogplugins.h
+++ b/src/settingsdialogplugins.h
@@ -1,6 +1,8 @@
 #ifndef SETTINGSDIALOGPLUGINS_H
 #define SETTINGSDIALOGPLUGINS_H
 
+#include "filterwidget.h"
+
 #include "settings.h"
 #include "settingsdialog.h"
 
@@ -26,6 +28,10 @@ private:
   constexpr static int ROLE_PLUGIN = Qt::UserRole;
   constexpr static int ROLE_SETTINGS = Qt::UserRole + 1;
   constexpr static int ROLE_DESCRIPTIONS = Qt::UserRole + 2;
+
+private:
+
+  MOBase::FilterWidget m_filter;
 };
 
 #endif // SETTINGSDIALOGPLUGINS_H

--- a/src/settingsdialogplugins.h
+++ b/src/settingsdialogplugins.h
@@ -21,10 +21,10 @@ private:
 
 private slots:
   /**
-   * @brief Clear and repopulate the plugin list.
+   * @brief Filter the plugin list according to the filter widget.
    *
    */
-  void populatePluginList();
+  void filterPluginList();
 
   /**
    * @brief Retrieve the plugin associated to the given item in the list.


### PR DESCRIPTION
Improve the way MO2 plugins are displayed in the settings dialog:

- Use `localizedName()` instead of `name()` to display localized (eh!) name.
- Use a tree instead of a list to display plugins per category.
    - I made the choice to only display plugins in one category, chosen in order of "importance", e.g. if a plugin implements both `IPluginGame` and `IPluginDiagnose`, it will only appear in the "Game" category because `IPluginDiagnose` is considered less important than `IPluginGame`.

I think the layout of this tab probably needs some modification (larger plugin list and smaller "Blacklisted Plugins"), but I'm very bad at layout management...

A small preview:

![image](https://user-images.githubusercontent.com/2393288/94614246-2b58d200-02a6-11eb-8517-2b3b78970c03.png)
