### PR TITLE
Stuff doesn't run

### DIFF
--- a/src/commandline.cpp
+++ b/src/commandline.cpp
@@ -95,8 +95,8 @@ std::optional<int> CommandLine::run(const std::wstring& line)
         if (c->name() == commandName) {
           // this is a command
 
-            // remove the command name itself
-            opts.erase(opts.begin());
+          // remove the command name itself
+          opts.erase(opts.begin());
 
           try
           {

--- a/src/commandline.h
+++ b/src/commandline.h
@@ -45,10 +45,10 @@ public:
   //
   po::positional_options_description positional() const;
 
-  // whether the command allows for unregistered options; this is only used for
-  // the old `launch` command and shouldn't be used anywhere else
+  // when this returns true, the command line is not parsed at all and doRun()
+  // is expected to use untouched()
   //
-  virtual bool allow_unregistered() const;
+  virtual bool legacy() const;
 
   // runs this command, eventually calls doRun()
   //
@@ -136,7 +136,7 @@ protected:
 class LaunchCommand : public Command
 {
 public:
-  bool allow_unregistered() const override;
+  bool legacy() const override;
 
 protected:
   Meta meta() const override;

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -17,8 +17,6 @@ int forwardToPrimary(MOMultiProcess& multiProcess, const cl::CommandLine& cl);
 
 int main(int argc, char *argv[])
 {
-  TimeThis tt("main()");
-
   MOShared::SetThisThreadName("main");
   setExceptionHandlers();
 
@@ -28,6 +26,9 @@ int main(int argc, char *argv[])
   }
 
   initLogging();
+
+  // must be after logging
+  TimeThis tt("main()");
 
   QApplication::setAttribute(Qt::AA_EnableHighDpiScaling);
   MOApplication app(cl, argc, argv);


### PR DESCRIPTION
- Don't attempt to parse the command line for `launch`, it fails in all sorts of ways
- Don't try to time stuff before logging is initialized, an exception before `initLogging()` will crash because `~TimeThis()` tries to log