### PR TITLE
Bunch of instance and command line stuff

### DIFF
--- a/src/createinstancedialog.cpp
+++ b/src/createinstancedialog.cpp
@@ -131,7 +131,7 @@ CreateInstanceDialog::CreateInstanceDialog(
   ui->pages->setCurrentIndex(0);
   ui->launch->setChecked(true);
 
-  if (!m_settings)
+  if (!InstanceManager::singleton().hasAnyInstances())
   {
     // first run of MO, there are no instances yet, force launch
     ui->launch->setEnabled(false);
@@ -314,6 +314,10 @@ void CreateInstanceDialog::finish()
   };
 
 
+  // don't restart if this is the first instance, it'll be selected and opened
+  const bool mustRestart = InstanceManager::singleton().hasAnyInstances();
+
+
   try
   {
     std::vector<std::unique_ptr<DirectoryCreator>> dirs;
@@ -396,9 +400,7 @@ void CreateInstanceDialog::finish()
     if (ui->launch->isChecked()) {
       InstanceManager::singleton().setCurrentInstance(ci.instanceName);
 
-      if (m_settings) {
-        // don't restart without settings, it happens on startup when there are
-        // no instances
+      if (mustRestart) {
         ExitModOrganizer(Exit::Restart);
         m_switching = true;
       }

--- a/src/instancemanager.cpp
+++ b/src/instancemanager.cpp
@@ -538,6 +538,12 @@ void InstanceManager::overrideProfile(const QString& profileName)
   m_overrideProfileName = profileName;
 }
 
+void InstanceManager::clearOverrides()
+{
+  m_overrideInstanceName = {};
+  m_overrideProfileName = {};
+}
+
 std::optional<Instance> InstanceManager::currentInstance() const
 {
   const QString profile = m_overrideProfileName ?

--- a/src/instancemanager.h
+++ b/src/instancemanager.h
@@ -232,6 +232,11 @@ public:
   //
   void overrideProfile(const QString& profileName);
 
+  // clears instance and profile overrides, used when restarting MO to select
+  // another instance
+  //
+  void clearOverrides();
+
   // returns a game plugin that considers the given directory valid
   //
   // this will check for an INI file in the directory and use its game name

--- a/src/instancemanagerdialog.cpp
+++ b/src/instancemanagerdialog.cpp
@@ -580,13 +580,17 @@ void InstanceManagerDialog::onSelection()
 
 void InstanceManagerDialog::createNew()
 {
-  CreateInstanceDialog dlg(m_pc, &Settings::instance(), this);
+  // there might not be settings available; the dialog can be shown when the
+  // last selected instance doesn't exist anymore
+  CreateInstanceDialog dlg(m_pc, Settings::maybeInstance(), this);
+
   if (dlg.exec() != QDialog::Accepted) {
     return;
   }
 
   if (dlg.switching()) {
     // restarting MO
+    accept();
     return;
   }
 

--- a/src/moapplication.cpp
+++ b/src/moapplication.cpp
@@ -170,12 +170,13 @@ int MOApplication::run(MOMultiProcess& multiProcess)
   {
     try
     {
-      // resets things when MO is "restarted"
-      resetForRestart();
-
       tt.stop();
+
       const auto r = doOneRun(multiProcess);
+
       if (r == RestartExitCode) {
+        // resets things when MO is "restarted"
+        resetForRestart();
         continue;
       }
 
@@ -396,12 +397,20 @@ std::optional<Instance> MOApplication::getCurrentInstance()
 
   if (!currentInstance)
   {
+    // clear any overrides that might have been given on the command line
+    m.clearOverrides();
+    m_cl.clear();
+
     currentInstance = selectInstance();
   }
   else
   {
     if (!QDir(currentInstance->directory()).exists()) {
       // the previously used instance doesn't exist anymore
+
+      // clear any overrides that might have been given on the command line
+      m.clearOverrides();
+      m_cl.clear();
 
       if (m.hasAnyInstances()) {
         MOShared::criticalOnTop(QObject::tr(
@@ -466,6 +475,9 @@ void MOApplication::resetForRestart()
 
   // don't reprocess command line
   m_cl.clear();
+
+  // clear instance and profile overrides
+  InstanceManager::singleton().clearOverrides();
 }
 
 bool MOApplication::setStyleFile(const QString& styleName)


### PR DESCRIPTION
- Clear instance manager overrides when restarting, or switching instances after starting MO with `moshortcut://instance:` won't do anything
- Clear overrides when the last selected instance can't be opened; MO would keep trying to open shortcuts even after selecting a different instance
- Command line was cleared too early, before the first run, so shortcuts were broken
- The instance manager dialog can actually be opened without an instance loaded if the last selected instance doesn't exist, `createNew()` would throw because it tried to access the global `Settings`
- Fixed some problems with parts of MO wanting to restart and others expecting flow to continue
- Fixed create instance dialog using settings pointer to decide whether to restart; it restarts when it's the first created instance, which is not always the case even if the settings are null, so just check whether there are instances