### PR TITLE
Implement loading/unloading of plugins without restarting

### DIFF
--- a/src/downloadmanager.cpp
+++ b/src/downloadmanager.cpp
@@ -201,7 +201,7 @@ QString DownloadManager::DownloadInfo::currentURL()
 
 
 DownloadManager::DownloadManager(NexusInterface *nexusInterface, QObject *parent) :
-  IDownloadManager(parent), m_NexusInterface(nexusInterface), m_DirWatcher(), m_ShowHidden(false),
+  m_NexusInterface(nexusInterface), m_DirWatcher(), m_ShowHidden(false),
   m_ParentWidget(nullptr)
 {
   m_OrganizerCore = dynamic_cast<OrganizerCore*>(parent);
@@ -1787,24 +1787,24 @@ QString DownloadManager::downloadPath(int id)
   return getFilePath(id);
 }
 
-bool DownloadManager::onDownloadComplete(const std::function<void(int)>& callback)
+boost::signals2::connection DownloadManager::onDownloadComplete(const std::function<void(int)>& callback)
 {
-  return m_DownloadComplete.connect(callback).connected();
+  return m_DownloadComplete.connect(callback);
 }
 
-bool DownloadManager::onDownloadPaused(const std::function<void(int)>& callback)
+boost::signals2::connection DownloadManager::onDownloadPaused(const std::function<void(int)>& callback)
 {
-  return m_DownloadPaused.connect(callback).connected();
+  return m_DownloadPaused.connect(callback);
 }
 
-bool DownloadManager::onDownloadFailed(const std::function<void(int)>& callback)
+boost::signals2::connection DownloadManager::onDownloadFailed(const std::function<void(int)>& callback)
 {
-  return m_DownloadFailed.connect(callback).connected();
+  return m_DownloadFailed.connect(callback);
 }
 
-bool DownloadManager::onDownloadRemoved(const std::function<void(int)>& callback)
+boost::signals2::connection DownloadManager::onDownloadRemoved(const std::function<void(int)>& callback)
 {
-  return m_DownloadRemoved.connect(callback).connected();
+  return m_DownloadRemoved.connect(callback);
 }
 
 int DownloadManager::indexByName(const QString &fileName) const

--- a/src/downloadmanager.h
+++ b/src/downloadmanager.h
@@ -48,7 +48,7 @@ class OrganizerCore;
 /*!
  * \brief manages downloading of files and provides progress information for gui elements
  **/
-class DownloadManager : public MOBase::IDownloadManager
+class DownloadManager : public QObject
 {
   Q_OBJECT
 
@@ -126,6 +126,8 @@ private:
   private:
     DownloadInfo() : m_TotalSize(0), m_ReQueried(false), m_Hidden(false), m_SpeedDiff(std::tuple<int,int,int,int,int>(0,0,0,0,0)), m_HasData(false) {}
   };
+
+  friend class DownloadManagerProxy;
 
   using SignalDownloadCallback = boost::signals2::signal<void(int)>;
 
@@ -366,14 +368,14 @@ public:
 
 public: // IDownloadManager interface:
 
-  int startDownloadURLs(const QStringList &urls) override;
-  int startDownloadNexusFile(int modID, int fileID) override;
-  QString downloadPath(int id) override;
+  int startDownloadURLs(const QStringList &urls);
+  int startDownloadNexusFile(int modID, int fileID);
+  QString downloadPath(int id);
 
-  bool onDownloadComplete(const std::function<void(int)>& callback) override;
-  bool onDownloadPaused(const std::function<void(int)>& callback) override;
-  bool onDownloadFailed(const std::function<void(int)>& callback) override;
-  bool onDownloadRemoved(const std::function<void(int)>& callback) override;
+  boost::signals2::connection onDownloadComplete(const std::function<void(int)>& callback);
+  boost::signals2::connection onDownloadPaused(const std::function<void(int)>& callback);
+  boost::signals2::connection onDownloadFailed(const std::function<void(int)>& callback);
+  boost::signals2::connection onDownloadRemoved(const std::function<void(int)>& callback);
 
   /**
    * @brief retrieve a download index from the filename

--- a/src/downloadmanagerproxy.cpp
+++ b/src/downloadmanagerproxy.cpp
@@ -7,7 +7,14 @@ using namespace MOBase;
 using namespace MOShared;
 
 DownloadManagerProxy::DownloadManagerProxy(OrganizerProxy* oproxy, DownloadManager* downloadManager) :
-  m_OrganizerProxy(oproxy), m_Proxied(downloadManager)
+  m_OrganizerProxy(oproxy), m_Proxied(downloadManager) { }
+
+DownloadManagerProxy::~DownloadManagerProxy()
+{
+  disconnectSignals();
+}
+
+void DownloadManagerProxy::connectSignals()
 {
   m_Connections.push_back(m_Proxied->onDownloadComplete(callSignalIfPluginActive(m_OrganizerProxy, m_DownloadComplete)));
   m_Connections.push_back(m_Proxied->onDownloadFailed(callSignalIfPluginActive(m_OrganizerProxy, m_DownloadFailed)));
@@ -15,11 +22,12 @@ DownloadManagerProxy::DownloadManagerProxy(OrganizerProxy* oproxy, DownloadManag
   m_Connections.push_back(m_Proxied->onDownloadPaused(callSignalIfPluginActive(m_OrganizerProxy, m_DownloadPaused)));
 }
 
-DownloadManagerProxy::~DownloadManagerProxy()
+void DownloadManagerProxy::disconnectSignals()
 {
   for (auto& conn : m_Connections) {
     conn.disconnect();
   }
+  m_Connections.clear();
 }
 
 int DownloadManagerProxy::startDownloadURLs(const QStringList& urls)

--- a/src/downloadmanagerproxy.h
+++ b/src/downloadmanagerproxy.h
@@ -25,6 +25,12 @@ public:
 
 private:
 
+  friend class OrganizerProxy;
+
+  // See OrganizerProxy::connectSignals().
+  void connectSignals();
+  void disconnectSignals();
+
   OrganizerProxy* m_OrganizerProxy;
   DownloadManager* m_Proxied;
 

--- a/src/downloadmanagerproxy.h
+++ b/src/downloadmanagerproxy.h
@@ -2,6 +2,7 @@
 #define DOWNLOADMANAGERPROXY_H
 
 #include <idownloadmanager.h>
+#include "downloadmanager.h"
 
 class OrganizerProxy;
 
@@ -10,8 +11,8 @@ class DownloadManagerProxy : public MOBase::IDownloadManager
 
 public:
 
-  DownloadManagerProxy(OrganizerProxy* oproxy, IDownloadManager* downloadManager);
-  virtual ~DownloadManagerProxy() { }
+  DownloadManagerProxy(OrganizerProxy* oproxy, DownloadManager* downloadManager);
+  virtual ~DownloadManagerProxy();
 
   int startDownloadURLs(const QStringList& urls) override;
   int startDownloadNexusFile(int modID, int fileID) override;
@@ -25,7 +26,14 @@ public:
 private:
 
   OrganizerProxy* m_OrganizerProxy;
-  IDownloadManager* m_Proxied;
+  DownloadManager* m_Proxied;
+
+  DownloadManager::SignalDownloadCallback m_DownloadComplete;
+  DownloadManager::SignalDownloadCallback m_DownloadPaused;
+  DownloadManager::SignalDownloadCallback m_DownloadFailed;
+  DownloadManager::SignalDownloadCallback m_DownloadRemoved;
+
+  std::vector<boost::signals2::connection> m_Connections;
 };
 
 #endif // ORGANIZERPROXY_H

--- a/src/installationmanager.h
+++ b/src/installationmanager.h
@@ -129,12 +129,6 @@ public:
   static QString getErrorString(Archive::Error errorCode);
 
   /**
-   * @brief register an installer-plugin
-   * @param the installer to register
-   */
-  void registerInstaller(MOBase::IPluginInstaller *installer);
-
-  /**
    * @return the extensions of archives supported by this installation manager.
    */
   QStringList getSupportedExtensions() const override;
@@ -256,13 +250,6 @@ signals:
 
 private:
 
