### PR TITLE
Fix advanced conflicts tab archive support

### DIFF
--- a/src/modinfodialogconflicts.cpp
+++ b/src/modinfodialogconflicts.cpp
@@ -911,7 +911,7 @@ std::optional<ConflictItem> AdvancedConflictsTab::createItem(
       }
       else {
         // only add nearest, which is the last element of alternatives
-        const auto& altOrigin = ds.getOriginByID((alternatives.end()-1)->first);
+        const auto& altOrigin = ds.getOriginByID(alternatives.back().first);
 
         before += altOrigin.getName();
       }

--- a/src/modinfodialogconflicts.cpp
+++ b/src/modinfodialogconflicts.cpp
@@ -918,7 +918,7 @@ std::optional<ConflictItem> AdvancedConflictsTab::createItem(
 
     }
     else {
-      // current mod is one of the alternatives, find it's position
+      // current mod is one of the alternatives, find its position
       
       auto currOrgId = currOrigin->getID();
 
@@ -933,7 +933,7 @@ std::optional<ConflictItem> AdvancedConflictsTab::createItem(
         if (showAllAlts) {
           // fills 'before' and 'after' with all the alternatives that come
           // before and after the current mod, trusting the alternatives vector to be 
-          // alredy sorted correctly
+          // already sorted correctly
           
           for (auto iter = alternatives.begin(); iter != alternatives.end(); iter++) {
             
@@ -959,7 +959,7 @@ std::optional<ConflictItem> AdvancedConflictsTab::createItem(
             }
           }
 
-          // also add the active winner origin (the one outsiede alternatives) to 'after'
+          // also add the active winner origin (the one outside alternatives) to 'after'
           if (!after.empty()) {
             after += L", ";
           }

--- a/src/modinfodialogconflicts.cpp
+++ b/src/modinfodialogconflicts.cpp
@@ -927,72 +927,70 @@ std::optional<ConflictItem> AdvancedConflictsTab::createItem(
           return currOrgId == alt.first;
       });
 
-      if (currModIter != alternatives.end()) {
-        isCurrOrigArchive = currModIter->second.first.size() > 0;
+      if (currModIter == alternatives.end()) {
+        log::error("Mod {} not found in the list of origins for file {}", currOrigin->getName(), fileName);
+        return {};
+      }
+
+      isCurrOrigArchive = currModIter->second.first.size() > 0;
+      
+      if (showAllAlts) {
+        // fills 'before' and 'after' with all the alternatives that come
+        // before and after the current mod, trusting the alternatives vector to be 
+        // already sorted correctly
         
-        if (showAllAlts) {
-          // fills 'before' and 'after' with all the alternatives that come
-          // before and after the current mod, trusting the alternatives vector to be 
-          // already sorted correctly
+        for (auto iter = alternatives.begin(); iter != alternatives.end(); iter++) {
           
-          for (auto iter = alternatives.begin(); iter != alternatives.end(); iter++) {
-            
-            const auto& altOrigin = ds.getOriginByID(iter->first);
+          const auto& altOrigin = ds.getOriginByID(iter->first);
 
-            if (iter < currModIter) {
-              // mod comes before current
+          if (iter < currModIter) {
+            // mod comes before current
 
-              if (!before.empty()) {
-                before += L", ";
-              }
-
-              before += altOrigin.getName();
+            if (!before.empty()) {
+              before += L", ";
             }
-            else if (iter > currModIter) {
-              // mod comes after current
 
-              if (!after.empty()) {
-                after += L", ";
-              }
+            before += altOrigin.getName();
+          }
+          else if (iter > currModIter) {
+            // mod comes after current
 
-              after += altOrigin.getName();
+            if (!after.empty()) {
+              after += L", ";
             }
+
+            after += altOrigin.getName();
           }
-
-          // also add the active winner origin (the one outside alternatives) to 'after'
-          if (!after.empty()) {
-            after += L", ";
-          }
-          after += ds.getOriginByID(fileOrigin).getName();
-
-
         }
-        else {
-          // only show nearest origins
 
-          // before
-          if (currModIter > alternatives.begin()) {
-            auto previousOrigId = (currModIter-1)->first;
-            before += ds.getOriginByID(previousOrigId).getName();
-          }
-
-          // after
-          if (currModIter < (alternatives.end() - 1)) {
-            auto followingOrigId = (currModIter + 1)->first;
-            after += ds.getOriginByID(followingOrigId).getName();
-          }
-          else {
-            // current mod is last of alternatives, so closest to the active winner
-
-            after += ds.getOriginByID(fileOrigin).getName();
-          }
-          
+        // also add the active winner origin (the one outside alternatives) to 'after'
+        if (!after.empty()) {
+          after += L", ";
         }
+        after += ds.getOriginByID(fileOrigin).getName();
+
 
       }
       else {
-        log::error("Mod {} not found in the list of origins for file {}", currOrigin->getName(), fileName);
-        return {};
+        // only show nearest origins
+
+        // before
+        if (currModIter > alternatives.begin()) {
+          auto previousOrigId = (currModIter-1)->first;
+          before += ds.getOriginByID(previousOrigId).getName();
+        }
+
+        // after
+        if (currModIter < (alternatives.end() - 1)) {
+          auto followingOrigId = (currModIter + 1)->first;
+          after += ds.getOriginByID(followingOrigId).getName();
+        }
+        else {
+          // current mod is last of alternatives, so closest to the active winner
+
+          after += ds.getOriginByID(fileOrigin).getName();
+        }
+        
       }
     }
   }

--- a/src/modinfodialogconflicts.cpp
+++ b/src/modinfodialogconflicts.cpp
@@ -887,6 +887,7 @@ std::optional<ConflictItem> AdvancedConflictsTab::createItem(
   std::wstring before, after;
 
   auto currOrigin = m_tab->origin();
+  bool isCurrOrigArchive = archive;
 
   if (!alternatives.empty()) {
     const bool showAllAlts = ui->conflictsAdvancedShowAll->isChecked();
@@ -927,6 +928,7 @@ std::optional<ConflictItem> AdvancedConflictsTab::createItem(
       });
 
       if (currModIter != alternatives.end()) {
+        isCurrOrigArchive = currModIter->second.first.size() > 0;
         
         if (showAllAlts) {
           // fills 'before' and 'after' with all the alternatives that come
@@ -1010,5 +1012,5 @@ std::optional<ConflictItem> AdvancedConflictsTab::createItem(
 
   return ConflictItem(
     std::move(beforeQS), std::move(relativeName), std::move(afterQS),
-    index, std::move(fileName), hasAlts, QString(), archive);
+    index, std::move(fileName), hasAlts, QString(), isCurrOrigArchive);
 }


### PR DESCRIPTION
Use the the existing sorting of the alternatives vector instead of relying on priority (archives don't follow priority).
Please review before merging.
Use italic for files from archives of the current mod instead of winning mod.