### PR TITLE
Write plugin list after edit.

### DIFF
--- a/src/pluginlist.cpp
+++ b/src/pluginlist.cpp
@@ -1340,6 +1340,7 @@ bool PluginList::setData(const QModelIndex &modIndex, const QVariant &value, int
         result = true;
       }
       refreshLoadOrder();
+      emit writePluginsList();
     }
   }
 


### PR DESCRIPTION
Fixes https://github.com/ModOrganizer2/modorganizer/issues/522

---

The other points in the PR have already been addressed as far as I can see (negative priority, ordering not enforced, etc.). I do not see a reason not to write the plugin list in this case, and it should have no impact on the rest of the code since the `Qt::EditRole` is only used for manual edit.