### PR TITLE
IPlugin::isActive refactoring

### DIFF
--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -186,6 +186,7 @@ add_filter(NAME src/settingsdialog GROUPS
 	settingsdialogplugins
 	settingsdialogsteam
 	settingsdialogworkarounds
+	disableproxyplugindialog
 )
 
 add_filter(NAME src/utilities GROUPS

--- a/src/disableproxyplugindialog.cpp
+++ b/src/disableproxyplugindialog.cpp
@@ -1,6 +1,6 @@
 #include "disableproxyplugindialog.h"
 
-#include "ui_proxyplugindialog.h"
+#include "ui_disableproxyplugindialog.h"
 
 using namespace MOBase;
 

--- a/src/disableproxyplugindialog.cpp
+++ b/src/disableproxyplugindialog.cpp
@@ -1,0 +1,30 @@
+#include "disableproxyplugindialog.h"
+
+#include "ui_proxyplugindialog.h"
+
+using namespace MOBase;
+
+DisableProxyPluginDialog::DisableProxyPluginDialog(
+  MOBase::IPlugin* proxyPlugin, std::vector<MOBase::IPlugin*> const& required, QWidget* parent)
+  : QDialog(parent), ui(new Ui::DisableProxyPluginDialog)
+{
+  ui->setupUi(this);
+
+  ui->topLabel->setText(QObject::tr(
+    "Disabling the '%1' plugin will prevent the following %2 plugin(s) from working:", "", required.size())
+    .arg(proxyPlugin->localizedName())
+    .arg(required.size()));
+
+  connect(ui->noBtn, &QPushButton::clicked, this, &QDialog::reject);
+  connect(ui->yesBtn, &QPushButton::clicked, this, &QDialog::accept);
+
+  ui->requiredPlugins->setSelectionMode(QAbstractItemView::NoSelection);
+  ui->requiredPlugins->setRowCount(required.size());
+  for (int i = 0; i < required.size(); ++i) {
+    ui->requiredPlugins->setItem(i, 0, new QTableWidgetItem(required[i]->localizedName()));
+    ui->requiredPlugins->setItem(i, 1, new QTableWidgetItem(required[i]->description()));
+    ui->requiredPlugins->setRowHeight(i, 9);
+  }
+  ui->requiredPlugins->verticalHeader()->setVisible(false);
+  ui->requiredPlugins->sortByColumn(0, Qt::AscendingOrder);
+}

--- a/src/disableproxyplugindialog.h
+++ b/src/disableproxyplugindialog.h
@@ -1,0 +1,43 @@
+/*
+Copyright (C) 2020 Mikaël Capelle. All rights reserved.
+
+This file is part of Mod Organizer.
+
+Mod Organizer is free software: you can redistribute it and/or modify
+it under the terms of the GNU General Public License as published by
+the Free Software Foundation, either version 3 of the License, or
+(at your option) any later version.
+
+Mod Organizer is distributed in the hope that it will be useful,
+but WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+GNU General Public License for more details.
+
+You should have received a copy of the GNU General Public License
+along with Mod Organizer.  If not, see <http://www.gnu.org/licenses/>.
+*/
+
+#ifndef DISABLEPROXYPLUGINDIALOG_H
+#define DISABLEPROXYPLUGINDIALOG_H
+
+#include <QDialog>
+
+#include "ipluginproxy.h"
+
+namespace Ui { class DisableProxyPluginDialog; }
+
+class DisableProxyPluginDialog : public QDialog {
+public:
+
+  DisableProxyPluginDialog(
+    MOBase::IPlugin* proxyPlugin,
+    std::vector<MOBase::IPlugin*> const& required,
+    QWidget* parent = nullptr);
+
+private slots:
+
+  Ui::DisableProxyPluginDialog* ui;
+
+};
+
+#endif

--- a/src/disableproxyplugindialog.ui
+++ b/src/disableproxyplugindialog.ui
@@ -1,0 +1,174 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<ui version="4.0">
+ <class>DisableProxyPluginDialog</class>
+ <widget class="QDialog" name="DisableProxyPluginDialog">
+  <property name="geometry">
+   <rect>
+    <x>0</x>
+    <y>0</y>
+    <width>522</width>
+    <height>417</height>
+   </rect>
+  </property>
+  <property name="windowTitle">
+   <string>Really disable plugin?</string>
+  </property>
+  <layout class="QVBoxLayout" name="verticalLayout">
+   <item>
+    <widget class="QWidget" name="horizontalWidget" native="true">
+     <property name="minimumSize">
+      <size>
+       <width>0</width>
+       <height>0</height>
+      </size>
+     </property>
+     <layout class="QHBoxLayout" name="horizontalLayout">
+      <item>
+       <widget class="QLabel" name="label_2">
+        <property name="sizePolicy">
+         <sizepolicy hsizetype="Fixed" vsizetype="Fixed">
+          <horstretch>0</horstretch>
+          <verstretch>0</verstretch>
+         </sizepolicy>
+        </property>
+        <property name="text">
+         <string/>
+        </property>
+        <property name="textFormat">
+         <enum>Qt::PlainText</enum>
+        </property>
+        <property name="pixmap">
+         <pixmap resource="resources.qrc">:/MO/gui/remove</pixmap>
+        </property>
+        <property name="alignment">
+         <set>Qt::AlignCenter</set>
+        </property>
+       </widget>
+      </item>
+      <item>
+       <spacer name="horizontalSpacer">
+        <property name="orientation">
+         <enum>Qt::Horizontal</enum>
+        </property>
+        <property name="sizeType">
+         <enum>QSizePolicy::Fixed</enum>
+        </property>
+        <property name="sizeHint" stdset="0">
+         <size>
+          <width>10</width>
+          <height>20</height>
+         </size>
+        </property>
+       </spacer>
+      </item>
+      <item>
+       <widget class="QLabel" name="topLabel">
+        <property name="text">
+         <string>Disabling the '%1' plugin will prevent the following plugins from working:</string>
+        </property>
+       </widget>
+      </item>
+     </layout>
+    </widget>
+   </item>
+   <item>
+    <widget class="QTableWidget" name="requiredPlugins">
+     <property name="columnCount">
+      <number>2</number>
+     </property>
+     <attribute name="horizontalHeaderStretchLastSection">
+      <bool>true</bool>
+     </attribute>
+     <column>
+      <property name="text">
+       <string>Plugin</string>
+      </property>
+     </column>
+     <column>
+      <property name="text">
+       <string>Description</string>
+      </property>
+     </column>
+    </widget>
+   </item>
+   <item>
+    <widget class="QLabel" name="label">
+     <property name="text">
+      <string>Do you want to continue? You will need to restart Mod Organizer for the change to take effect.</string>
+     </property>
+    </widget>
+   </item>
+   <item>
+    <widget class="QWidget" name="buttons" native="true">
+     <property name="minimumSize">
+      <size>
+       <width>0</width>
+       <height>0</height>
+      </size>
+     </property>
+     <layout class="QHBoxLayout" name="horizontalLayout_2">
+      <item>
+       <spacer name="horizontalSpacer_2">
+        <property name="orientation">
+         <enum>Qt::Horizontal</enum>
+        </property>
+        <property name="sizeHint" stdset="0">
+         <size>
+          <width>40</width>
+          <height>20</height>
+         </size>
+        </property>
+       </spacer>
+      </item>
+      <item>
+       <widget class="QPushButton" name="yesBtn">
+        <property name="minimumSize">
+         <size>
+          <width>80</width>
+          <height>0</height>
+         </size>
+        </property>
+        <property name="text">
+         <string>Yes</string>
+        </property>
+        <property name="icon">
+         <iconset resource="resources.qrc">
+          <normaloff>:/MO/gui/remove</normaloff>:/MO/gui/remove</iconset>
+        </property>
+       </widget>
+      </item>
+      <item>
+       <widget class="QPushButton" name="noBtn">
+        <property name="sizePolicy">
+         <sizepolicy hsizetype="Fixed" vsizetype="Fixed">
+          <horstretch>0</horstretch>
+          <verstretch>0</verstretch>
+         </sizepolicy>
+        </property>
+        <property name="minimumSize">
+         <size>
+          <width>80</width>
+          <height>0</height>
+         </size>
+        </property>
+        <property name="text">
+         <string>No</string>
+        </property>
+        <property name="default">
+         <bool>true</bool>
+        </property>
+        <property name="flat">
+         <bool>false</bool>
+        </property>
+       </widget>
+      </item>
+     </layout>
+    </widget>
+   </item>
+  </layout>
+ </widget>
+ <resources>
+  <include location="resources.qrc"/>
+ </resources>
+ <connections/>
+</ui>

--- a/src/installationmanager.h
+++ b/src/installationmanager.h
@@ -35,6 +35,7 @@ along with Mod Organizer.  If not, see <http://www.gnu.org/licenses/>.
 #include <errorcodes.h>
 
 #include "modinfo.h"
+#include "plugincontainer.h"
 
 
 /**
@@ -88,6 +89,11 @@ public:
   void setModsDirectory(const QString &modsDirectory) { m_ModsDirectory = modsDirectory; }
 
   /**
+   *
+   */
+  void setPluginContainer(const PluginContainer* pluginContainer);
+
+  /**
    * @brief update the directory where downloads are stored
    * @param downloadDirectory the download directory
    */
@@ -126,8 +132,8 @@ public:
    * @brief register an installer-plugin
    * @param the installer to register
    */
-  void registerInstaller(MOBase::IPluginInstaller *installer); 
-  
+  void registerInstaller(MOBase::IPluginInstaller *installer);
+
   /**
    * @return the extensions of archives supported by this installation manager.
    */
@@ -167,7 +173,7 @@ public:
    *
    * The flatten argument is not present here while it is present in the deprecated QStringList
    * version for multiple reasons: 1) it was never used, 2) it is kind of fishy because there
