### PR TITLE
More stuff 2

### DIFF
--- a/src/editexecutablesdialog.h
+++ b/src/editexecutablesdialog.h
@@ -225,9 +225,10 @@ private:
   bool canMove(const QListWidgetItem* item, int direction);
   void move(QListWidgetItem* item, int direction);
   bool isTitleConflicting(const QString& s);
-  void commitChanges();
+  bool commitChanges();
   void setDirty(bool b);
   void selectIndex(int i);
+  bool checkOutputMods(const ExecutablesList& exes);
 
   void addFromFile();
   void addEmpty();

--- a/src/editexecutablesdialog.ui
+++ b/src/editexecutablesdialog.ui
@@ -387,6 +387,9 @@ Right now the only case I know of where this needs to be overwritten is for the 
                  <property name="enabled">
                   <bool>false</bool>
                  </property>
+                 <property name="editable">
+                  <bool>true</bool>
+                 </property>
                 </widget>
                </item>
               </layout>

--- a/src/mainwindow.cpp
+++ b/src/mainwindow.cpp
@@ -1713,9 +1713,22 @@ void MainWindow::on_profileBox_currentIndexChanged(int index)
 
     if (ui->profileBox->currentIndex() == 0) {
       ui->profileBox->setCurrentIndex(previousIndex);
-      ProfilesDialog(ui->profileBox->currentText(), m_OrganizerCore, this).exec();
+
+      std::optional<QString> newSelection;
+
+      ProfilesDialog dlg(ui->profileBox->currentText(), m_OrganizerCore, this);
+      dlg.exec();
+      newSelection = dlg.selectedProfile();
+
       while (!refreshProfiles()) {
-        ProfilesDialog(ui->profileBox->currentText(), m_OrganizerCore, this).exec();
+        ProfilesDialog dlg(ui->profileBox->currentText(), m_OrganizerCore, this);
+        dlg.exec();
+        newSelection = dlg.selectedProfile();
+      }
+
+      if (newSelection) {
+        ui->profileBox->setCurrentText(*newSelection);
+        activateSelectedProfile();
       }
     } else {
       activateSelectedProfile();

--- a/src/mainwindow.cpp
+++ b/src/mainwindow.cpp
@@ -487,7 +487,6 @@ MainWindow::MainWindow(Settings &settings
 
   new QShortcut(QKeySequence(Qt::CTRL + Qt::Key_Enter), this, SLOT(openExplorer_activated()));
   new QShortcut(QKeySequence(Qt::CTRL + Qt::Key_Return), this, SLOT(openExplorer_activated()));
-  new QShortcut(QKeySequence::Refresh, this, SLOT(refreshProfile_activated()));
 
   setFilterShortcuts(ui->modList, ui->modFilterEdit);
   setFilterShortcuts(ui->espList, ui->espFilterEdit);
@@ -2290,6 +2289,11 @@ void MainWindow::tutorialTriggered()
 void MainWindow::on_actionInstallMod_triggered()
 {
   installMod();
+}
+
+void MainWindow::on_action_Refresh_triggered()
+{
+  refreshProfile_activated();
 }
 
 void MainWindow::on_actionAdd_Profile_triggered()

--- a/src/mainwindow.cpp
+++ b/src/mainwindow.cpp
@@ -2553,7 +2553,9 @@ void MainWindow::restoreBackup_clicked()
         if (!modDir.rename(modInfo->absolutePath(), destinationPath)) {
           reportError(tr("failed to rename \"%1\" to \"%2\"").arg(modInfo->absolutePath()).arg(destinationPath));
         }
+
         m_OrganizerCore.refresh();
+        updateModCount();
       }
     }
   }
@@ -2703,7 +2705,9 @@ void MainWindow::backupMod_clicked()
     QMessageBox::information(this, tr("Failed"),
       tr("Failed to create backup."));
   }
+
   m_OrganizerCore.refresh();
+  updateModCount();
 }
 
 
