### PR TITLE
Stuff

### DIFF
--- a/src/aboutdialog.ui
+++ b/src/aboutdialog.ui
@@ -441,17 +441,7 @@
               </item>
               <item>
                <property name="text">
-                <string notr="true">DoubleYou</string>
-               </property>
-              </item>
-              <item>
-               <property name="text">
-                <string notr="true">Drew Warwick</string>
-               </property>
-              </item>
-              <item>
-               <property name="text">
-                <string notr="true">deathneko11</string>
+                <string notr="true">BlueAmulet</string>
                </property>
               </item>
               <item>
@@ -462,6 +452,21 @@
               <item>
                <property name="text">
                 <string notr="true">Brixified</string>
+               </property>
+              </item>
+              <item>
+               <property name="text">
+                <string notr="true">deathneko11</string>
+               </property>
+              </item>
+              <item>
+               <property name="text">
+                <string notr="true">DoubleYou</string>
+               </property>
+              </item>
+              <item>
+               <property name="text">
+                <string notr="true">Drew Warwick</string>
                </property>
               </item>
               <item>
@@ -536,12 +541,12 @@
               </item>
               <item>
                <property name="text">
-                <string notr="true">z929669</string>
+                <string notr="true">thosrtanner</string>
                </property>
               </item>
               <item>
                <property name="text">
-                <string notr="true">thosrtanner</string>
+                <string notr="true">z929669</string>
                </property>
               </item>
              </widget>

--- a/src/downloadmanager.h
+++ b/src/downloadmanager.h
@@ -104,7 +104,9 @@ private:
     bool m_Hidden;
 
     static DownloadInfo *createNew(const MOBase::ModRepositoryFileInfo *fileInfo, const QStringList &URLs);