-   * is no way to know if a file is going to be overriden, 3) it is quite easy to flatten a 
+   * is no way to know if a file is going to be overriden, 3) it is quite easy to flatten a
    * IFileTree and thus to given a list of entries flattened (this was not possible with the
    * QStringList version since these were based on the name of the file inside the archive).
    */
@@ -185,7 +191,7 @@ public:
    * @return the path to the created file.
    */
   virtual QString createFile(std::shared_ptr<const MOBase::FileTreeEntry> entry) override;
-  
+
   /**
    * @brief Installs the given archive.
    *
@@ -278,6 +284,9 @@ private:
   bool extractFiles(QString extractPath, QString title, bool showFilenames, bool silent);
 
 private:
+
+  // The plugin container, mostly to check if installer are enabled or not:
+  const PluginContainer *m_PluginContainer;
 
   bool m_IsRunning;
 

--- a/src/installationmanager.h
+++ b/src/installationmanager.h
@@ -285,7 +285,7 @@ private:
 
 private:
 
-  // The plugin container, mostly to check if installer are enabled or not:
+  // The plugin container, mostly to check if installer are enabled or not.
   const PluginContainer *m_PluginContainer;
 
   bool m_IsRunning;
@@ -298,13 +298,13 @@ private:
   std::vector<MOBase::IPluginInstaller*> m_Installers;
   std::set<QString, CaseInsensitive> m_SupportedExtensions;
 
-  // Archive management:
+  // Archive management.
   std::unique_ptr<Archive> m_ArchiveHandler;
   QString m_CurrentFile;
   QString m_Password;
 
   // Map from entries in the tree that is used by the installer and absolute
-  // paths to temporary files:
+  // paths to temporary files.
   std::map<std::shared_ptr<const MOBase::FileTreeEntry>, QString> m_CreatedFiles;
   std::set<QString> m_TempFilesToDelete;
 };

--- a/src/iuserinterface.h
+++ b/src/iuserinterface.h
@@ -13,8 +13,6 @@
 class IUserInterface
 {
 public:
-  virtual void registerPluginTool(MOBase::IPluginTool *tool, QString name = QString(), QMenu *menu = nullptr) = 0;
-  virtual void registerPluginTools(std::vector<MOBase::IPluginTool *> toolPlugins) = 0;
   virtual void registerModPage(MOBase::IPluginModPage *modPage) = 0;
 
   virtual void installTranslator(const QString &name) = 0;

--- a/src/mainwindow.cpp
+++ b/src/mainwindow.cpp
@@ -1132,7 +1132,7 @@ void MainWindow::checkForProblemsImpl()
     size_t numProblems = 0;
     for (QObject *pluginObj : m_PluginContainer.plugins<QObject>()) {
       IPlugin *plugin = qobject_cast<IPlugin*>(pluginObj);
-      if (plugin == nullptr || plugin->isActive()) {
+      if (plugin == nullptr || m_PluginContainer.isEnabled(plugin)) {
         IPluginDiagnose *diagnose = qobject_cast<IPluginDiagnose*>(pluginObj);
         if (diagnose != nullptr)
           numProblems += diagnose->activeProblems().size();
@@ -1663,9 +1663,11 @@ void MainWindow::registerPluginTools(std::vector<IPluginTool *> toolPlugins)
     }
   );
 
+  // TODO: I don't know when this method is called? Maybe the check should be perform when
+  // the context menu is opened?
   // Remove inactive plugins
   toolPlugins.erase(
-    std::remove_if(toolPlugins.begin(), toolPlugins.end(), [](IPluginTool *plugin) -> bool { return !plugin->isActive(); }),
+    std::remove_if(toolPlugins.begin(), toolPlugins.end(), [this](IPluginTool *plugin) { return !m_PluginContainer.isEnabled(plugin); }),
     toolPlugins.end()
     );
 
@@ -5972,7 +5974,7 @@ void MainWindow::on_actionNotifications_triggered()
 
   future.waitForFinished();
 
-  ProblemsDialog problems(m_PluginContainer.plugins<QObject>(), this);
+  ProblemsDialog problems(m_PluginContainer, this);
   problems.exec();
 
   scheduleCheckForProblems();

--- a/src/mainwindow.cpp
+++ b/src/mainwindow.cpp
@@ -1652,6 +1652,9 @@ void MainWindow::registerPluginTool(IPluginTool *tool, QString name, QMenu *menu
   connect(action, SIGNAL(triggered()), this, SLOT(toolPluginInvoke()), Qt::QueuedConnection);
 
   menu->addAction(action);
+  if (!m_PluginContainer.isEnabled(tool)) {
+    action->setVisible(false);
+  }
 }
 
 void MainWindow::registerPluginTools(std::vector<IPluginTool *> toolPlugins)
@@ -1662,14 +1665,6 @@ void MainWindow::registerPluginTools(std::vector<IPluginTool *> toolPlugins)
       return left->displayName().toLower() < right->displayName().toLower();
     }
   );
-
-  // TODO: I don't know when this method is called? Maybe the check should be perform when
-  // the context menu is opened?
-  // Remove inactive plugins
-  toolPlugins.erase(
-    std::remove_if(toolPlugins.begin(), toolPlugins.end(), [this](IPluginTool *plugin) { return !m_PluginContainer.isEnabled(plugin); }),
-    toolPlugins.end()
-    );
 
   // Group the plugins into submenus
   QMap<QString, QList<QPair<QString, IPluginTool *>>> submenuMap;

--- a/src/mainwindow.h
+++ b/src/mainwindow.h
@@ -129,10 +129,6 @@ public:
 
   void saveArchiveList();
 
-  void registerPluginTool(MOBase::IPluginTool *tool, QString name = QString(), QMenu *menu = nullptr);
-  void registerPluginTools(std::vector<MOBase::IPluginTool *> toolPlugins);
-  void registerModPage(MOBase::IPluginModPage *modPage);
-
   void addPrimaryCategoryCandidates(QMenu *primaryCategoryMenu, ModInfo::Ptr info);
 
   void installTranslator(const QString &name);
@@ -160,7 +156,6 @@ public slots:
 
   void directory_refreshed();
 
-  void toolPluginInvoke();
   void modPagePluginInvoke();
 
 signals:
@@ -212,7 +207,11 @@ private:
   void setToolbarSize(const QSize& s);
   void setToolbarButtonStyle(Qt::ToolButtonStyle s);
 
+  void registerModPage(MOBase::IPluginModPage* modPage);
+  void registerPluginTool(MOBase::IPluginTool* tool, QString name = QString(), QMenu* menu = nullptr);
+
   void updateToolbarMenu();
+  void updateToolMenu();
   void updateViewMenu();
 
   QMenu* createPopupMenu() override;

--- a/src/mainwindow.h
+++ b/src/mainwindow.h
@@ -210,6 +210,7 @@ private:
 
   void updateToolbarMenu();
   void updateToolMenu();
+  void updateModPageMenu();
   void updateViewMenu();
 
   QMenu* createPopupMenu() override;

--- a/src/mainwindow.h
+++ b/src/mainwindow.h
@@ -156,8 +156,6 @@ public slots:
 
   void directory_refreshed();
 
-  void modPagePluginInvoke();
-
 signals:
 
   /**
@@ -324,8 +322,6 @@ private:
   QPersistentModelIndex m_ContextIdx;
   QTreeWidgetItem *m_ContextItem;
   QAction *m_ContextAction;
-
-  QAction* m_browseModPage;
 
   CategoryFactory &m_CategoryFactory;
 

--- a/src/mainwindow.ui
+++ b/src/mainwindow.ui
@@ -1411,6 +1411,7 @@ p, li { white-space: pre-wrap; }
    <addaction name="actionChange_Game"/>
    <addaction name="actionInstallMod"/>
    <addaction name="actionNexus"/>
+   <addaction name="actionModPage"/>
    <addaction name="actionAdd_Profile"/>
    <addaction name="actionModify_Executables"/>
    <addaction name="actionTool"/>
@@ -1682,6 +1683,27 @@ p, li { white-space: pre-wrap; }
    </property>
    <property name="shortcut">
     <string>Ctrl+N</string>
+   </property>
+  </action>
+  <action name="actionModPage">
+   <property name="icon">
+    <iconset resource="resources.qrc">
+     <normaloff>:/MO/gui/resources/internet-web-browser.png</normaloff>:/MO/gui/resources/internet-web-browser.png</iconset>
+   </property>
+   <property name="text">
+    <string>Browse Mod Page</string>
+   </property>
+   <property name="iconText">
+    <string>Browse Mod Page</string>
+   </property>
+   <property name="toolTip">
+    <string>Browse Mod Page</string>
+   </property>
+   <property name="statusTip">
+    <string>Browse Mod Page</string>
+   </property>
+   <property name="visible">
+    <bool>false</bool>
    </property>
   </action>
   <action name="actionUpdate">

--- a/src/organizercore.cpp
+++ b/src/organizercore.cpp
@@ -295,6 +295,11 @@ void OrganizerCore::connectPlugins(PluginContainer *container)
     m_GamePlugin = m_PluginContainer->managedGame(m_GameName);
     emit managedGameChanged(m_GamePlugin);
   }
+
+  connect(m_PluginContainer, &PluginContainer::pluginEnabled,
+    [&](IPlugin* plugin) { m_PluginEnabled(plugin); });
+  connect(m_PluginContainer, &PluginContainer::pluginDisabled,
+    [&](IPlugin* plugin) { m_PluginDisabled(plugin); });
 }
 
 void OrganizerCore::disconnectPlugins()
@@ -1223,6 +1228,16 @@ bool OrganizerCore::onProfileChanged(std::function<void(IProfile*, IProfile*)> c
 bool OrganizerCore::onPluginSettingChanged(std::function<void(QString const&, const QString& key, const QVariant&, const QVariant&)> const& func)
 {
   return m_PluginSettingChanged.connect(func).connected();
+}
+
+bool OrganizerCore::onPluginEnabled(std::function<void(const IPlugin*)> const& func)
+{
+  return m_PluginEnabled.connect(func).connected();
+}
+
+bool OrganizerCore::onPluginDisabled(std::function<void(const IPlugin*)> const& func)
+{
+  return m_PluginDisabled.connect(func).connected();
 }
 
 void OrganizerCore::refresh(bool saveChanges)

--- a/src/organizercore.cpp
+++ b/src/organizercore.cpp
@@ -287,6 +287,7 @@ void OrganizerCore::connectPlugins(PluginContainer *container)
       m_InstallationManager.getSupportedExtensions());
   m_PluginContainer = container;
   m_Updater.setPluginContainer(m_PluginContainer);
+  m_InstallationManager.setPluginContainer(m_PluginContainer);
   m_DownloadManager.setPluginContainer(m_PluginContainer);
   m_ModList.setPluginContainer(m_PluginContainer);
 
@@ -2040,7 +2041,7 @@ std::vector<Mapping> OrganizerCore::fileMapping(const QString &profileName,
   for (MOBase::IPluginFileMapper *mapper :
        m_PluginContainer->plugins<MOBase::IPluginFileMapper>()) {
     IPlugin *plugin = dynamic_cast<IPlugin *>(mapper);
-    if (plugin->isActive()) {
+    if (m_PluginContainer->isEnabled(plugin)) {
       MappingType pluginMap = mapper->mappings();
       result.reserve(result.size() + pluginMap.size());
       result.insert(result.end(), pluginMap.begin(), pluginMap.end());

--- a/src/organizercore.cpp
+++ b/src/organizercore.cpp
@@ -1465,10 +1465,13 @@ void OrganizerCore::loggedInAction(QWidget* parent, std::function<void ()> f)
 
 void OrganizerCore::requestDownload(const QUrl &url, QNetworkReply *reply)
 {
-  if (m_PluginContainer != nullptr) {
-    for (IPluginModPage *modPage :
-         m_PluginContainer->plugins<MOBase::IPluginModPage>()) {
-      ModRepositoryFileInfo *fileInfo = new ModRepositoryFileInfo();
+  if (!m_PluginContainer) {
+    return;
+  }
+  for (IPluginModPage *modPage :
+        m_PluginContainer->plugins<MOBase::IPluginModPage>()) {
+    if (m_PluginContainer->isEnabled(modPage)) {
+      ModRepositoryFileInfo* fileInfo = new ModRepositoryFileInfo();
       if (modPage->handlesDownload(url, reply->url(), *fileInfo)) {
         fileInfo->repository = modPage->name();
         m_DownloadManager.addDownload(reply, fileInfo);

--- a/src/organizercore.h
+++ b/src/organizercore.h
@@ -87,6 +87,7 @@ private:
   using SignalProfileRemoved = boost::signals2::signal<void(QString const&)>;
   using SignalProfileChanged = boost::signals2::signal<void (MOBase::IProfile *, MOBase::IProfile *)>;
   using SignalPluginSettingChanged = boost::signals2::signal<void (QString const&, const QString& key, const QVariant&, const QVariant&)>;
+  using SignalPluginEnabled = boost::signals2::signal<void(MOBase::IPlugin*)>;
 
 public:
 
@@ -335,6 +336,8 @@ public:
   bool onProfileRemoved(std::function<void(QString const&)> const& func);
   bool onProfileChanged(std::function<void(MOBase::IProfile*, MOBase::IProfile*)> const& func);
   bool onPluginSettingChanged(std::function<void(QString const&, const QString& key, const QVariant&, const QVariant&)> const& func);
+  bool onPluginEnabled(std::function<void(const MOBase::IPlugin*)> const& func);
+  bool onPluginDisabled(std::function<void(const MOBase::IPlugin*)> const& func);
 
   bool getArchiveParsing() const
   {
@@ -457,6 +460,8 @@ private:
   SignalProfileRemoved m_ProfileRemoved;
   SignalProfileChanged m_ProfileChanged;
   SignalPluginSettingChanged m_PluginSettingChanged;
+  SignalPluginEnabled m_PluginEnabled;
+  SignalPluginEnabled m_PluginDisabled;
 
   ModList m_ModList;
   PluginList m_PluginList;

--- a/src/organizerproxy.cpp
+++ b/src/organizerproxy.cpp
@@ -293,8 +293,36 @@ bool OrganizerProxy::onProfileChanged(std::function<void(MOBase::IProfile*, MOBa
   return m_Proxied->onProfileChanged(MOShared::callIfPluginActive(this, func));
 }
 
+// Always call these one, otherwise plugin cannot detect they are being enabled / disabled:
 bool OrganizerProxy::onPluginSettingChanged(std::function<void(QString const&, const QString& key, const QVariant&, const QVariant&)> const& func)
 {
-  // Always call this one, otherwise plugin cannot detect they are being enabled / disabled:
   return m_Proxied->onPluginSettingChanged(func);
+}
+
+bool OrganizerProxy::onPluginEnabled(std::function<void(const IPlugin*)> const& func)
+{
+  return m_Proxied->onPluginEnabled(func);
+}
+
+bool OrganizerProxy::onPluginEnabled(const QString& pluginName, std::function<void()> const& func)
+{
+  return m_Proxied->onPluginEnabled([=](const IPlugin* plugin) {
+    if (plugin->name().compare(pluginName, Qt::CaseInsensitive) == 0) {
+      func();
+    }
+  });
+}
+
+bool OrganizerProxy::onPluginDisabled(std::function<void(const IPlugin*)> const& func)
+{
+  return m_Proxied->onPluginDisabled(func);
+}
+
+bool OrganizerProxy::onPluginDisabled(const QString& pluginName, std::function<void()> const& func)
+{
+  return m_Proxied->onPluginDisabled([=](const IPlugin* plugin) {
+    if (plugin->name().compare(pluginName, Qt::CaseInsensitive) == 0) {
+      func();
+    }
+  });
 }

--- a/src/organizerproxy.cpp
+++ b/src/organizerproxy.cpp
@@ -83,6 +83,16 @@ void OrganizerProxy::modDataChanged(IModInterface *mod)
   m_Proxied->modDataChanged(mod);
 }
 
+bool OrganizerProxy::isPluginEnabled(QString const& pluginName) const
+{
+  return m_PluginContainer->isEnabled(pluginName);
+}
+
+bool OrganizerProxy::isPluginEnabled(IPlugin* plugin) const
+{
+  return m_PluginContainer->isEnabled(plugin);
+}
+
 QVariant OrganizerProxy::pluginSetting(const QString &pluginName, const QString &key) const
 {
   return m_Proxied->pluginSetting(pluginName, key);

--- a/src/organizerproxy.h
+++ b/src/organizerproxy.h
@@ -69,6 +69,10 @@ public:
   virtual QVariant pluginSetting(const QString& pluginName, const QString& key) const override;
   virtual void setPluginSetting(const QString& pluginName, const QString& key, const QVariant& value) override;
   virtual bool onPluginSettingChanged(std::function<void(QString const&, const QString& key, const QVariant&, const QVariant&)> const& func) override;
+  virtual bool onPluginEnabled(std::function<void(const MOBase::IPlugin*)> const& func) override;
+  virtual bool onPluginEnabled(const QString& pluginName, std::function<void()> const& func) override;
+  virtual bool onPluginDisabled(std::function<void(const MOBase::IPlugin*)> const& func) override;
+  virtual bool onPluginDisabled(const QString& pluginName, std::function<void()> const& func) override;
 
   virtual MOBase::IPluginGame const *managedGame() const;
 

--- a/src/organizerproxy.h
+++ b/src/organizerproxy.h
@@ -35,8 +35,6 @@ public:
   virtual MOBase::IPluginGame *getGame(const QString &gameName) const;
   virtual MOBase::IModInterface *createMod(MOBase::GuessedValue<QString> &name);
   virtual void modDataChanged(MOBase::IModInterface *mod);
-  virtual QVariant pluginSetting(const QString &pluginName, const QString &key) const;
-  virtual void setPluginSetting(const QString &pluginName, const QString &key, const QVariant &value);
   virtual QVariant persistent(const QString &pluginName, const QString &key, const QVariant &def = QVariant()) const;
   virtual void setPersistent(const QString &pluginName, const QString &key, const QVariant &value, bool sync = true);
   virtual QString pluginDataPath() const;
@@ -64,6 +62,12 @@ public:
   virtual bool onProfileRenamed(std::function<void(MOBase::IProfile*, QString const&, QString const&)> const& func) override;
   virtual bool onProfileRemoved(std::function<void(QString const&)> const& func) override;
   virtual bool onProfileChanged(std::function<void(MOBase::IProfile*, MOBase::IProfile*)> const& func) override;
+
+  // Plugin related:
+  virtual bool isPluginEnabled(QString const& pluginName) const override;
+  virtual bool isPluginEnabled(MOBase::IPlugin* plugin) const override;
+  virtual QVariant pluginSetting(const QString& pluginName, const QString& key) const override;
+  virtual void setPluginSetting(const QString& pluginName, const QString& key, const QVariant& value) override;
   virtual bool onPluginSettingChanged(std::function<void(QString const&, const QString& key, const QVariant&, const QVariant&)> const& func) override;
 
   virtual MOBase::IPluginGame const *managedGame() const;

--- a/src/plugincontainer.cpp
+++ b/src/plugincontainer.cpp
@@ -74,12 +74,13 @@ MOBase::IPluginProxy* PluginRequirements::proxy() const
   return m_PluginProxy;
 }
 
-std::vector<PluginRequirements::Problem> PluginRequirements::problems() const
+std::vector<IPluginRequirement::Problem> PluginRequirements::problems() const
 {
-  std::vector<Problem> result;
+  std::vector<IPluginRequirement::Problem> result;
   for (auto& requirement : m_Requirements) {
-    for (auto p : requirement->problems(m_Organizer)) {
-      result.push_back(Problem(requirement.get(), p));
+    auto p = requirement->check(m_Organizer);
+    if (p) {
+      result.push_back(*p);
     }
   }
   return result;

--- a/src/plugincontainer.cpp
+++ b/src/plugincontainer.cpp
@@ -180,10 +180,6 @@ void PluginContainer::setUserInterface(IUserInterface *userInterface, QWidget *w
     for (IPluginModPage *modPage : bf::at_key<IPluginModPage>(m_Plugins)) {
       userInterface->registerModPage(modPage);
     }
-
-    for (IPluginTool *tool : bf::at_key<IPluginTool>(m_Plugins)) {
-      userInterface->registerPluginTool(tool);
-    }
   }
 
   m_UserInterface = userInterface;

--- a/src/plugincontainer.cpp
+++ b/src/plugincontainer.cpp
@@ -329,11 +329,6 @@ bool PluginContainer::initPlugin(IPlugin *plugin, IPluginProxy *pluginProxy)
 
   m_Requirements.emplace(plugin, PluginRequirements(this, plugin, proxy, pluginProxy));
 
-  if (!plugin->master().isEmpty() && m_Requirements.at(plugin).hasRequirements()) {
-    log::warn("a plugin cannot have requirements if it has a master");
-    return false;
-  }
-
   return true;
 }
 

--- a/src/plugincontainer.cpp
+++ b/src/plugincontainer.cpp
@@ -78,8 +78,7 @@ std::vector<IPluginRequirement::Problem> PluginRequirements::problems() const
 {
   std::vector<IPluginRequirement::Problem> result;
   for (auto& requirement : m_Requirements) {
-    auto p = requirement->check(m_Organizer);
-    if (p) {
+    if (auto p = requirement->check(m_Organizer)) {
       result.push_back(*p);
     }
   }

--- a/src/plugincontainer.cpp
+++ b/src/plugincontainer.cpp
@@ -413,11 +413,11 @@ bool PluginContainer::initPlugin(IPlugin *plugin, IPluginProxy *pluginProxy, boo
   // Check if it is a proxy plugin:
   bool isProxy = dynamic_cast<IPluginProxy*>(plugin);
 
+  auto [it, bl] = m_Requirements.emplace(plugin, PluginRequirements(this, plugin, proxy, pluginProxy));
+
   if (!m_Organizer && !isProxy) {
     return true;
   }
-
-  auto [it, bl] = m_Requirements.emplace(plugin, PluginRequirements(this, plugin, proxy, pluginProxy));
 
   if (skipInit) {
     return true;
@@ -615,8 +615,6 @@ IPlugin* PluginContainer::registerPlugin(QObject *plugin, const QString &fileNam
       return dummy;
     }
   }
-
-  log::debug("no matching plugin interface");
 
   return nullptr;
 }

--- a/src/plugincontainer.cpp
+++ b/src/plugincontainer.cpp
@@ -624,6 +624,13 @@ void PluginContainer::setEnabled(MOBase::IPlugin* plugin, bool enable, bool depe
   }
 
   m_Organizer->setPersistent(plugin->name(), "enabled", enable, true);
+
+  if (enable) {
+    emit pluginEnabled(plugin);
+  }
+  else {
+    emit pluginDisabled(plugin);
+  }
 }
 
 MOBase::IPlugin* PluginContainer::plugin(QString const& pluginName) const

--- a/src/plugincontainer.cpp
+++ b/src/plugincontainer.cpp
@@ -167,7 +167,7 @@ std::vector<IPlugin*> PluginRequirements::children() const
     // Not checking master() but requirements().master() due to "hidden"
     // masters.
     // If the master has the same name as the plugin, this is a "hidden"
-    // master, we do not had it here.
+    // master, we do not add it here.
     if (plugin
         && m_PluginContainer->requirements(plugin).master() == m_Plugin
         && plugin->name() != m_Plugin->name()) {

--- a/src/plugincontainer.h
+++ b/src/plugincontainer.h
@@ -325,6 +325,12 @@ public: // IPluginDiagnose interface
 
 signals:
 
+  /**
+   * @brief Emitted plugins are enabled or disabled.
+   */
+  void pluginEnabled(MOBase::IPlugin*);
+  void pluginDisabled(MOBase::IPlugin*);
+
   void diagnosisUpdate();
 
 private:

