### PR TITLE
Refactor of alternatives vector to use classes for readability. 

### DIFF
--- a/src/filetree.cpp
+++ b/src/filetree.cpp
@@ -591,16 +591,16 @@ bool FileTree::showShellMenu(QPoint pos)
       }
 
       for (auto&& alt : alts) {
-        auto itor = menus.find(alt.originID);
+        auto itor = menus.find(alt.originID());
         if (itor == menus.end()) {
-          itor = menus.emplace(alt.originID, mw).first;
+          itor = menus.emplace(alt.originID(), mw).first;
         }
 
-        const auto fullPath = file->getFullPath(alt.originID);
+        const auto fullPath = file->getFullPath(alt.originID());
         if (fullPath.empty()) {
           log::error(
             "file {} not found in origin {}",
-            item->dataRelativeFilePath(), alt.originID);
+            item->dataRelativeFilePath(), alt.originID());
 
           continue;
         }

--- a/src/filetree.cpp
+++ b/src/filetree.cpp
@@ -591,16 +591,16 @@ bool FileTree::showShellMenu(QPoint pos)
       }
 
       for (auto&& alt : alts) {
-        auto itor = menus.find(alt.first);
+        auto itor = menus.find(alt.originID);
         if (itor == menus.end()) {
-          itor = menus.emplace(alt.first, mw).first;
+          itor = menus.emplace(alt.originID, mw).first;
         }
 
-        const auto fullPath = file->getFullPath(alt.first);
+        const auto fullPath = file->getFullPath(alt.originID);
         if (fullPath.empty()) {
           log::error(
             "file {} not found in origin {}",
-            item->dataRelativeFilePath(), alt.first);
+            item->dataRelativeFilePath(), alt.originID);
 
           continue;
         }

