### PR TITLE
Collapsible separators - Fix & Improvements

### DIFF
--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -149,6 +149,7 @@ add_filter(NAME src/modlist/view GROUPS
 	modlistviewactions
 	modlistcontextmenu
 	modflagicondelegate
+	modcontenticondelegate
 	modconflicticondelegate
 )
 

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -103,7 +103,6 @@ add_filter(NAME src/mainwindow GROUPS
 	filetree
 	filetreeitem
 	filetreemodel
-	filterlist
 	mainwindow
 	savestab
 	statusbar
@@ -145,6 +144,7 @@ add_filter(NAME src/modlist GROUPS
 )
 
 add_filter(NAME src/modlist/view GROUPS
+	filterlist
 	modlistview
 	modlistviewactions
 	modlistcontextmenu
@@ -202,6 +202,7 @@ add_filter(NAME src/settingsdialog GROUPS
 	settingsdialogplugins
 	settingsdialogsteam
 	settingsdialogworkarounds
+	settingsdialoguserinterface
 	disableproxyplugindialog
 )
 

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -151,6 +151,7 @@ add_filter(NAME src/modlist/view GROUPS
 	modflagicondelegate
 	modcontenticondelegate
 	modconflicticondelegate
+	modlistversiondelegate
 )
 
 add_filter(NAME src/plugins GROUPS

--- a/src/filterlist.cpp
+++ b/src/filterlist.cpp
@@ -234,7 +234,10 @@ void FilterList::restoreState(const Settings& s)
   s.widgets().restoreIndex(ui->filtersSeparators);
   s.widgets().restoreChecked(ui->filtersAnd);
   s.widgets().restoreChecked(ui->filtersOr);
-  s.widgets().restoreTreeCheckState(ui->filters, CriteriaItem::StateRole);
+
+  if (m_core.settings().interface().saveFilters()) {
+    s.widgets().restoreTreeCheckState(ui->filters, CriteriaItem::StateRole);
+  }
   checkCriteria();
 }
 

--- a/src/genericicondelegate.cpp
+++ b/src/genericicondelegate.cpp
@@ -4,20 +4,10 @@
 #include <QPixmapCache>
 
 
-GenericIconDelegate::GenericIconDelegate(QObject *parent, int role, int logicalIndex, int compactSize)
-  : IconDelegate(parent)
+GenericIconDelegate::GenericIconDelegate(QTreeView* parent, int role, int logicalIndex, int compactSize)
+  : IconDelegate(parent, logicalIndex, compactSize)
   , m_Role(role)
-  , m_LogicalIndex(logicalIndex)
-  , m_CompactSize(compactSize)
-  , m_Compact(false)
 {
-}
-
-void GenericIconDelegate::columnResized(int logicalIndex, int, int newSize)
-{
-  if (logicalIndex == m_LogicalIndex) {
-    m_Compact = newSize < m_CompactSize;
-  }
 }
 
 QList<QString> GenericIconDelegate::getIcons(const QModelIndex &index) const
@@ -25,7 +15,7 @@ QList<QString> GenericIconDelegate::getIcons(const QModelIndex &index) const
   QList<QString> result;
   if (index.isValid()) {
     for (const QVariant &var : index.data(m_Role).toList()) {
-      if (!m_Compact || !var.toString().isEmpty()) {
+      if (!compact() || !var.toString().isEmpty()) {
         result.append(var.toString());
       }
     }

--- a/src/genericicondelegate.h
+++ b/src/genericicondelegate.h
@@ -20,9 +20,8 @@ public:
    *                     of the view, the delegate will turn off this behaviour if the column is smaller than "compactSize"
    * @param compactSize see explanation of logicalIndex
    */
-  GenericIconDelegate(QObject *parent = nullptr, int role = Qt::UserRole + 1, int logicalIndex = -1, int compactSize = 150);
-public slots:
-  void columnResized(int logicalIndex, int oldSize, int newSize);
+  GenericIconDelegate(QTreeView* parent, int role = Qt::UserRole + 1, int logicalIndex = -1, int compactSize = 150);
+
 private:
   virtual QList<QString> getIcons(const QModelIndex &index) const;
   virtual size_t getNumIcons(const QModelIndex &index) const;

--- a/src/icondelegate.cpp
+++ b/src/icondelegate.cpp
@@ -27,9 +27,16 @@ along with Mod Organizer.  If not, see <http://www.gnu.org/licenses/>.
 
 using namespace MOBase;
 
-IconDelegate::IconDelegate(QObject* parent)
-  : QStyledItemDelegate(parent)
+IconDelegate::IconDelegate(QTreeView* view, int column, int compactSize) :
+  QStyledItemDelegate(view), m_column(column), m_compactSize(compactSize), m_compact(false)
 {
+  if (view) {
+    connect(view->header(), &QHeaderView::sectionResized, [=](int column, int, int size) {
+      if (column == m_column) {
+        m_compact = size < m_compactSize;
+      }
+      });
+  }
 }
 
 void IconDelegate::paintIcons(

--- a/src/icondelegate.cpp
+++ b/src/icondelegate.cpp
@@ -49,6 +49,8 @@ void IconDelegate::paintIcons(
   int iconWidth = icons.size() > 0 ? ((option.rect.width() / icons.size()) - 4) : 16;
   iconWidth = std::min(16, iconWidth);
 
+  const int margin = (option.rect.height() - iconWidth) / 2;
+
   painter->translate(option.rect.topLeft());
   for (const QString &iconId : icons) {
     if (iconId.isEmpty()) {
@@ -64,7 +66,7 @@ void IconDelegate::paintIcons(
       }
       QPixmapCache::insert(fullIconId, icon);
     }
-    painter->drawPixmap(x, 2, iconWidth, iconWidth, icon);
+    painter->drawPixmap(x, margin, iconWidth, iconWidth, icon);
     x += iconWidth + 4;
   }
 
@@ -79,6 +81,7 @@ void IconDelegate::paint(QPainter *painter, const QStyleOptionViewItem &option, 
   else {
     QStyledItemDelegate::paint(painter, option, index);
   }
+
   paintIcons(painter, option, index, getIcons(index));
 }
 

--- a/src/icondelegate.h
+++ b/src/icondelegate.h
@@ -20,9 +20,9 @@ along with Mod Organizer.  If not, see <http://www.gnu.org/licenses/>.
 #ifndef ICONDELEGATE_H
 #define ICONDELEGATE_H
 
-#include "modinfo.h"
-#include <QStyledItemDelegate>
 #include <QAbstractProxyModel>
+#include <QAbstractItemView>
+#include <QStyledItemDelegate>
 
 
 class IconDelegate : public QStyledItemDelegate
@@ -30,16 +30,28 @@ class IconDelegate : public QStyledItemDelegate
   Q_OBJECT;
 
 public:
-  explicit IconDelegate(QObject *parent = 0);
-  virtual void paint(QPainter *painter, const QStyleOptionViewItem &option, const QModelIndex &index) const;
+  explicit IconDelegate(QTreeView* view, int column = -1, int compactSize = 100);
+
+  void paint(QPainter *painter, const QStyleOptionViewItem& option, const QModelIndex& index) const override;
+
+protected:
+
+  // check if icons should be compacted or not
+  //
+  bool compact() const { return m_compact; }
 
   static void paintIcons(
     QPainter *painter, const QStyleOptionViewItem &option,
     const QModelIndex &index, const QList<QString>& icons);
 
-protected:
   virtual QList<QString> getIcons(const QModelIndex &index) const = 0;
   virtual size_t getNumIcons(const QModelIndex &index) const = 0;
+
+private:
+
+  int m_column;
+  int m_compactSize;
+  bool m_compact;
 };
 
 #endif // ICONDELEGATE_H

--- a/src/listdialog.cpp
+++ b/src/listdialog.cpp
@@ -26,6 +26,7 @@ ListDialog::ListDialog(QWidget *parent)
 {
   ui->setupUi(this);
   ui->filterEdit->setFocus();
+  connect(ui->choiceList, &QListWidget::itemDoubleClicked, this, &QDialog::accept);
 }
 
 ListDialog::~ListDialog()

--- a/src/mainwindow.cpp
+++ b/src/mainwindow.cpp
@@ -1495,7 +1495,6 @@ void MainWindow::startExeAction()
 void MainWindow::activateSelectedProfile()
 {
   m_OrganizerCore.setCurrentProfile(ui->profileBox->currentText());
-  ui->modList->setProfile(m_OrganizerCore.currentProfile());
 
   m_SavesTab->refreshSaveList();
   m_OrganizerCore.refresh();

--- a/src/moapplication.cpp
+++ b/src/moapplication.cpp
@@ -65,8 +65,18 @@ public:
   {
   }
 
-  void drawPrimitive(PrimitiveElement element, const QStyleOption* option, QPainter* painter, const QWidget* widget) const {
+  void drawPrimitive(
+    PrimitiveElement element, const QStyleOption* option,
+    QPainter* painter, const QWidget* widget) const override
+  {
     if (element == QStyle::PE_IndicatorItemViewItemDrop) {
+
+      // 0. Fix a bug that made the drop indicator sometimes appear on top
+      // of the mod list when selecting a mod.
+      if (option->rect.height() == 0
+        && option->rect.bottomRight() == QPoint(-1, -1)) {
+        return;
+      }
 
       // 1. full-width drop indicator
       QRect rect(option->rect);

--- a/src/moapplication.cpp
+++ b/src/moapplication.cpp
@@ -102,7 +102,7 @@ public:
           rect.topLeft() + QPoint(-5, -5)
         };
         painter->drawPolygon(tri, 3);
-        painter->drawLine(QPoint(rect.topLeft().x(), rect.topLeft().y()), rect.topRight());
+        painter->drawLine(rect.topLeft(), rect.topRight());
       }
       else {
         painter->drawRoundedRect(rect, 5, 5);

--- a/src/modconflicticondelegate.h
+++ b/src/modconflicticondelegate.h
@@ -4,6 +4,7 @@
 #include <array>
 
 #include "icondelegate.h"
+#include "modinfo.h"
 
 class ModListView;
 
@@ -12,11 +13,8 @@ class ModConflictIconDelegate : public IconDelegate
   Q_OBJECT;
 
 public:
-  explicit ModConflictIconDelegate(ModListView* parent = nullptr, int logicalIndex = -1, int compactSize = 80);
+  explicit ModConflictIconDelegate(ModListView* view, int logicalIndex = -1, int compactSize = 80);
   QSize sizeHint(const QStyleOptionViewItem& option, const QModelIndex &index) const override;
-
-public slots:
-  void columnResized(int logicalIndex, int oldSize, int newSize);
 
 protected:
 
@@ -25,6 +23,10 @@ protected:
 
   QList<QString> getIcons(const QModelIndex &index) const override;
   size_t getNumIcons(const QModelIndex &index) const override;
+
+  // constructor for color table
+  //
+  ModConflictIconDelegate() : ModConflictIconDelegate(nullptr) { }
 
 private:
   static constexpr std::array s_ConflictFlags{
@@ -43,10 +45,7 @@ private:
     ModInfo::FLAG_ARCHIVE_CONFLICT_OVERWRITTEN
   };
 
-  ModListView* m_View;
-  int m_LogicalIndex;
-  int m_CompactSize;
-  bool m_Compact;
+  ModListView* m_view;
 };
 
 #endif // MODCONFLICTICONDELEGATE_H

--- a/src/modcontenticondelegate.cpp
+++ b/src/modcontenticondelegate.cpp
@@ -1,0 +1,57 @@
+#include "modcontenticondelegate.h"
+
+#include "modlistview.h"
+
+ModContentIconDelegate::ModContentIconDelegate(ModListView* view, int column, int compactSize)
+  : IconDelegate(view, column, compactSize), m_view(view)
+{
+}
+
+QList<QString> ModContentIconDelegate::getIcons(const QModelIndex& index) const
+{
+  QVariant modIndex = index.data(ModList::IndexRole);
+
+  if (!modIndex.isValid()) {
+    return {};
+  }
+
+  bool compact;
+  auto icons = m_view->contentsIcons(index, &compact);
+
+  if (compact || this->compact()) {
+    icons.removeAll(QString());
+  }
+
+  return icons;
+}
+
+size_t ModContentIconDelegate::getNumIcons(const QModelIndex& index) const
+{
+  return getIcons(index).size();
+}
+
+bool ModContentIconDelegate::helpEvent(
+  QHelpEvent* event, QAbstractItemView* view, const QStyleOptionViewItem& option, const QModelIndex& index)
+{
+  if (!event || !view) {
+    return false;
+  }
+  if (event->type() == QEvent::ToolTip) {
+    // this code is from QAbstractItemDelegate::helpEvent, only the the way
+    // text is retrieved has been changed
+    QHelpEvent* he = static_cast<QHelpEvent*>(event);
+    const int precision = inherits("QItemDelegate") ? 10 : 6; // keep in sync with DBL_DIG in qitemdelegate.cpp
+    const QString tooltip = index.isValid() ? m_view->contentsTooltip(index) : QString();
+    QRect rect;
+    if (index.isValid()) {
+      const QRect r = view->visualRect(index);
+      rect = QRect(view->mapToGlobal(r.topLeft()), r.size());
+    }
+    QToolTip::showText(he->globalPos(), tooltip, view, rect);
+    event->setAccepted(!tooltip.isEmpty());
+    return true;
+  }
+  else {
+    return IconDelegate::helpEvent(event, view, option, index);
+  }
+}

--- a/src/modcontenticondelegate.h
+++ b/src/modcontenticondelegate.h
@@ -1,0 +1,30 @@
+#ifndef MODCONTENTICONDELEGATE_H
+#define MODCONTENTICONDELEGATE_H
+
+#include "icondelegate.h"
+
+class ModListView;
+
+class ModContentIconDelegate : public IconDelegate
+{
+  Q_OBJECT
+public:
+
+  explicit ModContentIconDelegate(ModListView* view, int column = -1, int compactSize = 150);
+
+  bool helpEvent(QHelpEvent* event, QAbstractItemView* view,
+    const QStyleOptionViewItem& option, const QModelIndex& index) override;
+
+protected:
+  QList<QString> getIcons(const QModelIndex& index) const override;
+  size_t getNumIcons(const QModelIndex& index) const override;
+
+  // constructor for color table
+  //
+  ModContentIconDelegate() : ModContentIconDelegate(nullptr) { }
+
+private:
+  ModListView* m_view;
+};
+
+#endif // GENERICICONDELEGATE_H

--- a/src/modflagicondelegate.cpp
+++ b/src/modflagicondelegate.cpp
@@ -5,19 +5,9 @@
 
 using namespace MOBase;
 
-ModFlagIconDelegate::ModFlagIconDelegate(QObject *parent, int logicalIndex, int compactSize)
-  : IconDelegate(parent)
-  , m_LogicalIndex(logicalIndex)
-  , m_CompactSize(compactSize)
-  , m_Compact(false)
+ModFlagIconDelegate::ModFlagIconDelegate(QTreeView* view, int column, int compactSize)
+  : IconDelegate(view, column, compactSize)
 {
-}
-
-void ModFlagIconDelegate::columnResized(int logicalIndex, int, int newSize)
-{
-  if (logicalIndex == m_LogicalIndex) {
-    m_Compact = newSize < m_CompactSize;
-  }
 }
 
 QList<QString> ModFlagIconDelegate::getIconsForFlags(
@@ -44,7 +34,7 @@ QList<QString> ModFlagIconDelegate::getIcons(const QModelIndex &index) const
 
   if (modid.isValid()) {
     ModInfo::Ptr info = ModInfo::getByIndex(modid.toInt());
-    return getIconsForFlags(info->getFlags(), m_Compact);
+    return getIconsForFlags(info->getFlags(), compact());
   }
 
   return {};

--- a/src/modflagicondelegate.cpp
+++ b/src/modflagicondelegate.cpp
@@ -1,12 +1,13 @@
 #include "modflagicondelegate.h"
 #include "modlist.h"
+#include "modlistview.h"
 #include <log.h>
 #include <QList>
 
 using namespace MOBase;
 
-ModFlagIconDelegate::ModFlagIconDelegate(QTreeView* view, int column, int compactSize)
-  : IconDelegate(view, column, compactSize)
+ModFlagIconDelegate::ModFlagIconDelegate(ModListView* view, int column, int compactSize)
+  : IconDelegate(view, column, compactSize), m_view(view)
 {
 }
 
@@ -33,8 +34,9 @@ QList<QString> ModFlagIconDelegate::getIcons(const QModelIndex &index) const
   QVariant modid = index.data(ModList::IndexRole);
 
   if (modid.isValid()) {
-    ModInfo::Ptr info = ModInfo::getByIndex(modid.toInt());
-    return getIconsForFlags(info->getFlags(), compact());
+    bool compact;
+    auto flags = m_view->modFlags(index, &compact);
+    return getIconsForFlags(flags, compact || this->compact());
   }
 
   return {};

--- a/src/modflagicondelegate.h
+++ b/src/modflagicondelegate.h
@@ -1,32 +1,30 @@
 #ifndef MODFLAGICONDELEGATE_H
 #define MODFLAGICONDELEGATE_H
 
+#include <QTreeView>
+
 #include "icondelegate.h"
+#include "modinfo.h"
 
 class ModFlagIconDelegate : public IconDelegate
 {
   Q_OBJECT;
 
 public:
-  explicit ModFlagIconDelegate(QObject *parent = 0, int logicalIndex = -1, int compactSize = 120);
+  explicit ModFlagIconDelegate(QTreeView* view, int column = -1, int compactSize = 120);
   QSize sizeHint(const QStyleOptionViewItem &option, const QModelIndex &index) const override;
 
-  static QList<QString> getIconsForFlags(
-    std::vector<ModInfo::EFlag> flags, bool compact);
-
+protected:
+  static QList<QString> getIconsForFlags(std::vector<ModInfo::EFlag> flags, bool compact);
   static QString getFlagIcon(ModInfo::EFlag flag);
 
-public slots:
-  void columnResized(int logicalIndex, int oldSize, int newSize);
-
-protected:
   QList<QString> getIcons(const QModelIndex &index) const override;
   size_t getNumIcons(const QModelIndex &index) const override;
 
-private:
-  int m_LogicalIndex;
-  int m_CompactSize;
-  bool m_Compact;
+  // constructor for color table
+  //
+  ModFlagIconDelegate() : ModFlagIconDelegate(nullptr) { }
+
 };
 
 #endif // MODFLAGICONDELEGATE_H

--- a/src/modflagicondelegate.h
+++ b/src/modflagicondelegate.h
@@ -6,12 +6,14 @@
 #include "icondelegate.h"
 #include "modinfo.h"
 
+class ModListView;
+
 class ModFlagIconDelegate : public IconDelegate
 {
   Q_OBJECT;
 
 public:
-  explicit ModFlagIconDelegate(QTreeView* view, int column = -1, int compactSize = 120);
+  explicit ModFlagIconDelegate(ModListView* view, int column = -1, int compactSize = 120);
   QSize sizeHint(const QStyleOptionViewItem &option, const QModelIndex &index) const override;
 
 protected:
@@ -24,6 +26,9 @@ protected:
   // constructor for color table
   //
   ModFlagIconDelegate() : ModFlagIconDelegate(nullptr) { }
+
+private:
+  ModListView* m_view;
 
 };
 

--- a/src/modinfo.cpp
+++ b/src/modinfo.cpp
@@ -49,6 +49,7 @@ using namespace MOBase;
 using namespace MOShared;
 
 
+const std::set<unsigned int> ModInfo::s_EmptySet;
 std::vector<ModInfo::Ptr> ModInfo::s_Collection;
 ModInfo::Ptr ModInfo::s_Overwrite;
 std::map<QString, unsigned int> ModInfo::s_ModsByName;

--- a/src/modinfo.h
+++ b/src/modinfo.h
@@ -868,46 +868,35 @@ public: // Nexus stuff
 
 public: // Conflicts
 
-  /**
-   * @return retrieve list of mods (as mod index) that are overwritten by this one.
-   *    Updates may be delayed.
-   */
-  virtual std::set<unsigned int> getModOverwrite() const {
-    return std::set<unsigned int>(); }
+  // retrieve the list of mods (as mod index) that are overwritten by this one.
+  // Updates may be delayed.
+  //
+  virtual const std::set<unsigned int>& getModOverwrite() const { return s_EmptySet; }
 
-  /**
-   * @return list of mods (as mod index) that overwrite this one. Updates may be delayed.
-   */
-  virtual std::set<unsigned int> getModOverwritten() const {
-    return std::set<unsigned int>(); }
+  // retrieve the list of mods (as mod index) that overwrite this one.
+  // Updates may be delayed.
+  //
+  virtual const std::set<unsigned int>& getModOverwritten() const { return s_EmptySet; }
 
-  /**
-   * @return retrieve list of mods (as mod index) with archives that are overwritten by
-   *     this one. Updates may be delayed
-   */
-  virtual std::set<unsigned int> getModArchiveOverwrite() const {
-    return std::set<unsigned int>(); }
+  // retrieve the list of mods (as mod index) with archives that are overwritten by
+  // this one. Updates may be delayed
+  //
+  virtual const std::set<unsigned int>& getModArchiveOverwrite() const { return s_EmptySet; }
 
-  /**
-   * @return list of mods (as mod index) with archives that overwrite this one. Updates
-   *     may be delayed.
-   */
-  virtual std::set<unsigned int> getModArchiveOverwritten() const {
-    return std::set<unsigned int>(); }
+  // retrieve the list of mods (as mod index) with archives that overwrite this one. Updates
+  // may be delayed.
+  //
+  virtual const std::set<unsigned int>& getModArchiveOverwritten() const { return s_EmptySet; }
 
-  /**
-   * @return the list of mods (as mod index) with archives that are overwritten by loose
-   *     files of this mod. Updates may be delayed.
-   */
-  virtual std::set<unsigned int> getModArchiveLooseOverwrite() const {
-    return std::set<unsigned int>(); }
+  // retrieve the list of mods (as mod index) with archives that are overwritten by loose
+  // files of this mod. Updates may be delayed.
+  //
+  virtual const std::set<unsigned int>& getModArchiveLooseOverwrite() const { return s_EmptySet; }
 
-  /**
-   * @return the list of mods (as mod index) with loose files that overwrite this one's
-   *     archive files. Updates may be delayed.
-   */
-  virtual std::set<unsigned int> getModArchiveLooseOverwritten() const {
-    return std::set<unsigned int>(); }
+  // retrieve the list of mods (as mod index) with loose files that overwrite this one's
+  // archive files. Updates may be delayed.
+  //
+  virtual const std::set<unsigned int>& getModArchiveLooseOverwritten() const { return s_EmptySet; }
 
   /**
    * @brief Update conflict information.
@@ -959,6 +948,10 @@ protected:
   std::set<int> m_Categories;
   MOBase::VersionInfo m_Version;
   bool m_PluginSelected = false;
+
+  // empty set that can be returned in overwrite functions by
+  // default
+  static const std::set<unsigned int> s_EmptySet;
 
 protected:
 

--- a/src/modinfowithconflictinfo.h
+++ b/src/modinfowithconflictinfo.h
@@ -52,21 +52,16 @@ public:
   /**
    * @brief clear all caches held for this mod
    */
-  virtual void clearCaches() override;
+  void clearCaches() override;
 
-  virtual std::set<unsigned int> getModOverwrite() const override { return m_OverwriteList; }
+  const std::set<unsigned int>& getModOverwrite() const override { return m_OverwriteList; }
+  const std::set<unsigned int>& getModOverwritten() const override { return m_OverwrittenList; }
+  const std::set<unsigned int>& getModArchiveOverwrite() const override { return m_ArchiveOverwriteList; }
+  const std::set<unsigned int>& getModArchiveOverwritten() const override { return m_ArchiveOverwrittenList; }
+  const std::set<unsigned int>& getModArchiveLooseOverwrite() const override { return m_ArchiveLooseOverwriteList; }
+  const std::set<unsigned int>& getModArchiveLooseOverwritten() const override { return m_ArchiveLooseOverwrittenList; }
 
-  virtual std::set<unsigned int> getModOverwritten() const override { return m_OverwrittenList; }
-
-  virtual std::set<unsigned int> getModArchiveOverwrite() const override { return m_ArchiveOverwriteList; }
-
-  virtual std::set<unsigned int> getModArchiveOverwritten() const override { return m_ArchiveOverwrittenList; }
-
-  virtual std::set<unsigned int> getModArchiveLooseOverwrite() const override { return m_ArchiveLooseOverwriteList; }
-
-  virtual std::set<unsigned int> getModArchiveLooseOverwritten() const override { return m_ArchiveLooseOverwrittenList; }
-
-  virtual void doConflictCheck() const override;
+  void doConflictCheck() const override;
 
 public slots:
 

--- a/src/modlist.cpp
+++ b/src/modlist.cpp
@@ -555,15 +555,16 @@ bool ModList::renameMod(int index, const QString &newName)
     m_Profile->cancelModlistWrite();
 
 
-    if (modInfo->setName(nameFixed))
+    if (modInfo->setName(nameFixed)) {
       // Notice there is a good chance that setName() updated the modinfo indexes
       // the modRenamed() call will refresh the indexes in the current profile
       // and update the modlists in all profiles
       emit modRenamed(oldName, nameFixed);
-  }
+    }
 
-  // invalidate the currently displayed state of this list
-  notifyChange(-1);
+    // invalidate the currently displayed state of this list
+    notifyChange(-1);
+  }
   return true;
 }
 

--- a/src/modlist.cpp
+++ b/src/modlist.cpp
@@ -194,30 +194,6 @@ QString ModList::getConflictFlagText(ModInfo::EConflictFlag flag, ModInfo::Ptr m
   }
 }
 
-
-QVariantList ModList::contentsToIcons(const std::set<int> &contents) const
-{
-  QVariantList result;
-  m_Organizer->modDataContents().forEachContentInOrOut(
-    contents,
-    [&result](auto const& content) { result.append(content.icon()); },
-    [&result](auto const&) { result.append(QString()); });
-  return result;
-}
-
-QString ModList::contentsToToolTip(const std::set<int> &contents) const
-{
-  QString result("<table cellspacing=7>");
-  m_Organizer->modDataContents().forEachContentIn(contents, [&result](auto const& content) {
-    result.append(QString("<tr><td><img src=\"%1\" width=32/></td>"
-      "<td valign=\"middle\">%2</td></tr>")
-      .arg(content.icon()).arg(content.name()));
-    });
-  result.append("</table>");
-  return result;
-}
-
-
 QVariant ModList::data(const QModelIndex &modelIndex, int role) const
 {
   if (m_Profile == nullptr) return QVariant();
@@ -385,9 +361,6 @@ QVariant ModList::data(const QModelIndex &modelIndex, int role) const
       default: return QtGroupingProxy::AGGR_NONE;
     }
   }
-  else if (role == ContentsRole) {
-    return contentsToIcons(modInfo->getContents());
-  }
   else if (role == GameNameRole) {
     return modInfo->gameName();
   }
@@ -493,9 +466,6 @@ QVariant ModList::data(const QModelIndex &modelIndex, int role) const
       }
 
       return result;
-    }
-    else if (column == COL_CONTENT) {
-      return contentsToToolTip(modInfo->getContents());
     }
     else if (column == COL_NAME) {
       try {

--- a/src/modlist.h
+++ b/src/modlist.h
@@ -69,19 +69,14 @@ public:
     // grouping I assume?)
     AggrRole = Qt::UserRole + 2,
 
-    // data(ContentsRole) contains mod data contents as a QVariantList
-    // containing icon paths
-    ContentsRole = Qt::UserRole + 3,
-
-    GameNameRole = Qt::UserRole + 4,
-
-    PriorityRole = Qt::UserRole + 5,
+    GameNameRole = Qt::UserRole + 3,
+    PriorityRole = Qt::UserRole + 4,
 
     // marking role for the scrollbar
-    ScrollMarkRole = Qt::UserRole + 6,
+    ScrollMarkRole = Qt::UserRole + 5,
 
     // this is the first available role
-    ModUserRole = Qt::UserRole + 7
+    ModUserRole = Qt::UserRole + 6
   };
 
   enum EColumn {
@@ -353,10 +348,6 @@ private:
   QString getConflictFlagText(ModInfo::EConflictFlag flag, ModInfo::Ptr modInfo) const;
 
   QString getColumnToolTip(int column) const;
-
-  QVariantList contentsToIcons(const std::set<int> &contentIds) const;
-
-  QString contentsToToolTip(const std::set<int> &contentsIds) const;
 
   ModList::EColumn getEnabledColumn(int index) const;
 

--- a/src/modlistbypriorityproxy.cpp
+++ b/src/modlistbypriorityproxy.cpp
@@ -183,25 +183,6 @@ bool ModListByPriorityProxy::setData(const QModelIndex& index, const QVariant& v
   return QAbstractProxyModel::setData(index, value, role);
 }
 
-std::pair<bool, bool> ModListByPriorityProxy::dropSeparators(const ModListDropInfo& dropInfo) const
-{
-  bool hasSeparator = false;
-  unsigned int firstRowIndex = -1;
-
-  int firstRowPriority = INT_MAX;
-  for (auto sourceRow : dropInfo.rows()) {
-    hasSeparator = hasSeparator || ModInfo::getByIndex(sourceRow)->isSeparator();
-    if (m_profile->getModPriority(sourceRow) < firstRowPriority) {
-      firstRowIndex = sourceRow;
-      firstRowPriority = m_profile->getModPriority(sourceRow);
-    }
-  }
-
-  bool firstRowSeparator = firstRowIndex != -1 && ModInfo::getByIndex(firstRowIndex)->isSeparator();
-
-  return { hasSeparator, firstRowSeparator };
-}
-
 bool ModListByPriorityProxy::canDropMimeData(const QMimeData* data, Qt::DropAction action, int row, int column, const QModelIndex& parent) const
 {
   ModListDropInfo dropInfo(data, m_core);
@@ -211,8 +192,19 @@ bool ModListByPriorityProxy::canDropMimeData(const QMimeData* data, Qt::DropActi
   }
 
   if (dropInfo.isModDrop()) {
+    bool hasSeparator = false;
+    unsigned int firstRowIndex = -1;
 
-    auto [hasSeparator, firstRowSeparator] = dropSeparators(dropInfo);
+    int firstRowPriority = INT_MAX;
+    for (auto sourceRow : dropInfo.rows()) {
+      hasSeparator = hasSeparator || ModInfo::getByIndex(sourceRow)->isSeparator();
+      if (m_profile->getModPriority(sourceRow) < firstRowPriority) {
+        firstRowIndex = sourceRow;
+        firstRowPriority = m_profile->getModPriority(sourceRow);
+      }
+    }
+
+    bool firstRowSeparator = firstRowIndex != -1 && ModInfo::getByIndex(firstRowIndex)->isSeparator();
 
     // row = -1 and invalid parent means we're dropping onto an item, we don't want to drop
     // separators onto items or items into their own separator

--- a/src/modlistbypriorityproxy.h
+++ b/src/modlistbypriorityproxy.h
@@ -55,11 +55,6 @@ protected slots:
 
 private:
 
-  // returns a pair of boolean, the first one indicates if the drop info
-  // contains separators, the first one if the first row is a separator
-  //
-  std::pair<bool, bool> dropSeparators(const ModListDropInfo& dropInfo) const;
-
   void buildTree();
 
   struct TreeItem {

--- a/src/modlistbypriorityproxy.h
+++ b/src/modlistbypriorityproxy.h
@@ -16,6 +16,7 @@
 #include "modlistview.h"
 
 class ModList;
+class ModListDropInfo;
 class Profile;
 
 class ModListByPriorityProxy : public QAbstractProxyModel
@@ -46,13 +47,18 @@ public:
 
 public slots:
 
-  void onDropEnter(const QMimeData* data, ModListView::DropPosition dropPosition);
+  void onDropEnter(const QMimeData* data, bool dropExpanded, ModListView::DropPosition dropPosition);
 
 protected slots:
 
   void modelDataChanged(const QModelIndex& topLeft, const QModelIndex& bottomRight, const QVector<int>& roles = QVector<int>());
 
 private:
+
+  // returns a pair of boolean, the first one indicates if the drop info
+  // contains separators, the first one if the first row is a separator
+  //
+  std::pair<bool, bool> dropSeparators(const ModListDropInfo& dropInfo) const;
 
   void buildTree();
 
@@ -83,6 +89,8 @@ private:
 private:
   OrganizerCore& m_core;
   Profile* m_profile;
+
+  bool m_dropExpanded = false;
   ModListView::DropPosition m_dropPosition = ModListView::DropPosition::OnItem;
 };
 

--- a/src/modlistcontextmenu.cpp
+++ b/src/modlistcontextmenu.cpp
@@ -23,13 +23,14 @@ ModListGlobalContextMenu::ModListGlobalContextMenu(OrganizerCore& core, ModListV
   if (modIndex.isValid()) {
     auto info = ModInfo::getByIndex(modIndex.toInt());
     if (!info->isBackup()) {
-      addAction(tr("Create empty mod"), [=]() { view->actions().createEmptyMod(index); });
-      addAction(tr("Create Separator"), [=]() { view->actions().createSeparator(index); });
+      addAction(info->isSeparator() ? tr("Create empty mod inside") : tr("Create empty mod before"),
+        [=]() { view->actions().createEmptyMod(index); });
+      addAction(tr("Create separator before"), [=]() { view->actions().createSeparator(index); });
     }
   }
   else {
-    addAction(tr("Create empty mod"), [=]() { view->actions().createEmptyMod(); });
-    addAction(tr("Create Separator"), [=]() { view->actions().createSeparator(); });
+    addAction(tr("Create empty mod at the end"), [=]() { view->actions().createEmptyMod(); });
+    addAction(tr("Create separator at the end"), [=]() { view->actions().createSeparator(); });
   }
 
   if (view->hasCollapsibleSeparators()) {

--- a/src/modlistcontextmenu.cpp
+++ b/src/modlistcontextmenu.cpp
@@ -27,6 +27,10 @@ ModListGlobalContextMenu::ModListGlobalContextMenu(OrganizerCore& core, ModListV
       addAction(tr("Create Separator"), [=]() { view->actions().createSeparator(index); });
     }
   }
+  else {
+    addAction(tr("Create empty mod"), [=]() { view->actions().createEmptyMod(); });
+    addAction(tr("Create Separator"), [=]() { view->actions().createSeparator(); });
+  }
 
   if (view->hasCollapsibleSeparators()) {
     addSeparator();

--- a/src/modlistversiondelegate.cpp
+++ b/src/modlistversiondelegate.cpp
@@ -41,8 +41,10 @@ void ModListVersionDelegate::paint(QPainter* painter, const QStyleOptionViewItem
       QSize pm = icon.actualSize(opt.decorationSize);
       pm.rwidth() += 2 * margin;
       opt.rect.setRect(opt.rect.x(), opt.rect.y(), pm.width(), opt.rect.height());
-
       drawDecoration(painter, opt, opt.rect, pixmap);
+
+      // add margin for next icon (if any)
+      opt.rect.adjust(opt.decorationSize.width() + margin, 0, 0, 0);
     }
 
     if (downgrade) {
@@ -51,7 +53,7 @@ void ModListVersionDelegate::paint(QPainter* painter, const QStyleOptionViewItem
 
       QSize pm = icon.actualSize(opt.decorationSize);
       pm.rwidth() += 2 * margin;
-      opt.rect.setRect(opt.rect.x() + opt.decorationSize.width() + margin, opt.rect.y(), pm.width(), opt.rect.height());
+      opt.rect.setRect(opt.rect.x(), opt.rect.y(), pm.width(), opt.rect.height());
 
       drawDecoration(painter, opt, opt.rect, pixmap);
 

--- a/src/modlistversiondelegate.cpp
+++ b/src/modlistversiondelegate.cpp
@@ -1,0 +1,60 @@
+#include "modlistversiondelegate.h"
+
+#include "modlistview.h"
+#include "log.h"
+
+ModListVersionDelegate::ModListVersionDelegate(ModListView* view) :
+  QItemDelegate(view), m_view(view) { }
+
+
+void ModListVersionDelegate::paint(QPainter* painter, const QStyleOptionViewItem& option, const QModelIndex& index) const
+{
+  m_view->itemDelegate()->paint(painter, option, index);
+
+  if (m_view->hasCollapsibleSeparators()
+    && m_view->model()->hasChildren(index)
+    && !m_view->isExpanded(index.sibling(index.row(), 0))) {
+    auto* model = m_view->model();
+
+    bool downgrade = false, upgrade = false;
+
+    for (int i = 0; i < model->rowCount(index); ++i) {
+      const auto mIndex = model->index(i, index.column(), index).data(ModList::IndexRole);
+      if (mIndex.isValid()) {
+        auto info = ModInfo::getByIndex(mIndex.toInt());
+        downgrade = downgrade || info->downgradeAvailable();
+        upgrade = upgrade || info->updateAvailable();
+      }
+    }
+
+    const int margin = m_view->style()->pixelMetric(QStyle::PM_FocusFrameHMargin, nullptr, m_view) + 1;
+
+    QStyleOptionViewItem opt(option);
+    const int sz = m_view->style()->pixelMetric(QStyle::PM_SmallIconSize, nullptr, m_view);
+    opt.decorationSize = QSize(sz, sz);
+    opt.decorationAlignment = Qt::AlignCenter;
+
+    if (upgrade) {
+      QIcon icon(":/MO/gui/update_available");
+      QPixmap pixmap = decoration(opt, icon);
+
+      QSize pm = icon.actualSize(opt.decorationSize);
+      pm.rwidth() += 2 * margin;
+      opt.rect.setRect(opt.rect.x(), opt.rect.y(), pm.width(), opt.rect.height());
+
+      drawDecoration(painter, opt, opt.rect, pixmap);
+    }
+
+    if (downgrade) {
+      QIcon icon(":/MO/gui/warning");
+      QPixmap pixmap = decoration(opt, icon);
+
+      QSize pm = icon.actualSize(opt.decorationSize);
+      pm.rwidth() += 2 * margin;
+      opt.rect.setRect(opt.rect.x() + opt.decorationSize.width() + margin, opt.rect.y(), pm.width(), opt.rect.height());
+
+      drawDecoration(painter, opt, opt.rect, pixmap);
+
+    }
+  }
+}

--- a/src/modlistversiondelegate.h
+++ b/src/modlistversiondelegate.h
@@ -1,0 +1,21 @@
+#ifndef MODLISTVERSIONDELEGATE_H
+#define MODLISTVERSIONDELEGATE_H
+
+#include <QStyledItemDelegate>
+
+class ModListView;
+
+class ModListVersionDelegate : public QItemDelegate
+{
+public:
+  ModListVersionDelegate(ModListView* view);
+
+  void paint(QPainter* painter, const QStyleOptionViewItem& option, const QModelIndex& index) const override;
+
+
+private:
+
+  ModListView* m_view;
+};
+
+#endif

--- a/src/modlistview.cpp
+++ b/src/modlistview.cpp
@@ -1311,6 +1311,30 @@ void ModListView::timerEvent(QTimerEvent* event)
   }
 }
 
+void ModListView::mousePressEvent(QMouseEvent* event)
+{
+  // we call the parent class first so that we can use the actual
+  // selection state of the item after
+  QTreeView::mousePressEvent(event);
+
+  const auto index = indexAt(event->pos());
+
+  if (event->isAccepted()
+    && hasCollapsibleSeparators()
+    && index.isValid() && model()->hasChildren(indexAt(event->pos()))
+    && (event->modifiers() & Qt::AltModifier)) {
+
+    const auto flag = selectionModel()->isSelected(index) ?
+      QItemSelectionModel::Select : QItemSelectionModel::Deselect;
+    const bool expanded = isExpanded(index);
+    const QItemSelection selection(
+      model()->index(0, index.column(), index),
+      model()->index(model()->rowCount(index) - 1, index.column(), index));
+    selectionModel()->select(selection, flag | QItemSelectionModel::Rows);
+    setExpanded(index, expanded);
+  }
+}
+
 bool ModListView::event(QEvent* event)
 {
   if (event->type() == QEvent::KeyPress

--- a/src/modlistview.cpp
+++ b/src/modlistview.cpp
@@ -19,6 +19,7 @@
 #include "modflagicondelegate.h"
 #include "modconflicticondelegate.h"
 #include "modcontenticondelegate.h"
+#include "modlistversiondelegate.h"
 #include "modlistviewactions.h"
 #include "modlistdropinfo.h"
 #include "modlistcontextmenu.h"
@@ -776,6 +777,7 @@ void ModListView::setup(OrganizerCore& core, CategoryFactory& factory, MainWindo
   setItemDelegateForColumn(ModList::COL_FLAGS, new ModFlagIconDelegate(this, ModList::COL_FLAGS, 120));
   setItemDelegateForColumn(ModList::COL_CONFLICTFLAGS, new ModConflictIconDelegate(this, ModList::COL_CONFLICTFLAGS, 80));
   setItemDelegateForColumn(ModList::COL_CONTENT, new ModContentIconDelegate(this, ModList::COL_CONTENT, 150));
+  setItemDelegateForColumn(ModList::COL_VERSION, new ModListVersionDelegate(this));
 
   if (m_core->settings().geometry().restoreState(header())) {
     // hack: force the resize-signal to be triggered because restoreState doesn't seem to do that

--- a/src/modlistview.cpp
+++ b/src/modlistview.cpp
@@ -1295,10 +1295,18 @@ void ModListView::dragMoveEvent(QDragMoveEvent* event)
 
 void ModListView::dropEvent(QDropEvent* event)
 {
+  // from Qt source
+  QModelIndex index;
+  if (viewport()->rect().contains(event->pos())) {
+    index = indexAt(event->pos());
+    if (!index.isValid() || !visualRect(index).contains(event->pos()))
+      index = QModelIndex();
+  }
+
   // this event is used by the byPriorityProxy to know if allow
   // dropping mod between a separator and its first mod (there
   // is no way to deduce this except using dropIndicatorPosition())
-  emit dropEntered(event->mimeData(), static_cast<DropPosition>(dropIndicatorPosition()));
+  emit dropEntered(event->mimeData(), isExpanded(index), static_cast<DropPosition>(dropIndicatorPosition()));
 
   // see selectedIndexes()
   m_inDragMoveEvent = true;

--- a/src/modlistview.cpp
+++ b/src/modlistview.cpp
@@ -820,6 +820,7 @@ void ModListView::setup(OrganizerCore& core, CategoryFactory& factory, MainWindo
     m_core->installDownload(row, priority);
   });
   connect(m_core->modList(), &ModList::externalArchiveDropped, [=](const QUrl& url, int priority) {
+    setWindowState(Qt::WindowActive);
     m_core->installArchive(url.toLocalFile(), priority, false, nullptr);
   });
   connect(m_core->modList(), &ModList::externalFolderDropped, this, &ModListView::onExternalFolderDropped);

--- a/src/modlistview.cpp
+++ b/src/modlistview.cpp
@@ -1357,6 +1357,12 @@ void ModListView::timerEvent(QTimerEvent* event)
 
 void ModListView::mousePressEvent(QMouseEvent* event)
 {
+  // allow alt+click to select all mods inside a separator
+  // when using collapsible separators
+  //
+  // similar code is also present in mouseReleaseEvent to
+  // avoid missing events
+
   // disable edit if Alt is pressed
   auto triggers = editTriggers();
   if (event->modifiers() & Qt::AltModifier) {

--- a/src/modlistview.cpp
+++ b/src/modlistview.cpp
@@ -41,13 +41,13 @@ using namespace MOShared;
 // handling (e.g. checkbox, edit, etc.), so we also need to override
 // the visualRect() function from the mod list view.
 //
-class ModListStyledItemDelegated : public QStyledItemDelegate
+class ModListStyledItemDelegate : public QStyledItemDelegate
 {
   ModListView* m_view;
 
 public:
 
-  ModListStyledItemDelegated(ModListView* view) :
+  ModListStyledItemDelegate(ModListView* view) :
     QStyledItemDelegate(view), m_view(view) { }
 
   void initStyleOption(QStyleOptionViewItem* option, const QModelIndex& index) const override
@@ -144,7 +144,7 @@ ModListView::ModListView(QWidget* parent)
   MOBase::setCustomizableColumns(this);
   setAutoExpandDelay(750);
 
-  setItemDelegate(new ModListStyledItemDelegated(this));
+  setItemDelegate(new ModListStyledItemDelegate(this));
 
   connect(this, &ModListView::doubleClicked, this, &ModListView::onDoubleClicked);
   connect(this, &ModListView::customContextMenuRequested, this, &ModListView::onCustomContextMenuRequested);
@@ -855,7 +855,7 @@ void ModListView::saveState(Settings& s) const
 QRect ModListView::visualRect(const QModelIndex& index) const
 {
   // this shift the visualRect() from QTreeView to match the new actual
-  // zone after removing indentation (see the ModListStyledItemDelegated)
+  // zone after removing indentation (see the ModListStyledItemDelegate)
   QRect rect = QTreeView::visualRect(index);
   if (hasCollapsibleSeparators()
     && index.column() == 0 && index.isValid()

--- a/src/modlistview.cpp
+++ b/src/modlistview.cpp
@@ -396,7 +396,7 @@ void ModListView::scrollToAndSelect(const QModelIndex& index)
   scrollTo(index);
   setCurrentIndex(index);
   selectionModel()->select(index, QItemSelectionModel::SelectCurrent | QItemSelectionModel::Rows);
-  QTimer::singleShot(0, [=] { setFocus(); });
+  QTimer::singleShot(50, [=] { setFocus(); });
 }
 
 void ModListView::refreshExpandedItems()

--- a/src/modlistview.h
+++ b/src/modlistview.h
@@ -23,6 +23,7 @@ class MainWindow;
 class Profile;
 class ModListByPriorityProxy;
 class ModListViewActions;
+class PluginListView;
 
 class ModListView : public QTreeView
 {
@@ -183,15 +184,14 @@ private:
   void onModInstalled(const QString& modName);
   void onModFilterActive(bool filterActive);
 
-  // overwrite markers
-  void clearOverwriteMarkers();
-  void setOverwriteMarkers(const std::set<unsigned int>& overwrite, const std::set<unsigned int>& overwritten);
-  void setArchiveOverwriteMarkers(const std::set<unsigned int>& overwrite, const std::set<unsigned int>& overwritten);
-  void setArchiveLooseOverwriteMarkers(const std::set<unsigned int>& overwrite, const std::set<unsigned int>& overwritten);
-
-  // set overwrite markers from the mod and repaint (if mod is nullptr, clear overwrite and repaint)
+  // clear overwrite markers (without repainting)
   //
-  void setOverwriteMarkers(ModInfo::Ptr mod);
+  void clearOverwriteMarkers();
+
+  // set overwrite markers from the mod in the given list and repaint (if the list
+  // is empty, clear overwrite and repaint)
+  //
+  void setOverwriteMarkers(const QModelIndexList& indexes);
 
   // retrieve the marker color for the given index
   //
@@ -251,6 +251,9 @@ private:
     QLabel* currentCategory;
     QPushButton* clearFilters;
     QComboBox* filterSeparators;
+
+    // the plugin list (for highligths)
+    PluginListView* pluginList;
   };
 
   OrganizerCore* m_core;

--- a/src/modlistview.h
+++ b/src/modlistview.h
@@ -90,8 +90,14 @@ public:
 
 signals:
 
+  // emitted for dragEnter events
+  //
   void dragEntered(const QMimeData* mimeData);
-  void dropEntered(const QMimeData* mimeData, DropPosition position);
+
+  // emitted for dropEnter events, the boolean indicates if the drop target
+  // is expanded and the position of the indicator
+  //
+  void dropEntered(const QMimeData* mimeData, bool dropExpanded, DropPosition position);
 
 public slots:
 

--- a/src/modlistview.h
+++ b/src/modlistview.h
@@ -161,6 +161,7 @@ protected:
   void dragEnterEvent(QDragEnterEvent* event) override;
   void dragMoveEvent(QDragMoveEvent* event) override;
   void dropEvent(QDropEvent* event) override;
+  void mousePressEvent(QMouseEvent* event) override;
   bool event(QEvent* event) override;
 
 protected slots:

--- a/src/modlistview.h
+++ b/src/modlistview.h
@@ -173,6 +173,7 @@ protected slots:
 private:
 
   friend class ModConflictIconDelegate;
+  friend class ModFlagIconDelegate;
   friend class ModContentIconDelegate;
   friend class ModListStyledItemDelegated;
   friend class ModListViewMarkingScrollBar;
@@ -194,6 +195,11 @@ private:
   // retrieve the marker color for the given index
   //
   QColor markerColor(const QModelIndex& index) const;
+
+  // retrieve the mod flags for the given index
+  //
+  std::vector<ModInfo::EFlag> modFlags(
+    const QModelIndex& index, bool* forceCompact = nullptr) const;
 
   // retrieve the conflicts flags for the given index
   //

--- a/src/modlistview.h
+++ b/src/modlistview.h
@@ -57,10 +57,6 @@ public:
   void restoreState(const Settings& s);
   void saveState(Settings& s) const;
 
-  // set the current profile
-  //
-  void setProfile(Profile* profile);
-
   // check if collapsible separators are currently used
   //
   bool hasCollapsibleSeparators() const;
@@ -170,6 +166,7 @@ protected slots:
   void onCustomContextMenuRequested(const QPoint& pos);
   void onDoubleClicked(const QModelIndex& index);
   void onFiltersCriteria(const std::vector<ModListSortProxy::Criteria>& filters);
+  void onProfileChanged(Profile* oldProfile, Profile* newProfile);
 
 private:
 

--- a/src/modlistview.h
+++ b/src/modlistview.h
@@ -79,10 +79,15 @@ public:
   std::optional<unsigned int> nextMod(unsigned int index) const;
   std::optional<unsigned int> prevMod(unsigned int index) const;
 
-  // check if the given mod is visible
+  // check if the given mod is visible, i.e. not filtered (returns true
+  // for collapsed mods)
   //
   bool isModVisible(unsigned int index) const;
   bool isModVisible(ModInfo::Ptr mod) const;
+
+  // focus the view, select the given index and scroll to it
+  //
+  void scrollToAndSelect(const QModelIndex& index);
 
   // refresh the view (to call when settings have been changed)
   //

--- a/src/modlistview.h
+++ b/src/modlistview.h
@@ -165,6 +165,7 @@ protected:
   void dragMoveEvent(QDragMoveEvent* event) override;
   void dropEvent(QDropEvent* event) override;
   void mousePressEvent(QMouseEvent* event) override;
+  void mouseReleaseEvent(QMouseEvent* event) override;
   bool event(QEvent* event) override;
 
 protected slots:

--- a/src/modlistview.h
+++ b/src/modlistview.h
@@ -169,7 +169,6 @@ protected slots:
 
   void onCustomContextMenuRequested(const QPoint& pos);
   void onDoubleClicked(const QModelIndex& index);
-  void onSelectionChanged(const QItemSelection& selected, const QItemSelection& deselected);
   void onFiltersCriteria(const std::vector<ModListSortProxy::Criteria>& filters);
 
 private:
@@ -183,6 +182,11 @@ private:
   void onModPrioritiesChanged(const QModelIndexList& indices);
   void onModInstalled(const QString& modName);
   void onModFilterActive(bool filterActive);
+
+  // refresh the overwrite markers and the highligthed plugins from
+  // the current selection
+  //
+  void refreshMarkersAndPlugins();
 
   // clear overwrite markers (without repainting)
   //
@@ -266,6 +270,10 @@ private:
   ModListByPriorityProxy* m_byPriorityProxy;
   QtGroupingProxy* m_byCategoryProxy;
   QtGroupingProxy* m_byNexusIdProxy;
+
+  // marker used to avoid calling refreshing markers to many
+  // time in a row
+  QTimer m_refreshMarkersTimer;
 
   // maintain collapsed items for each proxy to avoid
   // losing them on model reset

--- a/src/modlistview.h
+++ b/src/modlistview.h
@@ -173,6 +173,7 @@ protected slots:
 private:
 
   friend class ModConflictIconDelegate;
+  friend class ModContentIconDelegate;
   friend class ModListStyledItemDelegated;
   friend class ModListViewMarkingScrollBar;
 
@@ -198,6 +199,12 @@ private:
   //
   std::vector<ModInfo::EConflictFlag> conflictFlags(
     const QModelIndex& index, bool* forceCompact = nullptr) const;
+
+  // retrieve the content icons and tooltip for the given index
+  //
+  std::set<int> contents(const QModelIndex& index, bool* includeChildren) const;
+  QList<QString> contentsIcons(const QModelIndex& index, bool* forceCompact = nullptr) const;
+  QString contentsTooltip(const QModelIndex& index) const;
 
   // get/set the selected items on the view, this method return/take indices
   // from the mod list model, not the view, so it's safe to restore

--- a/src/modlistview.h
+++ b/src/modlistview.h
@@ -180,7 +180,7 @@ private:
   friend class ModConflictIconDelegate;
   friend class ModFlagIconDelegate;
   friend class ModContentIconDelegate;
-  friend class ModListStyledItemDelegated;
+  friend class ModListStyledItemDelegate;
   friend class ModListViewMarkingScrollBar;
 
   void onModPrioritiesChanged(const QModelIndexList& indices);

--- a/src/modlistviewactions.cpp
+++ b/src/modlistviewactions.cpp
@@ -123,8 +123,7 @@ void ModListViewActions::createEmptyMod(const QModelIndex& index) const
     }
   }
 
-  IModInterface* newMod = m_core.createMod(name);
-  if (newMod == nullptr) {
+  if (m_core.createMod(name) == nullptr) {
     return;
   }
 
@@ -164,16 +163,22 @@ void ModListViewActions::createSeparator(const QModelIndex& index) const
     newPriority = m_core.currentProfile()->getModPriority(index.data(ModList::IndexRole).toInt());
   }
 
-  if (m_core.createMod(name) == nullptr) { return; }
+  if (m_core.createMod(name) == nullptr) {
+    return;
+  }
+
   m_core.refresh();
 
+  const auto mIndex = ModInfo::getIndex(name);
   if (newPriority >= 0) {
-    m_core.modList()->changeModPriority(ModInfo::getIndex(name), newPriority);
+    m_core.modList()->changeModPriority(mIndex, newPriority);
   }
 
   if (auto c = m_core.settings().colors().previousSeparatorColor()) {
-    ModInfo::getByIndex(ModInfo::getIndex(name))->setColor(*c);
+    ModInfo::getByIndex(mIndex)->setColor(*c);
   }
+
+  m_view->scrollToAndSelect(m_view->indexModelToView(m_core.modList()->index(mIndex, 0)));
 }
 
 void ModListViewActions::checkModsForUpdates() const

--- a/src/organizercore.cpp
+++ b/src/organizercore.cpp
@@ -602,6 +602,7 @@ void OrganizerCore::setCurrentProfile(const QString &profileName)
 
   m_CurrentProfile->debugDump();
 
+  emit profileChanged(oldProfile.get(), m_CurrentProfile.get());
   m_ProfileChanged(oldProfile.get(), m_CurrentProfile.get());
 }
 

--- a/src/organizercore.h
+++ b/src/organizercore.h
@@ -406,6 +406,13 @@ signals:
 
   void close();
 
+  // emitted when the profile is changed, before notifying plugins
+  //
+  // the new profile can be stored but the old one is temporary and
+  // should not be
+  //
+  void profileChanged(Profile* oldProfile, Profile* newProfile);
+
   // Notify that the directory structure is ready to be used on the main thread
   // Use queued connections
   void directoryStructureReady();

--- a/src/settings.cpp
+++ b/src/settings.cpp
@@ -2195,6 +2195,16 @@ void InterfaceSettings::setCollapsibleSeparatorsConflicts(bool b)
   set(m_Settings, "Settings", "collapsible_separators_conflicts", b);
 }
 
+bool InterfaceSettings::saveFilters() const
+{
+  return get<bool>(m_Settings, "Settings", "save_filters", false);
+}
+
+void InterfaceSettings::setSaveFilters(bool b)
+{
+  set(m_Settings, "Settings", "save_filters", b);
+}
+
 bool InterfaceSettings::compactDownloads() const
 {
   return get<bool>(m_Settings, "Settings", "compact_downloads", false);

--- a/src/settings.cpp
+++ b/src/settings.cpp
@@ -1326,12 +1326,12 @@ void ColorSettings::setColorSeparatorScrollbar(bool b)
 
 QColor ColorSettings::idealTextColor(const QColor& rBackgroundColor)
 {
-  if (rBackgroundColor.alpha() == 0)
+  if (rBackgroundColor.alpha() < 50)
     return QColor(Qt::black);
 
-  const int THRESHOLD = 106 * 255.0f / rBackgroundColor.alpha();
-  int BackgroundDelta = (rBackgroundColor.red() * 0.299) + (rBackgroundColor.green() * 0.587) + (rBackgroundColor.blue() * 0.114);
-  return QColor((255 - BackgroundDelta <= THRESHOLD) ? Qt::black : Qt::white);
+  // "inverse' of luminance of the background
+  int iLuminance = (rBackgroundColor.red() * 0.299) + (rBackgroundColor.green() * 0.587) + (rBackgroundColor.blue() * 0.114);
+  return QColor(iLuminance >= 128 ? Qt::black : Qt::white);
 }
 
 

--- a/src/settings.cpp
+++ b/src/settings.cpp
@@ -2195,6 +2195,16 @@ void InterfaceSettings::setCollapsibleSeparatorsConflicts(bool b)
   set(m_Settings, "Settings", "collapsible_separators_conflicts", b);
 }
 
+bool InterfaceSettings::collapsibleSeparatorsPerProfile() const
+{
+  return get<bool>(m_Settings, "Settings", "collapsible_separators_per_profile", false);
+}
+
+void InterfaceSettings::setCollapsibleSeparatorsPerProfile(bool b)
+{
+  set(m_Settings, "Settings", "collapsible_separators_per_profile", b);
+}
+
 bool InterfaceSettings::saveFilters() const
 {
   return get<bool>(m_Settings, "Settings", "save_filters", false);

--- a/src/settings.h
+++ b/src/settings.h
@@ -631,6 +631,11 @@ public:
   bool collapsibleSeparatorsConflicts() const;
   void setCollapsibleSeparatorsConflicts(bool b);
 
+  // whether each profile should have its own expansion state
+  //
+  bool collapsibleSeparatorsPerProfile() const;
+  void setCollapsibleSeparatorsPerProfile(bool b);
+
   // whether to save/restore filter states between runs
   //
   bool saveFilters() const;

--- a/src/settings.h
+++ b/src/settings.h
@@ -631,6 +631,11 @@ public:
   bool collapsibleSeparatorsConflicts() const;
   void setCollapsibleSeparatorsConflicts(bool b);
 
+  // whether to save/restore filter states between runs
+  //
+  bool saveFilters() const;
+  void setSaveFilters(bool b);
+
   // whether to show compact downloads
   //
   bool compactDownloads() const;

--- a/src/settingsdialog.cpp
+++ b/src/settingsdialog.cpp
@@ -25,6 +25,7 @@ along with Mod Organizer.  If not, see <http://www.gnu.org/licenses/>.
 #include "settingsdialogpaths.h"
 #include "settingsdialogplugins.h"
 #include "settingsdialogsteam.h"
+#include "settingsdialoguserinterface.h"
 #include "settingsdialogworkarounds.h"
 
 using namespace MOBase;
@@ -39,6 +40,7 @@ SettingsDialog::SettingsDialog(PluginContainer *pluginContainer, Settings& setti
   ui->setupUi(this);
 
   m_tabs.push_back(std::unique_ptr<SettingsTab>(new GeneralSettingsTab(settings, *this)));
+  m_tabs.push_back(std::unique_ptr<SettingsTab>(new UserInterfaceSettingsTab(settings, *this)));
   m_tabs.push_back(std::unique_ptr<SettingsTab>(new PathsSettingsTab(settings, *this)));
   m_tabs.push_back(std::unique_ptr<SettingsTab>(new DiagnosticsSettingsTab(settings, *this)));
   m_tabs.push_back(std::unique_ptr<SettingsTab>(new NexusSettingsTab(settings, *this)));

--- a/src/settingsdialog.ui
+++ b/src/settingsdialog.ui
@@ -331,6 +331,19 @@ If you disable this feature, MO will only display official DLCs this way. Please
                  </property>
                 </widget>
                </item>
+               <item>
+                <widget class="QCheckBox" name="collapsibleSeparatorsPerProfileBox">
+                 <property name="toolTip">
+                  <string>Do not share the collapse/expanded state of separators between profiles.</string>
+                 </property>
+                 <property name="whatsThis">
+                  <string>Do not share the collapse/expanded state of separators between profiles.</string>
+                 </property>
+                 <property name="text">
+                  <string>Profile-specific collapse states for separators</string>
+                 </property>
+                </widget>
+               </item>
               </layout>
              </widget>
             </item>

--- a/src/settingsdialog.ui
+++ b/src/settingsdialog.ui
@@ -7,7 +7,7 @@
     <x>0</x>
     <y>0</y>
     <width>820</width>
-    <height>652</height>
+    <height>651</height>
    </rect>
   </property>
   <property name="windowTitle">
@@ -23,8 +23,132 @@
       <attribute name="title">
        <string>General</string>
       </attribute>
-      <layout class="QGridLayout" name="gridLayout" rowstretch="0,0,0,0,0,1,0">
-       <item row="6" column="0" colspan="2">
+      <layout class="QGridLayout" name="gridLayout" rowstretch="0,0,0,0,0,0,0,0,0">
+       <item row="5" column="0">
+        <widget class="QPushButton" name="resetDialogsButton">
+         <property name="maximumSize">
+          <size>
+           <width>16777215</width>
+           <height>16777215</height>
+          </size>
+         </property>
+         <property name="toolTip">
+          <string>Reset all choices made in dialogs.</string>
+         </property>
+         <property name="whatsThis">
+          <string>Reset all choices made in dialogs.</string>
+         </property>
+         <property name="text">
+          <string>Reset Dialog Choices</string>
+         </property>
+        </widget>
+       </item>
+       <item row="3" column="0">
+        <widget class="QCheckBox" name="changeGameConfirmation">
+         <property name="text">
+          <string>Show confirmation when changing instance</string>
+         </property>
+        </widget>
+       </item>
+       <item row="0" column="0">
+        <widget class="QWidget" name="widget_6" native="true">
+         <layout class="QGridLayout" name="gridLayout_5" columnstretch="0,1,0">
+          <property name="leftMargin">
+           <number>0</number>
+          </property>
+          <property name="topMargin">
+           <number>0</number>
+          </property>
+          <property name="rightMargin">
+           <number>0</number>
+          </property>
+          <property name="bottomMargin">
+           <number>0</number>
+          </property>
+          <item row="0" column="0">
+           <widget class="QLabel" name="label_5">
+            <property name="text">
+             <string>Language</string>
+            </property>
+           </widget>
+          </item>
+          <item row="2" column="0">
+           <widget class="QLabel" name="label_10">
+            <property name="text">
+             <string>Style</string>
+            </property>
+           </widget>
+          </item>
+          <item row="2" column="1">
+           <widget class="QComboBox" name="styleBox">
+            <property name="toolTip">
+             <string>Visual theme of the user interface.</string>
+            </property>
+            <property name="whatsThis">
+             <string>Visual theme of the user interface.</string>
+            </property>
+           </widget>
+          </item>
+          <item row="2" column="2">
+           <widget class="QPushButton" name="exploreStyles">
+            <property name="text">
+             <string>Explore...</string>
+            </property>
+           </widget>
+          </item>
+          <item row="0" column="1" colspan="2">
+           <widget class="QComboBox" name="languageBox">
+            <property name="toolTip">
+             <string>The language of the user interface.</string>
+            </property>
+            <property name="whatsThis">
+             <string>The language of the user interface.</string>
+            </property>
+           </widget>
+          </item>
+          <item row="1" column="1" colspan="2">
+           <widget class="LinkLabel" name="label_33">
+            <property name="toolTip">
+             <string>https://www.transifex.com/mod-organizer-2-team/mod-organizer-2/</string>
+            </property>
+            <property name="text">
+             <string>&lt;a href=&quot;https://www.transifex.com/mod-organizer-2-team/mod-organizer-2/&quot;&gt;Help translate Mod Organizer&lt;/a&gt;</string>
+            </property>
+            <property name="openExternalLinks">
+             <bool>true</bool>
+            </property>
+           </widget>
+          </item>
+         </layout>
+        </widget>
+       </item>
+       <item row="6" column="0">
+        <widget class="QPushButton" name="categoriesBtn">
+         <property name="toolTip">
+          <string>Modify the categories available to arrange your mods.</string>
+         </property>
+         <property name="whatsThis">
+          <string>Modify the categories available to arrange your mods.</string>
+         </property>
+         <property name="text">
+          <string>Configure Mod Categories</string>
+         </property>
+        </widget>
+       </item>
+       <item row="2" column="0">
+        <widget class="QCheckBox" name="centerDialogs">
+         <property name="toolTip">
+          <string>Dialogs will always be centered on the main window, but will remember their size.</string>
+         </property>
+         <property name="whatsThis">
+          <string>Dialogs will always be centered on the main window, but will remember their size.</string>
+         </property>
+         <property name="text">
+          <string>Always center dialogs</string>
+         </property>
+        </widget>
+       </item>
+       <item row="8" column="0" colspan="2">
         <spacer name="verticalSpacer">
          <property name="orientation">
           <enum>Qt::Vertical</enum>
@@ -37,7 +161,17 @@
          </property>
         </spacer>
        </item>
-       <item row="2" column="1">
+       <item row="4" column="0">
+        <widget class="QCheckBox" name="doubleClickPreviews">
+         <property name="toolTip">
+          <string>Whether double-clicking on a file opens the preview window or launches the program associated with it. This applies to the Data tab as well as the Conflicts and Filetree tabs in the mod info window.</string>
+         </property>
+         <property name="text">
+          <string>Open previews on double-click</string>
+         </property>
+        </widget>
+       </item>
+       <item row="1" column="0">
         <widget class="QGroupBox" name="groupBox_6">
          <property name="title">
           <string>Updates</string>
@@ -69,388 +203,293 @@
             </property>
            </widget>
           </item>
-          <item>
-           <spacer name="verticalSpacer_9">
-            <property name="orientation">
-             <enum>Qt::Vertical</enum>
-            </property>
-            <property name="sizeHint" stdset="0">
-             <size>
-              <width>0</width>
-              <height>0</height>
-             </size>
-            </property>
-           </spacer>
-          </item>
          </layout>
         </widget>
        </item>
-       <item row="0" column="0" rowspan="3">
-        <widget class="QGroupBox" name="groupBox">
-         <property name="title">
-          <string>User Interface</string>
+      </layout>
+     </widget>
+     <widget class="QWidget" name="uiTab">
+      <property name="accessibleName">
+       <string/>
+      </property>
+      <attribute name="title">
+       <string>User Interface</string>
+      </attribute>
+      <layout class="QVBoxLayout" name="verticalLayout_19">
+       <item>
+        <layout class="QHBoxLayout" name="horizontalLayout_11">
+         <property name="bottomMargin">
+          <number>0</number>
          </property>
-         <layout class="QVBoxLayout" name="verticalLayout_14">
-          <item>
-           <widget class="QWidget" name="widget_6" native="true">
-            <layout class="QGridLayout" name="gridLayout_5" columnstretch="0,1,0">
-             <property name="leftMargin">
-              <number>0</number>
-             </property>
-             <property name="topMargin">
-              <number>0</number>
-             </property>
-             <property name="rightMargin">
-              <number>0</number>
-             </property>
-             <property name="bottomMargin">
-              <number>0</number>
-             </property>
-             <item row="0" column="0">
-              <widget class="QLabel" name="label_5">
-               <property name="text">
-                <string>Language</string>
+         <item>
+          <widget class="QGroupBox" name="groupBox_4">
+           <property name="minimumSize">
+            <size>
+             <width>0</width>
+             <height>0</height>
+            </size>
+           </property>
+           <property name="title">
+            <string>Mod List</string>
+           </property>
+           <layout class="QVBoxLayout" name="verticalLayout_17">
+            <item>
+             <widget class="QCheckBox" name="colorSeparatorsBox">
+              <property name="toolTip">
+               <string>Colors set on separators will also be shown in the mod list scrollbar at the location of the separator. This can be useful for quickly navigating to a specific separator.</string>
+              </property>
+              <property name="whatsThis">
+               <string>Colors set on separators will also be shown in the mod list scrollbar at the location of the separator. This can be useful for quickly navigating to a specific separator.</string>
+              </property>
+              <property name="text">
+               <string>Show mod list separator colors on the scrollbar</string>
+              </property>
+              <property name="checked">
+               <bool>true</bool>
+              </property>
+             </widget>
+            </item>
+            <item>
+             <widget class="QCheckBox" name="displayForeignBox">
+              <property name="toolTip">
+               <string>Disable this to no longer display mods installed outside MO in the mod list (left pane). Assets from those mods will then be treated as having lowest mod priority together with the original game content.</string>
+              </property>
+              <property name="whatsThis">
+               <string>By default Mod Organizer will display esp+bsa bundles installed with foreign tools as mods (left pane). This allows you to control their priority in relation to other mods. This is particularly useful if you also use Steam Workshop to install mods.
+However, if you installed loose file mods outside MO which conflict with BSAs also installed outside MO those conflicts can't be resolved correctly.
+
+If you disable this feature, MO will only display official DLCs this way. Please note that plugins (esps, esms, and esls) displayed in the right pane are completely unaffected by this feature.</string>
+              </property>
+              <property name="text">
+               <string>Display mods installed outside MO</string>
+              </property>
+              <property name="checked">
+               <bool>true</bool>
+              </property>
+             </widget>
+            </item>
+            <item>
+             <widget class="QCheckBox" name="saveFiltersBox">
+              <property name="toolTip">
+               <string>Save the current filters when closing MO2 and restore them on startup.</string>
+              </property>
+              <property name="whatsThis">
+               <string>Save the current filters when closing MO2 and restore them on startup.</string>
+              </property>
+              <property name="text">
+               <string>Remembers selected filters after restarting MO</string>
+              </property>
+             </widget>
+            </item>
+            <item>
+             <spacer name="verticalSpacer_9">
+              <property name="orientation">
+               <enum>Qt::Vertical</enum>
+              </property>
+              <property name="sizeType">
+               <enum>QSizePolicy::Fixed</enum>
+              </property>
+              <property name="sizeHint" stdset="0">
+               <size>
+                <width>0</width>
+                <height>5</height>
+               </size>
+              </property>
+             </spacer>
+            </item>
+            <item>
+             <widget class="QGroupBox" name="collapsibleSeparatorsBox">
+              <property name="title">
+               <string>Collapsible Separators</string>
+              </property>
+              <property name="flat">
+               <bool>false</bool>
+              </property>
+              <property name="checkable">
+               <bool>true</bool>
+              </property>
+              <layout class="QVBoxLayout" name="verticalLayout_20">
+               <property name="leftMargin">
+                <number>7</number>
                </property>
-              </widget>
-             </item>
-             <item row="2" column="0">
-              <widget class="QLabel" name="label_10">
-               <property name="text">
-                <string>Style</string>
+               <property name="rightMargin">
+                <number>7</number>
                </property>
-              </widget>
-             </item>
-             <item row="2" column="1">
-              <widget class="QComboBox" name="styleBox">
-               <property name="toolTip">
-                <string>Visual theme of the user interface.</string>
-               </property>
-               <property name="whatsThis">
-                <string>Visual theme of the user interface.</string>
-               </property>
-              </widget>
-             </item>
-             <item row="2" column="2">
-              <widget class="QPushButton" name="exploreStyles">
-               <property name="text">
-                <string>Explore...</string>
-               </property>
-              </widget>
-             </item>
-             <item row="0" column="1" colspan="2">
-              <widget class="QComboBox" name="languageBox">
-               <property name="toolTip">
-                <string>The language of the user interface.</string>
-               </property>
-               <property name="whatsThis">
-                <string>The language of the user interface.</string>
-               </property>
-              </widget>
-             </item>
-             <item row="1" column="1" colspan="2">
-              <widget class="LinkLabel" name="label_33">
-               <property name="toolTip">
-                <string>https://www.transifex.com/mod-organizer-2-team/mod-organizer-2/</string>
-               </property>
-               <property name="text">
-                <string>&lt;a href=&quot;https://www.transifex.com/mod-organizer-2-team/mod-organizer-2/&quot;&gt;Help translate Mod Organizer&lt;/a&gt;</string>
-               </property>
-               <property name="openExternalLinks">
-                <bool>true</bool>
-               </property>
-              </widget>
-             </item>
-            </layout>
-           </widget>
-          </item>
-          <item>
-           <widget class="QCheckBox" name="centerDialogs">
-            <property name="toolTip">
-             <string>Dialogs will always be centered on the main window, but will remember their size.</string>
-            </property>
-            <property name="whatsThis">
-             <string>Dialogs will always be centered on the main window, but will remember their size.</string>
-            </property>
-            <property name="text">
-             <string>Always center dialogs</string>
-            </property>
-           </widget>
-          </item>
-          <item>
-           <widget class="QCheckBox" name="changeGameConfirmation">
-            <property name="text">
-             <string>Show confirmation when changing instance</string>
-            </property>
-           </widget>
-          </item>
-          <item>
-           <widget class="QCheckBox" name="doubleClickPreviews">
-            <property name="toolTip">
-             <string>Whether double-clicking on a file opens the preview window or launches the program associated with it. This applies to the Data tab as well as the Conflicts and Filetree tabs in the mod info window.</string>
-            </property>
-            <property name="text">
-             <string>Open previews on double-click</string>
-            </property>
-           </widget>
-          </item>
-          <item>
-           <widget class="QPushButton" name="resetDialogsButton">
-            <property name="maximumSize">
-             <size>
-              <width>16777215</width>
-              <height>16777215</height>
-             </size>
-            </property>
-            <property name="toolTip">
-             <string>Reset all choices made in dialogs.</string>
-            </property>
-            <property name="whatsThis">
-             <string>Reset all choices made in dialogs.</string>
-            </property>
-            <property name="text">
-             <string>Reset Dialog Choices</string>
-            </property>
-           </widget>
-          </item>
-          <item>
-           <widget class="QPushButton" name="categoriesBtn">
-            <property name="toolTip">
-             <string>Modify the categories available to arrange your mods.</string>
-            </property>
-            <property name="whatsThis">
-             <string>Modify the categories available to arrange your mods.</string>
-            </property>
-            <property name="text">
-             <string>Configure Mod Categories</string>
-            </property>
-           </widget>
-          </item>
-          <item>
-           <spacer name="verticalSpacer_11">
-            <property name="orientation">
-             <enum>Qt::Vertical</enum>
-            </property>
-            <property name="sizeHint" stdset="0">
-             <size>
-              <width>0</width>
-              <height>0</height>
-             </size>
-            </property>
-           </spacer>
-          </item>
-         </layout>
-        </widget>
+               <item>
+                <widget class="QCheckBox" name="collapsibleSeparatorsConflictsBox">
+                 <property name="toolTip">
+                  <string>Display mod conflicts on separator when collapsed.</string>
+                 </property>
+                 <property name="whatsThis">
+                  <string>Display mod conflicts on separator when collapsed.</string>
+                 </property>
+                 <property name="text">
+                  <string>Show conflicts on separators</string>
+                 </property>
+                 <property name="checked">
+                  <bool>true</bool>
+                 </property>
+                </widget>
+               </item>
+              </layout>
+             </widget>
+            </item>
+            <item>
+             <spacer name="verticalSpacer_12">
+              <property name="orientation">
+               <enum>Qt::Vertical</enum>
+              </property>
+              <property name="sizeType">
+               <enum>QSizePolicy::Expanding</enum>
+              </property>
+              <property name="sizeHint" stdset="0">
+               <size>
+                <width>0</width>
+                <height>0</height>
+               </size>
+              </property>
+             </spacer>
+            </item>
+           </layout>
+          </widget>
+         </item>
+         <item>
+          <widget class="QGroupBox" name="groupBox_5">
+           <property name="title">
+            <string>Download List</string>
+           </property>
+           <layout class="QVBoxLayout" name="verticalLayout_2">
+            <item>
+             <widget class="QCheckBox" name="showMetaBox">
+              <property name="toolTip">
+               <string>Show meta information instead of file names in the download list.</string>
+              </property>
+              <property name="whatsThis">
+               <string>Show meta information instead of file names in the download list.</string>
+              </property>
+              <property name="text">
+               <string>Show Meta Information</string>
+              </property>
+             </widget>
+            </item>
+            <item>
+             <widget class="QCheckBox" name="compactBox">
+              <property name="toolTip">
+               <string>Make the download list more compact.</string>
+              </property>
+              <property name="whatsThis">
+               <string>Make the download list more compact.</string>
+              </property>
+              <property name="text">
+               <string>Compact List</string>
+              </property>
+             </widget>
+            </item>
+            <item>
+             <spacer name="verticalSpacer_5">
+              <property name="orientation">
+               <enum>Qt::Vertical</enum>
+              </property>
+              <property name="sizeHint" stdset="0">
+               <size>
+                <width>0</width>
+                <height>0</height>
+               </size>
+              </property>
+             </spacer>
+            </item>
+           </layout>
+          </widget>
+         </item>
+        </layout>
        </item>
-       <item row="0" column="1">
-        <widget class="QGroupBox" name="groupBox_5">
-         <property name="title">
-          <string>Download List</string>
+       <item>
+        <layout class="QVBoxLayout" name="verticalLayout_18">
+         <item>
+          <widget class="QGroupBox" name="ModlistGroupBox">
+           <property name="title">
+            <string>Colors</string>
+           </property>
+           <layout class="QVBoxLayout" name="verticalLayout_13">
+            <item>
+             <widget class="ColorTable" name="colorTable">
+              <property name="editTriggers">
+               <set>QAbstractItemView::NoEditTriggers</set>
+              </property>
+              <property name="selectionMode">
+               <enum>QAbstractItemView::SingleSelection</enum>
+              </property>
+              <property name="selectionBehavior">
+               <enum>QAbstractItemView::SelectRows</enum>
+              </property>
+              <property name="verticalScrollMode">
+               <enum>QAbstractItemView::ScrollPerPixel</enum>
+              </property>
+              <property name="cornerButtonEnabled">
+               <bool>false</bool>
+              </property>
+              <attribute name="horizontalHeaderVisible">
+               <bool>false</bool>
+              </attribute>
+              <attribute name="horizontalHeaderHighlightSections">
+               <bool>false</bool>
+              </attribute>
+              <attribute name="horizontalHeaderStretchLastSection">
+               <bool>true</bool>
+              </attribute>
+              <attribute name="verticalHeaderVisible">
+               <bool>false</bool>
+              </attribute>
+             </widget>
+            </item>
+            <item>
+             <widget class="QWidget" name="widget_5" native="true">
+              <layout class="QHBoxLayout" name="horizontalLayout_3">
+               <property name="leftMargin">
+                <number>0</number>
+               </property>
+               <property name="topMargin">
+                <number>0</number>
+               </property>
+               <property name="rightMargin">
+                <number>0</number>
+               </property>
+               <property name="bottomMargin">
+                <number>0</number>
+               </property>
+               <item>
+                <widget class="QPushButton" name="resetColorsBtn">
+                 <property name="toolTip">
+                  <string>Reset all colors to their default value.</string>
+                 </property>
+                 <property name="whatsThis">
+                  <string>Reset all colors to their default value.</string>
+                 </property>
+                 <property name="text">
+                  <string>Reset Colors</string>
+                 </property>
+                </widget>
+               </item>
+              </layout>
+             </widget>
+            </item>
+           </layout>
+          </widget>
+         </item>
+        </layout>
+       </item>
+       <item>
+        <spacer name="verticalSpacer_13">
+         <property name="orientation">
+          <enum>Qt::Vertical</enum>
          </property>
-         <layout class="QVBoxLayout" name="verticalLayout_2">
-          <item>
-           <widget class="QCheckBox" name="showMetaBox">
-            <property name="toolTip">
-             <string>Show meta information instead of file names in the download list.</string>
-            </property>
-            <property name="whatsThis">
-             <string>Show meta information instead of file names in the download list.</string>
-            </property>
-            <property name="text">
-             <string>Show Meta Information</string>
-            </property>
-           </widget>
-          </item>
-          <item>
-           <widget class="QCheckBox" name="compactBox">
-            <property name="toolTip">
-             <string>Make the download list more compact.</string>
-            </property>
-            <property name="whatsThis">
-             <string>Make the download list more compact.</string>
-            </property>
-            <property name="text">
-             <string>Compact List</string>
-            </property>
-           </widget>
-          </item>
-          <item>
-           <spacer name="verticalSpacer_5">
-            <property name="orientation">
-             <enum>Qt::Vertical</enum>
-            </property>
-            <property name="sizeHint" stdset="0">
-             <size>
-              <width>0</width>
-              <height>0</height>
-             </size>
-            </property>
-           </spacer>
-          </item>
-         </layout>
-        </widget>
-       </item>
-       <item row="4" column="0" colspan="2">
-        <widget class="QGroupBox" name="ModlistGroupBox">
-         <property name="title">
-          <string>Colors</string>
-         </property>
-         <layout class="QVBoxLayout" name="verticalLayout_13">
-          <item>
-           <widget class="ColorTable" name="colorTable">
-            <property name="editTriggers">
-             <set>QAbstractItemView::NoEditTriggers</set>
-            </property>
-            <property name="selectionMode">
-             <enum>QAbstractItemView::SingleSelection</enum>
-            </property>
-            <property name="selectionBehavior">
-             <enum>QAbstractItemView::SelectRows</enum>
-            </property>
-            <property name="verticalScrollMode">
-             <enum>QAbstractItemView::ScrollPerPixel</enum>
-            </property>
-            <property name="cornerButtonEnabled">
-             <bool>false</bool>
-            </property>
-            <attribute name="horizontalHeaderVisible">
-             <bool>false</bool>
-            </attribute>
-            <attribute name="horizontalHeaderHighlightSections">
-             <bool>false</bool>
-            </attribute>
-            <attribute name="horizontalHeaderStretchLastSection">
-             <bool>true</bool>
-            </attribute>
-            <attribute name="verticalHeaderVisible">
-             <bool>false</bool>
-            </attribute>
-           </widget>
-          </item>
-          <item>
-           <widget class="QWidget" name="widget_5" native="true">
-            <layout class="QHBoxLayout" name="horizontalLayout_3">
-             <property name="leftMargin">
-              <number>0</number>
-             </property>
-             <property name="topMargin">
-              <number>0</number>
-             </property>
-             <property name="rightMargin">
-              <number>0</number>
-             </property>
-             <property name="bottomMargin">
-              <number>0</number>
-             </property>
-             <item>
-              <widget class="QCheckBox" name="colorSeparatorsBox">
-               <property name="toolTip">
-                <string>Colors set on separators will also be shown in the mod list scrollbar at the location of the separator. This can be useful for quickly navigating to a specific separator.</string>
-               </property>
-               <property name="whatsThis">
-                <string>Colors set on separators will also be shown in the mod list scrollbar at the location of the separator. This can be useful for quickly navigating to a specific separator.</string>
-               </property>
-               <property name="text">
-                <string>Show mod list separator colors on the scrollbar</string>
-               </property>
-               <property name="checked">
-                <bool>true</bool>
-               </property>
-              </widget>
-             </item>
-             <item>
-              <spacer name="horizontalSpacer_2">
-               <property name="orientation">
-                <enum>Qt::Horizontal</enum>
-               </property>
-               <property name="sizeHint" stdset="0">
-                <size>
-                 <width>40</width>
-                 <height>20</height>
-                </size>
-               </property>
-              </spacer>
-             </item>
-             <item>
-              <widget class="QPushButton" name="resetColorsBtn">
-               <property name="toolTip">
-                <string>Reset all colors to their default value.</string>
-               </property>
-               <property name="whatsThis">
-                <string>Reset all colors to their default value.</string>
-               </property>
-               <property name="text">
-                <string>Reset Colors</string>
-               </property>
-              </widget>
-             </item>
-            </layout>
-           </widget>
-          </item>
-         </layout>
-        </widget>
-       </item>
-       <item row="1" column="1">
-        <widget class="QGroupBox" name="groupBox_4">
-         <property name="minimumSize">
+         <property name="sizeHint" stdset="0">
           <size>
-           <width>0</width>
-           <height>0</height>
+           <width>20</width>
+           <height>40</height>
           </size>
          </property>
-         <property name="title">
-          <string>Mod List</string>
-         </property>
-         <layout class="QVBoxLayout" name="verticalLayout_17">
-          <item>
-           <widget class="QCheckBox" name="collapsibleSeparatorsBox">
-            <property name="toolTip">
-             <string>Allow collapsing separators when sorting by ascending priority.</string>
-            </property>
-            <property name="text">
-             <string>Use collapsible separators</string>
-            </property>
-            <property name="checked">
-             <bool>true</bool>
-            </property>
-            <property name="tristate">
-             <bool>false</bool>
-            </property>
-           </widget>
-          </item>
-          <item>
-           <widget class="QCheckBox" name="collapsibleSeparatorsConflictsBox">
-            <property name="toolTip">
-             <string>Display mod conflicts on separator when collapsed.</string>
-            </property>
-            <property name="whatsThis">
-             <string>Display mod conflicts on separator when collapsed.</string>
-            </property>
-            <property name="text">
-             <string>Show conflicts on separators</string>
-            </property>
-            <property name="checked">
-             <bool>true</bool>
-            </property>
-           </widget>
-          </item>
-          <item>
-           <spacer name="verticalSpacer_12">
-            <property name="orientation">
-             <enum>Qt::Vertical</enum>
-            </property>
-            <property name="sizeType">
-             <enum>QSizePolicy::Expanding</enum>
-            </property>
-            <property name="sizeHint" stdset="0">
-             <size>
-              <width>0</width>
-              <height>0</height>
-             </size>
-            </property>
-           </spacer>
-          </item>
-         </layout>
-        </widget>
+        </spacer>
        </item>
       </layout>
      </widget>
@@ -1520,25 +1559,6 @@ I don't yet know what the circumstances are, but user reports imply it is in som
            </property>
           </widget>
          </item>
-         <item row="2" column="1">
-          <widget class="QCheckBox" name="displayForeignBox">
-           <property name="toolTip">
-            <string>Disable this to no longer display mods installed outside MO in the mod list (left pane). Assets from those mods will then be treated as having lowest mod priority together with the original game content.</string>
-           </property>
-           <property name="whatsThis">
-            <string>By default Mod Organizer will display esp+bsa bundles installed with foreign tools as mods (left pane). This allows you to control their priority in relation to other mods. This is particularly useful if you also use Steam Workshop to install mods.
-However, if you installed loose file mods outside MO which conflict with BSAs also installed outside MO those conflicts can't be resolved correctly.
-
-If you disable this feature, MO will only display official DLCs this way. Please note that plugins (esps, esms, and esls) displayed in the right pane are completely unaffected by this feature.</string>
-           </property>
-           <property name="text">
-            <string>Display mods installed outside MO</string>
-           </property>
-           <property name="checked">
-            <bool>true</bool>
-           </property>
-          </widget>
-         </item>
          <item row="1" column="1">
           <widget class="QCheckBox" name="forceEnableBox">
            <property name="toolTip">
@@ -1572,7 +1592,7 @@ Uncheck this if you want to use Mod Organizer with total conversions (like Nehri
            </property>
           </widget>
          </item>
-         <item row="3" column="0">
+         <item row="2" column="1">
           <widget class="QCheckBox" name="enableArchiveParsingBox">
            <property name="toolTip">
             <string>Enable parsing of Archives. This is an Experimental Feature. Has negative effects on performance and known incorrectness.</string>
@@ -1824,16 +1844,7 @@ programs you are intentionally running.</string>
   <tabstop>tabWidget</tabstop>
   <tabstop>languageBox</tabstop>
   <tabstop>styleBox</tabstop>
-  <tabstop>centerDialogs</tabstop>
-  <tabstop>resetDialogsButton</tabstop>
-  <tabstop>categoriesBtn</tabstop>
-  <tabstop>showMetaBox</tabstop>
-  <tabstop>compactBox</tabstop>
-  <tabstop>checkForUpdates</tabstop>
   <tabstop>usePrereleaseBox</tabstop>
-  <tabstop>colorTable</tabstop>
-  <tabstop>colorSeparatorsBox</tabstop>
-  <tabstop>resetColorsBtn</tabstop>
   <tabstop>baseDirEdit</tabstop>
   <tabstop>browseBaseDirBtn</tabstop>
   <tabstop>downloadDirEdit</tabstop>
@@ -1869,8 +1880,6 @@ programs you are intentionally running.</string>
   <tabstop>hideUncheckedBox</tabstop>
   <tabstop>forceEnableBox</tabstop>
   <tabstop>lockGUIBox</tabstop>
-  <tabstop>displayForeignBox</tabstop>
-  <tabstop>enableArchiveParsingBox</tabstop>
   <tabstop>bsaDateBtn</tabstop>
   <tabstop>execBlacklistBtn</tabstop>
   <tabstop>resetGeometryBtn</tabstop>

--- a/src/settingsdialog.ui
+++ b/src/settingsdialog.ui
@@ -277,7 +277,7 @@ If you disable this feature, MO will only display official DLCs this way. Please
                <string>Save the current filters when closing MO2 and restore them on startup.</string>
               </property>
               <property name="text">
-               <string>Remembers selected filters after restarting MO</string>
+               <string>Remember selected filters after restarting MO</string>
               </property>
              </widget>
             </item>

--- a/src/settingsdialog.ui
+++ b/src/settingsdialog.ui
@@ -318,13 +318,13 @@ If you disable this feature, MO will only display official DLCs this way. Please
                <item>
                 <widget class="QCheckBox" name="collapsibleSeparatorsConflictsBox">
                  <property name="toolTip">
-                  <string>Display mod conflicts on separator when collapsed.</string>
+                  <string>Display mod conflicts on and from separator when collapsed, and show plugins from collapsed separators.</string>
                  </property>
                  <property name="whatsThis">
-                  <string>Display mod conflicts on separator when collapsed.</string>
+                  <string>Display mod conflicts on and from separator when collapsed, and show plugins from collapsed separators.</string>
                  </property>
                  <property name="text">
-                  <string>Show conflicts on separators</string>
+                  <string>Show conflicts and plugins on separators and from separators</string>
                  </property>
                  <property name="checked">
                   <bool>true</bool>

--- a/src/settingsdialoggeneral.cpp
+++ b/src/settingsdialoggeneral.cpp
@@ -17,31 +17,16 @@ GeneralSettingsTab::GeneralSettingsTab(Settings& s, SettingsDialog& d)
   addStyles();
   selectStyle();
 
-  ui->colorTable->load(s);
-
-  // connect before setting to trigger
-  QObject::connect(ui->collapsibleSeparatorsBox, &QCheckBox::stateChanged, [=](auto&& state) {
-    ui->collapsibleSeparatorsConflictsBox->setEnabled(state == Qt::Checked);
-  });
-
   ui->centerDialogs->setChecked(settings().geometry().centerDialogs());
   ui->changeGameConfirmation->setChecked(settings().interface().showChangeGameConfirmation());
   ui->doubleClickPreviews->setChecked(settings().interface().doubleClicksOpenPreviews());
-  ui->compactBox->setChecked(settings().interface().compactDownloads());
-  ui->showMetaBox->setChecked(settings().interface().metaDownloads());
   ui->checkForUpdates->setChecked(settings().checkForUpdates());
   ui->usePrereleaseBox->setChecked(settings().usePrereleases());
-  ui->colorSeparatorsBox->setChecked(settings().colors().colorSeparatorScrollbar());
-  ui->collapsibleSeparatorsConflictsBox->setChecked(settings().interface().collapsibleSeparatorsConflicts());
-  ui->collapsibleSeparatorsBox->setChecked(settings().interface().collapsibleSeparators());
 
   QObject::connect(ui->exploreStyles, &QPushButton::clicked, [&]{ onExploreStyles(); });
 
   QObject::connect(
     ui->categoriesBtn, &QPushButton::clicked, [&]{ onEditCategories(); });
-
-  QObject::connect(
-    ui->resetColorsBtn, &QPushButton::clicked, [&]{ onResetColors(); });
 
   QObject::connect(
     ui->resetDialogsButton, &QPushButton::clicked, [&]{ onResetDialogs(); });
@@ -67,18 +52,11 @@ void GeneralSettingsTab::update()
     emit settings().styleChanged(newStyle);
   }
 
-  ui->colorTable->commitColors();
-
   settings().geometry().setCenterDialogs(ui->centerDialogs->isChecked());
   settings().interface().setShowChangeGameConfirmation(ui->changeGameConfirmation->isChecked());
   settings().interface().setDoubleClicksOpenPreviews(ui->doubleClickPreviews->isChecked());
-  settings().interface().setCompactDownloads(ui->compactBox->isChecked());
-  settings().interface().setMetaDownloads(ui->showMetaBox->isChecked());
   settings().setCheckForUpdates(ui->checkForUpdates->isChecked());
   settings().setUsePrereleases(ui->usePrereleaseBox->isChecked());
-  settings().colors().setColorSeparatorScrollbar(ui->colorSeparatorsBox->isChecked());
-  settings().interface().setCollapsibleSeparators(ui->collapsibleSeparatorsBox->isChecked());
-  settings().interface().setCollapsibleSeparatorsConflicts(ui->collapsibleSeparatorsConflictsBox->isChecked());
 }
 
 void GeneralSettingsTab::addLanguages()
@@ -202,11 +180,6 @@ void GeneralSettingsTab::onEditCategories()
   if (dialog.exec() == QDialog::Accepted) {
     dialog.commitChanges();
   }
-}
-
-void GeneralSettingsTab::onResetColors()
-{
-  ui->colorTable->resetColors();
 }
 
 void GeneralSettingsTab::onResetDialogs()

--- a/src/settingsdialoggeneral.h
+++ b/src/settingsdialoggeneral.h
@@ -22,7 +22,6 @@ private:
 
   void onExploreStyles();
   void onEditCategories();
-  void onResetColors();
   void onResetDialogs();
 };
 

--- a/src/settingsdialoguserinterface.cpp
+++ b/src/settingsdialoguserinterface.cpp
@@ -1,0 +1,53 @@
+#include "settingsdialoguserinterface.h"
+#include "ui_settingsdialog.h"
+#include "shared/appconfig.h"
+#include "categoriesdialog.h"
+#include "colortable.h"
+#include <utility.h>
+#include <questionboxmemory.h>
+
+using namespace MOBase;
+
+UserInterfaceSettingsTab::UserInterfaceSettingsTab(Settings& s, SettingsDialog& d)
+  : SettingsTab(s, d)
+{
+
+  // connect before setting to trigger
+  QObject::connect(ui->collapsibleSeparatorsBox, &QGroupBox::toggled, [=](auto&& on) {
+    ui->collapsibleSeparatorsConflictsBox->setEnabled(on);
+  });
+
+  // mod list
+  ui->displayForeignBox->setChecked(settings().interface().displayForeign());
+  ui->colorSeparatorsBox->setChecked(settings().colors().colorSeparatorScrollbar());
+  ui->collapsibleSeparatorsConflictsBox->setChecked(settings().interface().collapsibleSeparatorsConflicts());
+  ui->collapsibleSeparatorsBox->setChecked(settings().interface().collapsibleSeparators());
+  ui->saveFiltersBox->setChecked(settings().interface().saveFilters());
+
+  // download list
+  ui->compactBox->setChecked(settings().interface().compactDownloads());
+  ui->showMetaBox->setChecked(settings().interface().metaDownloads());
+
+  // colors
+  ui->colorTable->load(s);
+
+  QObject::connect(ui->resetColorsBtn, &QPushButton::clicked, [&] { ui->colorTable->resetColors(); });
+
+}
+
+void UserInterfaceSettingsTab::update()
+{
+  // mod list
+  settings().colors().setColorSeparatorScrollbar(ui->colorSeparatorsBox->isChecked());
+  settings().interface().setDisplayForeign(ui->displayForeignBox->isChecked());
+  settings().interface().setCollapsibleSeparators(ui->collapsibleSeparatorsBox->isChecked());
+  settings().interface().setCollapsibleSeparatorsConflicts(ui->collapsibleSeparatorsConflictsBox->isChecked());
+  settings().interface().setSaveFilters(ui->saveFiltersBox->isChecked());
+
+  // download list
+  settings().interface().setCompactDownloads(ui->compactBox->isChecked());
+  settings().interface().setMetaDownloads(ui->showMetaBox->isChecked());
+
+  // colors
+  ui->colorTable->commitColors();
+}

--- a/src/settingsdialoguserinterface.cpp
+++ b/src/settingsdialoguserinterface.cpp
@@ -15,6 +15,7 @@ UserInterfaceSettingsTab::UserInterfaceSettingsTab(Settings& s, SettingsDialog& 
   // connect before setting to trigger
   QObject::connect(ui->collapsibleSeparatorsBox, &QGroupBox::toggled, [=](auto&& on) {
     ui->collapsibleSeparatorsConflictsBox->setEnabled(on);
+    ui->collapsibleSeparatorsPerProfileBox->setEnabled(on);
   });
 
   // mod list
@@ -22,6 +23,7 @@ UserInterfaceSettingsTab::UserInterfaceSettingsTab(Settings& s, SettingsDialog& 
   ui->colorSeparatorsBox->setChecked(settings().colors().colorSeparatorScrollbar());
   ui->collapsibleSeparatorsConflictsBox->setChecked(settings().interface().collapsibleSeparatorsConflicts());
   ui->collapsibleSeparatorsBox->setChecked(settings().interface().collapsibleSeparators());
+  ui->collapsibleSeparatorsPerProfileBox->setChecked(settings().interface().collapsibleSeparatorsPerProfile());
   ui->saveFiltersBox->setChecked(settings().interface().saveFilters());
 
   // download list
@@ -42,6 +44,7 @@ void UserInterfaceSettingsTab::update()
   settings().interface().setDisplayForeign(ui->displayForeignBox->isChecked());
   settings().interface().setCollapsibleSeparators(ui->collapsibleSeparatorsBox->isChecked());
   settings().interface().setCollapsibleSeparatorsConflicts(ui->collapsibleSeparatorsConflictsBox->isChecked());
+  settings().interface().setCollapsibleSeparatorsPerProfile(ui->collapsibleSeparatorsPerProfileBox->isChecked());
   settings().interface().setSaveFilters(ui->saveFiltersBox->isChecked());
 
   // download list

--- a/src/settingsdialoguserinterface.h
+++ b/src/settingsdialoguserinterface.h
@@ -1,0 +1,15 @@
+#ifndef SETTINGSDIALOGUSERINTERFACE_H
+#define SETTINGSDIALOGUSERINTERFACE_H
+
+#include "settingsdialog.h"
+#include "settings.h"
+
+class UserInterfaceSettingsTab : public SettingsTab
+{
+public:
+  UserInterfaceSettingsTab(Settings& settings, SettingsDialog& dialog);
+
+  void update() override;
+};
+
+#endif // SETTINGSDIALOGGENERAL_H

--- a/src/settingsdialogworkarounds.cpp
+++ b/src/settingsdialogworkarounds.cpp
@@ -24,7 +24,6 @@ WorkaroundsSettingsTab::WorkaroundsSettingsTab(Settings& s, SettingsDialog& d)
 
   ui->hideUncheckedBox->setChecked(settings().game().hideUncheckedPlugins());
   ui->forceEnableBox->setChecked(settings().game().forceEnableCoreFiles());
-  ui->displayForeignBox->setChecked(settings().interface().displayForeign());
   ui->lockGUIBox->setChecked(settings().interface().lockGUI());
   ui->enableArchiveParsingBox->setChecked(settings().archiveParsing());
 
@@ -48,7 +47,6 @@ void WorkaroundsSettingsTab::update()
 
   settings().game().setHideUncheckedPlugins(ui->hideUncheckedBox->isChecked());
   settings().game().setForceEnableCoreFiles(ui->forceEnableBox->isChecked());
-  settings().interface().setDisplayForeign(ui->displayForeignBox->isChecked());
   settings().interface().setLockGUI(ui->lockGUIBox->isChecked());
   settings().setArchiveParsing(ui->enableArchiveParsingBox->isChecked());
   settings().setExecutablesBlacklist(m_ExecutableBlacklist);


### PR DESCRIPTION
## Improvements

- Re-organize settings and add a new "User Interface" tab with some new options

![image](https://user-images.githubusercontent.com/2393288/104119413-5f28a680-532f-11eb-993d-58abd8e53565.png)

- Display contents from collapsed mods in separators
  - Conflict icons (already in the previous PR)
  - Mod contents + Tooltip
  - Mod flags
  - Version: only the icons for "Update available" and "Warning"
- Display conflicts from mods in collapsed separators when the separator is selected
- Alt+Click to select a separator with its children, collapsed or not.
- Allow double-click to accept the current choice in `ListDialog`.
- Minor visual improvements
  - Icons should now be vertically-centered on the row (contents, conflicts, etc.). This is hard to see on the default theme but more perceptible on theme such as VS Dark where the rows are taller.
  - Fix the "ideal text color" by merging the background with the color before computing the foreground color. Qt actually fills the background of the tree view before the background of each row, and since the conflicts background are semi-transparent, there were huge difference between light and dark theme which were not reflected in the foreground color. This aims to fix it.


## Fixes

- Partial fix for Shift+Click improper selection after editing an item, only works when the item has not been edited.
  - Fixing it more globally is more complex because we need to remember the selection, which is not easy since the name change can trigger a refresh... I'm not sure if it's worth it since I think the error mostly occurs when users trigger the edit by mistake while selecting mod, not when they are actually renaming mods.
- Add the "Create empty mod" and "Create separator" to the global context menu when clicking in a blank area in the mod list or using the toolbar button.
- Fix drop below collapsed separators that would drop at the beginning of the separator instead of at the end.

## Refactoring

- Some minor stuffs not worth detailing here.