--- a/src/plugincontainer.h
+++ b/src/plugincontainer.h
@@ -40,9 +40,24 @@ public:
   bool canEnable() const;
 
   /**
+   * @return true if this plugin has requirements (satisfied or not).
+   */
+  bool hasRequirements() const;
+
+  /**
    * @return the proxy that created this plugin, if any.
    */
   MOBase::IPluginProxy* proxy() const;
+
+  /**
+   * @return the master of this plugin, if any.
+   */
+  MOBase::IPlugin* master() const;
+
+  /**
+   * @return the plugins this plugin is master of.
+   */
+  std::vector<MOBase::IPlugin*> children() const;
 
   /**
    * @return the list of problems to be resolved before enabling the plugin.

--- a/src/plugincontainer.h
+++ b/src/plugincontainer.h
@@ -50,6 +50,11 @@ public:
   MOBase::IPluginProxy* proxy() const;
 
   /**
+   * @return the list of plugins this plugin proxies (if it's a proxy plugin).
+   */
+  std::vector<MOBase::IPlugin*> proxied() const;
+
+  /**
    * @return the master of this plugin, if any.
    */
   MOBase::IPlugin* master() const;
@@ -80,6 +85,11 @@ private:
 
   // Accumulator version for requiredFor() to avoid infinite recursion.
   void requiredFor(std::vector<MOBase::IPlugin*>& required, std::set<MOBase::IPlugin*>& visited) const;
