### PR TITLE
Crash when highlighting plugins from the Data directory

### DIFF
--- a/src/modlist.cpp
+++ b/src/modlist.cpp
@@ -860,9 +860,11 @@ void ModList::highlightMods(const QItemSelectionModel *selection, const MOShared
     if (fileEntry.get() != nullptr) {
 
       QString originName = QString::fromStdWString(directoryEntry.getOriginByID(fileEntry->getOrigin()).getName());
-
-      auto modInfo = ModInfo::getByName(originName);
-      modInfo->setPluginSelected(true);
+      const auto index = ModInfo::getIndex(originName);
+      if (index != UINT_MAX) {
+        auto modInfo = ModInfo::getByIndex(index);
+        modInfo->setPluginSelected(true);
+      }
     }
   }
   notifyChange(0, rowCount() - 1);


### PR DESCRIPTION
Highlighting plugins from the data directory would crash because the mod name is "data" and `getByName()` crashes with a mod name that doesn't exist. Look up its index first.