-    static DownloadInfo *createFromMeta(const QString &filePath, bool showHidden, const QString outputDirectory);
+    static DownloadInfo *createFromMeta(
+      const QString &filePath, bool showHidden, const QString outputDirectory,
+      std::optional<uint64_t> fileSize={});
 
     /**
      * @brief rename the file

--- a/src/env.cpp
+++ b/src/env.cpp
@@ -345,7 +345,9 @@ void Environment::dump(const Settings& s) const
 
   log::debug("modules loaded in process:");
   for (const auto& m : loadedModules()) {
-    log::debug(" . {}", m.toString());
+    if (m.interesting()) {
+      log::debug(" . {}", m.toString());
+    }
   }
 
   log::debug("displays:");

--- a/src/env.h
+++ b/src/env.h
@@ -309,6 +309,10 @@ bool registryValueExists(const QString& key, const QString& value);
 //
 void deleteRegistryKeyIfEmpty(const QString& name);
 
+// returns the path to this process
+//
+std::filesystem::path thisProcessPath();
+
 } // namespace env
 
 #endif // ENV_ENV_H

--- a/src/envfs.h
+++ b/src/envfs.h
@@ -12,8 +12,9 @@ struct File
   std::wstring name;
   std::wstring lcname;
   FILETIME lastModified;
+  uint64_t size;
 
-  File(std::wstring_view name, FILETIME ft);
+  File(std::wstring_view name, FILETIME ft, uint64_t size);
 };
 
 struct Directory
@@ -174,7 +175,7 @@ private:
 
 using DirStartF = void (void*, std::wstring_view);
 using DirEndF = void (void*, std::wstring_view);
-using FileF = void (void*, std::wstring_view, FILETIME);
+using FileF = void (void*, std::wstring_view, FILETIME, uint64_t);
 
 void setHandleCloserThreadCount(std::size_t n);
 

--- a/src/envmodule.cpp
+++ b/src/envmodule.cpp
@@ -308,6 +308,29 @@ QDateTime Module::getTimestamp(const VS_FIXEDFILEINFO& fi) const
     QTime(utc.wHour, utc.wMinute, utc.wSecond, utc.wMilliseconds));
 }
 
+bool Module::interesting() const
+{
+  static const auto windir = []() -> QString {
+    try
+    {
+      return QDir::toNativeSeparators(
+        MOBase::getKnownFolder(FOLDERID_Windows).path()) + "\\";
+    }
+    catch(...)
+    {
+      return "c:\\windows\\";
+    }
+  }();
+
+
+  if (m_path.startsWith(windir, Qt::CaseInsensitive)) {
+    return false;
+  }
+
+  return true;
+}
+
+
 QString Module::getMD5() const
 {
   static const std::set<QString> ignore = {

--- a/src/envmodule.h
+++ b/src/envmodule.h
@@ -66,6 +66,10 @@ public:
   //
   QString timestampString() const;
 
+  // returns false for modules in the Windows root directory
+  //
+  bool interesting() const;
+
   // returns a string with all the above information on one line
   //
   QString toString() const;

--- a/src/moapplication.cpp
+++ b/src/moapplication.cpp
@@ -254,7 +254,10 @@ int MOApplication::doOneRun(MOMultiProcess& multiProcess)
   sanity::checkEnvironment(env);
 
   const auto moduleNotification = env.onModuleLoaded(qApp, [](auto&& m) {
-    log::debug("loaded module {}", m.toString());
+    if (m.interesting()) {
+      log::debug("loaded module {}", m.toString());
+    }
+
     sanity::checkIncompatibleModule(m);
   });
 

--- a/src/nxmaccessmanager.cpp
+++ b/src/nxmaccessmanager.cpp
@@ -376,7 +376,7 @@ void ValidationAttempt::start(NXMAccessManager& m, const QString& key)
   m_timeout.start();
 
   log::debug(
-    "validator: attempt started with timeout of {} seconds", timeout().count());
+    "nexus: attempt started with timeout of {} seconds", timeout().count());
 }
 
 bool ValidationAttempt::sendRequest(
@@ -458,11 +458,11 @@ void ValidationAttempt::onFinished()
     return;
   }
 
-  log::debug("validator attempt: request has finished");
+  log::debug("nexus: request has finished");
 
   if (!m_reply) {
     // shouldn't happen
-    log::error("validator attempt: reply is null");
+    log::error("nexus: reply is null");
     setFailure(HardError, QObject::tr("Internal error"));
     return;
   }
@@ -472,7 +472,7 @@ void ValidationAttempt::onFinished()
 
   if (code == 0) {
     // request wasn't even sent
-    log::error("validator attempt: code is 0");
+    log::error("nexus: code is 0");
     setFailure(SoftError, m_reply->errorString());
     return;
   }
@@ -539,7 +539,7 @@ void ValidationAttempt::onFinished()
 
 void ValidationAttempt::onSslErrors(const QList<QSslError>& errors)
 {
-  log::error("validator attempt: ssl errors");
+  log::error("nexus: ssl errors");
 
   for (auto& e : errors) {
     log::error("  . {}", e.errorString());
@@ -557,7 +557,7 @@ void ValidationAttempt::setFailure(Result r, const QString& error)
 {
   if (r != Cancelled) {
     // don't spam the log
-    log::error("validator attempt: {}", error);
+    log::error("nexus: {}", error);
   }
 
   cleanup();
@@ -572,7 +572,7 @@ void ValidationAttempt::setFailure(Result r, const QString& error)
 
 void ValidationAttempt::setSuccess(const APIUserAccount& user)
 {
-  log::debug("validator attempt successful");
+  log::debug("nexus connection successful");
   cleanup();
 
   m_result = Success;
@@ -617,7 +617,7 @@ std::vector<std::chrono::seconds> NexusKeyValidator::getTimeouts() const
 void NexusKeyValidator::start(const QString& key, Behaviour b)
 {
   if (isActive()) {
-    log::debug("validator: trying to start while ongoing; ignoring");
+    log::debug("nexus: trying to start while ongoing; ignoring");
     return;
   }
 
@@ -655,7 +655,7 @@ void NexusKeyValidator::createAttempts(
 
 void NexusKeyValidator::cancel()
 {
-  log::debug("validator: cancelled");
+  log::debug("nexus: connection cancelled");
 
   for (auto&& a : m_attempts) {
     a->cancel();

--- a/src/profile.cpp
+++ b/src/profile.cpp
@@ -1123,10 +1123,6 @@ void Profile::debugDump() const
 
 
   for (const auto& status : m_ModStatus) {
-    if (status.m_Overwrite) {
-      continue;
-    }
-
     auto index = m_ModIndexByPriority.find(status.m_Priority);
     if (index == m_ModIndexByPriority.end()) {
       log::error("mod with priority {} not in priority map", status.m_Priority);
@@ -1136,6 +1132,10 @@ void Profile::debugDump() const
     auto m = ModInfo::getByIndex(index->second);
     if (!m) {
       log::error("mod index {} with priority {} not found", index->second, status.m_Priority);
+      continue;
+    }
+
+    if (m->hasFlag(ModInfo::FLAG_OVERWRITE)) {
       continue;
     }
 

--- a/src/sanitychecks.cpp
+++ b/src/sanitychecks.cpp
@@ -279,7 +279,8 @@ int checkUsvfsIncompatibilites(const env::Module& m)
   // these dlls seems to interfere with usvfs
 
   static const std::map<QString, QString> names = {
-    {"mactype64.dll", "Mactype"}
+    {"mactype64.dll", "Mactype"},
+    {"epclient64.dll", "Citrix ICA Client"}
   };
 
   const QFileInfo file(m.path());
@@ -290,7 +291,7 @@ int checkUsvfsIncompatibilites(const env::Module& m)
       log::warn("{}", QObject::tr(
         "%1 is loaded. This program is known to cause issues with "
         "Mod Organizer and its virtual filesystem, such script extenders "
-        "refusing to run. Consider uninstalling it.")
+        "or others programs refusing to run. Consider uninstalling it.")
         .arg(p.second));
 
       log::warn("{}", file.absoluteFilePath());

--- a/src/settings.cpp
+++ b/src/settings.cpp
@@ -1970,6 +1970,9 @@ void NexusSettings::dump() const
 
   log::debug("nxmhandler settings:");
 
+  QSettings handler("HKEY_CURRENT_USER\\Software\\Classes\\nxm\\", QSettings::NativeFormat);
+  log::debug(" - primary: {}", handler.value("shell/open/command/Default").toString());
+
   const auto noregister = getOptional<bool>(s, "General", "noregister");
 
   if (noregister) {

--- a/src/settings.cpp
+++ b/src/settings.cpp
@@ -1971,14 +1971,14 @@ void NexusSettings::dump() const
   log::debug("nxmhandler settings:");
 
   QSettings handler("HKEY_CURRENT_USER\\Software\\Classes\\nxm\\", QSettings::NativeFormat);
-  log::debug(" - primary: {}", handler.value("shell/open/command/Default").toString());
+  log::debug(" . primary: {}", handler.value("shell/open/command/Default").toString());
 
   const auto noregister = getOptional<bool>(s, "General", "noregister");
 
   if (noregister) {
-    log::debug(" - noregister: {}", *noregister);
+    log::debug(" . noregister: {}", *noregister);
   } else {
-    log::debug(" - noregister: (not found)");
+    log::debug(" . noregister: (not found)");
   }
 
   ScopedReadArray sra(s, "handlers");
@@ -1988,10 +1988,10 @@ void NexusSettings::dump() const
     const auto executable = sra.get<QVariant>("executable");
     const auto arguments = sra.get<QVariant>("arguments");
 
-    log::debug(" - handler:");
-    log::debug("    - games:      {}", games.toString());
-    log::debug("    - executable: {}", executable.toString());
-    log::debug("    - arguments:  {}", arguments.toString());
+    log::debug(" . handler:");
+    log::debug("    . games:      {}", games.toString());
+    log::debug("    . executable: {}", executable.toString());
+    log::debug("    . arguments:  {}", arguments.toString());
   });
 }
 

--- a/src/settings.cpp
+++ b/src/settings.cpp
@@ -479,7 +479,9 @@ QSettings::Status Settings::iniStatus() const
 void Settings::dump() const
 {
   static const QStringList ignore({
-    "username", "password", "nexus_api_key", "nexus_username", "nexus_password"
+    "username", "password",
+    "nexus_api_key", "nexus_username", "nexus_password",
+    "steam_username"
     });
 
   log::debug("settings:");

--- a/src/settings.h
+++ b/src/settings.h
@@ -528,6 +528,10 @@ public:
 
   std::vector<std::chrono::seconds> validationTimeouts() const;
 
+  // dumps nxmhandler stuff
+  //
+  void dump() const;
+
 private:
   Settings& m_Parent;
   QSettings& m_Settings;

--- a/src/shared/appconfig.inc
+++ b/src/shared/appconfig.inc
@@ -18,6 +18,8 @@ APPPARAM(std::wstring, proxyDLLOrig, L"steam_api_orig.dll") // needs to be ident
 APPPARAM(std::wstring, proxyDLLSource, L"proxy.dll")
 APPPARAM(std::wstring, vfs32DLLName, L"usvfs_x86.dll")
 APPPARAM(std::wstring, vfs64DLLName, L"usvfs_x64.dll")
+APPPARAM(std::wstring, nxmHandlerExe, L"nxmhandler.exe")
+APPPARAM(std::wstring, nxmHandlerIni, L"nxmhandler.ini")
 APPPARAM(std::wstring, portableLockFileName, L"portable.txt")
 APPPARAM(const wchar_t*, localSavePlaceholder, L"__MOProfileSave__\\")
 

--- a/src/shared/directoryentry.cpp
+++ b/src/shared/directoryentry.cpp
@@ -636,7 +636,7 @@ void DirectoryEntry::addFiles(
       onDirectoryEnd((Context*)pcx, path);
     },
 
-    [](void* pcx, std::wstring_view path, FILETIME ft)
+    [](void* pcx, std::wstring_view path, FILETIME ft, uint64_t)
     {
       onFile((Context*)pcx, path, ft);
     }

--- a/src/shared/util.cpp
+++ b/src/shared/util.cpp
@@ -210,12 +210,13 @@ std::wstring GetFileVersionString(const std::wstring &fileName)
 
 VersionInfo createVersionInfo()
 {
-  VS_FIXEDFILEINFO version = GetFileVersion(QApplication::applicationFilePath().toStdWString());
+  VS_FIXEDFILEINFO version = GetFileVersion(env::thisProcessPath().native());
 
   if (version.dwFileFlags & VS_FF_PRERELEASE)
   {
     // Pre-release builds need annotating
-    QString versionString = QString::fromStdWString(GetFileVersionString(QApplication::applicationFilePath().toStdWString()));
+    QString versionString = QString::fromStdWString(
+      GetFileVersionString(env::thisProcessPath().native()));
 
     // The pre-release flag can be set without the string specifying what type of pre-release
     bool noLetters = true;


### PR DESCRIPTION
- Added BlueAmulet to contributors, sorted list.

### Diagnostics
- Changed DLL filenames for OSDs to regexes to catch more, added Gigabyte 3D OSD and more Nahimic, plus Citrix for usvfs incompatibilities
- Don't log steam username when dumping settings on startup
- Dump content of nxmhandler.ini and primary handler from registry
- Replaced "validator blah" logs with just "nexus blah", clearer for users
- Overwrite was counted when dumping profile info so the totals didn't match
- Added MO version to dump filename so we don't have to guess when users upload them. I had to replace a few `QApplication` calls because this happens without Qt being initialized.
- Don't log modules in `%WINROOT%`.

### Download manager
- Use the same envfs stuff as for the file registry instead of `QDir`, much faster.
- Use a set to remember the filenames already seen instead of a constantly growing linear search.
- Use the file size from envfs in `createFromMeta()` instead of getting it again through `QFileInfo`.