+
+  // Retrieve the requirements from the underlying plugin, take ownership on them
+  // and store them. We cannot do this in the constructor because we want to have a
+  // constructed object before calling init().
+  void fetchRequirements();
 
   friend class PluginContainer;
 

--- a/src/plugincontainer.h
+++ b/src/plugincontainer.h
@@ -38,10 +38,10 @@ public:
 
 private:
 
-  const MOBase::PluginRequirement* m_Requirement;
+  const MOBase::IPluginRequirement* m_Requirement;
   OrganizerProxy* m_Proxy;
 
-  PluginRequirementProxy(const MOBase::PluginRequirement* requirement, OrganizerProxy* proxy);
+  PluginRequirementProxy(const MOBase::IPluginRequirement* requirement, OrganizerProxy* proxy);
 
   friend class PluginContainer;
 
@@ -160,16 +160,7 @@ public:
       return false;
     }
 
-    // Find all the names:
-    bool implement = false;
-    boost::mp11::mp_for_each<PluginTypeOrder>([oPlugin, &implement](const auto* p) {
-      using plugin_type = std::decay_t<decltype(*p)>;
-      if (qobject_cast<plugin_type*>(oPlugin)) {
-        implement = true;
-      }
-    });
-
-    return implement;
+    return qobject_cast<T*>(oPlugin);
   }
 
   /**
@@ -278,7 +269,7 @@ private:
   AccessPluginMap m_AccessPlugins;
 
   std::map<MOBase::IPlugin*, OrganizerProxy*> m_Proxies;
-  std::map<MOBase::IPlugin*, std::vector<std::unique_ptr<const MOBase::PluginRequirement>>> m_Requirements;
+  std::map<MOBase::IPlugin*, std::vector<std::unique_ptr<const MOBase::IPluginRequirement>>> m_Requirements;
 
   std::map<QString, MOBase::IPluginGame*> m_SupportedGames;
   std::vector<boost::signals2::connection> m_DiagnosisConnections;

--- a/src/plugincontainer.h
+++ b/src/plugincontainer.h
@@ -34,25 +34,6 @@ class OrganizerProxy;
 class PluginRequirements {
 public:
 
-  // Small intermediate class.
-  struct Problem {
-  public:
-
-    QString description() const { return m_Requirement->description(m_Id); }
-
-
-  private:
-    Problem(const MOBase::IPluginRequirement* requirement, unsigned int id) :
-      m_Requirement(requirement), m_Id(id) { }
-
-    const MOBase::IPluginRequirement* m_Requirement;
-    unsigned int m_Id;
-
-    friend class PluginRequirements;
-  };
-
-public:
-
   /**
    * @return true if the plugin can be enabled (all requirements are met).
    */
@@ -66,7 +47,7 @@ public:
   /**
    * @return the list of problems to be resolved before enabling the plugin.
    */
