### PR TITLE
Add more protection to modlist.txt when writing to it (WIP)

### DIFF
--- a/src/profile.h
+++ b/src/profile.h
@@ -398,6 +398,15 @@ private:
 
   static void renameModInList(QFile &modList, const QString &oldName, const QString &newName);
 
+  static void backupModListInProfile(const QString& profilePath);
+  static void restoreModListInProfile(const QString& profilePath);
+  static void removeModListBackupInProfile(const QString& profilePath);
+
+  void backupModList();
+  void restoreModList();
+  void removeModListBackup();
+  
+
 private:
 
   QDir m_Directory;


### PR DESCRIPTION
This moves modlist.txt to modlist.txt.bak when the mod list would be
modified and removes modlist.txt.bak when the modification is done.
Also, when loading a profile, any present modllist.txt.bak is renamed
back to modlist.txt.

Theoretically, this mitigates against crashes or other problems when
writing modlist.txt.  The hope is that the only remaining "dangerous"
operation is the .bak rename, which hopefully fails gracefully and
leaves the original file in place.