@@ -3321,6 +3325,8 @@ void MainWindow::refreshProfile_activated()
 
 void MainWindow::updateModCount()
 {
+  TimeThis tt("updateModCount");
+
   int activeCount = 0;
   int visActiveCount = 0;
   int backupCount = 0;

--- a/src/mainwindow.h
+++ b/src/mainwindow.h
@@ -557,6 +557,7 @@ private slots: // ui slots
   // actions
   void on_actionAdd_Profile_triggered();
   void on_actionInstallMod_triggered();
+  void on_action_Refresh_triggered();
   void on_actionModify_Executables_triggered();
   void on_actionNexus_triggered();
   void on_actionNotifications_triggered();

--- a/src/mainwindow.ui
+++ b/src/mainwindow.ui
@@ -1413,6 +1413,7 @@ p, li { white-space: pre-wrap; }
    <addaction name="actionNexus"/>
    <addaction name="actionModPage"/>
    <addaction name="actionAdd_Profile"/>
+   <addaction name="action_Refresh"/>
    <addaction name="actionModify_Executables"/>
    <addaction name="actionTool"/>
    <addaction name="actionSettings"/>
@@ -1482,6 +1483,7 @@ p, li { white-space: pre-wrap; }
      <addaction name="actionToolBarTextOnly"/>
      <addaction name="actionToolBarIconsAndText"/>
     </widget>
+    <addaction name="action_Refresh"/>
     <addaction name="menuToolbars"/>
     <addaction name="actionViewLog"/>
     <addaction name="separator"/>
@@ -1894,6 +1896,18 @@ p, li { white-space: pre-wrap; }
    </property>
    <property name="text">
     <string>Log</string>
+   </property>
+  </action>
+  <action name="action_Refresh">
+   <property name="icon">
+    <iconset resource="resources.qrc">
+     <normaloff>:/MO/gui/resources/view-refresh.png</normaloff>:/MO/gui/resources/view-refresh.png</iconset>
+   </property>
+   <property name="text">
+    <string>&amp;Refresh</string>
+   </property>
+   <property name="shortcut">
+    <string>F5</string>
    </property>
   </action>
  </widget>

--- a/src/pch.h
+++ b/src/pch.h
@@ -89,6 +89,7 @@
 #include <QColorDialog>
 #include <QComboBox>
 #include <QCommandLinkButton>
+#include <QCompleter>
 #include <QContextMenuEvent>
 #include <QCoreApplication>
 #include <QCryptographicHash>

--- a/src/profilesdialog.cpp
+++ b/src/profilesdialog.cpp
@@ -115,11 +115,29 @@ void ProfilesDialog::showEvent(QShowEvent *event)
   }
 }
 
-void ProfilesDialog::on_closeButton_clicked()
+void ProfilesDialog::on_close_clicked()
 {
   close();
 }
 