-  std::vector<Problem> problems() const;
+  std::vector<MOBase::IPluginRequirement::Problem> problems() const;
 
   /**
    * @return the name of the games (gameName()) this plugin can be used with, or an empty

--- a/src/plugincontainer.h
+++ b/src/plugincontainer.h
@@ -331,6 +331,20 @@ private:
 
   friend class PluginRequirements;
 
+
+  /**
+   * @brief Retrieved the (localized) names of interfaces implemented by the given
+   *     plugin.
+   *
+   * @param plugin The plugin to retrieve interface for.
+   *
+   * @return the (localized) names of interfaces implemented by this plugin.
+   *
+   * @note This function can be used to get implemented interfaces before registering
+   *     a plugin.
+   */
+  QStringList implementedInterfaces(QObject* plugin) const;
+
   /**
    * @brief Check if a plugin implements a "better" interface than another
    *     one, as specified by PluginTypeOrder.

--- a/src/plugincontainer.h
+++ b/src/plugincontainer.h
@@ -91,11 +91,15 @@ private:
   // constructed object before calling init().
   void fetchRequirements();
 
+  // Set the master for this plugin. This is required to "fake" masters for proxied plugins.
+  void setMaster(MOBase::IPlugin* master);
+
   friend class PluginContainer;
 
   PluginContainer* m_PluginContainer;
   MOBase::IPlugin* m_Plugin;
   MOBase::IPluginProxy* m_PluginProxy;
+  MOBase::IPlugin* m_Master;
   std::vector<std::unique_ptr<const MOBase::IPluginRequirement>> m_Requirements;
   MOBase::IOrganizer* m_Organizer;
   std::vector<MOBase::IPlugin*> m_RequiredFor;
@@ -107,6 +111,9 @@ private:
 };
 
 
+/**
+ *
+ */
 class PluginContainer : public QObject, public MOBase::IPluginDiagnose
 {
 
@@ -229,6 +236,10 @@ public:
    * @param t Name of the plugin to retrieve, or non-IPlugin interface.
    *
    * @return the corresponding plugin, or a null pointer.
+   *
+   * @note It is possible to have multiple plugins for the same name when
+   *     dealing with proxied plugins (e.g. Python), in which case the
+   *     most important one will be returned, as specified in PluginTypeOrder.
    */
   MOBase::IPlugin* plugin(QString const& pluginName) const;
   MOBase::IPlugin* plugin(MOBase::IPluginDiagnose* diagnose) const;
@@ -321,6 +332,17 @@ private:
   friend class PluginRequirements;
 
   /**
+   * @brief Check if a plugin implements a "better" interface than another
+   *     one, as specified by PluginTypeOrder.
+   *
+   * @param lhs, rhs The plugin to compare.
+   *
+   * @return true if the left plugin implements a better interface than the right
+   *     one, false otherwise (or if both implements the same interface).
+   */
+  bool isBetterInterface(QObject* lhs, QObject* rhs) const;
+
+  /**
    * @brief Find the QObject* corresponding to the given plugin.
    *
    * @param plugin The plugin to find the QObject* for.
@@ -341,7 +363,7 @@ private:
 
   void registerGame(MOBase::IPluginGame *game);
 
-  bool registerPlugin(QObject *pluginObj, const QString &fileName, MOBase::IPluginProxy *proxy);
+  MOBase::IPlugin* registerPlugin(QObject *pluginObj, const QString &fileName, MOBase::IPluginProxy *proxy);
 
   OrganizerCore *m_Organizer;
 

--- a/src/plugincontainer.h
+++ b/src/plugincontainer.h
@@ -40,6 +40,12 @@ public:
   bool canEnable() const;
 
   /**
+   * @return true if this is a core plugin, i.e. a plugin that should not be
+   *     manually enabled or disabled by the user.
+   */
+  bool isCorePlugin() const;
+
+  /**
    * @return true if this plugin has requirements (satisfied or not).
    */
   bool hasRequirements() const;
@@ -82,6 +88,9 @@ public:
   std::vector<MOBase::IPlugin*> requiredFor() const;
 
 private:
+
+  // The list of "Core" plugins.
+  static const std::set<QString> s_CorePlugins;
 
   // Accumulator version for requiredFor() to avoid infinite recursion.
   void requiredFor(std::vector<MOBase::IPlugin*>& required, std::set<MOBase::IPlugin*>& visited) const;

--- a/src/plugincontainer.h
+++ b/src/plugincontainer.h
@@ -376,10 +376,12 @@ private:
    *
    * @param plugin The plugin to initialize.
    * @param proxy The proxy that created this plugin (can be null).
+   * @param skipInit If true, IPlugin::init() will not be called, regardless
+   *     of the state of the container.
    *
    * @return true if the plugin was initialized correctly, false otherwise.
    */
-  bool initPlugin(MOBase::IPlugin *plugin, MOBase::IPluginProxy* proxy);
+  bool initPlugin(MOBase::IPlugin *plugin, MOBase::IPluginProxy* proxy, bool skipInit);
 
   void registerGame(MOBase::IPluginGame *game);
 

--- a/src/previewgenerator.cpp
+++ b/src/previewgenerator.cpp
@@ -18,14 +18,17 @@ along with Mod Organizer.  If not, see <http://www.gnu.org/licenses/>.
 */
 
 #include "previewgenerator.h"
+
 #include <QFileInfo>
 #include <QLabel>
 #include <QImageReader>
 #include <QTextEdit>
 #include <utility.h>
 
-PreviewGenerator::PreviewGenerator()
-{
+#include "plugincontainer.h"
+
+PreviewGenerator::PreviewGenerator(const PluginContainer* pluginContainer) :
+  m_PluginContainer(pluginContainer) {
   m_MaxSize = QGuiApplication::primaryScreen()->size() * 0.8;
 }
 
@@ -42,13 +45,13 @@ bool PreviewGenerator::previewSupported(const QString &fileExtension) const
   if (it == m_PreviewPlugins.end()) {
     return false;
   }
-  return it->second->isActive();
+  return m_PluginContainer->isEnabled(it->second);
 }
 
 QWidget *PreviewGenerator::genPreview(const QString &fileName) const
 {
   auto iter = m_PreviewPlugins.find(QFileInfo(fileName).suffix().toLower());
-  if (iter != m_PreviewPlugins.end() && iter->second->isActive()) {
+  if (iter != m_PreviewPlugins.end() && m_PluginContainer->isEnabled(iter->second)) {
     return iter->second->genFilePreview(fileName, m_MaxSize);
   } else {
     return nullptr;

--- a/src/previewgenerator.h
+++ b/src/previewgenerator.h
@@ -26,10 +26,12 @@ along with Mod Organizer.  If not, see <http://www.gnu.org/licenses/>.
 #include <functional>
 #include <ipluginpreview.h>
 
+class PluginContainer;
+
 class PreviewGenerator
 {
 public:
-  PreviewGenerator();
+  PreviewGenerator(const PluginContainer* pluginContainer);
 
   void registerPlugin(MOBase::IPluginPreview *plugin);
 
@@ -44,8 +46,8 @@ private:
 
 private:
 
+  const PluginContainer* m_PluginContainer;
   std::map<QString, MOBase::IPluginPreview*> m_PreviewPlugins;
-
   QSize m_MaxSize;
 
 };

--- a/src/problemsdialog.cpp
+++ b/src/problemsdialog.cpp
@@ -7,12 +7,13 @@
 #include <QPushButton>
 #include <Shellapi.h>
 
+#include "plugincontainer.h"
 
 using namespace MOBase;
 
 
-ProblemsDialog::ProblemsDialog(std::vector<QObject *> pluginObjects, QWidget *parent) :
-  QDialog(parent), ui(new Ui::ProblemsDialog), m_PluginObjects(pluginObjects),
+ProblemsDialog::ProblemsDialog(const PluginContainer& pluginContainer, QWidget *parent) :
+  QDialog(parent), ui(new Ui::ProblemsDialog), m_PluginContainer(pluginContainer),
   m_hasProblems(false)
 {
   ui->setupUi(this);
@@ -40,14 +41,10 @@ void ProblemsDialog::runDiagnosis()
   m_hasProblems = false;
   ui->problemsWidget->clear();
 
-  for(QObject *pluginObj : m_PluginObjects) {
-    IPlugin *plugin = qobject_cast<IPlugin*>(pluginObj);
-    if (plugin != nullptr && !plugin->isActive())
+  for (IPluginDiagnose *diagnose : m_PluginContainer.plugins<IPluginDiagnose>()) {
+    if (!m_PluginContainer.isEnabled(diagnose)) {
       continue;
-
-    IPluginDiagnose *diagnose = qobject_cast<IPluginDiagnose*>(pluginObj);
-    if (diagnose == nullptr)
-      continue;
+    }
 
     std::vector<unsigned int> activeProblems = diagnose->activeProblems();
     foreach (unsigned int key, activeProblems) {

--- a/src/problemsdialog.h
+++ b/src/problemsdialog.h
@@ -11,13 +11,14 @@ namespace Ui {
 class ProblemsDialog;
 }
 
+class PluginContainer;
 
 class ProblemsDialog : public QDialog
 {
   Q_OBJECT
 
 public:
-  explicit ProblemsDialog(std::vector<QObject*> pluginObjects, QWidget *parent = 0);
+  explicit ProblemsDialog(PluginContainer const& pluginContainer, QWidget *parent = 0);
   ~ProblemsDialog();
 
   // also saves and restores geometry
@@ -37,7 +38,7 @@ private slots:
 
 private:
   Ui::ProblemsDialog *ui;
-  std::vector<QObject *> m_PluginObjects;
+  const PluginContainer& m_PluginContainer;
   bool m_hasProblems;
 };
 

--- a/src/proxyutils.h
+++ b/src/proxyutils.h
@@ -10,7 +10,7 @@ namespace MOShared {
   template <class Fn, class T = int>
   auto callIfPluginActive(OrganizerProxy* proxy, Fn&& callback, T defaultReturn = T{}) {
     return [fn = std::forward<Fn>(callback), proxy, defaultReturn](auto&& ...args) {
-      if (proxy->plugin()->isActive()) {
+      if (proxy->isPluginEnabled(proxy->plugin())) {
         return fn(std::forward<decltype(args)>(args)...);
       }
       else {

--- a/src/settings.cpp
+++ b/src/settings.cpp
@@ -1280,19 +1280,22 @@ void PluginSettings::registerPlugin(IPlugin *plugin)
     const QString settingName = plugin->name() + "/" + setting.key;
 
     QVariant temp = get<QVariant>(
-      m_Settings, "Plugins", settingName, setting.defaultValue);
+      m_Settings, "Plugins", settingName, QVariant());
 
-    if (!temp.convert(setting.defaultValue.type())) {
+    // No previous enabled? Skip.
+    if (setting.key == "enabled" && (!temp.isValid() || !temp.canConvert<bool>())) {
+      continue;
+    }
+
+    if (!temp.isValid()) {
+      temp = setting.defaultValue;
+    }
+    else if (!temp.convert(setting.defaultValue.type())) {
       log::warn(
         "failed to interpret \"{}\" as correct type for \"{}\" in plugin \"{}\", using default",
         temp.toString(), setting.key, plugin->name());
 
       temp = setting.defaultValue;
-
-      // If there was no previous "enabled" value, skip it:
-      if (setting.key == "enabled") {
-        continue;
-      }
     }
 
     m_PluginSettings[plugin->name()][setting.key] = temp;

--- a/src/settings.cpp
+++ b/src/settings.cpp
@@ -1296,6 +1296,11 @@ void PluginSettings::registerPlugin(IPlugin *plugin)
       .arg(setting.description)
       .arg(setting.defaultValue.toString());
   }
+
+  if (!m_PluginSettings.contains("enabled")) {
+    m_PluginSettings[plugin->name()]["enabled"] = true;
+    m_PluginDescriptions[plugin->name()]["enabled"] = QString();
+  }
 }
 
 std::vector<MOBase::IPlugin*> PluginSettings::plugins() const

--- a/src/settings.cpp
+++ b/src/settings.cpp
@@ -1288,6 +1288,11 @@ void PluginSettings::registerPlugin(IPlugin *plugin)
         temp.toString(), setting.key, plugin->name());
 
       temp = setting.defaultValue;
+
+      // If there was no previous "enabled" value, skip it:
+      if (setting.key == "enabled") {
+        continue;
+      }
     }
 
     m_PluginSettings[plugin->name()][setting.key] = temp;
@@ -1297,9 +1302,15 @@ void PluginSettings::registerPlugin(IPlugin *plugin)
       .arg(setting.defaultValue.toString());
   }
 
-  if (!m_PluginSettings.contains("enabled")) {
-    m_PluginSettings[plugin->name()]["enabled"] = true;
-    m_PluginDescriptions[plugin->name()]["enabled"] = QString();
+  // Handle previous "enabled" settings:
+  if (m_PluginSettings[plugin->name()].contains("enabled")) {
+    setPersistent(plugin->name(), "enabled", m_PluginSettings[plugin->name()]["enabled"].toBool(), true);
+    m_PluginSettings[plugin->name()].remove("enabled");
+    m_PluginDescriptions[plugin->name()].remove("enabled");
+
+    // We need to drop it manually in Settings since it is not possible to remove plugin
+    // settings:
+    remove(m_Settings, "Plugins", plugin->name() + "/enabled");
   }
 }
 

--- a/src/settingsdialog.ui
+++ b/src/settingsdialog.ui
@@ -1128,6 +1128,9 @@
                <item>
                 <widget class="QWidget" name="pluginDescription" native="true">
                  <layout class="QFormLayout" name="pluginDescriptionLayout">
+                  <property name="labelAlignment">
+                   <set>Qt::AlignLeading|Qt::AlignLeft|Qt::AlignTop</set>
+                  </property>
                   <property name="leftMargin">
                    <number>6</number>
                   </property>
@@ -1136,12 +1139,18 @@
                     <property name="text">
                      <string>Author:</string>
                     </property>
+                    <property name="alignment">
+                     <set>Qt::AlignLeading|Qt::AlignLeft|Qt::AlignTop</set>
+                    </property>
                    </widget>
                   </item>
                   <item row="0" column="1">
                    <widget class="QLabel" name="authorLabel">
                     <property name="text">
                      <string/>
+                    </property>
+                    <property name="alignment">
+                     <set>Qt::AlignLeading|Qt::AlignLeft|Qt::AlignTop</set>
                     </property>
                    </widget>
                   </item>
@@ -1150,12 +1159,18 @@
                     <property name="text">
                      <string>Version:</string>
                     </property>
+                    <property name="alignment">
+                     <set>Qt::AlignLeading|Qt::AlignLeft|Qt::AlignTop</set>
+                    </property>
                    </widget>
                   </item>
                   <item row="1" column="1">
                    <widget class="QLabel" name="versionLabel">
                     <property name="text">
                      <string/>
+                    </property>
+                    <property name="alignment">
+                     <set>Qt::AlignLeading|Qt::AlignLeft|Qt::AlignTop</set>
                     </property>
                    </widget>
                   </item>
@@ -1164,12 +1179,18 @@
                     <property name="text">
                      <string>Description:</string>
                     </property>
+                    <property name="alignment">
+                     <set>Qt::AlignLeading|Qt::AlignLeft|Qt::AlignTop</set>
+                    </property>
                    </widget>
                   </item>
                   <item row="2" column="1">
                    <widget class="QLabel" name="descriptionLabel">
                     <property name="text">
                      <string/>
+                    </property>
+                    <property name="alignment">
+                     <set>Qt::AlignLeading|Qt::AlignLeft|Qt::AlignTop</set>
                     </property>
                     <property name="wordWrap">
                      <bool>true</bool>

--- a/src/settingsdialog.ui
+++ b/src/settingsdialog.ui
@@ -1111,8 +1111,8 @@
                </item>
               </layout>
              </widget>
-             <widget class="QWidget" name="widget" native="true">
-              <layout class="QVBoxLayout" name="verticalLayout_7" stretch="0,1">
+             <widget class="QWidget" name="pluginWidget" native="true">
+              <layout class="QVBoxLayout" name="verticalLayout_7" stretch="0,1,0">
                <property name="leftMargin">
                 <number>0</number>
                </property>
@@ -1126,63 +1126,65 @@
                 <number>0</number>
                </property>
                <item>
-                <layout class="QFormLayout" name="formLayout_2">
-                 <property name="leftMargin">
-                  <number>6</number>
-                 </property>
-                 <item row="0" column="0">
-                  <widget class="QLabel" name="label_13">
-                   <property name="text">
-                    <string>Author:</string>
-                   </property>
-                  </widget>
-                 </item>
-                 <item row="0" column="1">
-                  <widget class="QLabel" name="authorLabel">
-                   <property name="text">
-                    <string/>
-                   </property>
-                  </widget>
-                 </item>
-                 <item row="1" column="0">
-                  <widget class="QLabel" name="label_15">
-                   <property name="text">
-                    <string>Version:</string>
-                   </property>
-                  </widget>
-                 </item>
-                 <item row="1" column="1">
-                  <widget class="QLabel" name="versionLabel">
-                   <property name="text">
-                    <string/>
-                   </property>
-                  </widget>
-                 </item>
-                 <item row="2" column="1">
-                  <widget class="QLabel" name="descriptionLabel">
-                   <property name="text">
-                    <string/>
-                   </property>
-                   <property name="wordWrap">
-                    <bool>true</bool>
-                   </property>
-                  </widget>
-                 </item>
-                 <item row="2" column="0">
-                  <widget class="QLabel" name="label_14">
-                   <property name="text">
-                    <string>Description:</string>
-                   </property>
-                  </widget>
-                 </item>
-                 <item row="3" column="0">
-                  <widget class="QCheckBox" name="enabledCheckbox">
-                   <property name="text">
-                    <string>Enabled</string>
-                   </property>
-                  </widget>
-                 </item>
-                </layout>
+                <widget class="QWidget" name="pluginDescription" native="true">
+                 <layout class="QFormLayout" name="pluginDescriptionLayout">
+                  <property name="leftMargin">
+                   <number>6</number>
+                  </property>
+                  <item row="0" column="0">
+                   <widget class="QLabel" name="label_13">
+                    <property name="text">
+                     <string>Author:</string>
+                    </property>
+                   </widget>
+                  </item>
+                  <item row="0" column="1">
+                   <widget class="QLabel" name="authorLabel">
+                    <property name="text">
+                     <string/>
+                    </property>
+                   </widget>
+                  </item>
+                  <item row="1" column="0">
+                   <widget class="QLabel" name="label_15">
+                    <property name="text">
+                     <string>Version:</string>
+                    </property>
+                   </widget>
+                  </item>
+                  <item row="1" column="1">
+                   <widget class="QLabel" name="versionLabel">
+                    <property name="text">
+                     <string/>
+                    </property>
+                   </widget>
+                  </item>
+                  <item row="2" column="0">
+                   <widget class="QLabel" name="label_14">
+                    <property name="text">
+                     <string>Description:</string>
+                    </property>
+                   </widget>
+                  </item>
+                  <item row="2" column="1">
+                   <widget class="QLabel" name="descriptionLabel">
+                    <property name="text">
+                     <string/>
+                    </property>
+                    <property name="wordWrap">
+                     <bool>true</bool>
+                    </property>
+                   </widget>
+                  </item>
+                  <item row="3" column="0">
+                   <widget class="QCheckBox" name="enabledCheckbox">
+                    <property name="text">
+                     <string>Enabled</string>
+                    </property>
+                   </widget>
+                  </item>
+                 </layout>
+                </widget>
                </item>
                <item>
                 <widget class="QTreeWidget" name="pluginSettingsList">
@@ -1214,6 +1216,16 @@
                    <string>Value</string>
                   </property>
                  </column>
+                </widget>
+               </item>
+               <item>
+                <widget class="QLabel" name="noPluginLabel">
+                 <property name="text">
+                  <string>No plugin found.</string>
+                 </property>
+                 <property name="alignment">
+                  <set>Qt::AlignCenter</set>
+                 </property>
                 </widget>
                </item>
               </layout>

--- a/src/settingsdialog.ui
+++ b/src/settingsdialog.ui
@@ -1127,6 +1127,9 @@
                </property>
                <item>
                 <layout class="QFormLayout" name="formLayout_2">
+                 <property name="leftMargin">
+                  <number>6</number>
+                 </property>
                  <item row="0" column="0">
                   <widget class="QLabel" name="label_13">
                    <property name="text">
@@ -1169,6 +1172,13 @@
                   <widget class="QLabel" name="label_14">
                    <property name="text">
                     <string>Description:</string>
+                   </property>
+                  </widget>
+                 </item>
+                 <item row="3" column="0">
+                  <widget class="QCheckBox" name="enabledCheckbox">
+                   <property name="text">
+                    <string>Enabled</string>
                    </property>
                   </widget>
                  </item>

--- a/src/settingsdialogplugins.cpp
+++ b/src/settingsdialogplugins.cpp
@@ -187,7 +187,7 @@ void PluginsSettingsTab::on_checkboxEnabled_clicked(bool checked)
     if (!problems.empty()) {
       QStringList descriptions;
       for (auto& problem : problems) {
-        descriptions.append(problem.description());
+        descriptions.append(problem.shortDescription());
       }
       QMessageBox::warning(
         parentWidget(), QObject::tr("Cannot enable plugin"),

--- a/src/settingsdialogplugins.cpp
+++ b/src/settingsdialogplugins.cpp
@@ -242,7 +242,6 @@ void PluginsSettingsTab::on_checkboxEnabled_clicked(bool checked)
       for (auto& p : proxied) {
         pluginNames.append(p->localizedName());
       }
-      pluginNames.removeDuplicates();
       pluginNames.sort();
       QString message = QObject::tr(
         "<p>Disabling this plugin will prevent the following plugins from working:</p><ul>%1</ul>"
@@ -264,7 +263,6 @@ void PluginsSettingsTab::on_checkboxEnabled_clicked(bool checked)
       for (auto& p : requiredFor) {
         pluginNames.append(p->localizedName());
       }
-      pluginNames.removeDuplicates();
       pluginNames.sort();
       QString message = QObject::tr(
         "<p>Disabling this plugin will also disable the following plugins:</p><ul>%1</ul><p>Do you want to continue?</p>")

--- a/src/settingsdialogplugins.cpp
+++ b/src/settingsdialogplugins.cpp
@@ -128,7 +128,7 @@ void PluginsSettingsTab::filterPluginList()
         return regex.match(plugin->localizedName()).hasMatch();
       });
       for (auto* child : m_pluginContainer->requirements(plugin).children()) {
-        m_filter.matches([child](const QRegularExpression& regex) {
+        match = match || m_filter.matches([child](const QRegularExpression& regex) {
           return regex.match(child->localizedName()).hasMatch();
         });
       }

--- a/src/settingsdialogplugins.cpp
+++ b/src/settingsdialogplugins.cpp
@@ -241,7 +241,8 @@ void PluginsSettingsTab::on_checkboxEnabled_clicked(bool checked)
       if (m_pluginContainer->requirements(game).proxy() == plugin) {
         QMessageBox::warning(
           parentWidget(), QObject::tr("Cannot disable plugin"),
-          QObject::tr("This plugin is used by the current game plugin and cannot disabled."), QMessageBox::Ok);
+          QObject::tr("The '%1' plugin is used by the current game plugin and cannot disabled.")
+            .arg(plugin->localizedName()), QMessageBox::Ok);
           ui->enabledCheckbox->setChecked(true);
           return;
       }
@@ -254,9 +255,9 @@ void PluginsSettingsTab::on_checkboxEnabled_clicked(bool checked)
       }
       pluginNames.sort();
       QString message = QObject::tr(
-        "<p>Disabling this plugin will prevent the following plugins from working:</p><ul>%1</ul>"
+        "<p>Disabling the '%1' plugin will prevent the following plugins from working:</p><ul>%1</ul>"
         "<p>Do you want to continue? You will need to restart ModOrganizer2 for the change to take effect.</p>")
-        .arg("<li>" + pluginNames.join("</li><li>") + "</li>");
+        .arg(plugin->localizedName()).arg("<li>" + pluginNames.join("</li><li>") + "</li>");
       if (QMessageBox::critical(
         parentWidget(), QObject::tr("Really disable plugin?"), message,
         QMessageBox::Yes | QMessageBox::No) == QMessageBox::No) {
@@ -275,8 +276,8 @@ void PluginsSettingsTab::on_checkboxEnabled_clicked(bool checked)
       }
       pluginNames.sort();
       QString message = QObject::tr(
-        "<p>Disabling this plugin will also disable the following plugins:</p><ul>%1</ul><p>Do you want to continue?</p>")
-        .arg("<li>" + pluginNames.join("</li><li>") + "</li>");
+        "<p>Disabling the '%1' plugin will also disable the following plugins:</p><ul>%1</ul><p>Do you want to continue?</p>")
+        .arg(plugin->localizedName()).arg("<li>" + pluginNames.join("</li><li>") + "</li>");
       if (QMessageBox::warning(
         parentWidget(), QObject::tr("Really disable plugin?"), message,
         QMessageBox::Yes | QMessageBox::No) == QMessageBox::No) {
@@ -310,7 +311,7 @@ void PluginsSettingsTab::on_pluginsList_currentItemChanged(QTreeWidgetItem *curr
   ui->descriptionLabel->setText(plugin->description());
 
   ui->enabledCheckbox->setVisible(
-    !m_pluginContainer->implementInterface<MOBase::IPluginGame>(plugin)
+    !m_pluginContainer->requirements(plugin).isCorePlugin()
     && plugin->master().isEmpty());
   ui->enabledCheckbox->setChecked(m_pluginContainer->isEnabled(plugin));
 

--- a/src/settingsdialogplugins.cpp
+++ b/src/settingsdialogplugins.cpp
@@ -242,12 +242,13 @@ void PluginsSettingsTab::on_checkboxEnabled_clicked(bool checked)
       for (auto& p : proxied) {
         pluginNames.append(p->localizedName());
       }
+      pluginNames.removeDuplicates();
       pluginNames.sort();
       QString message = QObject::tr(
-        "<p>Disabling this plugin will prevent the following plugins from working correctly:</p><ul>%1</ul>"
+        "<p>Disabling this plugin will prevent the following plugins from working:</p><ul>%1</ul>"
         "<p>Do you want to continue? You will need to restart ModOrganizer2 for the change to take effect.</p>")
         .arg("<li>" + pluginNames.join("</li><li>") + "</li>");
-      if (QMessageBox::warning(
+      if (QMessageBox::critical(
         parentWidget(), QObject::tr("Really disable plugin?"), message,
         QMessageBox::Yes | QMessageBox::No) == QMessageBox::No) {
         ui->enabledCheckbox->setChecked(true);
@@ -263,6 +264,7 @@ void PluginsSettingsTab::on_checkboxEnabled_clicked(bool checked)
       for (auto& p : requiredFor) {
         pluginNames.append(p->localizedName());
       }
+      pluginNames.removeDuplicates();
       pluginNames.sort();
       QString message = QObject::tr(
         "<p>Disabling this plugin will also disable the following plugins:</p><ul>%1</ul><p>Do you want to continue?</p>")

--- a/src/settingsdialogplugins.cpp
+++ b/src/settingsdialogplugins.cpp
@@ -88,10 +88,9 @@ void PluginsSettingsTab::updateListItems()
       auto* item = topLevelItem->child(j);
       auto* plugin = this->plugin(item);
 
-      if (!m_pluginContainer->implementInterface<IPluginGame>(plugin)
-        && !m_pluginContainer->isEnabled(plugin)) {
-        item->setBackgroundColor(0, Qt::gray);
-      }
+      bool inactive = !m_pluginContainer->implementInterface<IPluginGame>(plugin)
+        && !m_pluginContainer->isEnabled(plugin);
+      // TODO: Better display.
     }
   }
 
@@ -198,7 +197,7 @@ void PluginsSettingsTab::on_checkboxEnabled_clicked(bool checked)
       return;
     }
 
-    m_pluginContainer->setEnabled(plugin, false, true);
+    m_pluginContainer->setEnabled(plugin, true, false);
   }
   else {
     // Custom check for proxy + current game:

--- a/src/settingsdialogplugins.cpp
+++ b/src/settingsdialogplugins.cpp
@@ -225,6 +225,8 @@ void PluginsSettingsTab::on_checkboxEnabled_clicked(bool checked)
   else {
     // Custom check for proxy + current game:
     if (m_pluginContainer->implementInterface<IPluginProxy>(plugin)) {
+
+      // Current game:
       auto* game = m_pluginContainer->managedGame();
       if (m_pluginContainer->requirements(game).proxy() == plugin) {
         QMessageBox::warning(
@@ -233,6 +235,25 @@ void PluginsSettingsTab::on_checkboxEnabled_clicked(bool checked)
           ui->enabledCheckbox->setChecked(true);
           return;
       }
+
+      // Check the proxied plugins:
+      auto proxied = requirements.proxied();
+      QStringList pluginNames;
+      for (auto& p : proxied) {
+        pluginNames.append(p->localizedName());
+      }
+      pluginNames.sort();
+      QString message = QObject::tr(
+        "<p>Disabling this plugin will prevent the following plugins from working correctly:</p><ul>%1</ul>"
+        "<p>Do you want to continue? You will need to restart ModOrganizer2 for the change to take effect.</p>")
+        .arg("<li>" + pluginNames.join("</li><li>") + "</li>");
+      if (QMessageBox::warning(
+        parentWidget(), QObject::tr("Really disable plugin?"), message,
+        QMessageBox::Yes | QMessageBox::No) == QMessageBox::No) {
+        ui->enabledCheckbox->setChecked(true);
+        return;
+      }
+
     }
 
     // Check if the plugins is required for other plugins:
@@ -254,6 +275,11 @@ void PluginsSettingsTab::on_checkboxEnabled_clicked(bool checked)
       }
     }
     m_pluginContainer->setEnabled(plugin, false, true);
+  }
+
+  // Proxy was disabled / enabled, need restart:
+  if (m_pluginContainer->implementInterface<IPluginProxy>(plugin)) {
+    dialog().setExitNeeded(Exit::Restart);
   }
 
   updateListItems();

--- a/src/settingsdialogplugins.cpp
+++ b/src/settingsdialogplugins.cpp
@@ -25,6 +25,7 @@ PluginsSettingsTab::PluginsSettingsTab(Settings& s, PluginContainer* pluginConta
     item->setFont(0, font);
     topItems[interfaceName] = item;
     item->setExpanded(true);
+    item->setFlags(item->flags() & ~Qt::ItemIsSelectable);
   }
   ui->pluginsList->setHeaderHidden(true);
 
@@ -112,6 +113,7 @@ void PluginsSettingsTab::updateListItems()
 
 void PluginsSettingsTab::filterPluginList()
 {
+  auto selectedItems = ui->pluginsList->selectedItems();
   QTreeWidgetItem* firstNotHidden = nullptr;
 
   for (auto i = 0; i < ui->pluginsList->topLevelItemCount(); ++i) {
@@ -150,13 +152,21 @@ void PluginsSettingsTab::filterPluginList()
   }
 
   // Unselect item if hidden:
-  auto selectedItems = ui->pluginsList->selectedItems();
-  if (!selectedItems.isEmpty() && selectedItems[0]->isHidden()) {
-    selectedItems[0]->setSelected(false);
-
-    if (firstNotHidden) {
-      firstNotHidden->setSelected(true);
+  if (firstNotHidden) {
+    ui->pluginDescription->setVisible(true);
+    ui->pluginSettingsList->setVisible(true);
+    ui->noPluginLabel->setVisible(false);
+    if (selectedItems.isEmpty()) {
+      ui->pluginsList->setCurrentItem(firstNotHidden);
     }
+    else if (selectedItems[0]->isHidden()) {
+      ui->pluginsList->setCurrentItem(firstNotHidden);
+    }
+  }
+  else {
+    ui->pluginDescription->setVisible(false);
+    ui->pluginSettingsList->setVisible(false);
+    ui->noPluginLabel->setVisible(true);
   }
 
 }

--- a/src/settingsdialogplugins.cpp
+++ b/src/settingsdialogplugins.cpp
@@ -31,7 +31,7 @@ PluginsSettingsTab::PluginsSettingsTab(Settings& s, PluginContainer* pluginConta
   // display plugin settings
   QSet<QString> handledNames;
   for (IPlugin* plugin : settings().plugins().plugins()) {
-    if (handledNames.contains(plugin->name()) || !plugin->master().isEmpty()) {
+    if (handledNames.contains(plugin->name()) || m_pluginContainer->requirements(plugin).master()) {
       continue;
     }
 

--- a/src/settingsdialogplugins.cpp
+++ b/src/settingsdialogplugins.cpp
@@ -310,9 +310,17 @@ void PluginsSettingsTab::on_pluginsList_currentItemChanged(QTreeWidgetItem *curr
   ui->versionLabel->setText(plugin->version().canonicalString());
   ui->descriptionLabel->setText(plugin->description());
 
+  ui->enabledCheckbox->setDisabled(false);
+  ui->enabledCheckbox->setToolTip("");
   ui->enabledCheckbox->setVisible(
-    !m_pluginContainer->requirements(plugin).isCorePlugin()
+    !m_pluginContainer->implementInterface<IPluginGame>(plugin)
     && plugin->master().isEmpty());
+  if (m_pluginContainer->requirements(plugin).isCorePlugin()) {
+    ui->enabledCheckbox->setDisabled(true);
+    ui->enabledCheckbox->setToolTip(
+      QObject::tr("This plugin is required for Mod Organizer to work properly and cannot be disabled."));
+  }
+
   ui->enabledCheckbox->setChecked(m_pluginContainer->isEnabled(plugin));
 
   QVariantMap settings = current->data(0, ROLE_SETTINGS).toMap();

--- a/src/settingsdialogplugins.h
+++ b/src/settingsdialogplugins.h
@@ -16,10 +16,17 @@ public:
 
 private:
   void on_pluginsList_currentItemChanged(QTreeWidgetItem *current, QTreeWidgetItem *previous);
+  void on_checkboxEnabled_clicked(bool checked);
   void deleteBlacklistItem();
   void storeSettings(QTreeWidgetItem *pluginItem);
 
 private slots:
+
+  /**
+   * @brief Update the list item to display inactive plugins.
+   */
+  void updateListItems();
+
   /**
    * @brief Filter the plugin list according to the filter widget.
    *


### PR DESCRIPTION
This is a follow-up PR from https://github.com/ModOrganizer2/modorganizer/issues/1288

See the [`uibase`  PR](https://github.com/ModOrganizer2/modorganizer-uibase/pull/100) for the interface change and how it "impacts" plugins. I will explain here how this is handled on the MO2 side.

## Changes:

### `PluginContainer` and `PluginsSettingsTab`

This is where most changes take place.

- A bunch of very useful methods, such as `IPlugin* plugin(QString pluginName)` and `IPlugin* plugin(IPluginDiagnose*)` to get a `IPlugin` object from its name or the corresponding diagnose plugin (which does not inherit `IPlugin`).
- `isEnabled` and `setEnabled` methods &mdash; `setEnabled` handle master plugins (e.g. if you enable or disable a master, it enables or disables the children), and can also handle disabling of dependencies.
- `implementInterface` to check if a plugin implements a specific interface.

A new `PluginRequirements` class has been added that basically wraps the return value of `IPlugin::requirements` and add a few extra methods related to proxies and master plugins. This is mostly used for the plugins tab of the settings dialog.

The enabled/disabled state for plugins is stored in persistence rather than settings now.

**How it works?**

- If you try to enable a plugin that you cannot enable because one of the requirements is not met, you'll get a popup saying that the plugin cannot be enabled (and why) and the plugin will stay disabled.
- If you try to disable a plugins that is required by other plugins, you'll get a warning, but you can still continue, in which case all the other plugins will be disabled.
- For proxy plugins, it's a little different:
    - If you enable or disable the proxy plugin, MO2 will ask for a restart when closing the settings dialog.
    - If you try to disable a proxy plugin, MO2 will tell you that the proxied plugins will not work. The proxied plugins are not disabled (they will not show-up after restart anyway).
    - If you try to disable a proxy and the currently managed game uses it (e.g. you try to disable the proxy plugin while you're using a basic game plugin), you'll get a warning and the plugin will stay enabled.
- Plugins are grouped under their `master` and you can only enable or disable the master:

![image](https://user-images.githubusercontent.com/2393288/98861642-ef4c8b80-2465-11eb-9c32-f6a255d391b5.png)

- If a proxied plugins implement multiple interfaces (e.g. STALKER Anomaly), this corresponds to multiple `IPlugin` for MO2, which is annoying to deal with:
     - A fake master dependency is created between the plugins - The master plugin is the one considered "most-relevant" (e.g. a game plugin is more relevant than a file mapper or a diganose).
     - In the plugin settings tab, only one plugin will be visible since all the settings are shared anyway.

## Other changes:

- **Fixed:** If a proxied plugin implements multiple interfaces, `init()` is only called once (before it was called for every interfaces).
- Plugins are enabled by default. If a plugin provides an `enabled` setting, the setting is ignored (mostly for existing plugins). For migration, the current "enabled" setting is used and removed (e.g. if a plugin was disabled, it'll remain disabled but the setting is moved to persistent).
- The Mod Page button / menu is now updated when a plugin is enabled / disabled:
    - The "button" switch from a standard button (Nexus) to a normal menu when there is at least one ModPage plugin. Before the button would simply get a dropdown next to it, which I found misleading since the button itself would then be non reactive...
- The Tool menu is now dynamic and will only show enabled plugins. Before, it showed plugins that were enabled when starting MO2.
