### PR TITLE
Fix usage of isActive

### DIFF
--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -195,6 +195,7 @@ add_filter(NAME src/utilities GROUPS
 	shared/windows_error
 	thread_utils
 	json
+	glob_matching
 )
 
 add_filter(NAME src/widgets GROUPS

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -33,7 +33,6 @@ add_filter(NAME src/core GROUPS
 	nexusinterface
 	nxmaccessmanager
 	organizercore
-	organizerproxy
 	apiuseraccount
 	processrunner
 	qdirfiletree
@@ -145,6 +144,14 @@ add_filter(NAME src/profiles GROUPS
 	profile
 	profileinputdialog
 	profilesdialog
+)
+
+add_filter(NAME src/proxies GROUPS
+	downloadmanagerproxy
+	modlistproxy
+	organizerproxy
+	pluginlistproxy
+	proxyutils
 )
 
 add_filter(NAME src/register GROUPS

--- a/src/downloadmanagerproxy.cpp
+++ b/src/downloadmanagerproxy.cpp
@@ -1,0 +1,44 @@
+#include "downloadmanagerproxy.h"
+
+#include "proxyutils.h"
+#include "organizerproxy.h"
+
+using namespace MOBase;
+
+DownloadManagerProxy::DownloadManagerProxy(OrganizerProxy* oproxy, IDownloadManager* downloadManager) :
+  m_OrganizerProxy(oproxy), m_Proxied(downloadManager) { }
+
+int DownloadManagerProxy::startDownloadURLs(const QStringList& urls)
+{
+  return m_Proxied->startDownloadURLs(urls);
+}
+
+int DownloadManagerProxy::startDownloadNexusFile(int modID, int fileID)
+{
+  return m_Proxied->startDownloadNexusFile(modID, fileID);
+}
+
+QString DownloadManagerProxy::downloadPath(int id)
+{
+  return m_Proxied->downloadPath(id);
+}
+
+bool DownloadManagerProxy::onDownloadComplete(const std::function<void(int)>& callback)
+{
+  return m_Proxied->onDownloadComplete(MOShared::callIfPluginActive(m_OrganizerProxy, callback));
+}
+
+bool DownloadManagerProxy::onDownloadPaused(const std::function<void(int)>& callback)
+{
+  return m_Proxied->onDownloadPaused(MOShared::callIfPluginActive(m_OrganizerProxy, callback));
+}
+
+bool DownloadManagerProxy::onDownloadFailed(const std::function<void(int)>& callback)
+{
+  return m_Proxied->onDownloadFailed(MOShared::callIfPluginActive(m_OrganizerProxy, callback));
+}
+
+bool DownloadManagerProxy::onDownloadRemoved(const std::function<void(int)>& callback)
+{
+  return m_Proxied->onDownloadRemoved(MOShared::callIfPluginActive(m_OrganizerProxy, callback));
+}

--- a/src/downloadmanagerproxy.h
+++ b/src/downloadmanagerproxy.h
@@ -1,0 +1,31 @@
+#ifndef DOWNLOADMANAGERPROXY_H
+#define DOWNLOADMANAGERPROXY_H
+
+#include <idownloadmanager.h>
+
+class OrganizerProxy;
+
+class DownloadManagerProxy : public MOBase::IDownloadManager
+{
+
+public:
+
+  DownloadManagerProxy(OrganizerProxy* oproxy, IDownloadManager* downloadManager);
+  virtual ~DownloadManagerProxy() { }
+
+  int startDownloadURLs(const QStringList& urls) override;
+  int startDownloadNexusFile(int modID, int fileID) override;
+  QString downloadPath(int id) override;
+
+  bool onDownloadComplete(const std::function<void(int)>& callback) override;
+  bool onDownloadPaused(const std::function<void(int)>& callback) override;
+  bool onDownloadFailed(const std::function<void(int)>& callback) override;
+  bool onDownloadRemoved(const std::function<void(int)>& callback) override;
+
+private:
+
+  OrganizerProxy* m_OrganizerProxy;
+  IDownloadManager* m_Proxied;
+};
+
+#endif // ORGANIZERPROXY_H

--- a/src/installationmanager.cpp
+++ b/src/installationmanager.cpp
@@ -872,7 +872,9 @@ QStringList InstallationManager::getSupportedExtensions() const
 void InstallationManager::notifyInstallationStart(QString const& archive, bool reinstallation, ModInfo::Ptr  currentMod)
 {
   for (auto* installer : m_Installers) {
-    installer->onInstallationStart(archive, reinstallation, currentMod.get());
+    if (installer->isActive()) {
+      installer->onInstallationStart(archive, reinstallation, currentMod.get());
+    }
   }
 }
 
@@ -881,6 +883,8 @@ void InstallationManager::notifyInstallationEnd(
   ModInfo::Ptr  newMod)
 {
   for (auto* installer : m_Installers) {
-    installer->onInstallationEnd(result, newMod.get());
+    if (installer->isActive()) {
+      installer->onInstallationEnd(result, newMod.get());
+    }
   }
 }

--- a/src/mainwindow.cpp
+++ b/src/mainwindow.cpp
@@ -5094,6 +5094,9 @@ void MainWindow::on_actionSettings_triggered()
   instManager->setModsDirectory(settings.paths().mods());
   instManager->setDownloadDirectory(settings.paths().downloads());
 
+  // Schedule a problem check since diagnose plugins may have been enabled / disabled.
+  scheduleCheckForProblems();
+
   fixCategories();
   refreshFilters();
 

--- a/src/modlistproxy.cpp
+++ b/src/modlistproxy.cpp
@@ -1,0 +1,53 @@
+#include "modlistproxy.h"
+#include "organizerproxy.h"
+#include "proxyutils.h"
+
+using namespace MOBase;
+
+ModListProxy::ModListProxy(OrganizerProxy* oproxy, IModList* modlist) :
+  m_OrganizerProxy(oproxy), m_Proxied(modlist) { }
+
+QString ModListProxy::displayName(const QString& internalName) const
+{
+  return m_Proxied->displayName(internalName);
+}
+
+QStringList ModListProxy::allMods() const
+{
+  return m_Proxied->allMods();
+}
+
+IModList::ModStates ModListProxy::state(const QString& name) const
+{
+  return m_Proxied->state(name);
+}
+
+bool ModListProxy::setActive(const QString& name, bool active)
+{
+  return m_Proxied->setActive(name, active);
+}
+
+int ModListProxy::setActive(const QStringList& names, bool active)
+{
+  return m_Proxied->setActive(names, active);
+}
+
+int ModListProxy::priority(const QString& name) const
+{
+  return m_Proxied->priority(name);
+}
+
+bool ModListProxy::setPriority(const QString& name, int newPriority)
+{
+  return m_Proxied->setPriority(name, newPriority);
+}
+
+bool ModListProxy::onModStateChanged(const std::function<void(const std::map<QString, ModStates>&)>& func)
+{
+  return m_Proxied->onModStateChanged(MOShared::callIfPluginActive(m_OrganizerProxy, func));
+}
+
+bool ModListProxy::onModMoved(const std::function<void(const QString&, int, int)>& func)
+{
+  return m_Proxied->onModMoved(MOShared::callIfPluginActive(m_OrganizerProxy, func));
+}

--- a/src/modlistproxy.h
+++ b/src/modlistproxy.h
@@ -1,0 +1,32 @@
+#ifndef MODLISTPROXY_H
+#define MODLISTPROXY_H
+
+#include <imodlist.h>
+
+class OrganizerProxy;
+
+class ModListProxy : public MOBase::IModList
+{
+
+public:
+
+  ModListProxy(OrganizerProxy* oproxy, IModList* modlist);
+  virtual ~ModListProxy() { }
+
+  QString displayName(const QString& internalName) const override;
+  QStringList allMods() const override;
+  ModStates state(const QString& name) const override;
+  bool setActive(const QString& name, bool active) override;
+  int setActive(const QStringList& names, bool active) override;
+  int priority(const QString& name) const override;
+  bool setPriority(const QString& name, int newPriority) override;
+  bool onModStateChanged(const std::function<void(const std::map<QString, ModStates>&)>& func) override;
+  bool onModMoved(const std::function<void(const QString&, int, int)>& func) override;
+
+private:
+
+  OrganizerProxy* m_OrganizerProxy;
+  IModList* m_Proxied;
+};
+
+#endif // ORGANIZERPROXY_H

--- a/src/organizerproxy.cpp
+++ b/src/organizerproxy.cpp
@@ -278,7 +278,8 @@ bool OrganizerProxy::onModInstalled(const std::function<void(const QString&)>& f
 
 bool OrganizerProxy::onUserInterfaceInitialized(std::function<void(QMainWindow*)> const& func)
 {
-  return m_Proxied->onUserInterfaceInitialized(MOShared::callIfPluginActive(this, func));
+  // Always call this one to allow plugin to initialize themselves even when not active:
+  return m_Proxied->onUserInterfaceInitialized(func);
 }
 
 bool OrganizerProxy::onProfileChanged(std::function<void(MOBase::IProfile*, MOBase::IProfile*)> const& func)
@@ -288,5 +289,6 @@ bool OrganizerProxy::onProfileChanged(std::function<void(MOBase::IProfile*, MOBa
 
 bool OrganizerProxy::onPluginSettingChanged(std::function<void(QString const&, const QString& key, const QVariant&, const QVariant&)> const& func)
 {
-  return m_Proxied->onPluginSettingChanged(MOShared::callIfPluginActive(this, func));
+  // Always call this one, otherwise plugin cannot detect they are being enabled / disabled:
+  return m_Proxied->onPluginSettingChanged(func);
 }

--- a/src/organizerproxy.h
+++ b/src/organizerproxy.h
@@ -1,18 +1,28 @@
 #ifndef ORGANIZERPROXY_H
 #define ORGANIZERPROXY_H
 
+#include <memory>
 
+#include <iplugin.h>
 #include <imoinfo.h>
 
 class OrganizerCore;
 class PluginContainer;
+class DownloadManagerProxy;
+class ModListProxy;
+class PluginListProxy;
 
 class OrganizerProxy : public MOBase::IOrganizer
 {
 
 public:
 
-  OrganizerProxy(OrganizerCore *organizer, PluginContainer *pluginContainer, const QString &pluginName);
+  OrganizerProxy(OrganizerCore *organizer, PluginContainer *pluginContainer, MOBase::IPlugin *plugin);
+
+  /**
+   * @return the plugin corresponding to this proxy.
+   */
+  MOBase::IPlugin* plugin() const { return m_Plugin;  }
 
   virtual MOBase::IModRepositoryBridge *createNexusBridge() const;
   virtual QString profileName() const;
@@ -65,7 +75,11 @@ private:
   OrganizerCore *m_Proxied;
   PluginContainer *m_PluginContainer;
 
-  QString m_PluginName;
+  MOBase::IPlugin *m_Plugin;
+
+  std::unique_ptr<DownloadManagerProxy> m_DownloadManagerProxy;
+  std::unique_ptr<ModListProxy> m_ModListProxy;
+  std::unique_ptr<PluginListProxy> m_PluginListProxy;
 
 };
 

--- a/src/plugincontainer.cpp
+++ b/src/plugincontainer.cpp
@@ -173,7 +173,7 @@ bool PluginContainer::verifyPlugin(IPlugin *plugin)
 {
   if (plugin == nullptr) {
     return false;
-  } else if (!plugin->init(new OrganizerProxy(m_Organizer, this, plugin->name()))) {
+  } else if (!plugin->init(new OrganizerProxy(m_Organizer, this, plugin))) {
     log::warn("plugin failed to initialize");
     return false;
   }

--- a/src/pluginlistproxy.cpp
+++ b/src/pluginlistproxy.cpp
@@ -1,0 +1,73 @@
+#include "pluginlistproxy.h"
+#include "organizerproxy.h"
+#include "proxyutils.h"
+
+using namespace MOBase;
+
+PluginListProxy::PluginListProxy(OrganizerProxy* oproxy, IPluginList* pluginlist) :
+  m_OrganizerProxy(oproxy), m_Proxied(pluginlist) { }
+
+QStringList PluginListProxy::pluginNames() const 
+{
+  return m_Proxied->pluginNames();
+}
+
+IPluginList::PluginStates PluginListProxy::state(const QString& name) const
+{
+  return m_Proxied->state(name);
+}
+
+void PluginListProxy::setState(const QString& name, PluginStates state)
+{
+  return m_Proxied->setState(name, state);
+}
+
+int PluginListProxy::priority(const QString& name) const
+{
+  return m_Proxied->priority(name);
+}
+
+bool PluginListProxy::setPriority(const QString& name, int newPriority)
+{
+  return m_Proxied->setPriority(name, newPriority);
+}
+
+int PluginListProxy::loadOrder(const QString& name) const
+{
+  return m_Proxied->loadOrder(name);
+}
+
+void PluginListProxy::setLoadOrder(const QStringList& pluginList)
+{
+  return m_Proxied->setLoadOrder(pluginList);
+}
+
+bool PluginListProxy::isMaster(const QString& name) const
+{
+  return m_Proxied->isMaster(name);
+}
+
+QStringList PluginListProxy::masters(const QString& name) const
+{
+  return m_Proxied->masters(name);
+}
+
+QString PluginListProxy::origin(const QString& name) const
+{
+  return m_Proxied->origin(name);
+}
+
+bool PluginListProxy::onRefreshed(const std::function<void()>& callback) 
+{
+  return m_Proxied->onRefreshed(MOShared::callIfPluginActive(m_OrganizerProxy, callback));
+}
+
+bool PluginListProxy::onPluginMoved(const std::function<void(const QString&, int, int)>& func)
+{
+  return m_Proxied->onPluginMoved(MOShared::callIfPluginActive(m_OrganizerProxy, func));
+}
+
+bool PluginListProxy::onPluginStateChanged(const std::function<void(const std::map<QString, PluginStates>&)> &func)
+{
+  return m_Proxied->onPluginStateChanged(MOShared::callIfPluginActive(m_OrganizerProxy, func));
+}

--- a/src/pluginlistproxy.h
+++ b/src/pluginlistproxy.h
@@ -1,0 +1,36 @@
+#ifndef PLUGINLISTPROXY_H
+#define PLUGINLISTPROXY_H
+
+#include <ipluginlist.h>
+
+class OrganizerProxy;
+
+class PluginListProxy : public MOBase::IPluginList
+{
+
+public:
+
+  PluginListProxy(OrganizerProxy* oproxy, IPluginList* pluginlist);
+  virtual ~PluginListProxy() { }
+
+  QStringList pluginNames() const override;
+  PluginStates state(const QString& name) const override;
+  void setState(const QString& name, PluginStates state) override;
+  int priority(const QString& name) const override;
+  bool setPriority(const QString& name, int newPriority) override;
+  int loadOrder(const QString& name) const override;
+  void setLoadOrder(const QStringList& pluginList) override;
+  bool isMaster(const QString& name) const override;
+  QStringList masters(const QString& name) const override;
+  QString origin(const QString& name) const override;
+  bool onRefreshed(const std::function<void()>& callback) override;
+  bool onPluginMoved(const std::function<void(const QString&, int, int)>& func) override;
+  bool onPluginStateChanged(const std::function<void(const std::map<QString, PluginStates>&)>& func) override;
+
+private:
+
+  OrganizerProxy* m_OrganizerProxy;
+  IPluginList* m_Proxied;
+};
+
+#endif // ORGANIZERPROXY_H

--- a/src/previewgenerator.cpp
+++ b/src/previewgenerator.cpp
@@ -38,13 +38,17 @@ void PreviewGenerator::registerPlugin(MOBase::IPluginPreview *plugin)
 
 bool PreviewGenerator::previewSupported(const QString &fileExtension) const
 {
-  return m_PreviewPlugins.find(fileExtension.toLower()) != m_PreviewPlugins.end();
+  auto it = m_PreviewPlugins.find(fileExtension.toLower());
+  if (it == m_PreviewPlugins.end()) {
+    return false;
+  }
+  return it->second->isActive();
 }
 
 QWidget *PreviewGenerator::genPreview(const QString &fileName) const
 {
   auto iter = m_PreviewPlugins.find(QFileInfo(fileName).suffix().toLower());
-  if (iter != m_PreviewPlugins.end()) {
+  if (iter != m_PreviewPlugins.end() && iter->second->isActive()) {
     return iter->second->genFilePreview(fileName, m_MaxSize);
   } else {
     return nullptr;

--- a/src/proxyutils.h
+++ b/src/proxyutils.h
@@ -1,0 +1,26 @@
+#ifndef PROXYUTILS_H
+#define PROXYUTILS_H
+
+#include <type_traits>
+
+#include "organizerproxy.h"
+
+namespace MOShared {
+
+  template <class Fn, class T = int>
+  auto callIfPluginActive(OrganizerProxy* proxy, Fn&& callback, T defaultReturn = T{}) {
+    return [fn = std::forward<Fn>(callback), proxy, defaultReturn](auto&& ...args) {
+      if (proxy->plugin()->isActive()) {
+        return fn(std::forward<decltype(args)>(args)...);
+      }
+      else {
+        if constexpr (!std::is_same_v<std::invoke_result_t<std::decay_t<Fn>, decltype(args)... >, void>) {
+          return defaultReturn;
+        }
+      }
+    };
+  }
+
+}
+
+#endif


### PR DESCRIPTION
Changes:

* [x]  Check `isActive` before calling `IPluginInstaller::onInstallationStart` and `IPluginInstaller::onInstallationEnd`.
* [x]  Skip registered callbacks from inactive plugins:
  - This uses proxy-class to keep track of the plugin that registered the callbacks.
  * [x]  `IOrganizer`
  * [x]  `IModList`
  * [x]  `IPluginList`
  * [x]  `IDownloadManager` - This requires changing the Qt signals to boost signal, but since these callbacks are not currently used by plugins (these actually do not work), it's not an issue.
  * [x]  <s>`IModRepositoryBridge` - Same as `IDownloadManager`.</s> Not doing this since it could break some plugin and is actually not useful since bridge are separate, so plugins will not get callbacks (signals) unless they make request, and they should not make request if they're disabled.
* [x]  Do not use inactive preview plugins.
* [x]  <s>Do not fetch problems from inactive diagnose plugins.</s> Already done?