+void ProfilesDialog::on_select_clicked()
+{
+  const Profile::Ptr currentProfile = ui->profilesList->currentItem()
+    ->data(Qt::UserRole)
+    .value<Profile::Ptr>();
+
+  if (!currentProfile) {
+    return;
+  }
+
+  m_Selected = currentProfile->name();
+  close();
+}
+
+std::optional<QString> ProfilesDialog::selectedProfile() const
+{
+  return m_Selected;
+}
 
 QListWidgetItem *ProfilesDialog::addItem(const QString &name)
 {
@@ -142,6 +160,7 @@ void ProfilesDialog::createProfile(const QString &name, bool useDefaultSettings)
     newItem->setData(Qt::UserRole, QVariant::fromValue(profile));
     ui->profilesList->addItem(newItem);
     m_FailState = false;
+    ui->profilesList->setCurrentItem(newItem);
     emit profileCreated(profile.get());
   } catch (const std::exception&) {
     m_FailState = true;
@@ -157,6 +176,7 @@ void ProfilesDialog::createProfile(const QString &name, const Profile &reference
     newItem->setData(Qt::UserRole, QVariant::fromValue(profile));
     ui->profilesList->addItem(newItem);
     m_FailState = false;
+    ui->profilesList->setCurrentItem(newItem);
     emit profileCreated(profile.get());
   } catch (const std::exception&) {
     m_FailState = true;
@@ -346,6 +366,11 @@ void ProfilesDialog::on_profilesList_currentItemChanged(QListWidgetItem *current
     ui->removeProfileButton->setEnabled(false);
     ui->renameButton->setEnabled(false);
   }
+}
+
+void ProfilesDialog::on_profilesList_itemActivated(QListWidgetItem* item)
+{
+  on_select_clicked();
 }
 
 void ProfilesDialog::on_localSavesBox_stateChanged(int state)

--- a/src/profilesdialog.cpp
+++ b/src/profilesdialog.cpp
@@ -250,6 +250,12 @@ void ProfilesDialog::on_renameButton_clicked()
 {
   Profile::Ptr currentProfile = ui->profilesList->currentItem()->data(Qt::UserRole).value<Profile::Ptr>();
 
+  if (currentProfile->name() == m_ActiveProfileName) {
+    QMessageBox::warning(this, tr("Renaming active profile"),
+      tr("The active profile cannot be renamed. Please change to a different profile first."));
+    return;
+  }
+
   bool valid = false;
   QString name;
 
@@ -265,7 +271,7 @@ void ProfilesDialog::on_renameButton_clicked()
   }
 
   ui->profilesList->currentItem()->setText(name);
-  
+
   QString oldName = currentProfile->name();
   currentProfile->rename(name);
 

--- a/src/profilesdialog.h
+++ b/src/profilesdialog.h
@@ -63,6 +63,11 @@ public:
    **/
   bool failed() const { return m_FailState; }
 
+  // if the dialog was closed with the 'select' button, returns the name of the
+  // selected profile; if the dialog was closed with 'cancel', returns empty
+  //
+  std::optional<QString> selectedProfile() const;
+
 signals:
 
   /**
@@ -95,7 +100,8 @@ private:
 
 private slots:
 
-  void on_closeButton_clicked();
+  void on_close_clicked();
+  void on_select_clicked();
 
   void on_addProfileButton_clicked();
 
@@ -104,6 +110,7 @@ private slots:
   void on_copyProfileButton_clicked();
 
   void on_profilesList_currentItemChanged(QListWidgetItem *current, QListWidgetItem *previous);
+  void on_profilesList_itemActivated(QListWidgetItem* item);
 
   void on_removeProfileButton_clicked();
 
@@ -119,6 +126,7 @@ private:
   bool m_FailState;
   MOBase::IPluginGame const *m_Game;
   QString m_ActiveProfileName;
+  std::optional<QString> m_Selected;
 };
 
 #endif // PROFILESDIALOG_H

--- a/src/profilesdialog.ui
+++ b/src/profilesdialog.ui
@@ -13,59 +13,74 @@
   <property name="windowTitle">
    <string>Profiles</string>
   </property>
-  <layout class="QHBoxLayout" name="horizontalLayout">
+  <layout class="QVBoxLayout" name="verticalLayout_3">
    <item>
-    <layout class="QVBoxLayout" name="verticalLayout_2">
-     <item>
-      <widget class="QListWidget" name="profilesList">
-       <property name="toolTip">
-        <string>List of Profiles</string>
-       </property>
-       <property name="whatsThis">
-        <string>&lt;!DOCTYPE HTML PUBLIC &quot;-//W3C//DTD HTML 4.0//EN&quot; &quot;http://www.w3.org/TR/REC-html40/strict.dtd&quot;&gt;
+    <widget class="QWidget" name="widget" native="true">
+     <layout class="QHBoxLayout" name="horizontalLayout_3">
+      <property name="leftMargin">
+       <number>0</number>
+      </property>
+      <property name="topMargin">
+       <number>0</number>
+      </property>
+      <property name="rightMargin">
+       <number>0</number>
+      </property>
+      <property name="bottomMargin">
+       <number>0</number>
+      </property>
+      <item>
+       <layout class="QVBoxLayout" name="verticalLayout_2">
+        <item>
+         <widget class="QListWidget" name="profilesList">
+          <property name="toolTip">
+           <string>List of Profiles</string>
+          </property>
+          <property name="whatsThis">
+           <string>&lt;!DOCTYPE HTML PUBLIC &quot;-//W3C//DTD HTML 4.0//EN&quot; &quot;http://www.w3.org/TR/REC-html40/strict.dtd&quot;&gt;
 &lt;html&gt;&lt;head&gt;&lt;meta name=&quot;qrichtext&quot; content=&quot;1&quot; /&gt;&lt;style type=&quot;text/css&quot;&gt;
 p, li { white-space: pre-wrap; }
 &lt;/style&gt;&lt;/head&gt;&lt;body style=&quot; font-family:'MS Shell Dlg 2'; font-size:8pt; font-weight:400; font-style:normal;&quot;&gt;
 &lt;p style=&quot; margin-top:0px; margin-bottom:0px; margin-left:0px; margin-right:0px; -qt-block-indent:0; text-indent:0px;&quot;&gt;&lt;span style=&quot; font-size:8.25pt;&quot;&gt;This is the list of profiles. Each profile contains its own list and installation order of enabled mods (from a shared pool), its own list and load order of enabled plugins (esps/esms), a copy of the games ini-file and an optional savegame filter.&lt;/span&gt;&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
-       </property>
-      </widget>
-     </item>
-     <item>
-      <widget class="QCheckBox" name="localSavesBox">
-       <property name="toolTip">
-        <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;If checked, save games are stored locally to this profile and will not appear when starting with a different profile.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
-       </property>
-       <property name="whatsThis">
-        <string>If checked, save games are local to this profile and will not appear when starting with a different profile.</string>
-       </property>
-       <property name="text">
-        <string>Use profile-specific Save Games</string>
-       </property>
-      </widget>
-     </item>
-     <item>
-      <widget class="QCheckBox" name="localIniFilesBox">
-       <property name="toolTip">
-        <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;If checked MO2 will use his own profile-specific game INI files, so that the &amp;quot;Global&amp;quot; ones in MyGames can be left vanilla. This different set of INI files is then offered to the game instead of the default one.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
-       </property>
-       <property name="whatsThis">
-        <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;If checked, MO2 will use a local set of game INI files (configuration and settings files), different from the default ones found in MyGames. This way changes to the INI settings will only affect this profile and the Global INI files can remain vanilla. MO2 will then show the profile INI files to the game instead of the Global ones.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
-       </property>
-       <property name="text">
-        <string>Use profile-specific Game INI Files</string>
-       </property>
-       <property name="checked">
-        <bool>false</bool>
-       </property>
-      </widget>
-     </item>
-     <item>
-      <widget class="QCheckBox" name="invalidationBox">
-       <property name="toolTip">
-        <string>This ensures data files from mods are actually used. You want to enable this unless you use a different tool for Archive Invalidation.</string>
-       </property>
-       <property name="whatsThis">
-        <string>&lt;!DOCTYPE HTML PUBLIC &quot;-//W3C//DTD HTML 4.0//EN&quot; &quot;http://www.w3.org/TR/REC-html40/strict.dtd&quot;&gt;
+          </property>
+         </widget>
+        </item>
+        <item>
+         <widget class="QCheckBox" name="localSavesBox">
+          <property name="toolTip">
+           <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;If checked, save games are stored locally to this profile and will not appear when starting with a different profile.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
+          </property>
+          <property name="whatsThis">
+           <string>If checked, save games are local to this profile and will not appear when starting with a different profile.</string>
+          </property>
+          <property name="text">
+           <string>Use profile-specific Save Games</string>
+          </property>
+         </widget>
+        </item>
+        <item>
+         <widget class="QCheckBox" name="localIniFilesBox">
+          <property name="toolTip">
+           <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;If checked MO2 will use his own profile-specific game INI files, so that the &amp;quot;Global&amp;quot; ones in MyGames can be left vanilla. This different set of INI files is then offered to the game instead of the default one.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
+          </property>
+          <property name="whatsThis">
+           <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;If checked, MO2 will use a local set of game INI files (configuration and settings files), different from the default ones found in MyGames. This way changes to the INI settings will only affect this profile and the Global INI files can remain vanilla. MO2 will then show the profile INI files to the game instead of the Global ones.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
+          </property>
+          <property name="text">
+           <string>Use profile-specific Game INI Files</string>
+          </property>
+          <property name="checked">
+           <bool>false</bool>
+          </property>
+         </widget>
+        </item>
+        <item>
+         <widget class="QCheckBox" name="invalidationBox">
+          <property name="toolTip">
+           <string>This ensures data files from mods are actually used. You want to enable this unless you use a different tool for Archive Invalidation.</string>
+          </property>
+          <property name="whatsThis">
+           <string>&lt;!DOCTYPE HTML PUBLIC &quot;-//W3C//DTD HTML 4.0//EN&quot; &quot;http://www.w3.org/TR/REC-html40/strict.dtd&quot;&gt;
 &lt;html&gt;&lt;head&gt;&lt;meta name=&quot;qrichtext&quot; content=&quot;1&quot; /&gt;&lt;style type=&quot;text/css&quot;&gt;
 p, li { white-space: pre-wrap; }
 &lt;/style&gt;&lt;/head&gt;&lt;body style=&quot; font-family:'MS Shell Dlg 2'; font-size:8.25pt; font-weight:400; font-style:normal;&quot;&gt;
@@ -73,111 +88,149 @@ p, li { white-space: pre-wrap; }
 &lt;p style=&quot; margin-top:0px; margin-bottom:0px; margin-left:0px; margin-right:0px; -qt-block-indent:0; text-indent:0px;&quot;&gt;&lt;span style=&quot; font-size:8pt;&quot;&gt;The Mod Organizer uses a workaround called &amp;quot;BSA redirection&amp;quot; (google is your friend) to fix this issue reliably and without further work. Simply activate and forget.&lt;/span&gt;&lt;/p&gt;
 &lt;p style=&quot;-qt-paragraph-type:empty; margin-top:0px; margin-bottom:0px; margin-left:0px; margin-right:0px; -qt-block-indent:0; text-indent:0px; font-size:8pt;&quot;&gt;&lt;/p&gt;
 &lt;p style=&quot; margin-top:0px; margin-bottom:0px; margin-left:0px; margin-right:0px; -qt-block-indent:0; text-indent:0px;&quot;&gt;&lt;span style=&quot; font-size:8pt;&quot;&gt;With Skyrim this bug seems to be fixed to a degree but whether a mod becomes active still depends on file dates. Therefore, it still makes sense to activate this.&lt;/span&gt;&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
-       </property>
-       <property name="text">
-        <string>Automatic Archive Invalidation</string>
-       </property>
-      </widget>
-     </item>
-    </layout>
+          </property>
+          <property name="text">
+           <string>Automatic Archive Invalidation</string>
+          </property>
+         </widget>
+        </item>
+       </layout>
+      </item>
+      <item>
+       <layout class="QVBoxLayout" name="verticalLayout">
+        <item>
+         <widget class="QPushButton" name="addProfileButton">
+          <property name="toolTip">
+           <string>Create a new profile from scratch</string>
+          </property>
+          <property name="whatsThis">
+           <string>Create a new profile from scratch</string>
+          </property>
+          <property name="text">
+           <string>Create</string>
+          </property>
+         </widget>
+        </item>
+        <item>
+         <widget class="QPushButton" name="copyProfileButton">
+          <property name="enabled">
+           <bool>false</bool>
+          </property>
+          <property name="toolTip">
+           <string>Clone the selected profile</string>
+          </property>
+          <property name="whatsThis">
+           <string>This creates a new profile with the same settings and active mods as the selected one.</string>
+          </property>
+          <property name="text">
+           <string>Copy</string>
+          </property>
+         </widget>
+        </item>
+        <item>
+         <widget class="QPushButton" name="removeProfileButton">
+          <property name="enabled">
+           <bool>false</bool>
+          </property>
+          <property name="toolTip">
+           <string>Delete the selected Profile. This can not be un-done!</string>
+          </property>
+          <property name="whatsThis">
+           <string>Delete the selected Profile. This can not be un-done!</string>
+          </property>
+          <property name="text">
+           <string>Remove</string>
+          </property>
+         </widget>
+        </item>
+        <item>
+         <widget class="QPushButton" name="renameButton">
+          <property name="enabled">
+           <bool>false</bool>
+          </property>
+          <property name="text">
+           <string>Rename</string>
+          </property>
+         </widget>
+        </item>
+        <item>
+         <widget class="QPushButton" name="transferButton">
+          <property name="enabled">
+           <bool>false</bool>
+          </property>
+          <property name="toolTip">
+           <string>Transfer save games to the selected profile.</string>
+          </property>
+          <property name="whatsThis">
+           <string>Transfer save games to the selected profile.</string>
+          </property>
+          <property name="text">
+           <string>Transfer Saves</string>
+          </property>
+         </widget>
+        </item>
+        <item>
+         <spacer name="verticalSpacer">
+          <property name="orientation">
+           <enum>Qt::Vertical</enum>
+          </property>
+          <property name="sizeHint" stdset="0">
+           <size>
+            <width>20</width>
+            <height>40</height>
+           </size>
+          </property>
+         </spacer>
+        </item>
+       </layout>
+      </item>
+     </layout>
+    </widget>
    </item>
    <item>
-    <layout class="QVBoxLayout" name="verticalLayout">
-     <item>
-      <widget class="QPushButton" name="addProfileButton">
-       <property name="toolTip">
-        <string>Create a new profile from scratch</string>
-       </property>
-       <property name="whatsThis">
-        <string>Create a new profile from scratch</string>
-       </property>
-       <property name="text">
-        <string>Create</string>
-       </property>
-      </widget>
-     </item>
-     <item>
-      <widget class="QPushButton" name="copyProfileButton">
-       <property name="enabled">
-        <bool>false</bool>
-       </property>
-       <property name="toolTip">
-        <string>Clone the selected profile</string>
-       </property>
-       <property name="whatsThis">
-        <string>This creates a new profile with the same settings and active mods as the selected one.</string>
-       </property>
-       <property name="text">
-        <string>Copy</string>
-       </property>
-      </widget>
-     </item>
-     <item>
-      <widget class="QPushButton" name="removeProfileButton">
-       <property name="enabled">
-        <bool>false</bool>
-       </property>
-       <property name="toolTip">
-        <string>Delete the selected Profile. This can not be un-done!</string>
-       </property>
-       <property name="whatsThis">
-        <string>Delete the selected Profile. This can not be un-done!</string>
-       </property>
-       <property name="text">
-        <string>Remove</string>
-       </property>
-      </widget>
-     </item>
-     <item>
-      <widget class="QPushButton" name="renameButton">
-       <property name="enabled">
-        <bool>false</bool>
-       </property>
-       <property name="text">
-        <string>Rename</string>
-       </property>
-      </widget>
-     </item>
-     <item>
-      <widget class="QPushButton" name="transferButton">
-       <property name="enabled">
-        <bool>false</bool>
-       </property>
-       <property name="toolTip">
-        <string>Transfer save games to the selected profile.</string>
-       </property>
-       <property name="whatsThis">
-        <string>Transfer save games to the selected profile.</string>
-       </property>
-       <property name="text">
-        <string>Transfer Saves</string>
-       </property>
-      </widget>
-     </item>
-     <item>
-      <spacer name="verticalSpacer">
-       <property name="orientation">
-        <enum>Qt::Vertical</enum>
-       </property>
-       <property name="sizeHint" stdset="0">
-        <size>
-         <width>20</width>
-         <height>40</height>
-        </size>
-       </property>
-      </spacer>
-     </item>
-     <item>
-      <widget class="QPushButton" name="closeButton">
-       <property name="toolTip">
-        <string/>
-       </property>
-       <property name="text">
-        <string>Close</string>
-       </property>
-      </widget>
-     </item>
-    </layout>
+    <widget class="QWidget" name="widget_2" native="true">
+     <layout class="QHBoxLayout" name="horizontalLayout">
+      <property name="leftMargin">
+       <number>0</number>
+      </property>
+      <property name="topMargin">
+       <number>0</number>
+      </property>
+      <property name="rightMargin">
+       <number>0</number>
+      </property>
+      <property name="bottomMargin">
+       <number>0</number>
+      </property>
+      <item>
+       <spacer name="horizontalSpacer">
+        <property name="orientation">
+         <enum>Qt::Horizontal</enum>
+        </property>
+        <property name="sizeHint" stdset="0">
+         <size>
+          <width>40</width>
+          <height>20</height>
+         </size>
+        </property>
+       </spacer>
+      </item>
+      <item>
+       <widget class="QPushButton" name="select">
+        <property name="text">
+         <string>Select</string>
+        </property>
+       </widget>
+      </item>
+      <item>
+       <widget class="QPushButton" name="close">
+        <property name="text">
+         <string>Close</string>
+        </property>
+       </widget>
+      </item>
+     </layout>
+    </widget>
    </item>
   </layout>
  </widget>


### PR DESCRIPTION
- Disallow renaming the active profile (fixes #926)
- Added refresh button to the toolbar and menu
- Update mod count when creating/restoring backups (fixes #720)
- Editable combobox for the output mod in the executables dialog
- Added "Select" button in the profiles dialog, handle doube-click on items, select new profiles on creation/copy