### PR TITLE
Conflict lists sorting not using natsort

### DIFF
--- a/src/modinfodialogconflicts.cpp
+++ b/src/modinfodialogconflicts.cpp
@@ -559,12 +559,18 @@ GeneralConflictsTab::GeneralConflictsTab(
 
   m_filterOverwrite.setEdit(ui->overwriteLineEdit);
   m_filterOverwrite.setList(ui->overwriteTree);
+  m_filterOverwrite.setUseSourceSort(true);
+  m_filterOverwrite.setUpdateDelay(false);
 
   m_filterOverwritten.setEdit(ui->overwrittenLineEdit);
   m_filterOverwritten.setList(ui->overwrittenTree);
+  m_filterOverwritten.setUseSourceSort(true);
+  m_filterOverwritten.setUpdateDelay(false);
 
   m_filterNoConflicts.setEdit(ui->noConflictLineEdit);
   m_filterNoConflicts.setList(ui->noConflictTree);
+  m_filterNoConflicts.setUseSourceSort(true);
+  m_filterNoConflicts.setUpdateDelay(false);
 
   QObject::connect(
     ui->overwriteTree, &QTreeView::doubleClicked,
@@ -789,9 +795,10 @@ AdvancedConflictsTab::AdvancedConflictsTab(
     m_tab(tab), ui(pui), m_core(oc),
     m_model(new AdvancedConflictListModel(ui->conflictsAdvancedList))
 {
-
   m_filter.setEdit(ui->conflictsAdvancedFilter);
   m_filter.setList(ui->conflictsAdvancedList);
+  m_filter.setUseSourceSort(true);
+  m_filter.setUpdateDelay(false);
 
   // left-elide the overwrites column so that the nearest are visible
   ui->conflictsAdvancedList->setItemDelegateForColumn(

--- a/src/modinfodialogimages.cpp
+++ b/src/modinfodialogimages.cpp
@@ -63,6 +63,7 @@ ImagesTab::ImagesTab(ModInfoDialogTabContext cx) :
   ui->imagesShowDDS->setEnabled(m_ddsAvailable);
 
   m_filter.setEdit(ui->imagesFilter);
+  m_filter.setUpdateDelay(false);
   connect(&m_filter, &FilterWidget::changed, [&]{ onFilterChanged(); });
 
   connect(ui->imagesExplore, &QAbstractButton::clicked, [&]{ onExplore(); });

--- a/src/modinfodialogtextfiles.cpp
+++ b/src/modinfodialogtextfiles.cpp
@@ -23,8 +23,12 @@ public:
     return {};
   }
 
-  int rowCount(const QModelIndex& ={}) const override
+  int rowCount(const QModelIndex& index={}) const override
   {
+    // no child nodes
+    if (index.isValid())
+      return 0;
+
     return static_cast<int>(m_files.size());
   }
 
@@ -114,6 +118,7 @@ GenericFilesTab::GenericFilesTab(
 
   m_filter.setEdit(filter);
   m_filter.setList(m_list);
+  m_filter.setUpdateDelay(false);
 
   QObject::connect(
     m_list->selectionModel(), &QItemSelectionModel::currentRowChanged,


### PR DESCRIPTION
Conflict lists were not using source sorting so they wouldn't use the case insensitive natsort. Needs [this PR on uibase](https://github.com/ModOrganizer2/modorganizer-uibase/pull/93).

Also:
- Fixed stack overflow when searching text files/ini lists because they reported children to infinity and beyond
- Removed update delays for filters in mod info dialog