-  struct ByPriority {
-    bool operator()(MOBase::IPluginInstaller *LHS, MOBase::IPluginInstaller *RHS) const
-    {
-      return LHS->priority() > RHS->priority();
-    }
-  };
-
   struct CaseInsensitive {
       bool operator() (const QString &LHS, const QString &RHS) const
       {
@@ -294,8 +281,6 @@ private:
 
   QString m_ModsDirectory;
   QString m_DownloadsDirectory;
-
-  std::vector<MOBase::IPluginInstaller*> m_Installers;
 
   // Archive management.
   std::unique_ptr<Archive> m_ArchiveHandler;

--- a/src/iuserinterface.h
+++ b/src/iuserinterface.h
@@ -17,8 +17,6 @@ public:
 
   virtual void installTranslator(const QString &name) = 0;
 
-  virtual void disconnectPlugins() = 0;
-
   virtual bool closeWindow() = 0;
   virtual void setWindowEnabled(bool enabled) = 0;
 

--- a/src/mainwindow.cpp
+++ b/src/mainwindow.cpp
@@ -512,8 +512,6 @@ MainWindow::MainWindow(Settings &settings
   m_Tutorial.expose("espList", m_OrganizerCore.pluginList());
 
   m_OrganizerCore.setUserInterface(this);
-  m_PluginContainer.setUserInterface(this);
-  connect(this, &MainWindow::userInterfaceInitialized, &m_OrganizerCore, &OrganizerCore::userInterfaceInitialized);
   for (const QString &fileName : m_PluginContainer.pluginFileNames()) {
     installTranslator(QFileInfo(fileName).baseName());
   }
@@ -705,7 +703,6 @@ MainWindow::~MainWindow()
   try {
     cleanup();
 
-    m_PluginContainer.setUserInterface(nullptr);
     m_OrganizerCore.setUserInterface(nullptr);
 
     if (m_IntegratedBrowser) {
@@ -741,14 +738,6 @@ void MainWindow::updateWindowTitle(const APIUserAccount& user)
 void MainWindow::onRequestsChanged(const APIStats& stats, const APIUserAccount& user)
 {
   ui->statusBar->setAPI(stats, user);
-}
-
-
-void MainWindow::disconnectPlugins()
-{
-  if (ui->actionTool->menu() != nullptr) {
-    ui->actionTool->menu()->clear();
-  }
 }
 
 
@@ -1413,8 +1402,8 @@ void MainWindow::showEvent(QShowEvent *event)
     m_WasVisible = true;
     updateProblemsButton();
 
-    // Notify plugin that the UI is initialized:
-    emit userInterfaceInitialized();
+    // Notify plugin that the MO2 is ready:
+    m_PluginContainer.startPlugins(this);
   }
 }
 

--- a/src/mainwindow.cpp
+++ b/src/mainwindow.cpp
@@ -474,7 +474,16 @@ MainWindow::MainWindow(Settings &settings
     if (m_PluginContainer.implementInterface<IPluginModPage>(plugin)) { updateModPageMenu(); } });
   connect(&m_PluginContainer, &PluginContainer::pluginDisabled, this, [this](IPlugin* plugin) {
     if (m_PluginContainer.implementInterface<IPluginModPage>(plugin)) { updateModPageMenu(); } });
-
+  connect(&m_PluginContainer, &PluginContainer::pluginRegistered, this, [this](IPlugin* plugin) {
+    updateModPageMenu();
+    scheduleCheckForProblems();
+    updateDownloadView();
+  });
+  connect(&m_PluginContainer, &PluginContainer::pluginUnregistered, this, [this](IPlugin* plugin) {
+    updateModPageMenu();
+    scheduleCheckForProblems();
+    updateDownloadView();
+  });
 
   connect(&m_OrganizerCore, &OrganizerCore::modInstalled, this, &MainWindow::modInstalled);
   connect(&m_OrganizerCore, &OrganizerCore::close, this, &QMainWindow::close);

--- a/src/mainwindow.cpp
+++ b/src/mainwindow.cpp
@@ -474,16 +474,8 @@ MainWindow::MainWindow(Settings &settings
     if (m_PluginContainer.implementInterface<IPluginModPage>(plugin)) { updateModPageMenu(); } });
   connect(&m_PluginContainer, &PluginContainer::pluginDisabled, this, [this](IPlugin* plugin) {
     if (m_PluginContainer.implementInterface<IPluginModPage>(plugin)) { updateModPageMenu(); } });
-  connect(&m_PluginContainer, &PluginContainer::pluginRegistered, this, [this](IPlugin* plugin) {
-    updateModPageMenu();
-    scheduleCheckForProblems();
-    updateDownloadView();
-  });
-  connect(&m_PluginContainer, &PluginContainer::pluginUnregistered, this, [this](IPlugin* plugin) {
-    updateModPageMenu();
-    scheduleCheckForProblems();
-    updateDownloadView();
-  });
+  connect(&m_PluginContainer, &PluginContainer::pluginRegistered, this, &MainWindow::onPluginRegistrationChanged);
+  connect(&m_PluginContainer, &PluginContainer::pluginUnregistered, this, &MainWindow::onPluginRegistrationChanged);
 
   connect(&m_OrganizerCore, &OrganizerCore::modInstalled, this, &MainWindow::modInstalled);
   connect(&m_OrganizerCore, &OrganizerCore::close, this, &QMainWindow::close);
@@ -5197,6 +5189,13 @@ void MainWindow::on_actionSettings_triggered()
       m_OrganizerCore.checkForUpdates();
     }
   }
+}
+
+void MainWindow::onPluginRegistrationChanged()
+{
+  updateModPageMenu();
+  scheduleCheckForProblems();
+  updateDownloadView();
 }
 
 void MainWindow::on_actionNexus_triggered()

--- a/src/mainwindow.h
+++ b/src/mainwindow.h
@@ -635,6 +635,8 @@ private slots: // ui slots
   void on_saveModsButton_clicked();
   void on_managedArchiveLabel_linkHovered(const QString &link);
 
+  void onPluginRegistrationChanged();
+
   void storeSettings();
   void readSettings();
   void setupModList();

--- a/src/mainwindow.h
+++ b/src/mainwindow.h
@@ -133,8 +133,6 @@ public:
 
   void installTranslator(const QString &name);
 
-  virtual void disconnectPlugins();
-
   void displayModInformation(
     ModInfo::Ptr modInfo, unsigned int modIndex, ModInfoTabIDs tabID) override;
 
@@ -167,12 +165,6 @@ signals:
    * @brief emitted when the selected style changes
    */
   void styleChanged(const QString &styleFile);
-
-  /**
-   * @brief emitted when the user interface has been completely initialized
-   */
-  void userInterfaceInitialized();
-
 
   void modListDataChanged(const QModelIndex &topLeft, const QModelIndex &bottomRight);
 

--- a/src/modlist.cpp
+++ b/src/modlist.cpp
@@ -1020,19 +1020,19 @@ bool ModList::setPriority(const QString &name, int newPriority)
   }
 }
 
-bool ModList::onModInstalled(const std::function<void(MOBase::IModInterface*)>& func)
+boost::signals2::connection ModList::onModInstalled(const std::function<void(MOBase::IModInterface*)>& func)
 {
-  return m_ModInstalled.connect(func).connected();
+  return m_ModInstalled.connect(func);
 }
 
-bool ModList::onModRemoved(const std::function<void(QString const&)>& func)
+boost::signals2::connection ModList::onModRemoved(const std::function<void(QString const&)>& func)
 {
-  return m_ModRemoved.connect(func).connected();
+  return m_ModRemoved.connect(func);
 }
 
-bool ModList::onModStateChanged(const std::function<void(const std::map<QString, ModStates>&)>& func)
+boost::signals2::connection ModList::onModStateChanged(const std::function<void(const std::map<QString, IModList::ModStates>&)>& func)
 {
-  return m_ModStateChanged.connect(func).connected();
+  return m_ModStateChanged.connect(func);
 }
 
 void ModList::notifyModInstalled(MOBase::IModInterface* mod) const
