### PR TITLE
Allow '.' in findFiles and filter on file name, not full paths.

### DIFF
--- a/src/organizercore.cpp
+++ b/src/organizercore.cpp
@@ -959,13 +959,13 @@ QStringList OrganizerCore::findFiles(
 {
   QStringList result;
   DirectoryEntry *dir = m_DirectoryStructure;
-  if (!path.isEmpty())
+  if (!path.isEmpty() && path != ".")
     dir = dir->findSubDirectoryRecursive(ToWString(path));
   if (dir != nullptr) {
     std::vector<FileEntryPtr> files = dir->getFiles();
     for (FileEntryPtr &file: files) {
       QString fullPath = ToQString(file->getFullPath());
-      if (filter(fullPath)) {
+      if (filter(ToQString(file->getName()))) {
         result.append(fullPath);
       }
     }


### PR DESCRIPTION
The filter in `findFiles` is supposed to filter on filename, not filepath (from `uibase`):

> find files in the virtual directory matching the filename filter

Furthermore, `findFiles` does not recurse so there is no reason to filter on something other than the filename.

This will not break anything, here are the places where `findFiles` was used before:

- https://github.com/ModOrganizer2/modorganizer/blob/master/src/mainwindow.cpp#L2005
- https://github.com/ModOrganizer2/modorganizer-check_fnis/blob/4b5f570184a587202eb19b7ed0d0bf90b8819fb5/src/checkfnis.cpp#L173
- https://github.com/ModOrganizer2/modorganizer-diagnose_basic/blob/master/src/diagnosebasic.cpp#L245
- https://github.com/ModOrganizer2/modorganizer-form43_checker/blob/master/src/Form43Checker.py#L93
- https://github.com/ModOrganizer2/modorganizer-installer_fomod_csharp/blob/master/src/base_script.cpp
- https://github.com/ModOrganizer2/modorganizer-installer_fomod/blob/master/src/installerfomod.cpp#L170
    - This one is actually currently broken since it tries to compare the filename exactly, which can never match.

It's also used in the OMOD installer but this does not change anything.