### PR TITLE
Fixed incorrect instance icons

### DIFF
--- a/src/instancemanager.cpp
+++ b/src/instancemanager.cpp
@@ -644,6 +644,13 @@ bool InstanceManager::allowedToChangeInstance() const
   return !QFile::exists(lockFile);
 }
 
+MOBase::IPluginGame* InstanceManager::gamePluginForDirectory(
+  const QString& instanceDir, PluginContainer& plugins) const
+{
+  return const_cast<MOBase::IPluginGame*>(gamePluginForDirectory(
+    instanceDir, const_cast<const PluginContainer&>(plugins)));
+}
+
 const MOBase::IPluginGame* InstanceManager::gamePluginForDirectory(
   const QString& instanceDir, const PluginContainer& plugins) const
 {

--- a/src/instancemanager.h
+++ b/src/instancemanager.h
@@ -251,6 +251,9 @@ public:
   const MOBase::IPluginGame* gamePluginForDirectory(
     const QString& dir, const PluginContainer& plugins) const;
 
+  MOBase::IPluginGame* gamePluginForDirectory(
+    const QString& dir, PluginContainer& plugins) const;
+
   // clears the instance name from the registry; on restart, this will make MO
   // either select the portable instance if it exists, or display the instance
   // selection/creation dialog

--- a/src/instancemanagerdialog.h
+++ b/src/instancemanagerdialog.h
@@ -17,7 +17,7 @@ class InstanceManagerDialog : public QDialog
 
 public:
   explicit InstanceManagerDialog(
-    const PluginContainer& pc, QWidget *parent = nullptr);
+    PluginContainer& pc, QWidget *parent = nullptr);
 
   ~InstanceManagerDialog();
 
@@ -91,7 +91,7 @@ private:
   static const std::size_t NoSelection = -1;
 
   std::unique_ptr<Ui::InstanceManagerDialog> ui;
-  const PluginContainer& m_pc;
+  PluginContainer& m_pc;
   std::vector<std::unique_ptr<Instance>> m_instances;
   MOBase::FilterWidget m_filter;
   QStandardItemModel* m_model;


### PR DESCRIPTION
Fixed `instanceIcon()` so it works when game plugins fail auto detection but the instance has a custom path. I also had to change `PluginContainer` to non const in a few places because I have to call `setGamePath()` on the plugins.