### PR TITLE
Collapsible separators in descending priority.

### DIFF
--- a/src/modlistbypriorityproxy.cpp
+++ b/src/modlistbypriorityproxy.cpp
@@ -234,10 +234,8 @@ bool ModListByPriorityProxy::canDropMimeData(const QMimeData* data, Qt::DropActi
   }
 
   // the row may be outside of the children list if we insert at the end
-  if (!parent.isValid()) {
-    if (row >= m_Root.children.size()) {
-      return false;
-    }
+  if (!parent.isValid() && row >= m_Root.children.size()) {
+    return false;
   }
 
   return QAbstractProxyModel::canDropMimeData(data, action, row, column, parent);

--- a/src/modlistbypriorityproxy.cpp
+++ b/src/modlistbypriorityproxy.cpp
@@ -104,9 +104,6 @@ void ModListByPriorityProxy::buildTree()
       std::make_move_iterator(backups.begin()), std::make_move_iterator(backups.end()));
   }
 
-  // we do not really care about their position in the root
-  // as long as those are not in a separator
-
   endResetModel();
 }
 

--- a/src/modlistbypriorityproxy.cpp
+++ b/src/modlistbypriorityproxy.cpp
@@ -257,25 +257,29 @@ bool ModListByPriorityProxy::dropMimeData(const QMimeData* data, Qt::DropAction 
   else {
 
     if (row >= 0) {
-      MOBase::log::debug("row={}, name={}, expand={}, drop={}", row, m_Root.children[row]->mod->name(), m_dropExpanded, m_dropPosition);
       if (!parent.isValid()) {
         if (row < m_Root.children.size()) {
-          sourceRow = m_Root.children[row]->index;
-          if (row > 0
-            && m_sortOrder == Qt::AscendingOrder
-            && m_Root.children[row - 1]->mod->isSeparator()
-            && !m_Root.children[row - 1]->children.empty()
-            && m_dropExpanded
-            && m_dropPosition == ModListView::DropPosition::BelowItem) {
+          if (m_sortOrder == Qt::AscendingOrder) {
+            sourceRow = m_Root.children[row]->index;
+            if (row > 0
+              && m_sortOrder == Qt::AscendingOrder
+              && m_Root.children[row - 1]->mod->isSeparator()
+              && !m_Root.children[row - 1]->children.empty()
+              && m_dropExpanded
+              && m_dropPosition == ModListView::DropPosition::BelowItem) {
               sourceRow = m_Root.children[row - 1]->children[0]->index;
+            }
           }
-          else if (row > 0
-            && m_sortOrder == Qt::DescendingOrder
-            && m_Root.children[row]->mod->isSeparator()
-            && !m_Root.children[row]->children.empty()
-            && (!m_dropExpanded
-              || m_dropPosition == ModListView::DropPosition::AboveItem)) {
-              sourceRow = m_Root.children[row]->children.back()->index;
+          else {
+            sourceRow = m_Root.children[row - 1]->index;
+            if (row > 0
+              && m_sortOrder == Qt::DescendingOrder
+              && m_Root.children[row - 1]->mod->isSeparator()
+              && !m_Root.children[row - 1]->children.empty()
+              && (!m_dropExpanded
+                || m_dropPosition == ModListView::DropPosition::AboveItem)) {
+              sourceRow = m_Root.children[row - 1]->children.back()->index;
+            }
           }
         }
         else {
@@ -285,12 +289,25 @@ bool ModListByPriorityProxy::dropMimeData(const QMimeData* data, Qt::DropAction 
       else {
         auto* item = static_cast<TreeItem*>(parent.internalPointer());
 
-        if (row < item->children.size()) {
-          sourceRow = item->children[row]->index;
+        if (m_sortOrder == Qt::DescendingOrder
+          && row == 0 && m_dropPosition == ModListView::DropPosition::AboveItem) {
+          sourceRow = item->index;
         }
-        else if (parent.row() + 1 < m_Root.children.size()) {
-          sourceRow = m_Root.children[parent.row() + 1]->index;
+        else {
+
+          if (m_sortOrder == Qt::DescendingOrder) {
+            row--;
+          }
+
+          if (row < item->children.size()) {
+            sourceRow = item->children[row]->index;
+          }
+          else if (parent.row() + 1 < m_Root.children.size()) {
+            sourceRow = m_Root.children[parent.row() + 1]->index;
+          }
         }
+
+
       }
     }
     else if (parent.isValid()) {

--- a/src/modlistbypriorityproxy.h
+++ b/src/modlistbypriorityproxy.h
@@ -28,6 +28,13 @@ public:
   ~ModListByPriorityProxy();
 
   void setProfile(Profile* profile);
+
+  // set the sort order but does not refresh the proxy
+  //
+  void setSortOrder(Qt::SortOrder order);
+
+  // refresh the proxy by rebuilding the inner structure
+  //
   void refresh();
 
   void setSourceModel(QAbstractItemModel* sourceModel) override;
@@ -83,6 +90,7 @@ private:
   OrganizerCore& m_core;
   Profile* m_profile;
 
+  Qt::SortOrder m_sortOrder = Qt::AscendingOrder;
   bool m_dropExpanded = false;
   ModListView::DropPosition m_dropPosition = ModListView::DropPosition::OnItem;
 };

--- a/src/modlistsortproxy.cpp
+++ b/src/modlistsortproxy.cpp
@@ -620,7 +620,7 @@ bool ModListSortProxy::canDropMimeData(const QMimeData* data, Qt::DropAction act
   // in the regular model, when dropping between rows, the row-value passed to
   // the sourceModel is inconsistent between ascending and descending ordering.
   // This should fix that
-  if (sortOrder() == Qt::DescendingOrder) {
+  if (sortOrder() == Qt::DescendingOrder && row != -1) {
     --row;
   }
 
@@ -645,7 +645,7 @@ bool ModListSortProxy::dropMimeData(const QMimeData *data, Qt::DropAction action
   // in the regular model, when dropping between rows, the row-value passed to
   // the sourceModel is inconsistent between ascending and descending ordering.
   // This should fix that
-  if (sortOrder() == Qt::DescendingOrder) {
+  if (sortOrder() == Qt::DescendingOrder && row != -1) {
     --row;
   }
 

--- a/src/modlistsortproxy.cpp
+++ b/src/modlistsortproxy.cpp
@@ -18,6 +18,7 @@ along with Mod Organizer.  If not, see <http://www.gnu.org/licenses/>.
 */
 
 #include "modlistsortproxy.h"
+#include "modlistbypriorityproxy.h"
 #include "modlistdropinfo.h"
 #include "modinfo.h"
 #include "profile.h"
@@ -279,7 +280,6 @@ bool ModListSortProxy::filterMatchesModOr(ModInfo::Ptr info, bool enabled) const
 
 bool ModListSortProxy::optionsMatchMod(ModInfo::Ptr info, bool) const
 {
-
   return true;
 }
 
@@ -598,6 +598,11 @@ bool ModListSortProxy::filterAcceptsRow(int source_row, const QModelIndex &paren
   }
 }
 
+bool ModListSortProxy::sourceIsByPriorityProxy() const
+{
+  return dynamic_cast<ModListByPriorityProxy*>(sourceModel()) != nullptr;
+}
+
 bool ModListSortProxy::canDropMimeData(const QMimeData* data, Qt::DropAction action, int row, int column, const QModelIndex& parent) const
 {
   ModListDropInfo dropInfo(data, *m_Organizer);
@@ -620,7 +625,7 @@ bool ModListSortProxy::canDropMimeData(const QMimeData* data, Qt::DropAction act
   // in the regular model, when dropping between rows, the row-value passed to
   // the sourceModel is inconsistent between ascending and descending ordering.
   // This should fix that
-  if (sortOrder() == Qt::DescendingOrder && row != -1) {
+  if (sortOrder() == Qt::DescendingOrder && row != -1 && !sourceIsByPriorityProxy()) {
     --row;
   }
 
@@ -645,7 +650,7 @@ bool ModListSortProxy::dropMimeData(const QMimeData *data, Qt::DropAction action
   // in the regular model, when dropping between rows, the row-value passed to
   // the sourceModel is inconsistent between ascending and descending ordering.
   // This should fix that
-  if (sortOrder() == Qt::DescendingOrder && row != -1) {
+  if (sortOrder() == Qt::DescendingOrder && row != -1 && !sourceIsByPriorityProxy()) {
     --row;
   }
 

--- a/src/modlistsortproxy.cpp
+++ b/src/modlistsortproxy.cpp
@@ -617,6 +617,13 @@ bool ModListSortProxy::canDropMimeData(const QMimeData* data, Qt::DropAction act
     }
   }
 
+  // in the regular model, when dropping between rows, the row-value passed to
+  // the sourceModel is inconsistent between ascending and descending ordering.
+  // This should fix that
+  if (sortOrder() == Qt::DescendingOrder) {
+    --row;
+  }
+
   return QSortFilterProxyModel::canDropMimeData(data, action, row, column, parent);
 }
 

--- a/src/modlistsortproxy.cpp
+++ b/src/modlistsortproxy.cpp
@@ -622,9 +622,7 @@ bool ModListSortProxy::canDropMimeData(const QMimeData* data, Qt::DropAction act
     }
   }
 
-  // in the regular model, when dropping between rows, the row-value passed to
-  // the sourceModel is inconsistent between ascending and descending ordering.
-  // This should fix that
+  // see dropMimeData for details
   if (sortOrder() == Qt::DescendingOrder && row != -1 && !sourceIsByPriorityProxy()) {
     --row;
   }
@@ -648,8 +646,11 @@ bool ModListSortProxy::dropMimeData(const QMimeData *data, Qt::DropAction action
   }
 
   // in the regular model, when dropping between rows, the row-value passed to
-  // the sourceModel is inconsistent between ascending and descending ordering.
-  // This should fix that
+  // the sourceModel is inconsistent between ascending and descending ordering
+  //
+  // we want to fix that, but we cannot do it for the by-priority proxy because
+  // it messes up with non top-level items, so we simply forward the row and the
+  // by-priority proxy will fix the row for us
   if (sortOrder() == Qt::DescendingOrder && row != -1 && !sourceIsByPriorityProxy()) {
     --row;
   }

--- a/src/modlistsortproxy.h
+++ b/src/modlistsortproxy.h
@@ -140,6 +140,10 @@ private:
   bool filterMatchesModAnd(ModInfo::Ptr info, bool enabled) const;
   bool filterMatchesModOr(ModInfo::Ptr info, bool enabled) const;
 
+  // check if the source model is the by-priority proxy
+  //
+  bool sourceIsByPriorityProxy() const;
+
 private slots:
 
   void aboutToChangeData();

--- a/src/modlistview.cpp
+++ b/src/modlistview.cpp
@@ -209,6 +209,11 @@ int ModListView::sortColumn() const
   return m_sortProxy ? m_sortProxy->sortColumn() : -1;
 }
 
+Qt::SortOrder ModListView::sortOrder() const
+{
+  return m_sortProxy ? m_sortProxy->sortOrder() : Qt::AscendingOrder;
+}
+
 ModListView::GroupByMode ModListView::groupByMode() const
 {
   if (m_sortProxy == nullptr) {

--- a/src/modlistview.cpp
+++ b/src/modlistview.cpp
@@ -687,7 +687,7 @@ void ModListView::updateGroupByProxy()
   else if (groupIndex == GroupBy::NEXUS_ID) {
     nextProxy = m_byNexusIdProxy;
   }
-  else if (m_core->settings().interface().collapsibleSeparators()
+  else if (m_core->settings().interface().collapsibleSeparators(m_sortProxy->sortOrder())
     && m_sortProxy->sortColumn() == ModList::COL_PRIORITY) {
     m_byPriorityProxy->setSortOrder(m_sortProxy->sortOrder());
     nextProxy = m_byPriorityProxy;

--- a/src/modlistview.cpp
+++ b/src/modlistview.cpp
@@ -683,8 +683,8 @@ void ModListView::updateGroupByProxy()
     nextProxy = m_byNexusIdProxy;
   }
   else if (m_core->settings().interface().collapsibleSeparators()
-    && m_sortProxy->sortColumn() == ModList::COL_PRIORITY
-    && m_sortProxy->sortOrder() == Qt::AscendingOrder) {
+    && m_sortProxy->sortColumn() == ModList::COL_PRIORITY) {
+    m_byPriorityProxy->setSortOrder(m_sortProxy->sortOrder());
     nextProxy = m_byPriorityProxy;
   }
 

--- a/src/modlistview.h
+++ b/src/modlistview.h
@@ -61,9 +61,10 @@ public:
   //
   bool hasCollapsibleSeparators() const;
 
-  // the column by which the mod list is currently sorted
+  // the column/order by which the mod list is currently sorted
   //
   int sortColumn() const;
+  Qt::SortOrder sortOrder() const;
 
   // the current group mode
   //

--- a/src/settings.cpp
+++ b/src/settings.cpp
@@ -2175,14 +2175,17 @@ void InterfaceSettings::setStyleName(const QString& name)
   set(m_Settings, "Settings", "style", name);
 }
 
-bool InterfaceSettings::collapsibleSeparators() const
+bool InterfaceSettings::collapsibleSeparators(Qt::SortOrder order) const
 {
-  return get<bool>(m_Settings, "Settings", "collapsible_separators", true);
+  return get<bool>(m_Settings, "Settings",
+    order == Qt::AscendingOrder ? "collapsible_separators_asc" : "collapsible_separators_dsc",
+    order == Qt::AscendingOrder);
 }
 
-void InterfaceSettings::setCollapsibleSeparators(bool b)
+void InterfaceSettings::setCollapsibleSeparators(bool ascending, bool descending)
 {
-  set(m_Settings, "Settings", "collapsible_separators", b);
+  set(m_Settings, "Settings", "collapsible_separators_asc", ascending);
+  set(m_Settings, "Settings", "collapsible_separators_dsc", descending);
 }
 
 bool InterfaceSettings::collapsibleSeparatorsConflicts() const

--- a/src/settings.h
+++ b/src/settings.h
@@ -623,8 +623,8 @@ public:
 
   // whether to use collapsible separators when possible
   //
-  bool collapsibleSeparators() const;
-  void setCollapsibleSeparators(bool b);
+  bool collapsibleSeparators(Qt::SortOrder order) const;
+  void setCollapsibleSeparators(bool ascending, bool descending);
 
   // whether to display mod conflicts on separators when collapsed
   //

--- a/src/settingsdialog.ui
+++ b/src/settingsdialog.ui
@@ -306,7 +306,10 @@ If you disable this feature, MO will only display official DLCs this way. Please
                <bool>false</bool>
               </property>
               <property name="checkable">
-               <bool>true</bool>
+               <bool>false</bool>
+              </property>
+              <property name="checked">
+               <bool>false</bool>
               </property>
               <layout class="QVBoxLayout" name="verticalLayout_20">
                <property name="leftMargin">
@@ -315,6 +318,54 @@ If you disable this feature, MO will only display official DLCs this way. Please
                <property name="rightMargin">
                 <number>7</number>
                </property>
+               <item>
+                <widget class="QWidget" name="widget_8" native="true">
+                 <property name="minimumSize">
+                  <size>
+                   <width>0</width>
+                   <height>0</height>
+                  </size>
+                 </property>
+                 <layout class="QHBoxLayout" name="horizontalLayout_13">
+                  <property name="leftMargin">
+                   <number>0</number>
+                  </property>
+                  <property name="topMargin">
+                   <number>0</number>
+                  </property>
+                  <property name="rightMargin">
+                   <number>0</number>
+                  </property>
+                  <property name="bottomMargin">
+                   <number>0</number>
+                  </property>
+                  <item>
+                   <widget class="QLabel" name="label_18">
+                    <property name="text">
+                     <string>When sorting by</string>
+                    </property>
+                   </widget>
+                  </item>
+                  <item>
+                   <widget class="QCheckBox" name="collapsibleSeparatorsAscBox">
+                    <property name="text">
+                     <string>ascending priority</string>
+                    </property>
+                    <property name="checked">
+                     <bool>true</bool>
+                    </property>
+                   </widget>
+                  </item>
+                  <item>
+                   <widget class="QCheckBox" name="collapsibleSeparatorsDscBox">
+                    <property name="text">
+                     <string>descending  priority</string>
+                    </property>
+                   </widget>
+                  </item>
+                 </layout>
+                </widget>
+               </item>
                <item>
                 <widget class="QCheckBox" name="collapsibleSeparatorsConflictsBox">
                  <property name="toolTip">

--- a/src/settingsdialoguserinterface.cpp
+++ b/src/settingsdialoguserinterface.cpp
@@ -13,16 +13,15 @@ UserInterfaceSettingsTab::UserInterfaceSettingsTab(Settings& s, SettingsDialog& 
 {
 
   // connect before setting to trigger
-  QObject::connect(ui->collapsibleSeparatorsBox, &QGroupBox::toggled, [=](auto&& on) {
-    ui->collapsibleSeparatorsConflictsBox->setEnabled(on);
-    ui->collapsibleSeparatorsPerProfileBox->setEnabled(on);
-  });
+  QObject::connect(ui->collapsibleSeparatorsAscBox, &QCheckBox::toggled, [=] { updateCollapsibleSeparatorsGroup(); });
+  QObject::connect(ui->collapsibleSeparatorsDscBox, &QCheckBox::toggled, [=] { updateCollapsibleSeparatorsGroup(); });
 
   // mod list
   ui->displayForeignBox->setChecked(settings().interface().displayForeign());
   ui->colorSeparatorsBox->setChecked(settings().colors().colorSeparatorScrollbar());
   ui->collapsibleSeparatorsConflictsBox->setChecked(settings().interface().collapsibleSeparatorsConflicts());
-  ui->collapsibleSeparatorsBox->setChecked(settings().interface().collapsibleSeparators());
+  ui->collapsibleSeparatorsAscBox->setChecked(settings().interface().collapsibleSeparators(Qt::AscendingOrder));
+  ui->collapsibleSeparatorsDscBox->setChecked(settings().interface().collapsibleSeparators(Qt::DescendingOrder));
   ui->collapsibleSeparatorsPerProfileBox->setChecked(settings().interface().collapsibleSeparatorsPerProfile());
   ui->saveFiltersBox->setChecked(settings().interface().saveFilters());
 
@@ -42,7 +41,8 @@ void UserInterfaceSettingsTab::update()
   // mod list
   settings().colors().setColorSeparatorScrollbar(ui->colorSeparatorsBox->isChecked());
   settings().interface().setDisplayForeign(ui->displayForeignBox->isChecked());
-  settings().interface().setCollapsibleSeparators(ui->collapsibleSeparatorsBox->isChecked());
+  settings().interface().setCollapsibleSeparators(
+    ui->collapsibleSeparatorsAscBox->isChecked(), ui->collapsibleSeparatorsDscBox->isChecked());
   settings().interface().setCollapsibleSeparatorsConflicts(ui->collapsibleSeparatorsConflictsBox->isChecked());
   settings().interface().setCollapsibleSeparatorsPerProfile(ui->collapsibleSeparatorsPerProfileBox->isChecked());
   settings().interface().setSaveFilters(ui->saveFiltersBox->isChecked());
@@ -53,4 +53,12 @@ void UserInterfaceSettingsTab::update()
 
   // colors
   ui->colorTable->commitColors();
+}
+
+void UserInterfaceSettingsTab::updateCollapsibleSeparatorsGroup()
+{
+  const auto checked = ui->collapsibleSeparatorsAscBox->isChecked() ||
+    ui->collapsibleSeparatorsDscBox->isChecked();
+  ui->collapsibleSeparatorsConflictsBox->setEnabled(checked);
+  ui->collapsibleSeparatorsPerProfileBox->setEnabled(checked);
 }

--- a/src/settingsdialoguserinterface.h
+++ b/src/settingsdialoguserinterface.h
@@ -10,6 +10,12 @@ public:
   UserInterfaceSettingsTab(Settings& settings, SettingsDialog& dialog);
 
   void update() override;
+
+protected slots:
+
+  // enable/disable the collapsible separators group depending on
+  // the checkbox states
+  void updateCollapsibleSeparatorsGroup();
 };
 
 #endif // SETTINGSDIALOGGENERAL_H


### PR DESCRIPTION
Too much pressure.

---

All the new stuff is conditional to the sort order so it should have 0 impact on the existing implementation. I tested and fixed what I could, so it looks ok for me... Probably a good idea to put it in the next dev-build to get feedback.

I had to move the "fix drop position" for descending priority (`--row`) from the sort proxy to the by-priority proxy because there were cases that were broken when non-flat source models were used. It's probably kind of broken for category and nexus ID group by but that's not new.

There are some entries in menu that do not make sense when sorting by descending priority so these should probably be conditionally named (like "Send to Top" or "Create empty mod before").
