### PR TITLE
Allow extended selection in log list and implement copy.

### DIFF
--- a/src/copyeventfilter.cpp
+++ b/src/copyeventfilter.cpp
@@ -4,8 +4,8 @@
 #include <QGuiApplication>
 #include <QKeyEvent>
 
-CopyEventFilter::CopyEventFilter(QAbstractItemView* view, int role) :
-  CopyEventFilter(view, [=](auto& index) { return index.data(role).toString(); })
+CopyEventFilter::CopyEventFilter(QAbstractItemView* view, int column, int role) :
+  CopyEventFilter(view, [=](auto& index) { return index.sibling(index.row(), column).data(role).toString(); })
 {
 
 }
@@ -27,7 +27,7 @@ void CopyEventFilter::copySelection() const
   QModelIndexList selectedRows = m_view->selectionModel()->selectedRows();
   std::sort(selectedRows.begin(), selectedRows.end(), [=](const auto& lidx, const auto& ridx) {
     return m_view->visualRect(lidx).top() < m_view->visualRect(ridx).top();
-    });
+  });
 
   QStringList rows;
   for (auto& idx : selectedRows) {

--- a/src/copyeventfilter.h
+++ b/src/copyeventfilter.h
@@ -23,7 +23,7 @@ class CopyEventFilter : public QObject
 
 public:
 
-  CopyEventFilter(QAbstractItemView* view, int role = Qt::DisplayRole);
+  CopyEventFilter(QAbstractItemView* view, int column = 0, int role = Qt::DisplayRole);
   CopyEventFilter(QAbstractItemView* view, std::function<QString(const QModelIndex&)> format);
 
   // copy the selection of the view associated with this

--- a/src/loglist.h
+++ b/src/loglist.h
@@ -22,6 +22,7 @@ along with Mod Organizer.  If not, see <http://www.gnu.org/licenses/>.
 
 
 #include "shared/appconfig.h"
+#include "copyeventfilter.h"
 #include <log.h>
 #include <QTreeView>
 #include <deque>
@@ -40,6 +41,8 @@ public:
   void clear();
 
   const std::deque<MOBase::log::Entry>& entries() const;
+
+  QString formattedMessage(const QModelIndex& index) const;
 
 protected:
   QModelIndex index(int row, int column, const QModelIndex& parent) const override;
@@ -77,6 +80,7 @@ public:
 private:
   OrganizerCore* m_core;
   QTimer m_timer;
+  CopyEventFilter m_copyFilter;
 
   void onContextMenu(const QPoint& pos);
   void onNewEntry();

--- a/src/mainwindow.cpp
+++ b/src/mainwindow.cpp
@@ -2317,12 +2317,6 @@ void MainWindow::openInstanceFolder()
   shell::Explore(dataPath);
 }
 
-void MainWindow::openLogsFolder()
-{
-	QString logsPath = qApp->property("dataPath").toString() + "/" + QString::fromStdWString(AppConfig::logPath());
-  shell::Explore(logsPath);
-}
-
 void MainWindow::openInstallFolder()
 {
   shell::Explore(qApp->applicationDirPath());
@@ -2400,7 +2394,7 @@ QMenu *MainWindow::openFolderMenu()
 	FolderMenu->addAction(tr("Open MO2 Install folder"), this, SLOT(openInstallFolder()));
 	FolderMenu->addAction(tr("Open MO2 Plugins folder"), this, SLOT(openPluginsFolder()));
   FolderMenu->addAction(tr("Open MO2 Stylesheets folder"), this, SLOT(openStylesheetsFolder()));
-  FolderMenu->addAction(tr("Open MO2 Logs folder"), this, SLOT(openLogsFolder()));
+  FolderMenu->addAction(tr("Open MO2 Logs folder"), [=] { ui->logList->openLogsFolder(); });
 
 	return FolderMenu;
 }

--- a/src/mainwindow.h
+++ b/src/mainwindow.h
@@ -348,7 +348,6 @@ private slots:
   bool shouldStartTutorial() const;
 
   void openInstanceFolder();
-  void openLogsFolder();
   void openInstallFolder();
 	void openPluginsFolder();
   void openStylesheetsFolder();

--- a/src/mainwindow.ui
+++ b/src/mainwindow.ui
@@ -1550,6 +1550,9 @@ p, li { white-space: pre-wrap; }
        <property name="alternatingRowColors">
         <bool>true</bool>
        </property>
+       <property name="selectionMode">
+        <enum>QAbstractItemView::ExtendedSelection</enum>
+       </property>
        <property name="rootIsDecorated">
         <bool>false</bool>
        </property>


### PR DESCRIPTION
What the title says.

I kept the "Copy all" menu entry, although it can now be done with Ctrl+A Ctrl+C or Ctrl+A and right-click > copy.