### PR TITLE
Fix running shortcuts with locking disabled

### DIFF
--- a/src/commandline.cpp
+++ b/src/commandline.cpp
@@ -206,9 +206,11 @@ std::optional<int> CommandLine::setupCore(OrganizerCore& organizer) const
   if (m_shortcut.isValid()) {
     if (m_shortcut.hasExecutable()) {
       try {
+        // make sure MO doesn't exit even if locking is disabled, ForceWait and
+        // PreventExit will do that
         organizer.processRunner()
           .setFromShortcut(m_shortcut)
-          .setWaitForCompletion()
+          .setWaitForCompletion(ProcessRunner::ForceWait, UILocker::PreventExit)
           .run();
 
         return 0;
@@ -229,9 +231,12 @@ std::optional<int> CommandLine::setupCore(OrganizerCore& organizer) const
     try
     {
       // pass the remaining parameters to the binary
+      //
+      // make sure MO doesn't exit even if locking is disabled, ForceWait and
+      // PreventExit will do that
       organizer.processRunner()
         .setFromFileOrExecutable(exeName, m_untouched)
-        .setWaitForCompletion()
+        .setWaitForCompletion(ProcessRunner::ForceWait, UILocker::PreventExit)
         .run();
 
       return 0;


### PR DESCRIPTION
When locking is disabled, MO exits early and child processes may not all be hooked. Happens with skse, for example.

 I changed the `setWaitForCompletion()` calls to pass `ForceWait` and `PreventExit`. When locking is disabled, this will wait for the process normally but without showing the ui. I had to change references to `UILocker::Session` to pointers because they can now be null.

The large change with the `switch` is because it's now inside an `if` for the pointer.

Fixes #422.