@@ -1047,7 +1047,7 @@ void ModList::notifyModRemoved(QString const& modName) const
 
 void ModList::notifyModStateChanged(QList<unsigned int> modIndices) const
 {
-  std::map<QString, ModStates> mods;
+  std::map<QString, IModList::ModStates> mods;
   for (auto modIndex : modIndices) {
     ModInfo::Ptr modInfo = ModInfo::getByIndex(modIndex);
     mods.emplace(modInfo->name(), state(modIndex));
@@ -1055,10 +1055,9 @@ void ModList::notifyModStateChanged(QList<unsigned int> modIndices) const
   m_ModStateChanged(mods);
 }
 
-bool ModList::onModMoved(const std::function<void (const QString &, int, int)> &func)
+boost::signals2::connection ModList::onModMoved(const std::function<void (const QString &, int, int)> &func)
 {
-  auto conn = m_ModMoved.connect(func);
-  return conn.connected();
+  return m_ModMoved.connect(func);
 }
 
 bool ModList::dropURLs(const QMimeData *mimeData, int row, const QModelIndex &parent)

--- a/src/modlist.h
+++ b/src/modlist.h
@@ -49,7 +49,7 @@ class OrganizerCore;
  * This is used in a view in the main window of MO. It combines general information about
  * the mods from ModInfo with status information from the Profile
  **/
-class ModList : public QAbstractItemModel, public MOBase::IModList
+class ModList : public QAbstractItemModel
 {
   Q_OBJECT
 
@@ -70,9 +70,11 @@ public:
     COL_LASTCOLUMN = COL_NOTES,
   };
 
+  friend class ModListProxy;
+
   using SignalModInstalled = boost::signals2::signal<void(MOBase::IModInterface*)>;
   using SignalModRemoved = boost::signals2::signal<void(QString const&)>;
-  using SignalModStateChanged = boost::signals2::signal<void (const std::map<QString, ModStates>&)>;
+  using SignalModStateChanged = boost::signals2::signal<void (const std::map<QString, MOBase::IModList::ModStates>&)>;
   using SignalModMoved = boost::signals2::signal<void (const QString &, int, int)>;
 
 public:
@@ -153,37 +155,37 @@ public:
 public:
 
   /// \copydoc MOBase::IModList::displayName
-  virtual QString displayName(const QString &internalName) const override;
+  QString displayName(const QString &internalName) const;
 
   /// \copydoc MOBase::IModList::allMods
-  virtual QStringList allMods() const override;
-  virtual QStringList allModsByProfilePriority(MOBase::IProfile* profile = nullptr) const override;
+  QStringList allMods() const;
+  QStringList allModsByProfilePriority(MOBase::IProfile* profile = nullptr) const;
 
   // \copydoc MOBase::IModList::getMod
-  MOBase::IModInterface* getMod(const QString& name) const override;
+  MOBase::IModInterface* getMod(const QString& name) const;
 
   // \copydoc MOBase::IModList::remove
-  bool removeMod(MOBase::IModInterface* mod) override;
+  bool removeMod(MOBase::IModInterface* mod);
 
   /// \copydoc MOBase::IModList::state
-  virtual ModStates state(const QString &name) const override;
+  MOBase::IModList::ModStates state(const QString &name) const;
 
   /// \copydoc MOBase::IModList::setActive
-  virtual bool setActive(const QString &name, bool active) override;
+  bool setActive(const QString &name, bool active);
 
   /// \copydoc MOBase::IModList::setActive
-  int setActive(const QStringList& names, bool active) override;
+  int setActive(const QStringList& names, bool active);
 
   /// \copydoc MOBase::IModList::priority
-  virtual int priority(const QString &name) const override;
+  int priority(const QString &name) const;
 
   /// \copydoc MOBase::IModList::setPriority
-  virtual bool setPriority(const QString &name, int newPriority) override;
+  bool setPriority(const QString &name, int newPriority);
 
-  bool onModInstalled(const std::function<void(MOBase::IModInterface*)>& func) override;
-  bool onModRemoved(const std::function<void(QString const&)>& func) override;
-  bool onModStateChanged(const std::function<void(const std::map<QString, ModStates>&)>& func) override;
-  bool onModMoved(const std::function<void (const QString &, int, int)> &func) override;
+  boost::signals2::connection onModInstalled(const std::function<void(MOBase::IModInterface*)>& func);
+  boost::signals2::connection onModRemoved(const std::function<void(QString const&)>& func);
+  boost::signals2::connection onModStateChanged(const std::function<void(const std::map<QString, MOBase::IModList::ModStates>&)>& func);
+  boost::signals2::connection onModMoved(const std::function<void (const QString &, int, int)> &func);
 
 public: // implementation of virtual functions of QAbstractItemModel
 
@@ -335,7 +337,7 @@ private:
 
   bool dropMod(const QMimeData *mimeData, int row, const QModelIndex &parent);
 
-  ModStates state(unsigned int modIndex) const;
+  MOBase::IModList::ModStates state(unsigned int modIndex) const;
 
   bool moveSelection(QAbstractItemView *itemView, int direction);
 
@@ -359,7 +361,7 @@ private:
 
   struct TModInfoChange {
     QString name;
-    QFlags<IModList::ModState> state;
+    QFlags<MOBase::IModList::ModState> state;
   };
 
 private:

--- a/src/modlistproxy.cpp
+++ b/src/modlistproxy.cpp
@@ -1,11 +1,26 @@
 #include "modlistproxy.h"
 #include "organizerproxy.h"
 #include "proxyutils.h"
+#include "modlist.h"
 
 using namespace MOBase;
+using namespace MOShared;
 
-ModListProxy::ModListProxy(OrganizerProxy* oproxy, IModList* modlist) :
-  m_OrganizerProxy(oproxy), m_Proxied(modlist) { }
+ModListProxy::ModListProxy(OrganizerProxy* oproxy, ModList* modlist) :
+  m_OrganizerProxy(oproxy), m_Proxied(modlist)
+{
+  m_Connections.push_back(m_Proxied->onModInstalled(callSignalIfPluginActive(m_OrganizerProxy, m_ModInstalled)));
+  m_Connections.push_back(m_Proxied->onModMoved(callSignalIfPluginActive(m_OrganizerProxy, m_ModMoved)));
+  m_Connections.push_back(m_Proxied->onModRemoved(callSignalIfPluginActive(m_OrganizerProxy, m_ModRemoved)));
+  m_Connections.push_back(m_Proxied->onModStateChanged(callSignalIfPluginActive(m_OrganizerProxy, m_ModStateChanged)));
+}
+
+ModListProxy::~ModListProxy()
+{
+  for (auto& conn : m_Connections) {
+    conn.disconnect();
+  }
+}
 
 QString ModListProxy::displayName(const QString& internalName) const
 {
@@ -59,20 +74,20 @@ bool ModListProxy::setPriority(const QString& name, int newPriority)
 
 bool ModListProxy::onModInstalled(const std::function<void(IModInterface*)>& func)
 {
-  return m_Proxied->onModInstalled(MOShared::callIfPluginActive(m_OrganizerProxy, func));
+  return m_ModInstalled.connect(func).connected();
 }
 
 bool ModListProxy::onModRemoved(const std::function<void(QString const&)>& func)
 {
-  return m_Proxied->onModRemoved(MOShared::callIfPluginActive(m_OrganizerProxy, func));
+  return m_ModRemoved.connect(func).connected();
 }
 
 bool ModListProxy::onModStateChanged(const std::function<void(const std::map<QString, ModStates>&)>& func)
 {
-  return m_Proxied->onModStateChanged(MOShared::callIfPluginActive(m_OrganizerProxy, func));
+  return m_ModStateChanged.connect(func).connected();
 }
 
 bool ModListProxy::onModMoved(const std::function<void(const QString&, int, int)>& func)
 {
-  return m_Proxied->onModMoved(MOShared::callIfPluginActive(m_OrganizerProxy, func));
+  return m_ModMoved.connect(func).connected();
 }

--- a/src/modlistproxy.cpp
+++ b/src/modlistproxy.cpp
@@ -7,7 +7,14 @@ using namespace MOBase;
 using namespace MOShared;
 
 ModListProxy::ModListProxy(OrganizerProxy* oproxy, ModList* modlist) :
-  m_OrganizerProxy(oproxy), m_Proxied(modlist)
+  m_OrganizerProxy(oproxy), m_Proxied(modlist) { }
+
+ModListProxy::~ModListProxy()
+{
+  disconnectSignals();
+}
+
+void ModListProxy::connectSignals()
 {
   m_Connections.push_back(m_Proxied->onModInstalled(callSignalIfPluginActive(m_OrganizerProxy, m_ModInstalled)));
   m_Connections.push_back(m_Proxied->onModMoved(callSignalIfPluginActive(m_OrganizerProxy, m_ModMoved)));
@@ -15,11 +22,12 @@ ModListProxy::ModListProxy(OrganizerProxy* oproxy, ModList* modlist) :
   m_Connections.push_back(m_Proxied->onModStateChanged(callSignalIfPluginActive(m_OrganizerProxy, m_ModStateChanged)));
 }
 
-ModListProxy::~ModListProxy()
+void ModListProxy::disconnectSignals()
 {
   for (auto& conn : m_Connections) {
     conn.disconnect();
   }
+  m_Connections.clear();
 }
 
 QString ModListProxy::displayName(const QString& internalName) const

--- a/src/modlistproxy.h
+++ b/src/modlistproxy.h
@@ -31,6 +31,12 @@ public:
 
 private:
 
+  friend class OrganizerProxy;
+
+  // See OrganizerProxy::connectSignals().
+  void connectSignals();
+  void disconnectSignals();
+
   OrganizerProxy* m_OrganizerProxy;
   ModList* m_Proxied;
 

--- a/src/modlistproxy.h
+++ b/src/modlistproxy.h
@@ -2,6 +2,7 @@
 #define MODLISTPROXY_H
 
 #include <imodlist.h>
+#include "modlist.h"
 
 class OrganizerProxy;
 
@@ -10,8 +11,8 @@ class ModListProxy : public MOBase::IModList
 
 public:
 
-  ModListProxy(OrganizerProxy* oproxy, IModList* modlist);
-  virtual ~ModListProxy() { }
+  ModListProxy(OrganizerProxy* oproxy, ModList* modlist);
+  virtual ~ModListProxy();
 
   QString displayName(const QString& internalName) const override;
   QStringList allMods() const override;
@@ -31,7 +32,14 @@ public:
 private:
 
   OrganizerProxy* m_OrganizerProxy;
-  IModList* m_Proxied;
+  ModList* m_Proxied;
+
+  ModList::SignalModInstalled m_ModInstalled;
+  ModList::SignalModMoved m_ModMoved;
+  ModList::SignalModRemoved m_ModRemoved;
+  ModList::SignalModStateChanged m_ModStateChanged;
+
+  std::vector<boost::signals2::connection> m_Connections;
 };
 
 #endif // ORGANIZERPROXY_H

--- a/src/organizercore.cpp
+++ b/src/organizercore.cpp
@@ -72,6 +72,7 @@
 #include <tuple>
 #include <utility>
 
+#include "organizerproxy.h"
 
 using namespace MOShared;
 using namespace MOBase;
@@ -96,7 +97,7 @@ OrganizerCore::OrganizerCore(Settings &settings)
   , m_Settings(settings)
   , m_Updater(&NexusInterface::instance())
   , m_ModList(m_PluginContainer, this)
-  , m_PluginList(this)
+  , m_PluginList(*this)
   , m_DirectoryRefresher(new DirectoryRefresher(settings.refreshThreadCount()))
   , m_DirectoryStructure(new DirectoryEntry(L"data", nullptr, 0))
   , m_DownloadManager(&NexusInterface::instance(), this)
@@ -1527,6 +1528,11 @@ PluginListSortProxy *OrganizerCore::createPluginListProxyModel()
 IPluginGame const *OrganizerCore::managedGame() const
 {
   return m_GamePlugin;
+}
+
+IOrganizer const* OrganizerCore::managedGameOrganizer() const
+{
+  return m_PluginContainer->requirements(m_GamePlugin).m_Organizer;
 }
 
 std::vector<QString> OrganizerCore::enabledArchives()

--- a/src/organizercore.cpp
+++ b/src/organizercore.cpp
@@ -291,7 +291,7 @@ void OrganizerCore::connectPlugins(PluginContainer *container)
   m_ModList.setPluginContainer(m_PluginContainer);
 
   if (!m_GameName.isEmpty()) {
-    m_GamePlugin = m_PluginContainer->managedGame(m_GameName);
+    m_GamePlugin = m_PluginContainer->game(m_GameName);
     emit managedGameChanged(m_GamePlugin);
   }
 

--- a/src/organizercore.cpp
+++ b/src/organizercore.cpp
@@ -301,25 +301,6 @@ void OrganizerCore::connectPlugins(PluginContainer *container)
     [&](IPlugin* plugin) { m_PluginDisabled(plugin); });
 }
 
