### PR TITLE
Write back the updated list of archives during bsaListRefresh.

### DIFF
--- a/src/organizercore.cpp
+++ b/src/organizercore.cpp
@@ -1232,6 +1232,7 @@ void OrganizerCore::refreshBSAList()
 
     if (m_UserInterface != nullptr) {
       m_UserInterface->updateBSAList(m_DefaultArchives, m_ActiveArchives);
+      m_UserInterface->archivesWriter().write();
     }
 
     m_ArchivesInit = true;


### PR DESCRIPTION
This will make it so that refreshing actually updates the list of internal enabled archives, but two refreshes are still needed to observe an actual change in archive conflicts.