### PR TITLE
Don't delete user directories by default

### DIFF
--- a/src/instancemanagerdialog.cpp
+++ b/src/instancemanagerdialog.cpp
@@ -473,12 +473,18 @@ void InstanceManagerDialog::deleteInstance()
     auto* item = new QListWidgetItem(f.path);
 
     if (f.mandatoryDelete) {
+      // disable, cannot uncheck mandatory items
       item->setFlags(item->flags() & (~Qt::ItemIsEnabled));
+
+      // checked by default
+      item->setCheckState(Qt::Checked);
     } else {
       item->setFlags(item->flags() | Qt::ItemIsUserCheckable);
+
+      // unchecked by default
+      item->setCheckState(Qt::Unchecked);
     }
 
-    item->setCheckState(Qt::Checked);
     list->addItem(item);
   }
 


### PR DESCRIPTION
In the delete instance dialog, uncheck directories changed by the user by default to match the old behaviour of deleting an instance. In the future, it'd be nice to have a way of tagging some objects as being:

- Mandatory, such as `ModOrganizer.ini` for a portable instance (checked and disabled),
- Suggested, such as `webcache` and `logs` (checked and enabled),
- Optional, such as `mods` and `downloads` (unchecked and enabled)