### PR TITLE
Fix game selection not appearing on startup

### DIFF
--- a/src/createinstancedialog.cpp
+++ b/src/createinstancedialog.cpp
@@ -455,7 +455,7 @@ void CreateInstanceDialog::updateNavigation()
 bool CreateInstanceDialog::canNext() const
 {
   const auto i = ui->pages->currentIndex();
-  return m_pages[i]->ready();
+  return m_pages[i]->skip() || m_pages[i]->ready();
 }
 
 bool CreateInstanceDialog::canBack() const


### PR DESCRIPTION
When the selected game directory isn't recognized by the plugin, the create instance dialog is shown in single page mode to show the game selection page only. It calls `next()` to skip until the selected page, but it used to just call `ready()`, which returns false for pages like the instance type since they come before the game selection page and they don't actually have anything selected. It should also call `skip()` to check if the page must be skipped even if it's missing information.