--- a/src/filetreemodel.cpp
+++ b/src/filetreemodel.cpp
@@ -1129,8 +1129,8 @@ std::wstring FileTreeModel::makeModName(
   std::wstring name = origin.getName();
 
   const auto& archive = file.getArchive();
-  if (!archive.name.empty()) {
-    name += L" (" + archive.name + L")";
+  if (!archive.name().empty()) {
+    name += L" (" + archive.name() + L")";
   }
 
   return name;
@@ -1184,7 +1184,7 @@ QString FileTreeModel::makeTooltip(const FileTreeItem& item) const
     QStringList list;
 
     for (auto&& alt : alternatives) {
-      const auto& origin = m_core.directoryStructure()->getOriginByID(alt.originID);
+      const auto& origin = m_core.directoryStructure()->getOriginByID(alt.originID());
       list.push_back(QString::fromStdWString(origin.getName()));
     }
 

--- a/src/filetreemodel.cpp
+++ b/src/filetreemodel.cpp
@@ -1129,8 +1129,8 @@ std::wstring FileTreeModel::makeModName(
   std::wstring name = origin.getName();
 
   const auto& archive = file.getArchive();
-  if (!archive.first.empty()) {
-    name += L" (" + archive.first + L")";
+  if (!archive.name.empty()) {
+    name += L" (" + archive.name + L")";
   }
 
   return name;
@@ -1183,8 +1183,8 @@ QString FileTreeModel::makeTooltip(const FileTreeItem& item) const
     const auto alternatives = file->getAlternatives();
     QStringList list;
 
-    for (auto&& alt : file->getAlternatives()) {
-      const auto& origin = m_core.directoryStructure()->getOriginByID(alt.first);
+    for (auto&& alt : alternatives) {
+      const auto& origin = m_core.directoryStructure()->getOriginByID(alt.originID);
       list.push_back(QString::fromStdWString(origin.getName()));
     }
 

--- a/src/modinfodialogconflicts.cpp
+++ b/src/modinfodialogconflicts.cpp
@@ -520,7 +520,7 @@ std::vector<QAction*> ConflictsTab::createGotoActions(const ConflictItem* item)
 
   // add all alternatives
   for (const auto& alt : file->getAlternatives()) {
-    const auto& o = ds.getOriginByID(alt.first);
+    const auto& o = ds.getOriginByID(alt.originID);
     if (o.getID() != origin()->getID()) {
       mods.push_back(ToQString(o.getName()));
     }
@@ -683,7 +683,7 @@ bool GeneralConflictsTab::update()
         auto currId = m_tab->origin()->getID();
         auto currModAlt = std::find_if(alternatives.begin(), alternatives.end(),
           [&currId](auto const& alt) {
-            return currId == alt.first;
+            return currId == alt.originID;
           });
 
         if (currModAlt == alternatives.end()) {
@@ -691,7 +691,7 @@ bool GeneralConflictsTab::update()
           continue;
         }
 
-        bool currModFileArchive = currModAlt->second.first.size() > 0;
+        bool currModFileArchive = currModAlt->isFromArchive();
 
         m_overwrittenModel->add(createOverwrittenItem(
           file->getIndex(), fileOrigin, archive,
@@ -731,10 +731,10 @@ ConflictItem GeneralConflictsTab::createOverwriteItem(
       altString += L", ";
     }
 
-    altString += ds.getOriginByID(alt.first).getName();
+    altString += ds.getOriginByID(alt.originID).getName();
   }
 
-  auto origin = ToQString(ds.getOriginByID(alternatives.back().first).getName());
+  auto origin = ToQString(ds.getOriginByID(alternatives.back().originID).getName());
 
   return ConflictItem(
     ToQString(altString), std::move(relativeName), QString(), index,
@@ -1005,7 +1005,7 @@ std::optional<ConflictItem> AdvancedConflictsTab::createItem(
       if (showAllAlts) {
         for (const auto& alt : alternatives)
         {
-          const auto& altOrigin = ds.getOriginByID(alt.first);
+          const auto& altOrigin = ds.getOriginByID(alt.originID);
           if (!before.empty()) {
             before += L", ";
           }
@@ -1015,7 +1015,7 @@ std::optional<ConflictItem> AdvancedConflictsTab::createItem(
       }
       else {
         // only add nearest, which is the last element of alternatives
-        const auto& altOrigin = ds.getOriginByID(alternatives.back().first);
+        const auto& altOrigin = ds.getOriginByID(alternatives.back().originID);
 
         before += altOrigin.getName();
       }
@@ -1028,7 +1028,7 @@ std::optional<ConflictItem> AdvancedConflictsTab::createItem(
 
       auto currModIter = std::find_if(alternatives.begin(), alternatives.end(),
         [&currOrgId](auto const& alt) {
-          return currOrgId == alt.first;
+          return currOrgId == alt.originID;
       });
 
       if (currModIter == alternatives.end()) {
@@ -1036,7 +1036,7 @@ std::optional<ConflictItem> AdvancedConflictsTab::createItem(
         return {};
       }
 
-      isCurrOrigArchive = currModIter->second.first.size() > 0;
+      isCurrOrigArchive = currModIter->isFromArchive();
       
       if (showAllAlts) {
         // fills 'before' and 'after' with all the alternatives that come
@@ -1045,7 +1045,7 @@ std::optional<ConflictItem> AdvancedConflictsTab::createItem(
         
         for (auto iter = alternatives.begin(); iter != alternatives.end(); iter++) {
           
-          const auto& altOrigin = ds.getOriginByID(iter->first);
+          const auto& altOrigin = ds.getOriginByID(iter->originID);
 
           if (iter < currModIter) {
             // mod comes before current
@@ -1080,13 +1080,13 @@ std::optional<ConflictItem> AdvancedConflictsTab::createItem(
 
         // before
         if (currModIter > alternatives.begin()) {
-          auto previousOrigId = (currModIter-1)->first;
+          auto previousOrigId = (currModIter-1)->originID;
           before += ds.getOriginByID(previousOrigId).getName();
         }
 
         // after
         if (currModIter < (alternatives.end() - 1)) {
-          auto followingOrigId = (currModIter + 1)->first;
+          auto followingOrigId = (currModIter + 1)->originID;
           after += ds.getOriginByID(followingOrigId).getName();
         }
         else {

--- a/src/modinfodialogconflicts.cpp
+++ b/src/modinfodialogconflicts.cpp
@@ -520,7 +520,7 @@ std::vector<QAction*> ConflictsTab::createGotoActions(const ConflictItem* item)
 
   // add all alternatives
   for (const auto& alt : file->getAlternatives()) {
-    const auto& o = ds.getOriginByID(alt.originID);
+    const auto& o = ds.getOriginByID(alt.originID());
     if (o.getID() != origin()->getID()) {
       mods.push_back(ToQString(o.getName()));
     }
@@ -683,7 +683,7 @@ bool GeneralConflictsTab::update()
         auto currId = m_tab->origin()->getID();
         auto currModAlt = std::find_if(alternatives.begin(), alternatives.end(),
           [&currId](auto const& alt) {
-            return currId == alt.originID;
+            return currId == alt.originID();
           });
 
         if (currModAlt == alternatives.end()) {
@@ -731,10 +731,10 @@ ConflictItem GeneralConflictsTab::createOverwriteItem(
       altString += L", ";
     }
 
-    altString += ds.getOriginByID(alt.originID).getName();
+    altString += ds.getOriginByID(alt.originID()).getName();
   }
 
-  auto origin = ToQString(ds.getOriginByID(alternatives.back().originID).getName());
+  auto origin = ToQString(ds.getOriginByID(alternatives.back().originID()).getName());
 
   return ConflictItem(
     ToQString(altString), std::move(relativeName), QString(), index,
@@ -1005,7 +1005,7 @@ std::optional<ConflictItem> AdvancedConflictsTab::createItem(
       if (showAllAlts) {
         for (const auto& alt : alternatives)
         {
-          const auto& altOrigin = ds.getOriginByID(alt.originID);
+          const auto& altOrigin = ds.getOriginByID(alt.originID());
           if (!before.empty()) {
             before += L", ";
           }
@@ -1015,7 +1015,7 @@ std::optional<ConflictItem> AdvancedConflictsTab::createItem(
       }
       else {
         // only add nearest, which is the last element of alternatives
-        const auto& altOrigin = ds.getOriginByID(alternatives.back().originID);
+        const auto& altOrigin = ds.getOriginByID(alternatives.back().originID());
 
         before += altOrigin.getName();
       }
@@ -1028,7 +1028,7 @@ std::optional<ConflictItem> AdvancedConflictsTab::createItem(
 
       auto currModIter = std::find_if(alternatives.begin(), alternatives.end(),
         [&currOrgId](auto const& alt) {
-          return currOrgId == alt.originID;
+          return currOrgId == alt.originID();
       });
 
       if (currModIter == alternatives.end()) {
@@ -1045,7 +1045,7 @@ std::optional<ConflictItem> AdvancedConflictsTab::createItem(
         
         for (auto iter = alternatives.begin(); iter != alternatives.end(); iter++) {
           
-          const auto& altOrigin = ds.getOriginByID(iter->originID);
+          const auto& altOrigin = ds.getOriginByID(iter->originID());
 
           if (iter < currModIter) {
             // mod comes before current
@@ -1080,13 +1080,13 @@ std::optional<ConflictItem> AdvancedConflictsTab::createItem(
 
         // before
         if (currModIter > alternatives.begin()) {
-          auto previousOrigId = (currModIter-1)->originID;
+          auto previousOrigId = (currModIter-1)->originID();
           before += ds.getOriginByID(previousOrigId).getName();
         }
 
         // after
         if (currModIter < (alternatives.end() - 1)) {
-          auto followingOrigId = (currModIter + 1)->originID;
+          auto followingOrigId = (currModIter + 1)->originID();
           after += ds.getOriginByID(followingOrigId).getName();
         }
         else {

--- a/src/modinfowithconflictinfo.cpp
+++ b/src/modinfowithconflictinfo.cpp
@@ -145,19 +145,18 @@ void ModInfoWithConflictInfo::doConflictCheck() const
       }
 
       auto alternatives = file->getAlternatives();
-      if ((alternatives.size() == 0) || (alternatives.back().first == dataID)) {
+      if ((alternatives.size() == 0) || (alternatives.back().originID == dataID)) {
         // no alternatives -> no conflict
         providesAnything = true;
       } else {
         // Get the archive data for the current mod
-        bool found = file->getOrigin() == origin.getID();
-        std::pair<std::wstring, int> archiveData;
-        if (found)
+        DataArchiveOrigin archiveData;
+        if (file->getOrigin() == origin.getID())
           archiveData = file->getArchive();
         else {
-          for (auto alts : alternatives) {
-            if (alts.first == origin.getID()) {
-              archiveData = alts.second;
+          for (auto alt : alternatives) {
+            if (alt.originID == origin.getID()) {
+              archiveData = alt.archive;
               break;
             }
           }
@@ -167,25 +166,27 @@ void ModInfoWithConflictInfo::doConflictCheck() const
         if (file->getOrigin() != origin.getID()) {
           FilesOrigin &altOrigin = (*m_DirectoryStructure)->getOriginByID(file->getOrigin());
           unsigned int altIndex = ModInfo::getIndex(ToQString(altOrigin.getName()));
-          if (file->getArchive().first.size() == 0)
-            if (archiveData.first.size() == 0)
+          if (!file->isFromArchive()) {
+            if (!archiveData.isValid())
               m_OverwrittenList.insert(altIndex);
             else
               m_ArchiveLooseOverwrittenList.insert(altIndex);
-          else
-              m_ArchiveOverwrittenList.insert(altIndex);
+          }
+          else {
+            m_ArchiveOverwrittenList.insert(altIndex);
+          }
         } else {
           providesAnything = true;
         }
 
         // Sort out the alternatives
         for (auto altInfo : alternatives) {
-          if ((altInfo.first != dataID) && (altInfo.first != origin.getID())) {
-            FilesOrigin &altOrigin = (*m_DirectoryStructure)->getOriginByID(altInfo.first);
+          if ((altInfo.originID != dataID) && (altInfo.originID != origin.getID())) {
+            FilesOrigin &altOrigin = (*m_DirectoryStructure)->getOriginByID(altInfo.originID);
             QString altOriginName = ToQString(altOrigin.getName());
             unsigned int altIndex = ModInfo::getIndex(altOriginName);
-            if (altInfo.second.first.size() == 0) {
-              if (archiveData.first.size() == 0) {
+            if (!altInfo.isFromArchive()) {
+              if (!archiveData.isValid()) {
                 if (origin.getPriority() > altOrigin.getPriority()) {
                   m_OverwriteList.insert(altIndex);
                 } else {
@@ -195,12 +196,12 @@ void ModInfoWithConflictInfo::doConflictCheck() const
                 m_ArchiveLooseOverwrittenList.insert(altIndex);
               }
             } else {
-              if (archiveData.first.size() == 0) {
+              if (!archiveData.isValid()) {
                 m_ArchiveLooseOverwriteList.insert(altIndex);
               } else {
-                if (archiveData.second > altInfo.second.second) {
+                if (archiveData.order > altInfo.archive.order) {
                   m_ArchiveOverwriteList.insert(altIndex);
-                } else if (archiveData.second < altInfo.second.second) {
+                } else if (archiveData.order < altInfo.archive.order) {
                   m_ArchiveOverwrittenList.insert(altIndex);
                 }
               }

--- a/src/modinfowithconflictinfo.cpp
+++ b/src/modinfowithconflictinfo.cpp
@@ -145,7 +145,7 @@ void ModInfoWithConflictInfo::doConflictCheck() const
       }
 
       auto alternatives = file->getAlternatives();
-      if ((alternatives.size() == 0) || (alternatives.back().originID == dataID)) {
+      if ((alternatives.size() == 0) || (alternatives.back().originID() == dataID)) {
         // no alternatives -> no conflict
         providesAnything = true;
       } else {
@@ -155,8 +155,8 @@ void ModInfoWithConflictInfo::doConflictCheck() const
           archiveData = file->getArchive();
         else {
           for (auto alt : alternatives) {
-            if (alt.originID == origin.getID()) {
-              archiveData = alt.archive;
+            if (alt.originID() == origin.getID()) {
+              archiveData = alt.archive();
               break;
             }
           }
@@ -181,8 +181,8 @@ void ModInfoWithConflictInfo::doConflictCheck() const
 
         // Sort out the alternatives
         for (auto altInfo : alternatives) {
-          if ((altInfo.originID != dataID) && (altInfo.originID != origin.getID())) {
-            FilesOrigin &altOrigin = (*m_DirectoryStructure)->getOriginByID(altInfo.originID);
+          if ((altInfo.originID() != dataID) && (altInfo.originID() != origin.getID())) {
+            FilesOrigin &altOrigin = (*m_DirectoryStructure)->getOriginByID(altInfo.originID());
             QString altOriginName = ToQString(altOrigin.getName());
             unsigned int altIndex = ModInfo::getIndex(altOriginName);
             if (!altInfo.isFromArchive()) {
@@ -199,9 +199,9 @@ void ModInfoWithConflictInfo::doConflictCheck() const
               if (!archiveData.isValid()) {
                 m_ArchiveLooseOverwriteList.insert(altIndex);
               } else {
-                if (archiveData.order > altInfo.archive.order) {
+                if (archiveData.order() > altInfo.archive().order()) {
                   m_ArchiveOverwriteList.insert(altIndex);
-                } else if (archiveData.order < altInfo.archive.order) {
+                } else if (archiveData.order() < altInfo.archive().order()) {
                   m_ArchiveOverwrittenList.insert(altIndex);
                 }
               }

--- a/src/modinfowithconflictinfo.cpp
+++ b/src/modinfowithconflictinfo.cpp
@@ -154,7 +154,7 @@ void ModInfoWithConflictInfo::doConflictCheck() const
         if (file->getOrigin() == origin.getID())
           archiveData = file->getArchive();
         else {
-          for (auto alt : alternatives) {
+          for (const auto& alt : alternatives) {
             if (alt.originID() == origin.getID()) {
               archiveData = alt.archive();
               break;
@@ -180,7 +180,7 @@ void ModInfoWithConflictInfo::doConflictCheck() const
         }
 
         // Sort out the alternatives
-        for (auto altInfo : alternatives) {
+        for (const auto& altInfo : alternatives) {
           if ((altInfo.originID() != dataID) && (altInfo.originID() != origin.getID())) {
             FilesOrigin &altOrigin = (*m_DirectoryStructure)->getOriginByID(altInfo.originID());
             QString altOriginName = ToQString(altOrigin.getName());

--- a/src/modlist.cpp
+++ b/src/modlist.cpp
@@ -854,25 +854,15 @@ void ModList::highlightMods(const QItemSelectionModel *selection, const MOShared
       ModInfo::getByIndex(i)->setPluginSelected(false);
   }
   for (QModelIndex idx : selection->selectedRows(PluginList::COL_NAME)) {
-    QString modName = idx.data().toString();
+    QString pluginName = idx.data().toString();
 
-    const MOShared::FileEntryPtr fileEntry = directoryEntry.findFile(modName.toStdWString());
+    const MOShared::FileEntryPtr fileEntry = directoryEntry.findFile(pluginName.toStdWString());
     if (fileEntry.get() != nullptr) {
-      bool archive = false;
-      std::vector<std::pair<int, std::pair<std::wstring, int>>> origins;
-      {
-        std::vector<std::pair<int, std::pair<std::wstring, int>>> alternatives = fileEntry->getAlternatives();
-        origins.insert(origins.end(), std::pair<int, std::pair<std::wstring, int>>(fileEntry->getOrigin(archive), fileEntry->getArchive()));
-      }
-      for (auto originInfo : origins) {
-        MOShared::FilesOrigin& origin = directoryEntry.getOriginByID(originInfo.first);
-        for (unsigned int i = 0; i < ModInfo::getNumMods(); ++i) {
-          if (ModInfo::getByIndex(i)->internalName() == QString::fromStdWString(origin.getName())) {
-            ModInfo::getByIndex(i)->setPluginSelected(true);
-            break;
-          }
-        }
-      }
+
+      QString originName = QString::fromStdWString(directoryEntry.getOriginByID(fileEntry->getOrigin()).getName());
+
+      auto modInfo = ModInfo::getByName(originName);
+      modInfo->setPluginSelected(true);
     }
   }
   notifyChange(0, rowCount() - 1);

--- a/src/organizercore.cpp
+++ b/src/organizercore.cpp
@@ -921,7 +921,7 @@ QStringList OrganizerCore::getFileOrigins(const QString &fileName) const
         m_DirectoryStructure->getOriginByID(file->getOrigin()).getName()));
     foreach (auto i, file->getAlternatives()) {
       result.append(
-          ToQString(m_DirectoryStructure->getOriginByID(i.first).getName()));
+          ToQString(m_DirectoryStructure->getOriginByID(i.originID).getName()));
     }
   }
   return result;
@@ -945,10 +945,10 @@ QList<MOBase::IOrganizer::FileInfo> OrganizerCore::findFileInfos(
       info.origins.append(ToQString(
           m_DirectoryStructure->getOriginByID(file->getOrigin(fromArchive))
               .getName()));
-      info.archive = fromArchive ? ToQString(file->getArchive().first) : "";
+      info.archive = fromArchive ? ToQString(file->getArchive().name) : "";
       foreach (auto idx, file->getAlternatives()) {
         info.origins.append(
-            ToQString(m_DirectoryStructure->getOriginByID(idx.first).getName()));
+            ToQString(m_DirectoryStructure->getOriginByID(idx.originID).getName()));
       }
 
       if (filter(info)) {
@@ -1049,7 +1049,7 @@ bool OrganizerCore::previewFileWithAlternatives(
     // don't bother with the vector of origins, just add them as they come
     addFunc(file->getOrigin());
     for (auto alt : file->getAlternatives()) {
-      addFunc(alt.first);
+      addFunc(alt.originID);
     }
   } else {
     std::vector<int> origins;
@@ -1059,10 +1059,10 @@ bool OrganizerCore::previewFileWithAlternatives(
 
     // add other origins, push to front if it's the selected one
     for (auto alt : file->getAlternatives()) {
-      if (alt.first == selectedOrigin) {
-        origins.insert(origins.begin(), alt.first);
+      if (alt.originID == selectedOrigin) {
+        origins.insert(origins.begin(), alt.originID);
       } else {
-        origins.push_back(alt.first);
+        origins.push_back(alt.originID);
       }
     }
 

--- a/src/organizercore.cpp
+++ b/src/organizercore.cpp
@@ -921,7 +921,7 @@ QStringList OrganizerCore::getFileOrigins(const QString &fileName) const
         m_DirectoryStructure->getOriginByID(file->getOrigin()).getName()));
     foreach (auto i, file->getAlternatives()) {
       result.append(
-          ToQString(m_DirectoryStructure->getOriginByID(i.originID).getName()));
+          ToQString(m_DirectoryStructure->getOriginByID(i.originID()).getName()));
     }
   }
   return result;
@@ -945,10 +945,10 @@ QList<MOBase::IOrganizer::FileInfo> OrganizerCore::findFileInfos(
       info.origins.append(ToQString(
           m_DirectoryStructure->getOriginByID(file->getOrigin(fromArchive))
               .getName()));
-      info.archive = fromArchive ? ToQString(file->getArchive().name) : "";
+      info.archive = fromArchive ? ToQString(file->getArchive().name()) : "";
       foreach (auto idx, file->getAlternatives()) {
         info.origins.append(
-            ToQString(m_DirectoryStructure->getOriginByID(idx.originID).getName()));
+            ToQString(m_DirectoryStructure->getOriginByID(idx.originID()).getName()));
       }
 
       if (filter(info)) {
@@ -1049,7 +1049,7 @@ bool OrganizerCore::previewFileWithAlternatives(
     // don't bother with the vector of origins, just add them as they come
     addFunc(file->getOrigin());
     for (auto alt : file->getAlternatives()) {
-      addFunc(alt.originID);
+      addFunc(alt.originID());
     }
   } else {
     std::vector<int> origins;
@@ -1059,10 +1059,10 @@ bool OrganizerCore::previewFileWithAlternatives(
 
     // add other origins, push to front if it's the selected one
     for (auto alt : file->getAlternatives()) {
-      if (alt.originID == selectedOrigin) {
-        origins.insert(origins.begin(), alt.originID);
+      if (alt.originID() == selectedOrigin) {
+        origins.insert(origins.begin(), alt.originID());
       } else {
-        origins.push_back(alt.originID);
+        origins.push_back(alt.originID());
       }
     }
 

--- a/src/organizercore.cpp
+++ b/src/organizercore.cpp
@@ -919,7 +919,7 @@ QStringList OrganizerCore::getFileOrigins(const QString &fileName) const
   if (file.get() != nullptr) {
     result.append(ToQString(
         m_DirectoryStructure->getOriginByID(file->getOrigin()).getName()));
-    foreach (auto i, file->getAlternatives()) {
+    foreach (const auto& i, file->getAlternatives()) {
       result.append(
           ToQString(m_DirectoryStructure->getOriginByID(i.originID()).getName()));
     }
@@ -938,7 +938,7 @@ QList<MOBase::IOrganizer::FileInfo> OrganizerCore::findFileInfos(
     dir = dir->findSubDirectoryRecursive(ToWString(path));
   if (dir != nullptr) {
     std::vector<FileEntryPtr> files = dir->getFiles();
-    foreach (FileEntryPtr file, files) {
+    for (FileEntryPtr file : files) {
       IOrganizer::FileInfo info;
       info.filePath    = ToQString(file->getFullPath());
       bool fromArchive = false;
@@ -946,7 +946,7 @@ QList<MOBase::IOrganizer::FileInfo> OrganizerCore::findFileInfos(
           m_DirectoryStructure->getOriginByID(file->getOrigin(fromArchive))
               .getName()));
       info.archive = fromArchive ? ToQString(file->getArchive().name()) : "";
-      foreach (auto idx, file->getAlternatives()) {
+      for (const auto& idx : file->getAlternatives()) {
         info.origins.append(
             ToQString(m_DirectoryStructure->getOriginByID(idx.originID()).getName()));
       }
@@ -1048,7 +1048,7 @@ bool OrganizerCore::previewFileWithAlternatives(
   if (selectedOrigin == -1) {
     // don't bother with the vector of origins, just add them as they come
     addFunc(file->getOrigin());
-    for (auto alt : file->getAlternatives()) {
+    for (const auto& alt : file->getAlternatives()) {
       addFunc(alt.originID());
     }
   } else {
@@ -1058,7 +1058,7 @@ bool OrganizerCore::previewFileWithAlternatives(
     origins.push_back(file->getOrigin());
 
     // add other origins, push to front if it's the selected one
-    for (auto alt : file->getAlternatives()) {
+    for (const auto& alt : file->getAlternatives()) {
       if (alt.originID() == selectedOrigin) {
         origins.insert(origins.begin(), alt.originID());
       } else {

--- a/src/pluginlist.cpp
+++ b/src/pluginlist.cpp
@@ -154,7 +154,7 @@ void PluginList::highlightPlugins(const QItemSelectionModel *selection, const MO
           MOShared::FileEntryPtr file = directoryEntry.findFile(plugin.toStdWString());
           if (file && file->getOrigin() != origin.getID()) {
             const auto alternatives = file->getAlternatives();
-            if (std::find_if(alternatives.begin(), alternatives.end(), [&](const FileAlternative& element) { return element.originID == origin.getID(); }) == alternatives.end())
+            if (std::find_if(alternatives.begin(), alternatives.end(), [&](const FileAlternative& element) { return element.originID() == origin.getID(); }) == alternatives.end())
               continue;
           }
           std::map<QString, int>::iterator iter = m_ESPsByName.find(plugin.toLower());

--- a/src/pluginlist.cpp
+++ b/src/pluginlist.cpp
@@ -153,8 +153,8 @@ void PluginList::highlightPlugins(const QItemSelectionModel *selection, const MO
         for (auto plugin : plugins) {
           MOShared::FileEntryPtr file = directoryEntry.findFile(plugin.toStdWString());
           if (file && file->getOrigin() != origin.getID()) {
-            const std::vector<std::pair<int, std::pair<std::wstring, int>>> alternatives = file->getAlternatives();
-            if (std::find_if(alternatives.begin(), alternatives.end(), [&](const std::pair<int, std::pair<std::wstring, int>>& element) { return element.first == origin.getID(); }) == alternatives.end())
+            const auto alternatives = file->getAlternatives();
+            if (std::find_if(alternatives.begin(), alternatives.end(), [&](const FileAlternative& element) { return element.originID == origin.getID(); }) == alternatives.end())
               continue;
           }
           std::map<QString, int>::iterator iter = m_ESPsByName.find(plugin.toLower());

--- a/src/processrunner.cpp
+++ b/src/processrunner.cpp
@@ -153,7 +153,7 @@ InterestingProcess findInterestingProcessInTrees(const env::Process& root)
   }
 
   auto isHidden = [&](auto&& p) {
-    for (auto h : hiddenList) {
+    for (auto& h : hiddenList) {
       if (p.name().contains(h, Qt::CaseInsensitive)) {
         return true;
       }

--- a/src/shared/fileentry.cpp
+++ b/src/shared/fileentry.cpp
@@ -192,7 +192,7 @@ bool FileEntry::isFromArchive(std::wstring archiveName) const
     return true;
   }
 
-  for (auto alternative : m_Alternatives) {
+  for (const auto& alternative : m_Alternatives) {
     if (alternative.archive().name().compare(archiveName) == 0) {
       return true;
     }

--- a/src/shared/fileentry.cpp
+++ b/src/shared/fileentry.cpp
@@ -44,7 +44,7 @@ void FileEntry::addOrigin(
 
     auto itor = std::find_if(
       m_Alternatives.begin(), m_Alternatives.end(),
-      [&](auto&& i) { return i.originID == m_Origin; });
+      [&](auto&& i) { return i.originID() == m_Origin; });
 
     if (itor == m_Alternatives.end()) {
       m_Alternatives.push_back({m_Origin, m_Archive});
@@ -64,13 +64,13 @@ void FileEntry::addOrigin(
     }
 
     for (auto iter = m_Alternatives.begin(); iter != m_Alternatives.end(); ++iter) {
-      if (iter->originID == origin) {
+      if (iter->originID() == origin) {
         // already an origin
         return;
       }
 
       if ((m_Parent != nullptr) &&
-        (m_Parent->getOriginByID(iter->originID).getPriority() < m_Parent->getOriginByID(origin).getPriority())) {
+        (m_Parent->getOriginByID(iter->originID()).getPriority() < m_Parent->getOriginByID(origin).getPriority())) {
         m_Alternatives.insert(iter, {origin, {std::wstring(archive.begin(), archive.end()), order}});
         found = true;
         break;
@@ -92,17 +92,17 @@ bool FileEntry::removeOrigin(OriginID origin)
       // find alternative with the highest priority
       auto currentIter = m_Alternatives.begin();
       for (auto iter = m_Alternatives.begin(); iter != m_Alternatives.end(); ++iter) {
-        if (iter->originID != origin) {
+        if (iter->originID() != origin) {
           //Both files are not from archives.
           if (!iter->isFromArchive() && !currentIter->isFromArchive()) {
-            if ((m_Parent->getOriginByID(iter->originID).getPriority() > m_Parent->getOriginByID(currentIter->originID).getPriority())) {
+            if ((m_Parent->getOriginByID(iter->originID()).getPriority() > m_Parent->getOriginByID(currentIter->originID()).getPriority())) {
               currentIter = iter;
             }
           }
           else {
             //Both files are from archives
             if (iter->isFromArchive() && currentIter->isFromArchive()) {
-              if (iter->archive.order > currentIter->archive.order) {
+              if (iter->archive().order() > currentIter->archive().order()) {
                 currentIter = iter;
               }
             }
@@ -116,8 +116,8 @@ bool FileEntry::removeOrigin(OriginID origin)
         }
       }
 
-      OriginID currentID = currentIter->originID;
-      m_Archive = currentIter->archive;
+      OriginID currentID = currentIter->originID();
+      m_Archive = currentIter->archive();
       m_Alternatives.erase(currentIter);
 
       m_Origin = currentID;
@@ -129,7 +129,7 @@ bool FileEntry::removeOrigin(OriginID origin)
   } else {
     auto newEnd = std::remove_if(
       m_Alternatives.begin(), m_Alternatives.end(),
-      [&](auto &i) { return i.originID == origin; });
+      [&](auto &i) { return i.originID() == origin; });
 
     if (newEnd != m_Alternatives.end()) {
       m_Alternatives.erase(newEnd, m_Alternatives.end());
@@ -146,12 +146,12 @@ void FileEntry::sortOrigins()
 
   std::sort(m_Alternatives.begin(), m_Alternatives.end(), [&](auto&& LHS, auto&& RHS) {
     if (!LHS.isFromArchive() && !RHS.isFromArchive()) {
-      int l = m_Parent->getOriginByID(LHS.originID).getPriority();
+      int l = m_Parent->getOriginByID(LHS.originID()).getPriority();
       if (l < 0) {
         l = INT_MAX;
       }
 
-      int r = m_Parent->getOriginByID(RHS.originID).getPriority();
+      int r = m_Parent->getOriginByID(RHS.originID()).getPriority();
       if (r < 0) {
         r = INT_MAX;
       }
@@ -160,8 +160,8 @@ void FileEntry::sortOrigins()
     }
 
     if (LHS.isFromArchive() && RHS.isFromArchive()) {
-      int l = LHS.archive.order; if (l < 0) l = INT_MAX;
-      int r = RHS.archive.order; if (r < 0) r = INT_MAX;
+      int l = LHS.archive().order(); if (l < 0) l = INT_MAX;
+      int r = RHS.archive().order(); if (r < 0) r = INT_MAX;
 
       return l < r;
     }
@@ -174,8 +174,8 @@ void FileEntry::sortOrigins()
     });
 
   if (!m_Alternatives.empty()) {
-    m_Origin = m_Alternatives.back().originID;
-    m_Archive = m_Alternatives.back().archive;
+    m_Origin = m_Alternatives.back().originID();
+    m_Archive = m_Alternatives.back().archive();
     m_Alternatives.pop_back();
   }
 }
@@ -188,12 +188,12 @@ bool FileEntry::isFromArchive(std::wstring archiveName) const
     return m_Archive.isValid();
   }
 
-  if (m_Archive.name.compare(archiveName) == 0) {
+  if (m_Archive.name().compare(archiveName) == 0) {
     return true;
   }
 
   for (auto alternative : m_Alternatives) {
-    if (alternative.archive.name.compare(archiveName) == 0) {
+    if (alternative.archive().name().compare(archiveName) == 0) {
       return true;
     }
   }

--- a/src/shared/fileentry.h
+++ b/src/shared/fileentry.h
@@ -54,11 +54,11 @@ public:
 
   OriginID getOrigin(bool &archive) const
   {
-    archive = (m_Archive.first.length() != 0);
+    archive = m_Archive.isValid();
     return m_Origin;
   }
 
-  const std::pair<std::wstring, int> &getArchive() const
+  const DataArchiveOrigin &getArchive() const
   {
     return m_Archive;
   }
@@ -107,7 +107,7 @@ private:
   FileIndex m_Index;
   std::wstring m_Name;
   OriginID m_Origin;
-  std::pair<std::wstring, int> m_Archive;
+  DataArchiveOrigin m_Archive;
   AlternativesVector m_Alternatives;
   DirectoryEntry *m_Parent;
   mutable FILETIME m_FileTime;

--- a/src/shared/fileregister.cpp
+++ b/src/shared/fileregister.cpp
@@ -172,7 +172,7 @@ void FileRegister::unregisterFile(FileEntryPtr file)
   const auto& alternatives = file->getAlternatives();
 
   for (auto iter = alternatives.begin(); iter != alternatives.end(); ++iter) {
-    m_OriginConnection->getByID(iter->originID).removeFile(file->getIndex());
+    m_OriginConnection->getByID(iter->originID()).removeFile(file->getIndex());
   }
 
   // unregister from directory

--- a/src/shared/fileregister.cpp
+++ b/src/shared/fileregister.cpp
@@ -171,8 +171,8 @@ void FileRegister::unregisterFile(FileEntryPtr file)
   m_OriginConnection->getByID(originID).removeFile(file->getIndex());
   const auto& alternatives = file->getAlternatives();
 
-  for (auto iter = alternatives.begin(); iter != alternatives.end(); ++iter) {
-    m_OriginConnection->getByID(iter->originID()).removeFile(file->getIndex());
+  for (const auto& alt : alternatives) {
+    m_OriginConnection->getByID(alt.originID()).removeFile(file->getIndex());
   }
 
   // unregister from directory

--- a/src/shared/fileregister.cpp
+++ b/src/shared/fileregister.cpp
@@ -172,7 +172,7 @@ void FileRegister::unregisterFile(FileEntryPtr file)
   const auto& alternatives = file->getAlternatives();
 
   for (auto iter = alternatives.begin(); iter != alternatives.end(); ++iter) {
-    m_OriginConnection->getByID(iter->first).removeFile(file->getIndex());
+    m_OriginConnection->getByID(iter->originID).removeFile(file->getIndex());
   }
 
   // unregister from directory

--- a/src/shared/fileregisterfwd.h
+++ b/src/shared/fileregisterfwd.h
@@ -42,15 +42,36 @@ using OriginID = int;
 constexpr FileIndex InvalidFileIndex = UINT_MAX;
 constexpr OriginID InvalidOriginID = -1;
 
-
-// a vector of {originId, {archiveName, order}}
-//
-// if a file is in an archive, archiveName is the name of the bsa and order
+// if a file is in an archive, name is the name of the bsa and order
 // is the order of the associated plugin in the plugins list
-//
 // is a file is not in an archive, archiveName is empty and order is usually
 // -1
-using AlternativesVector = std::vector<std::pair<OriginID, std::pair<std::wstring, int>>>;
+struct DataArchiveOrigin
+{
+  std::wstring name = L"";
+  int order = -1;
+  
+  bool isValid() const {
+    return name.size() > 0;
+  }
+
+  DataArchiveOrigin(std::wstring pname, int porder)
+    : name(pname), order(porder) {}
+
+  DataArchiveOrigin() {}
+};
+
+struct FileAlternative
+{
+  OriginID originID = -1;
+  DataArchiveOrigin archive;
+
+  bool isFromArchive() const {
+    return archive.isValid();
+  }
+};
+
+using AlternativesVector = std::vector<FileAlternative>;
 
 struct DirectoryStats
 {

--- a/src/shared/fileregisterfwd.h
+++ b/src/shared/fileregisterfwd.h
@@ -46,29 +46,44 @@ constexpr OriginID InvalidOriginID = -1;
 // is the order of the associated plugin in the plugins list
 // is a file is not in an archive, archiveName is empty and order is usually
 // -1
-struct DataArchiveOrigin
+class DataArchiveOrigin
 {
-  std::wstring name = L"";
-  int order = -1;
+  std::wstring name_ = L"";
+  int order_ = -1;
+  
+public:
+
+  int order() const { return order_; }
+  const std::wstring& name() const { return name_; }
   
   bool isValid() const {
-    return name.size() > 0;
+    return name_.size() > 0;
   }
 
-  DataArchiveOrigin(std::wstring pname, int porder)
-    : name(pname), order(porder) {}
+  DataArchiveOrigin(std::wstring name, int order)
+    : name_(std::move(name)), order_(order) {}
 
-  DataArchiveOrigin() {}
+  DataArchiveOrigin() = default;
 };
 
-struct FileAlternative
+class FileAlternative
 {
-  OriginID originID = -1;
-  DataArchiveOrigin archive;
+  OriginID originID_ = -1;
+  DataArchiveOrigin archive_;
+
+public:
+
+  OriginID originID() const { return originID_; }
+  const DataArchiveOrigin& archive() const { return archive_; }
 
   bool isFromArchive() const {
-    return archive.isValid();
+    return archive_.isValid();
   }
+
+  FileAlternative() = default;
+
+  FileAlternative(OriginID originID, DataArchiveOrigin archive) 
+    : originID_(originID), archive_(std::move(archive)) {}
 };
 
 using AlternativesVector = std::vector<FileAlternative>;

--- a/src/syncoverwritedialog.cpp
+++ b/src/syncoverwritedialog.cpp
@@ -104,7 +104,7 @@ void SyncOverwriteDialog::readTree(const QString &path, DirectoryEntry *director
         addToComboBox(combo, ToQString(m_DirectoryStructure->getOriginByID(origin).getName()), origin);
         const auto &alternatives = entry->getAlternatives();
         for (auto iter = alternatives.begin(); iter != alternatives.end(); ++iter) {
-          addToComboBox(combo, ToQString(m_DirectoryStructure->getOriginByID(iter->originID).getName()), iter->originID);
+          addToComboBox(combo, ToQString(m_DirectoryStructure->getOriginByID(iter->originID()).getName()), iter->originID());
         }
         combo->setCurrentIndex(combo->count() - 1);
       } else {

--- a/src/syncoverwritedialog.cpp
+++ b/src/syncoverwritedialog.cpp
@@ -102,9 +102,9 @@ void SyncOverwriteDialog::readTree(const QString &path, DirectoryEntry *director
         bool ignore;
         int origin = entry->getOrigin(ignore);
         addToComboBox(combo, ToQString(m_DirectoryStructure->getOriginByID(origin).getName()), origin);
-        const std::vector<std::pair<int, std::pair<std::wstring, int>>> &alternatives = entry->getAlternatives();
-        for (std::vector<std::pair<int, std::pair<std::wstring, int>>>::const_iterator iter = alternatives.begin(); iter != alternatives.end(); ++iter) {
-          addToComboBox(combo, ToQString(m_DirectoryStructure->getOriginByID(iter->first).getName()), iter->first);
+        const auto &alternatives = entry->getAlternatives();
+        for (auto iter = alternatives.begin(); iter != alternatives.end(); ++iter) {
+          addToComboBox(combo, ToQString(m_DirectoryStructure->getOriginByID(iter->originID).getName()), iter->originID);
         }
         combo->setCurrentIndex(combo->count() - 1);
       } else {

--- a/src/syncoverwritedialog.cpp
+++ b/src/syncoverwritedialog.cpp
@@ -103,8 +103,8 @@ void SyncOverwriteDialog::readTree(const QString &path, DirectoryEntry *director
         int origin = entry->getOrigin(ignore);
         addToComboBox(combo, ToQString(m_DirectoryStructure->getOriginByID(origin).getName()), origin);
         const auto &alternatives = entry->getAlternatives();
-        for (auto iter = alternatives.begin(); iter != alternatives.end(); ++iter) {
-          addToComboBox(combo, ToQString(m_DirectoryStructure->getOriginByID(iter->originID()).getName()), iter->originID());
+        for (const auto& alt : alternatives) {
+          addToComboBox(combo, ToQString(m_DirectoryStructure->getOriginByID(alt.originID()).getName()), alt.originID());
         }
         combo->setCurrentIndex(combo->count() - 1);
       } else {


### PR DESCRIPTION
Changed the alternatives vector from being a pair of a pair to proper FileAlternative class containing originID and DataArchiveOrigin, containing a name() and an oder().