-void OrganizerCore::disconnectPlugins()
-{
-  m_AboutToRun.disconnect_all_slots();
-  m_FinishedRun.disconnect_all_slots();
-  m_UserInterfaceInitialized.disconnect_all_slots();
-  m_ProfileChanged.disconnect_all_slots();
-  m_PluginSettingChanged.disconnect_all_slots();
-
-  m_ModList.disconnectSlots();
-  m_PluginList.disconnectSlots();
-  m_Updater.setPluginContainer(nullptr);
-  m_DownloadManager.setPluginContainer(nullptr);
-  m_ModList.setPluginContainer(nullptr);
-
-  m_Settings.plugins().clearPlugins();
-  m_GamePlugin      = nullptr;
-  m_PluginContainer = nullptr;
-}
-
 void OrganizerCore::setManagedGame(MOBase::IPluginGame *game)
 {
   m_GameName   = game->gameName();

--- a/src/organizercore.cpp
+++ b/src/organizercore.cpp
@@ -1184,58 +1184,56 @@ bool OrganizerCore::previewFile(
   return true;
 }
 
-bool OrganizerCore::onAboutToRun(
+boost::signals2::connection OrganizerCore::onAboutToRun(
     const std::function<bool(const QString &)> &func)
 {
-  auto conn = m_AboutToRun.connect(func);
-  return conn.connected();
+  return m_AboutToRun.connect(func);
 }
 
-bool OrganizerCore::onFinishedRun(
+boost::signals2::connection OrganizerCore::onFinishedRun(
     const std::function<void(const QString &, unsigned int)> &func)
 {
-  auto conn = m_FinishedRun.connect(func);
-  return conn.connected();
+  return m_FinishedRun.connect(func);
 }
 
-bool OrganizerCore::onUserInterfaceInitialized(std::function<void(QMainWindow*)> const& func)
+boost::signals2::connection OrganizerCore::onUserInterfaceInitialized(std::function<void(QMainWindow*)> const& func)
 {
-  return m_UserInterfaceInitialized.connect(func).connected();
+  return m_UserInterfaceInitialized.connect(func);
 }
 
-bool OrganizerCore::onProfileCreated(std::function<void(MOBase::IProfile*)> const& func)
+boost::signals2::connection OrganizerCore::onProfileCreated(std::function<void(MOBase::IProfile*)> const& func)
 {
-  return m_ProfileCreated.connect(func).connected();
+  return m_ProfileCreated.connect(func);
 }
 
-bool OrganizerCore::onProfileRenamed(std::function<void(MOBase::IProfile*, QString const&, QString const&)> const& func)
+boost::signals2::connection OrganizerCore::onProfileRenamed(std::function<void(MOBase::IProfile*, QString const&, QString const&)> const& func)
 {
-  return m_ProfileRenamed.connect(func).connected();
+  return m_ProfileRenamed.connect(func);
 }
 
-bool OrganizerCore::onProfileRemoved(std::function<void(QString const&)> const& func)
+boost::signals2::connection OrganizerCore::onProfileRemoved(std::function<void(QString const&)> const& func)
 {
-  return m_ProfileRemoved.connect(func).connected();
+  return m_ProfileRemoved.connect(func);
 }
 
-bool OrganizerCore::onProfileChanged(std::function<void(IProfile*, IProfile*)> const& func)
+boost::signals2::connection OrganizerCore::onProfileChanged(std::function<void(IProfile*, IProfile*)> const& func)
 {
-  return m_ProfileChanged.connect(func).connected();
+  return m_ProfileChanged.connect(func);
 }
 
-bool OrganizerCore::onPluginSettingChanged(std::function<void(QString const&, const QString& key, const QVariant&, const QVariant&)> const& func)
+boost::signals2::connection OrganizerCore::onPluginSettingChanged(std::function<void(QString const&, const QString& key, const QVariant&, const QVariant&)> const& func)
 {
-  return m_PluginSettingChanged.connect(func).connected();
+  return m_PluginSettingChanged.connect(func);
 }
 
-bool OrganizerCore::onPluginEnabled(std::function<void(const IPlugin*)> const& func)
+boost::signals2::connection OrganizerCore::onPluginEnabled(std::function<void(const IPlugin*)> const& func)
 {
-  return m_PluginEnabled.connect(func).connected();
+  return m_PluginEnabled.connect(func);
 }
 
-bool OrganizerCore::onPluginDisabled(std::function<void(const IPlugin*)> const& func)
+boost::signals2::connection OrganizerCore::onPluginDisabled(std::function<void(const IPlugin*)> const& func)
 {
-  return m_PluginDisabled.connect(func).connected();
+  return m_PluginDisabled.connect(func);
 }
 
 void OrganizerCore::refresh(bool saveChanges)

--- a/src/organizercore.h
+++ b/src/organizercore.h
@@ -61,6 +61,8 @@ class OrganizerCore : public QObject, public MOBase::IPluginDiagnose
 
 private:
 
+  friend class OrganizerProxy;
+
   struct SignalCombinerAnd
   {
     typedef bool result_type;
@@ -87,7 +89,7 @@ private:
   using SignalProfileRemoved = boost::signals2::signal<void(QString const&)>;
   using SignalProfileChanged = boost::signals2::signal<void (MOBase::IProfile *, MOBase::IProfile *)>;
   using SignalPluginSettingChanged = boost::signals2::signal<void (QString const&, const QString& key, const QVariant&, const QVariant&)>;
-  using SignalPluginEnabled = boost::signals2::signal<void(MOBase::IPlugin*)>;
+  using SignalPluginEnabled = boost::signals2::signal<void(const MOBase::IPlugin*)>;
 
 public:
 
@@ -328,16 +330,16 @@ public:
   ModList *modList();
   void refresh(bool saveChanges = true);
 
-  bool onAboutToRun(const std::function<bool(const QString&)>& func);
-  bool onFinishedRun(const std::function<void(const QString&, unsigned int)>& func);
-  bool onUserInterfaceInitialized(std::function<void(QMainWindow*)> const& func);
-  bool onProfileCreated(std::function<void(MOBase::IProfile*)> const& func);
-  bool onProfileRenamed(std::function<void(MOBase::IProfile*, QString const&, QString const&)> const& func);
-  bool onProfileRemoved(std::function<void(QString const&)> const& func);
-  bool onProfileChanged(std::function<void(MOBase::IProfile*, MOBase::IProfile*)> const& func);
-  bool onPluginSettingChanged(std::function<void(QString const&, const QString& key, const QVariant&, const QVariant&)> const& func);
-  bool onPluginEnabled(std::function<void(const MOBase::IPlugin*)> const& func);
-  bool onPluginDisabled(std::function<void(const MOBase::IPlugin*)> const& func);
+  boost::signals2::connection onAboutToRun(const std::function<bool(const QString&)>& func);
+  boost::signals2::connection onFinishedRun(const std::function<void(const QString&, unsigned int)>& func);
+  boost::signals2::connection onUserInterfaceInitialized(std::function<void(QMainWindow*)> const& func);
+  boost::signals2::connection onProfileCreated(std::function<void(MOBase::IProfile*)> const& func);
+  boost::signals2::connection onProfileRenamed(std::function<void(MOBase::IProfile*, QString const&, QString const&)> const& func);
+  boost::signals2::connection onProfileRemoved(std::function<void(QString const&)> const& func);
+  boost::signals2::connection onProfileChanged(std::function<void(MOBase::IProfile*, MOBase::IProfile*)> const& func);
+  boost::signals2::connection onPluginSettingChanged(std::function<void(QString const&, const QString& key, const QVariant&, const QVariant&)> const& func);
+  boost::signals2::connection onPluginEnabled(std::function<void(const MOBase::IPlugin*)> const& func);
+  boost::signals2::connection onPluginDisabled(std::function<void(const MOBase::IPlugin*)> const& func);
 
   bool getArchiveParsing() const
   {

--- a/src/organizercore.h
+++ b/src/organizercore.h
@@ -201,7 +201,6 @@ public:
 
   void setUserInterface(IUserInterface* ui);
   void connectPlugins(PluginContainer *container);
-  void disconnectPlugins();
 
   void setManagedGame(MOBase::IPluginGame *game);
 

--- a/src/organizercore.h
+++ b/src/organizercore.h
@@ -234,6 +234,13 @@ public:
   MOBase::IPluginGame const *managedGame() const;
 
   /**
+   * @brief Retrieve the organizer proxy of the currently managed game.
+   *
+   */
+  MOBase::IOrganizer const* managedGameOrganizer() const;
+
+
+  /**
    * @return the list of contents for the currently managed game, or an empty vector
    *     if the game plugin does not implement the ModDataContent feature.
    */

--- a/src/organizerproxy.cpp
+++ b/src/organizerproxy.cpp
@@ -22,7 +22,6 @@ OrganizerProxy::OrganizerProxy(OrganizerCore* organizer, PluginContainer* plugin
   : m_Proxied(organizer)
   , m_PluginContainer(pluginContainer)
   , m_Plugin(plugin)
-  , m_PluginName(plugin->name())
   , m_DownloadManagerProxy(std::make_unique<DownloadManagerProxy>(this, organizer->downloadManager()))
   , m_ModListProxy(std::make_unique<ModListProxy>(this, organizer->modList()))
   , m_PluginListProxy(std::make_unique<PluginListProxy>(this, organizer->pluginList())) { }

--- a/src/organizerproxy.cpp
+++ b/src/organizerproxy.cpp
@@ -43,7 +43,7 @@ OrganizerProxy::OrganizerProxy(OrganizerCore* organizer, PluginContainer* plugin
 
 OrganizerProxy::~OrganizerProxy()
 {
-  log::debug("~OrganizerProxy() for {}.", m_PluginName);
+  log::debug("Deleting organizer proxy for plugin '{}'.", m_PluginName);
   for (auto& conn : m_Connections) {
     conn.disconnect();
   }

--- a/src/organizerproxy.cpp
+++ b/src/organizerproxy.cpp
@@ -54,8 +54,6 @@ void OrganizerProxy::connectSignals()
 
 void OrganizerProxy::disconnectSignals()
 {
-  log::debug("Disconnecting organizer proxy for plugin '{}'.", m_PluginName);
-
   // Disconnect the child proxies.
   m_DownloadManagerProxy->disconnectSignals();
   m_ModListProxy->disconnectSignals();

--- a/src/organizerproxy.cpp
+++ b/src/organizerproxy.cpp
@@ -22,10 +22,31 @@ OrganizerProxy::OrganizerProxy(OrganizerCore* organizer, PluginContainer* plugin
   : m_Proxied(organizer)
   , m_PluginContainer(pluginContainer)
   , m_Plugin(plugin)
+  , m_PluginName(plugin->name())
   , m_DownloadManagerProxy(std::make_unique<DownloadManagerProxy>(this, organizer->downloadManager()))
   , m_ModListProxy(std::make_unique<ModListProxy>(this, organizer->modList()))
   , m_PluginListProxy(std::make_unique<PluginListProxy>(this, organizer->pluginList()))
 {
+  m_Connections.push_back(m_Proxied->onAboutToRun(callSignalIfPluginActive(this, m_AboutToRun, true)));
+  m_Connections.push_back(m_Proxied->onFinishedRun(callSignalIfPluginActive(this, m_FinishedRun)));
+  m_Connections.push_back(m_Proxied->onProfileCreated(callSignalIfPluginActive(this, m_ProfileCreated)));
+  m_Connections.push_back(m_Proxied->onProfileRenamed(callSignalIfPluginActive(this, m_ProfileRenamed)));
+  m_Connections.push_back(m_Proxied->onProfileRemoved(callSignalIfPluginActive(this, m_ProfileRemoved)));
+  m_Connections.push_back(m_Proxied->onProfileChanged(callSignalIfPluginActive(this, m_ProfileChanged)));
+
+  m_Connections.push_back(m_Proxied->onUserInterfaceInitialized(callSignalAlways(m_UserInterfaceInitialized)));
+  m_Connections.push_back(m_Proxied->onPluginSettingChanged(callSignalAlways(m_PluginSettingChanged)));
+  m_Connections.push_back(m_Proxied->onPluginEnabled(callSignalAlways(m_PluginEnabled)));
+  m_Connections.push_back(m_Proxied->onPluginDisabled(callSignalAlways(m_PluginDisabled)));
+
+}
+
+OrganizerProxy::~OrganizerProxy()
+{
+  log::debug("~OrganizerProxy() for {}.", m_PluginName);
+  for (auto& conn : m_Connections) {
+    conn.disconnect();
+  }
 }
 
 IModRepositoryBridge *OrganizerProxy::createNexusBridge() const
@@ -265,68 +286,68 @@ MOBase::IPluginGame const *OrganizerProxy::managedGame() const
 
 bool OrganizerProxy::onAboutToRun(const std::function<bool(const QString&)>& func)
 {
-  return m_Proxied->onAboutToRun(MOShared::callIfPluginActive(this, func, true));
+  return m_Proxied->onAboutToRun(MOShared::callIfPluginActive(this, func, true)).connected();
 }
 
 bool OrganizerProxy::onFinishedRun(const std::function<void(const QString&, unsigned int)>& func)
 {
-  return m_Proxied->onFinishedRun(MOShared::callIfPluginActive(this, func));
+  return m_Proxied->onFinishedRun(MOShared::callIfPluginActive(this, func)).connected();
+}
+
+bool OrganizerProxy::onProfileCreated(std::function<void(IProfile*)> const& func)
+{
+  return m_ProfileCreated.connect(func).connected();
+}
+
+bool OrganizerProxy::onProfileRenamed(std::function<void(IProfile*, QString const&, QString const&)> const& func)
+{
+  return m_ProfileRenamed.connect(func).connected();
+}
+
+bool OrganizerProxy::onProfileRemoved(std::function<void(QString const&)> const& func)
+{
+  return m_ProfileRemoved.connect(func).connected();
+}
+
+bool OrganizerProxy::onProfileChanged(std::function<void(MOBase::IProfile*, MOBase::IProfile*)> const& func)
+{
+  return m_ProfileChanged.connect(func).connected();
 }
 
 bool OrganizerProxy::onUserInterfaceInitialized(std::function<void(QMainWindow*)> const& func)
 {
   // Always call this one to allow plugin to initialize themselves even when not active:
-  return m_Proxied->onUserInterfaceInitialized(func);
-}
-
-bool OrganizerProxy::onProfileCreated(std::function<void(IProfile*)> const& func)
-{
-  return m_Proxied->onProfileCreated(MOShared::callIfPluginActive(this, func));
-}
-
-bool OrganizerProxy::onProfileRenamed(std::function<void(IProfile*, QString const&, QString const&)> const& func)
-{
-  return m_Proxied->onProfileRenamed(MOShared::callIfPluginActive(this, func));
-}
-
-bool OrganizerProxy::onProfileRemoved(std::function<void(QString const&)> const& func)
-{
-  return m_Proxied->onProfileRemoved(MOShared::callIfPluginActive(this, func));
-}
-
-bool OrganizerProxy::onProfileChanged(std::function<void(MOBase::IProfile*, MOBase::IProfile*)> const& func)
-{
-  return m_Proxied->onProfileChanged(MOShared::callIfPluginActive(this, func));
+  return m_UserInterfaceInitialized.connect(func).connected();
 }
 
 // Always call these one, otherwise plugin cannot detect they are being enabled / disabled:
 bool OrganizerProxy::onPluginSettingChanged(std::function<void(QString const&, const QString& key, const QVariant&, const QVariant&)> const& func)
 {
-  return m_Proxied->onPluginSettingChanged(func);
+  return m_PluginSettingChanged.connect(func).connected();
 }
 
 bool OrganizerProxy::onPluginEnabled(std::function<void(const IPlugin*)> const& func)
 {
-  return m_Proxied->onPluginEnabled(func);
+  return m_PluginEnabled.connect(func).connected();
 }
 
 bool OrganizerProxy::onPluginEnabled(const QString& pluginName, std::function<void()> const& func)
 {
-  return m_Proxied->onPluginEnabled([=](const IPlugin* plugin) {
+  return onPluginEnabled([=](const IPlugin* plugin) {
     if (plugin->name().compare(pluginName, Qt::CaseInsensitive) == 0) {
       func();
     }
-  });
+    });
 }
 
 bool OrganizerProxy::onPluginDisabled(std::function<void(const IPlugin*)> const& func)
 {
-  return m_Proxied->onPluginDisabled(func);
+  return m_PluginDisabled.connect(func).connected();
 }
 
 bool OrganizerProxy::onPluginDisabled(const QString& pluginName, std::function<void()> const& func)
 {
-  return m_Proxied->onPluginDisabled([=](const IPlugin* plugin) {
+  return onPluginDisabled([=](const IPlugin* plugin) {
     if (plugin->name().compare(pluginName, Qt::CaseInsensitive) == 0) {
       func();
     }

--- a/src/organizerproxy.h
+++ b/src/organizerproxy.h
@@ -21,10 +21,14 @@ public:
   OrganizerProxy(OrganizerCore *organizer, PluginContainer *pluginContainer, MOBase::IPlugin *plugin);
   ~OrganizerProxy();
 
+public:
+
   /**
    * @return the plugin corresponding to this proxy.
    */
   MOBase::IPlugin* plugin() const { return m_Plugin;  }
+
+public: // IOrganizer interface
 
   virtual MOBase::IModRepositoryBridge *createNexusBridge() const;
   virtual QString profileName() const;
@@ -82,6 +86,19 @@ protected:
 
   // The container needs access to some callbacks to simulate startup.
   friend class PluginContainer;
+
+  /**
+   * @brief Connect the signals from this proxy and all the child proxies (plugin list, mod
+   *   list, etc.) to the actual implementation. Before this call, plugins can register signals
+   *   but they won't be triggered.
+   */
+  void connectSignals();
+
+  /**
+   * @brief Disconnect the signals from this proxy and all the child proxies (plugin list, mod
+   *   list, etc.) from the actual implementation.
+   */
+  void disconnectSignals();
 
 private:
 

--- a/src/organizerproxy.h
+++ b/src/organizerproxy.h
@@ -6,7 +6,8 @@
 #include <iplugin.h>
 #include <imoinfo.h>
 
-class OrganizerCore;
+#include "organizercore.h"
+
 class PluginContainer;
 class DownloadManagerProxy;
 class ModListProxy;
@@ -18,6 +19,7 @@ class OrganizerProxy : public MOBase::IOrganizer
 public:
 
   OrganizerProxy(OrganizerCore *organizer, PluginContainer *pluginContainer, MOBase::IPlugin *plugin);
+  ~OrganizerProxy();
 
   /**
    * @return the plugin corresponding to this proxy.
@@ -76,12 +78,31 @@ public:
 
   virtual MOBase::IPluginGame const *managedGame() const;
 
+protected:
+
+  // The container needs access to some callbacks to simulate startup.
+  friend class PluginContainer;
+
 private:
 
   OrganizerCore *m_Proxied;
   PluginContainer *m_PluginContainer;
 
   MOBase::IPlugin *m_Plugin;
+  QString m_PluginName;
+
+  OrganizerCore::SignalAboutToRunApplication m_AboutToRun;
+  OrganizerCore::SignalFinishedRunApplication m_FinishedRun;
+  OrganizerCore::SignalUserInterfaceInitialized m_UserInterfaceInitialized;
+  OrganizerCore::SignalProfileCreated m_ProfileCreated;
+  OrganizerCore::SignalProfileRenamed m_ProfileRenamed;
+  OrganizerCore::SignalProfileRemoved m_ProfileRemoved;
+  OrganizerCore::SignalProfileChanged m_ProfileChanged;
+  OrganizerCore::SignalPluginSettingChanged m_PluginSettingChanged;
+  OrganizerCore::SignalPluginEnabled m_PluginEnabled;
+  OrganizerCore::SignalPluginEnabled m_PluginDisabled;
+
+  std::vector<boost::signals2::connection> m_Connections;
 
   std::unique_ptr<DownloadManagerProxy> m_DownloadManagerProxy;
   std::unique_ptr<ModListProxy> m_ModListProxy;

--- a/src/organizerproxy.h
+++ b/src/organizerproxy.h
@@ -106,7 +106,6 @@ private:
   PluginContainer *m_PluginContainer;
 
   MOBase::IPlugin *m_Plugin;
-  QString m_PluginName;
 
   OrganizerCore::SignalAboutToRunApplication m_AboutToRun;
   OrganizerCore::SignalFinishedRunApplication m_FinishedRun;

--- a/src/plugincontainer.cpp
+++ b/src/plugincontainer.cpp
@@ -560,7 +560,6 @@ IPlugin* PluginContainer::registerPlugin(QObject *plugin, const QString& filepat
     IPluginPreview *preview = qobject_cast<IPluginPreview*>(plugin);
     if (initPlugin(preview, pluginProxy, skipInit)) {
       bf::at_key<IPluginPreview>(m_Plugins).push_back(preview);
-      m_PreviewGenerator.registerPlugin(preview);
       return preview;
     }
   }

--- a/src/plugincontainer.cpp
+++ b/src/plugincontainer.cpp
@@ -850,6 +850,11 @@ void PluginContainer::loadPlugin(QString const& filepath)
 void PluginContainer::unloadPlugin(MOBase::IPlugin* plugin, QObject* object)
 {
   if (auto* game = qobject_cast<IPluginGame*>(object)) {
+
+    if (game == managedGame()) {
+      throw Exception("cannot unload the plugin for the currently managed game");
+    }
+
     unregisterGame(game);
   }
 

--- a/src/plugincontainer.cpp
+++ b/src/plugincontainer.cpp
@@ -855,8 +855,8 @@ void PluginContainer::unloadPlugin(MOBase::IPlugin* plugin, QObject* object)
     unregisterGame(game);
   }
 
-  // We need to do this BEFORE unloading from the proxy otherwise the
-  // qobject_cast won't work.
+  // We need to remove from the m_Plugins maps BEFORE unloading from the proxy
+  // otherwise the qobject_cast to check the plugin type will not work.
   bf::for_each(m_Plugins, [object](auto& t) {
     using type = typename std::decay_t<decltype(t.second)>::value_type;
 

--- a/src/plugincontainer.cpp
+++ b/src/plugincontainer.cpp
@@ -696,7 +696,7 @@ QString PluginContainer::filepath(MOBase::IPlugin* plugin) const
   return as_qobject(plugin)->property("filepath").toString();
 }
 
-IPluginGame *PluginContainer::managedGame(const QString &name) const
+IPluginGame *PluginContainer::game(const QString &name) const
 {
   auto iter = m_SupportedGames.find(name);
   if (iter != m_SupportedGames.end()) {

--- a/src/plugincontainer.cpp
+++ b/src/plugincontainer.cpp
@@ -943,11 +943,6 @@ void PluginContainer::reloadPlugin(QString const& filepath)
 
 void PluginContainer::unloadPlugins()
 {
-  // disconnect all slots before unloading plugins so plugins don't have to take care of that
-  if (m_Organizer) {
-    m_Organizer->disconnectPlugins();
-  }
-
   bf::for_each(m_Plugins, [](auto& t) { t.second.clear(); });
   bf::for_each(m_AccessPlugins, [](auto& t) { t.second.clear(); });
   m_Requirements.clear();

--- a/src/plugincontainer.cpp
+++ b/src/plugincontainer.cpp
@@ -301,6 +301,9 @@ void PluginContainer::setUserInterface(IUserInterface *userInterface)
     for (IPluginTool* tool : bf::at_key<IPluginTool>(m_Plugins)) {
       tool->setParentWidget(userInterface->mainWindow());
     }
+    for (IPluginInstaller* installer : bf::at_key<IPluginInstaller>(m_Plugins)) {
+      installer->setParentWidget(userInterface->mainWindow());
+    }
   }
 
   m_UserInterface = userInterface;
@@ -537,7 +540,7 @@ IPlugin* PluginContainer::registerPlugin(QObject *plugin, const QString &fileNam
     if (initPlugin(installer, pluginProxy, skipInit)) {
       bf::at_key<IPluginInstaller>(m_Plugins).push_back(installer);
       if (m_Organizer) {
-        m_Organizer->installationManager()->registerInstaller(installer);
+        installer->setInstallationManager(m_Organizer->installationManager());
       }
       return installer;
     }

--- a/src/plugincontainer.h
+++ b/src/plugincontainer.h
@@ -209,7 +209,6 @@ public:
   void reloadPlugin(QString const& filepath);
 
   void loadPlugins();
-  void unloadPlugins();
 
   /**
    * @brief Find the game plugin corresponding to the given name.
@@ -370,21 +369,29 @@ private:
 
   friend class PluginRequirements;
 
-  /**
-   * @return the organizer proxy for the given plugin.
-   */
+  // Unload all the plugins.
+  void unloadPlugins();
+
+  // Retrieve the organizer proxy for the given plugin.
   OrganizerProxy* organizerProxy(MOBase::IPlugin* plugin) const;
 
-  /**
-   * @return the proxy plugin that instantiated the given plugin, or a null pointer
-   *   if the plugin was not instantiated by a proxy.
-   */
+  // Retrieve the proxy plugin that instantiated the given plugin, or a null pointer
+  // if the plugin was not instantiated by a proxy.
   MOBase::IPluginProxy* pluginProxy(MOBase::IPlugin* plugin) const;
 
-  /**
-   * @return the path to the file or folder corresponding to the plugin.
-   */
+  // Retrieve the path to the file or folder corresponding to the plugin.
   QString filepath(MOBase::IPlugin* plugin) const;
+
+  // Load plugins from the given filepath using the given proxy.
+  std::vector<QObject*> loadProxied(const QString& filepath, MOBase::IPluginProxy* proxy);
+
+  // Load the Qt plugin from the given file.
+  QObject* loadQtPlugin(const QString& filepath);
+
+  // See startPlugins for more details. This is simply an intermediate function
+  // that can be used when loading plugins after initialization. This uses the
+  // user interface in m_UserInterface.
+  void startPluginsImpl(const std::vector<QObject*>& plugins) const;
 
   /**
    * @brief Unload the given plugin.
@@ -396,24 +403,6 @@ private:
    * @param object The QObject corresponding to the plugin.
    */
   void unloadPlugin(MOBase::IPlugin* plugin, QObject* object);
-
-  /**
-   * @brief Load plugins from the given filepath using the given proxy.
-   *
-   * @param filepath Path to a folder/file containing plugin(s) that can be load by the given proxy.
-   * @param proxy Proxy to use to load plugins.
-   *
-   * @return the list of created plugins.
-   */
-  std::vector<QObject*> loadProxied(const QString& filepath, MOBase::IPluginProxy* proxy);
-
-  // Load the Qt plugin from the given file.
-  QObject* loadQtPlugin(const QString& filepath);
-
-  // See startPlugins for more details. This is simply an intermediate function
-  // that can be used when loading plugins after initialization. This uses the
-  // user interface in m_UserInterface.
-  void startPluginsImpl(const std::vector<QObject*>& plugins) const;
 
   /**
    * @brief Retrieved the (localized) names of interfaces implemented by the given

--- a/src/plugincontainer.h
+++ b/src/plugincontainer.h
@@ -335,10 +335,16 @@ public: // IPluginDiagnose interface
 signals:
 
   /**
-   * @brief Emitted plugins are enabled or disabled.
+   * @brief Emitted when plugins are enabled or disabled.
    */
   void pluginEnabled(MOBase::IPlugin*);
   void pluginDisabled(MOBase::IPlugin*);
+
+  /**
+   * @brief Emitted when plugins are registered or unregistered.
+   */
+  void pluginRegistered(MOBase::IPlugin*);
+  void pluginUnregistered(MOBase::IPlugin*);
 
   void diagnosisUpdate();
 

--- a/src/plugincontainer.h
+++ b/src/plugincontainer.h
@@ -186,10 +186,23 @@ public:
 
 public:
 
-  PluginContainer(OrganizerCore *organizer);
+  PluginContainer(OrganizerCore* organizer);
   virtual ~PluginContainer();
 
-  void setUserInterface(IUserInterface *userInterface);
+  /**
+   * @brief Start the plugins.
+   *
+   * This function should not be called before MO2 is ready and plugins can be
+   * started, and will do the following:
+   *   - connect the callbacks of the plugins,
+   *   - set the parent widget for plugins that can have one,
+   *   - notify plugins that MO2 has been started, including:
+   *     - triggering a call to the "profile changed" callback for the initial profile,
+   *     - triggering a call to the "user interface initialized" callback.
+   *
+   * @param userInterface The main user interface to use for the plugins.
+   */
+  void startPlugins(IUserInterface* userInterface);
 
   void loadPlugin(QString const& filepath);
   void unloadPlugin(QString const& filepath);
@@ -392,21 +405,15 @@ private:
    *
    * @return the list of created plugins.
    */
-  std::vector<MOBase::IPlugin*> loadProxied(const QString& filepath, MOBase::IPluginProxy* proxy);
+  std::vector<QObject*> loadProxied(const QString& filepath, MOBase::IPluginProxy* proxy);
 
-  /**
-   * @brief Load the Qt plugin from the given file.
-   *
-   * @param filepath Path to the DLL containing the Qt plugin.
-   */
-  MOBase::IPlugin* loadQtPlugin(const QString& filepath);
+  // Load the Qt plugin from the given file.
+  QObject* loadQtPlugin(const QString& filepath);
 
-  /**
-   * @brief Simulate MO2 startup for the given plugins.
-   *
-   * @param plugins Plugins to simulate startup for.
-   */
-  void simulateStartup(const std::vector<MOBase::IPlugin*>& plugins) const;
+  // See startPlugins for more details. This is simply an intermediate function
+  // that can be used when loading plugins after initialization. This uses the
+  // user interface in m_UserInterface.
+  void startPluginsImpl(const std::vector<QObject*>& plugins) const;
 
   /**
    * @brief Retrieved the (localized) names of interfaces implemented by the given

--- a/src/plugincontainer.h
+++ b/src/plugincontainer.h
@@ -462,8 +462,10 @@ private:
 
   MOBase::IPlugin* registerPlugin(QObject *pluginObj, const QString &fileName, MOBase::IPluginProxy *proxy);
 
+  // Core organizer, can be null (e.g. on first MO2 startup).
   OrganizerCore *m_Organizer;
 
+  // Main user interface, can be null until MW has been initialized.
   IUserInterface *m_UserInterface;
 
   PluginMap m_Plugins;

--- a/src/plugincontainer.h
+++ b/src/plugincontainer.h
@@ -395,6 +395,13 @@ private:
   std::vector<MOBase::IPlugin*> loadProxied(const QString& filepath, MOBase::IPluginProxy* proxy);
 
   /**
+   * @brief Load the Qt plugin from the given file.
+   *
+   * @param filepath Path to the DLL containing the Qt plugin.
+   */
+  MOBase::IPlugin* loadQtPlugin(const QString& filepath);
+
+  /**
    * @brief Simulate MO2 startup for the given plugins.
    *
    * @param plugins Plugins to simulate startup for.

--- a/src/plugincontainer.h
+++ b/src/plugincontainer.h
@@ -204,22 +204,19 @@ public:
    */
   void startPlugins(IUserInterface* userInterface);
 
+  /**
+   * @brief Load, unload or reload the plugin at the given path.
+   *
+   */
   void loadPlugin(QString const& filepath);
   void unloadPlugin(QString const& filepath);
   void reloadPlugin(QString const& filepath);
 
-  void loadPlugins();
-
   /**
-   * @brief Find the game plugin corresponding to the given name.
+   * @brief Load all plugins.
    *
-   * @param name The name of the game to find a plugin for (as returned by
-   *     IPluginGame::gameName()).
-   *
-   * @return the game plugin for the given name, or a null pointer if no
-   *     plugin exists for this game.
    */
-  MOBase::IPluginGame *managedGame(const QString &name) const;
+  void loadPlugins();
 
   /**
    * @brief Retrieve the list of plugins of the given type.
@@ -270,6 +267,17 @@ public:
   MOBase::IPlugin* plugin(QString const& pluginName) const;
   MOBase::IPlugin* plugin(MOBase::IPluginDiagnose* diagnose) const;
   MOBase::IPlugin* plugin(MOBase::IPluginFileMapper* mapper) const;
+
+  /**
+   * @brief Find the game plugin corresponding to the given name.
+   *
+   * @param name The name of the game to find a plugin for (as returned by
+   *     IPluginGame::gameName()).
+   *
+   * @return the game plugin for the given name, or a null pointer if no
+   *     plugin exists for this game.
+   */
+  MOBase::IPluginGame* game(const QString& name) const;
 
   /**
    * @return the IPlugin interface to the currently managed game.

--- a/src/pluginlistproxy.cpp
+++ b/src/pluginlistproxy.cpp
@@ -6,18 +6,26 @@ using namespace MOBase;
 using namespace MOShared;
 
 PluginListProxy::PluginListProxy(OrganizerProxy* oproxy, PluginList* pluginlist) :
-  m_OrganizerProxy(oproxy), m_Proxied(pluginlist)
+  m_OrganizerProxy(oproxy), m_Proxied(pluginlist) { }
+
+PluginListProxy::~PluginListProxy()
+{
+  disconnectSignals();
+}
+
+void PluginListProxy::connectSignals()
 {
   m_Connections.push_back(m_Proxied->onRefreshed(callSignalIfPluginActive(m_OrganizerProxy, m_Refreshed)));
   m_Connections.push_back(m_Proxied->onPluginMoved(callSignalIfPluginActive(m_OrganizerProxy, m_PluginMoved)));
   m_Connections.push_back(m_Proxied->onPluginStateChanged(callSignalIfPluginActive(m_OrganizerProxy, m_PluginStateChanged)));
 }
 
-PluginListProxy::~PluginListProxy()
+void PluginListProxy::disconnectSignals()
 {
   for (auto& conn : m_Connections) {
     conn.disconnect();
   }
+  m_Connections.clear();
 }
 
 QStringList PluginListProxy::pluginNames() const

--- a/src/pluginlistproxy.cpp
+++ b/src/pluginlistproxy.cpp
@@ -3,11 +3,24 @@
 #include "proxyutils.h"
 
 using namespace MOBase;
+using namespace MOShared;
 
-PluginListProxy::PluginListProxy(OrganizerProxy* oproxy, IPluginList* pluginlist) :
-  m_OrganizerProxy(oproxy), m_Proxied(pluginlist) { }
+PluginListProxy::PluginListProxy(OrganizerProxy* oproxy, PluginList* pluginlist) :
+  m_OrganizerProxy(oproxy), m_Proxied(pluginlist)
+{
+  m_Connections.push_back(m_Proxied->onRefreshed(callSignalIfPluginActive(m_OrganizerProxy, m_Refreshed)));
+  m_Connections.push_back(m_Proxied->onPluginMoved(callSignalIfPluginActive(m_OrganizerProxy, m_PluginMoved)));
+  m_Connections.push_back(m_Proxied->onPluginStateChanged(callSignalIfPluginActive(m_OrganizerProxy, m_PluginStateChanged)));
+}
 
-QStringList PluginListProxy::pluginNames() const 
+PluginListProxy::~PluginListProxy()
+{
+  for (auto& conn : m_Connections) {
+    conn.disconnect();
+  }
+}
+
+QStringList PluginListProxy::pluginNames() const
 {
   return m_Proxied->pluginNames();
 }
@@ -57,17 +70,17 @@ QString PluginListProxy::origin(const QString& name) const
   return m_Proxied->origin(name);
 }
 
-bool PluginListProxy::onRefreshed(const std::function<void()>& callback) 
+bool PluginListProxy::onRefreshed(const std::function<void()>& func)
 {
-  return m_Proxied->onRefreshed(MOShared::callIfPluginActive(m_OrganizerProxy, callback));
+  return m_Refreshed.connect(func).connected();
 }
 
 bool PluginListProxy::onPluginMoved(const std::function<void(const QString&, int, int)>& func)
 {
-  return m_Proxied->onPluginMoved(MOShared::callIfPluginActive(m_OrganizerProxy, func));
+  return m_PluginMoved.connect(func).connected();
 }
 
 bool PluginListProxy::onPluginStateChanged(const std::function<void(const std::map<QString, PluginStates>&)> &func)
 {
-  return m_Proxied->onPluginStateChanged(MOShared::callIfPluginActive(m_OrganizerProxy, func));
+  return m_PluginStateChanged.connect(func).connected();
 }

--- a/src/pluginlistproxy.h
+++ b/src/pluginlistproxy.h
@@ -30,6 +30,12 @@ public:
 
 private:
 
+  friend class OrganizerProxy;
+
+  // See OrganizerProxy::connectSignals().
+  void connectSignals();
+  void disconnectSignals();
+
   OrganizerProxy* m_OrganizerProxy;
   PluginList* m_Proxied;
 

--- a/src/pluginlistproxy.h
+++ b/src/pluginlistproxy.h
@@ -2,6 +2,7 @@
 #define PLUGINLISTPROXY_H
 
 #include <ipluginlist.h>
+#include "pluginlist.h"
 
 class OrganizerProxy;
 
@@ -10,8 +11,8 @@ class PluginListProxy : public MOBase::IPluginList
 
 public:
 
-  PluginListProxy(OrganizerProxy* oproxy, IPluginList* pluginlist);
-  virtual ~PluginListProxy() { }
+  PluginListProxy(OrganizerProxy* oproxy, PluginList* pluginlist);
+  virtual ~PluginListProxy();
 
   QStringList pluginNames() const override;
   PluginStates state(const QString& name) const override;
@@ -30,7 +31,13 @@ public:
 private:
 
   OrganizerProxy* m_OrganizerProxy;
-  IPluginList* m_Proxied;
+  PluginList* m_Proxied;
+
+  PluginList::SignalRefreshed m_Refreshed;
+  PluginList::SignalPluginMoved m_PluginMoved;
+  PluginList::SignalPluginStateChanged m_PluginStateChanged;
+
+  std::vector<boost::signals2::connection> m_Connections;
 };
 
 #endif // ORGANIZERPROXY_H

--- a/src/previewgenerator.cpp
+++ b/src/previewgenerator.cpp
@@ -29,14 +29,14 @@ along with Mod Organizer.  If not, see <http://www.gnu.org/licenses/>.
 
 using namespace MOBase;
 
-PreviewGenerator::PreviewGenerator(const PluginContainer* pluginContainer) :
+PreviewGenerator::PreviewGenerator(const PluginContainer& pluginContainer) :
   m_PluginContainer(pluginContainer) {
   m_MaxSize = QGuiApplication::primaryScreen()->size() * 0.8;
 }
 
 bool PreviewGenerator::previewSupported(const QString &fileExtension) const
 {
-  auto& previews = m_PluginContainer->plugins<IPluginPreview>();
+  auto& previews = m_PluginContainer.plugins<IPluginPreview>();
   for (auto* preview : previews) {
     if (preview->supportedExtensions().contains(fileExtension)) {
       return true;
@@ -48,9 +48,9 @@ bool PreviewGenerator::previewSupported(const QString &fileExtension) const
 QWidget *PreviewGenerator::genPreview(const QString &fileName) const
 {
   const QString ext = QFileInfo(fileName).suffix().toLower();
-  auto& previews = m_PluginContainer->plugins<IPluginPreview>();
+  auto& previews = m_PluginContainer.plugins<IPluginPreview>();
   for (auto* preview : previews) {
-    if (m_PluginContainer->isEnabled(preview) && preview->supportedExtensions().contains(ext)) {
+    if (m_PluginContainer.isEnabled(preview) && preview->supportedExtensions().contains(ext)) {
       return preview->genFilePreview(fileName, m_MaxSize);
     }
   }

--- a/src/previewgenerator.h
+++ b/src/previewgenerator.h
@@ -33,21 +33,13 @@ class PreviewGenerator
 public:
   PreviewGenerator(const PluginContainer* pluginContainer);
 
-  void registerPlugin(MOBase::IPluginPreview *plugin);
-
   bool previewSupported(const QString &fileExtension) const;
 
   QWidget *genPreview(const QString &fileName) const;
 
 private:
 
-  QWidget *genImagePreview(const QString &fileName) const;
-  QWidget *genTxtPreview(const QString &fileName) const;
-
-private:
-
   const PluginContainer* m_PluginContainer;
-  std::map<QString, MOBase::IPluginPreview*> m_PreviewPlugins;
   QSize m_MaxSize;
 
 };

--- a/src/previewgenerator.h
+++ b/src/previewgenerator.h
@@ -31,7 +31,7 @@ class PluginContainer;
 class PreviewGenerator
 {
 public:
-  PreviewGenerator(const PluginContainer* pluginContainer);
+  PreviewGenerator(const PluginContainer& pluginContainer);
 
   bool previewSupported(const QString &fileExtension) const;
 
@@ -39,7 +39,7 @@ public:
 
 private:
 
-  const PluginContainer* m_PluginContainer;
+  const PluginContainer& m_PluginContainer;
   QSize m_MaxSize;
 
 };

--- a/src/proxyutils.h
+++ b/src/proxyutils.h
@@ -21,6 +21,21 @@ namespace MOShared {
     };
   }
 
+  // We need to connect to the organizer.
+  template <class Signal, class T = int>
+  auto callSignalIfPluginActive(OrganizerProxy* proxy, const Signal& signal, T defaultReturn = T{}) {
+    return callIfPluginActive(proxy, [&signal](auto&&... args) {
+      return signal(std::forward<decltype(args)>(args)...);
+    }, defaultReturn);
+  }
+
+  template <class Signal, class T = int>
+  auto callSignalAlways(const Signal& signal) {
+    return [&signal](auto&&... args) {
+      return signal(std::forward<decltype(args)>(args)...);
+    };
+  }
+
 }
 
 #endif

--- a/src/settings.cpp
+++ b/src/settings.cpp
@@ -1317,6 +1317,16 @@ void PluginSettings::registerPlugin(IPlugin *plugin)
   }
 }
 
+void PluginSettings::unregisterPlugin(IPlugin* plugin)
+{
+  auto it = std::find(m_Plugins.begin(), m_Plugins.end(), plugin);
+  if (it != m_Plugins.end()) {
+    m_Plugins.erase(it);
+  }
+  m_PluginSettings.remove(plugin->name());
+  m_PluginDescriptions.remove(plugin->name());
+}
+
 std::vector<MOBase::IPlugin*> PluginSettings::plugins() const
 {
   return m_Plugins;

--- a/src/settings.h
+++ b/src/settings.h
@@ -304,9 +304,10 @@ public:
   //
   void clearPlugins();
 
-  // adds the given plugin to the list and loads all of its settings
+  // adds/removes the given plugin to the list and loads all of its settings
   //
   void registerPlugin(MOBase::IPlugin *plugin);
+  void unregisterPlugin(MOBase::IPlugin* plugin);
 
   // returns all the registered plugins
   //


### PR DESCRIPTION
The core of this PR is the addition of `load`, `unload` and `reload` methods to `PluginContainer` to load/unload/reload plugins/extensions without having to restart MO2.

**Relevant changes:**

- Similar to the "support extensions" PR, I moved stuff around to avoid issues when adding/removing plugins, in particular I removed the list of installers from the installation manager (the manager now directly query the plugin container when required).
- I added a few `unregisterPlugin` methods where it was needed, mostly for `Settings`. There are also signals associated which are currently only used within `MainWindow` to perform a few things (taken from the section used to handle the dialog settings).
- All the plugin callbacks have been moved to the proxy, thus it's easier to disconnect the signals when the plugin is removed or access plugin-specific callbacks when the plugin is loaded. 
  - The actual implementation still have their own signals, but those are only registered by the proxy themselves to actual dispatch to the plugins.
  - Unfortunately, I had to make `PluginList` not implement `IPluginList` (I wanted to avoid having the `onXXX` methods returning `bool`). This means that I could not pass it to the game plugins, so I had to find an appropriate plugin list proxy (I used the one from the game plugin).
    - This was a small bug since the game plugins would received the actual plugin list instead of a proxy, it has probably 0 impact (why would you register a callback in write/read plugin lists?).
- In order to properly load a plugin, we need to "simulate" a MO2 startup, so some methods are called manually. This relies on the callbacks from the proxy of the plugin(s) being loaded. Currently only the following callbacks are triggered: `userInterfaceInitialized` and `profileChanged`.

In order to avoid some duplication and exposing too much things, I made use of a few `friend` declaration, not sure if this is something used a lot in MO2.