### PR TITLE
UI fixes and others.

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -12,17 +12,17 @@ The project took up speed again after a few more coders showed up in late 2017, 
 ## Help Wanted!
 Mod Organizer 2 is an open project in the hands of the community, there are problems that need to be solved and things that could be added. MO2 really needs developers and if you have the programming skills and some free time you can really improve the experience of the modding community.
 
-To have more information, please join the open MO2 Development discord server :* [ModOrganizerDevs](https://discord.gg/vD2ZbfX)
+To have more information, please join the open MO2 Development discord server: [Mod Organizer 2](https://discord.gg/vD2ZbfX)
 If you want to help translate MO2 to your language you should join the discord server too and head to the #translation channel.
-To setup a development environment on your machine, there is the [umbrella project](https://github.com/Modorganizer2/modorganizer-umbrella) that handles that.
-If you want to submit your code changes, please use a good formating style like the default one in Visual Studio.
+To setup a development environment on your machine, there is the [mob project](https://github.com/modorganizer2/mob) that handles that.
+If you want to submit your code changes, please use a good formatting style like the default one in Visual Studio.
 
 Through the work of a few people of the community MO2 has come quite far, now it needs some more of those people to go further.
 
 ## Reporting Issues:
-Issues should be reported to the GitHub page or on the open discord server: [ModOrganizerDevs](https://discord.gg/vD2ZbfX). Here is also where dev builds are tested, bugs are reported and investigated, suggestions are discussed and a lot more.
+Issues should be reported to the GitHub page or on the open discord server: [Mod Organizer 2](https://discord.gg/vD2ZbfX). Here is also where dev builds are tested, bugs are reported and investigated, suggestions are discussed and a lot more.
 
-Credits to Tannin, LePresidente, Silarn, erasmux, AL12, LostDragonist, AnyOldName3 and many others for the development.
+Credits to Tannin, LePresidente, Silarn, erasmux, AL12, LostDragonist, AnyOldName3, isa, Holt59 and many others for the development.
 
 ## Download Location
 
@@ -35,11 +35,11 @@ Credits to Tannin, LePresidente, Silarn, erasmux, AL12, LostDragonist, AnyOldNam
 
 ## Building
 
-Please refer to [Modorganizer2/modorganizer-umbrella](https://github.com/Modorganizer2/modorganizer-umbrella) for build instructions.
+Please refer to [Modorganizer2/mob](https://github.com/modorganizer2/mob) for build instructions.
 
 ## Other Repositories
 
-MO2 consists of multiple repositories on github. The Umbrella project will download them automatically as required. They should however also be buildable individually.
+MO2 consists of multiple repositories on github. The mob project will download them automatically as required. They should however also be buildable individually.
 Here is a complete list:
 
 * https://github.com/LePresidente/cpython-1
@@ -47,6 +47,7 @@ Here is a complete list:
 * https://github.com/ModOrganizer2/githubpp
 * https://github.com/ModOrganizer2/modorganizer
 * https://github.com/ModOrganizer2/modorganizer-archive
+* https://github.com/ModOrganizer2/modorganizer-basic_games
 * https://github.com/ModOrganizer2/modorganizer-bsatk
 * https://github.com/ModOrganizer2/modorganizer-bsa_extractor
 * https://github.com/ModOrganizer2/modorganizer-check_fnis
@@ -68,11 +69,13 @@ Here is a complete list:
 * https://github.com/ModOrganizer2/modorganizer-game_skyrimVR
 * https://github.com/ModOrganizer2/modorganizer-game_ttw
 * https://github.com/ModOrganizer2/modorganizer-installer_bain
+* https://github.com/ModOrganizer2/modorganizer-installer_wizard
 * https://github.com/ModOrganizer2/modorganizer-installer_bundle
 * https://github.com/ModOrganizer2/modorganizer-installer_fomod
 * https://github.com/ModOrganizer2/modorganizer-installer_fomod_csharp
 * https://github.com/ModOrganizer2/modorganizer-installer_manual
 * https://github.com/ModOrganizer2/modorganizer-installer_ncc
+* https://github.com/ModOrganizer2/modorganizer-installer_omod
 * https://github.com/ModOrganizer2/modorganizer-installer_quick
 * https://github.com/ModOrganizer2/modorganizer-lootcli
 * https://github.com/ModOrganizer2/modorganizer-NCC

--- a/src/aboutdialog.ui
+++ b/src/aboutdialog.ui
@@ -220,6 +220,11 @@
                 <string notr="true">isa</string>
                </property>
               </item>
+              <item>
+               <property name="text">
+                <string>Holt59</string>
+               </property>
+              </item>
              </widget>
             </item>
            </layout>
@@ -254,11 +259,6 @@
               <item>
                <property name="text">
                 <string notr="true">przester</string>
-               </property>
-              </item>
-              <item>
-               <property name="text">
-                <string notr="true">Holt59</string>
                </property>
               </item>
              </widget>
@@ -491,12 +491,22 @@
               </item>
               <item>
                <property name="text">
+                <string>Luca|EzioTheDeadPoet</string>
+               </property>
+              </item>
+              <item>
+               <property name="text">
                 <string notr="true">ogrotten</string>
                </property>
               </item>
               <item>
                <property name="text">
                 <string notr="true">outdatedtv</string>
+               </property>
+              </item>
+              <item>
+               <property name="text">
+                <string>Patchier</string>
                </property>
               </item>
               <item>

--- a/src/modlistcontextmenu.cpp
+++ b/src/modlistcontextmenu.cpp
@@ -20,17 +20,23 @@ ModListGlobalContextMenu::ModListGlobalContextMenu(OrganizerCore& core, ModListV
   addAction(tr("Install Mod..."), [=]() { view->actions().installMod(); });
 
   auto modIndex = index.data(ModList::IndexRole);
-  if (modIndex.isValid()) {
+  if (modIndex.isValid() && view->sortColumn() == ModList::COL_PRIORITY) {
     auto info = ModInfo::getByIndex(modIndex.toInt());
     if (!info->isBackup()) {
-      addAction(info->isSeparator() ? tr("Create empty mod inside") : tr("Create empty mod before"),
-        [=]() { view->actions().createEmptyMod(index); });
-      addAction(tr("Create separator before"), [=]() { view->actions().createSeparator(index); });
+      QString text = tr("Create empty mod above");
+      if (info->isSeparator()) {
+        text = tr("Create empty mod inside");
+      }
+      else if (view->sortOrder() == Qt::DescendingOrder) {
+        text = tr("Create empty mod below");
+      }
+      addAction(text, [=]() { view->actions().createEmptyMod(index); });
+      addAction(tr("Create separator above"), [=]() { view->actions().createSeparator(index); });
     }
   }
   else {
-    addAction(tr("Create empty mod at the end"), [=]() { view->actions().createEmptyMod(); });
-    addAction(tr("Create separator at the end"), [=]() { view->actions().createSeparator(); });
+    addAction(tr("Create empty mod"), [=]() { view->actions().createEmptyMod(); });
+    addAction(tr("Create separator"), [=]() { view->actions().createSeparator(); });
   }
 
   if (view->hasCollapsibleSeparators()) {

--- a/src/modlistcontextmenu.h
+++ b/src/modlistcontextmenu.h
@@ -25,6 +25,9 @@ protected:
 
   friend class ModListContextMenu;
 
+  // populate the menu
+  void populate(OrganizerCore& core, ModListView* view, const QModelIndex& index);
+
   // creates a "All mods" context menu for the given index (can be invalid).
   ModListGlobalContextMenu(OrganizerCore& core, ModListView* view, const QModelIndex& index, QWidget* parent = nullptr);
 

--- a/src/modlistversiondelegate.cpp
+++ b/src/modlistversiondelegate.cpp
@@ -1,10 +1,13 @@
 #include "modlistversiondelegate.h"
 
+#include "settings.h"
 #include "modlistview.h"
 #include "log.h"
 
-ModListVersionDelegate::ModListVersionDelegate(ModListView* view) :
-  QItemDelegate(view), m_view(view) { }
+ModListVersionDelegate::ModListVersionDelegate(ModListView* view, Settings& settings) :
+  QItemDelegate(view), m_view(view), m_settings(settings)
+{
+}
 
 
 void ModListVersionDelegate::paint(QPainter* painter, const QStyleOptionViewItem& option, const QModelIndex& index) const
@@ -13,6 +16,7 @@ void ModListVersionDelegate::paint(QPainter* painter, const QStyleOptionViewItem
 
   if (m_view->hasCollapsibleSeparators()
     && m_view->model()->hasChildren(index)
+    && m_settings.interface().collapsibleSeparatorsIcons(ModList::COL_VERSION)
     && !m_view->isExpanded(index.sibling(index.row(), 0))) {
     auto* model = m_view->model();
 

--- a/src/modlistversiondelegate.h
+++ b/src/modlistversiondelegate.h
@@ -4,18 +4,19 @@
 #include <QStyledItemDelegate>
 
 class ModListView;
+class Settings;
 
 class ModListVersionDelegate : public QItemDelegate
 {
 public:
-  ModListVersionDelegate(ModListView* view);
+  ModListVersionDelegate(ModListView* view, Settings& settings);
 
   void paint(QPainter* painter, const QStyleOptionViewItem& option, const QModelIndex& index) const override;
 
 
 private:
-
   ModListView* m_view;
+  Settings& m_settings;
 };
 
 #endif

--- a/src/modlistview.cpp
+++ b/src/modlistview.cpp
@@ -787,7 +787,7 @@ void ModListView::setup(OrganizerCore& core, CategoryFactory& factory, MainWindo
   setItemDelegateForColumn(ModList::COL_FLAGS, new ModFlagIconDelegate(this, ModList::COL_FLAGS, 120));
   setItemDelegateForColumn(ModList::COL_CONFLICTFLAGS, new ModConflictIconDelegate(this, ModList::COL_CONFLICTFLAGS, 80));
   setItemDelegateForColumn(ModList::COL_CONTENT, new ModContentIconDelegate(this, ModList::COL_CONTENT, 150));
-  setItemDelegateForColumn(ModList::COL_VERSION, new ModListVersionDelegate(this));
+  setItemDelegateForColumn(ModList::COL_VERSION, new ModListVersionDelegate(this, core.settings()));
 
   if (m_core->settings().geometry().restoreState(header())) {
     // hack: force the resize-signal to be triggered because restoreState doesn't seem to do that
@@ -1140,6 +1140,7 @@ std::vector<ModInfo::EFlag> ModListView::modFlags(const QModelIndex& index, bool
   bool compact = false;
   if (info->isSeparator()
     && hasCollapsibleSeparators()
+    && m_core->settings().interface().collapsibleSeparatorsIcons(ModList::COL_FLAGS)
     && !isExpanded(index.sibling(index.row(), 0))) {
 
     // combine the child conflicts
@@ -1170,6 +1171,7 @@ std::vector<ModInfo::EConflictFlag> ModListView::conflictFlags(const QModelIndex
   bool compact = false;
   if (info->isSeparator()
     && hasCollapsibleSeparators()
+    && m_core->settings().interface().collapsibleSeparatorsIcons(ModList::COL_CONFLICTFLAGS)
     && !isExpanded(index.sibling(index.row(), 0))) {
 
     // combine the child conflicts
@@ -1204,6 +1206,7 @@ std::set<int> ModListView::contents(const QModelIndex& index, bool* includeChild
 
   if (info->isSeparator()
     && hasCollapsibleSeparators()
+    && m_core->settings().interface().collapsibleSeparatorsIcons(ModList::COL_CONTENT)
     && !isExpanded(index.sibling(index.row(), 0))) {
 
     // combine the child contents

--- a/src/modlistview.cpp
+++ b/src/modlistview.cpp
@@ -1029,7 +1029,7 @@ void ModListView::refreshMarkersAndPlugins()
 {
   QModelIndexList indexes = selectionModel()->selectedRows();
 
-  if (m_core->settings().interface().collapsibleSeparatorsConflicts()) {
+  if (m_core->settings().interface().collapsibleSeparatorsHighlightFrom()) {
     for (auto& idx : selectionModel()->selectedRows()) {
       if (hasCollapsibleSeparators()
         && model()->hasChildren(idx)
@@ -1103,7 +1103,7 @@ QColor ModListView::markerColor(const QModelIndex& index) const
   // collapsed separator
   auto rowIndex = index.sibling(index.row(), 0);
   if (hasCollapsibleSeparators()
-    && m_core->settings().interface().collapsibleSeparatorsConflicts()
+    && m_core->settings().interface().collapsibleSeparatorsHighlightTo()
     && model()->hasChildren(rowIndex) && !isExpanded(rowIndex)) {
 
     std::vector<QColor> colors;
@@ -1140,7 +1140,6 @@ std::vector<ModInfo::EFlag> ModListView::modFlags(const QModelIndex& index, bool
   bool compact = false;
   if (info->isSeparator()
     && hasCollapsibleSeparators()
-    && m_core->settings().interface().collapsibleSeparatorsConflicts()
     && !isExpanded(index.sibling(index.row(), 0))) {
 
     // combine the child conflicts
@@ -1171,7 +1170,6 @@ std::vector<ModInfo::EConflictFlag> ModListView::conflictFlags(const QModelIndex
   bool compact = false;
   if (info->isSeparator()
     && hasCollapsibleSeparators()
-    && m_core->settings().interface().collapsibleSeparatorsConflicts()
     && !isExpanded(index.sibling(index.row(), 0))) {
 
     // combine the child conflicts
@@ -1206,7 +1204,6 @@ std::set<int> ModListView::contents(const QModelIndex& index, bool* includeChild
 
   if (info->isSeparator()
     && hasCollapsibleSeparators()
-    && m_core->settings().interface().collapsibleSeparatorsConflicts()
     && !isExpanded(index.sibling(index.row(), 0))) {
 
     // combine the child contents

--- a/src/modlistview.cpp
+++ b/src/modlistview.cpp
@@ -214,6 +214,11 @@ Qt::SortOrder ModListView::sortOrder() const
   return m_sortProxy ? m_sortProxy->sortOrder() : Qt::AscendingOrder;
 }
 
+bool ModListView::isFilterActive() const
+{
+  return m_sortProxy && m_sortProxy->isFilterActive();
+}
+
 ModListView::GroupByMode ModListView::groupByMode() const
 {
   if (m_sortProxy == nullptr) {
@@ -293,16 +298,6 @@ std::optional<unsigned int> ModListView::prevMod(unsigned int  modIndex) const
   }
 
   return {};
-}
-
-void ModListView::enableAllVisible()
-{
-  m_core->modList()->setActive(indexViewToModel(flatIndex(model())), true);
-}
-
-void ModListView::disableAllVisible()
-{
-  m_core->modList()->setActive(indexViewToModel(flatIndex(model())), false);
 }
 
 void ModListView::setFilterCriteria(const std::vector<ModListSortProxy::Criteria>& criteria)

--- a/src/modlistview.h
+++ b/src/modlistview.h
@@ -66,6 +66,10 @@ public:
   int sortColumn() const;
   Qt::SortOrder sortOrder() const;
 
+  // check if a filter is currently active
+  //
+  bool isFilterActive() const;
+
   // the current group mode
   //
   GroupByMode groupByMode() const;
@@ -106,11 +110,6 @@ signals:
   void dropEntered(const QMimeData* mimeData, bool dropExpanded, DropPosition position);
 
 public slots:
-
-  // enable/disable all visible mods
-  //
-  void enableAllVisible();
-  void disableAllVisible();
 
   // set the filter criteria/options for mods
   //

--- a/src/modlistviewactions.cpp
+++ b/src/modlistviewactions.cpp
@@ -172,6 +172,11 @@ void ModListViewActions::createSeparator(const QModelIndex& index) const
   int newPriority = -1;
   if (index.isValid() && m_view->sortColumn() == ModList::COL_PRIORITY) {
     newPriority = m_core.currentProfile()->getModPriority(index.data(ModList::IndexRole).toInt());
+
+    // descending order, we need to fix the priority
+    if (m_view->sortOrder() == Qt::DescendingOrder) {
+      newPriority++;
+    }
   }
 
   if (m_core.createMod(name) == nullptr) {

--- a/src/modlistviewactions.cpp
+++ b/src/modlistviewactions.cpp
@@ -17,6 +17,7 @@
 #include "modinfodialog.h"
 #include "modlist.h"
 #include "modlistview.h"
+#include "modelutils.h"
 #include "messagedialog.h"
 #include "nexusinterface.h"
 #include "nxmaccessmanager.h"
@@ -195,6 +196,17 @@ void ModListViewActions::createSeparator(const QModelIndex& index) const
   }
 
   m_view->scrollToAndSelect(m_view->indexModelToView(m_core.modList()->index(mIndex, 0)));
+}
+
+void ModListViewActions::setAllMatchingModsEnabled(bool enabled) const
+{
+  const auto allIndex = m_view->indexViewToModel(flatIndex(m_view->model()));
+  const QString message = enabled ?
+    tr("Really enable %1 mod(s)?") : tr("Really disable %1 mod(s)?");
+  if (QMessageBox::question(m_parent, tr("Confirm"), message.arg(allIndex.size()),
+    QMessageBox::Yes | QMessageBox::No) == QMessageBox::Yes) {
+    m_core.modList()->setActive(allIndex, enabled);
+  }
 }
 
 void ModListViewActions::checkModsForUpdates() const

--- a/src/modlistviewactions.h
+++ b/src/modlistviewactions.h
@@ -41,6 +41,10 @@ public:
   void createEmptyMod(const QModelIndex& index = QModelIndex()) const;
   void createSeparator(const QModelIndex& index = QModelIndex()) const;
 
+  // enable/disable all non-filtered mods
+  //
+  void setAllMatchingModsEnabled(bool enabled) const;
+
   // check all mods for update
   //
   void checkModsForUpdates() const;

--- a/src/organizercore.cpp
+++ b/src/organizercore.cpp
@@ -808,6 +808,9 @@ ModInfo::Ptr OrganizerCore::installDownload(int index, int priority)
         reportError(tr("mod not found: %1").arg(qUtf8Printable(modName)));
       }
       m_DownloadManager.markInstalled(index);
+      if (settings().interface().hideDownloadsAfterInstallation()) {
+        m_DownloadManager.removeDownload(index, false);
+      }
       emit modInstalled(modName);
       return modInfo;
     }

--- a/src/settings.cpp
+++ b/src/settings.cpp
@@ -2208,6 +2208,16 @@ void InterfaceSettings::setCollapsibleSeparatorsHighlightFrom(bool b)
   set(m_Settings, "Settings", "collapsible_separators_conflicts_from", b);
 }
 
+bool InterfaceSettings::collapsibleSeparatorsIcons(int column) const
+{
+  return get<bool>(m_Settings, "Settings", QString("collapsible_separators_icons_%1").arg(column), true);
+}
+
+void InterfaceSettings::setCollapsibleSeparatorsIcons(int column, bool show)
+{
+  set(m_Settings, "Settings", QString("collapsible_separators_icons_%1").arg(column), show);
+}
+
 bool InterfaceSettings::collapsibleSeparatorsPerProfile() const
 {
   return get<bool>(m_Settings, "Settings", "collapsible_separators_per_profile", false);

--- a/src/settings.cpp
+++ b/src/settings.cpp
@@ -2188,14 +2188,24 @@ void InterfaceSettings::setCollapsibleSeparators(bool ascending, bool descending
   set(m_Settings, "Settings", "collapsible_separators_dsc", descending);
 }
 
-bool InterfaceSettings::collapsibleSeparatorsConflicts() const
+bool InterfaceSettings::collapsibleSeparatorsHighlightTo() const
 {
-  return get<bool>(m_Settings, "Settings", "collapsible_separators_conflicts", true);
+  return get<bool>(m_Settings, "Settings", "collapsible_separators_conflicts_to", true);
 }
 
-void InterfaceSettings::setCollapsibleSeparatorsConflicts(bool b)
+void InterfaceSettings::setCollapsibleSeparatorsHighlightTo(bool b)
 {
-  set(m_Settings, "Settings", "collapsible_separators_conflicts", b);
+  set(m_Settings, "Settings", "collapsible_separators_conflicts_to", b);
+}
+
+bool InterfaceSettings::collapsibleSeparatorsHighlightFrom() const
+{
+  return get<bool>(m_Settings, "Settings", "collapsible_separators_conflicts_from", true);
+}
+
+void InterfaceSettings::setCollapsibleSeparatorsHighlightFrom(bool b)
+{
+  set(m_Settings, "Settings", "collapsible_separators_conflicts_from", b);
 }
 
 bool InterfaceSettings::collapsibleSeparatorsPerProfile() const

--- a/src/settings.cpp
+++ b/src/settings.cpp
@@ -2258,6 +2258,16 @@ void InterfaceSettings::setMetaDownloads(bool b)
   set(m_Settings, "Settings", "meta_downloads", b);
 }
 
+bool InterfaceSettings::hideDownloadsAfterInstallation() const
+{
+  return get<bool>(m_Settings, "Settings", "autohide_downloads", false);
+}
+
+void InterfaceSettings::setHideDownloadsAfterInstallation(bool b)
+{
+  set(m_Settings, "Settings", "autohide_downloads", b);
+}
+
 bool InterfaceSettings::hideAPICounter() const
 {
   return get<bool>(m_Settings, "Settings", "hide_api_counter", false);

--- a/src/settings.h
+++ b/src/settings.h
@@ -626,10 +626,17 @@ public:
   bool collapsibleSeparators(Qt::SortOrder order) const;
   void setCollapsibleSeparators(bool ascending, bool descending);
 
-  // whether to display mod conflicts on separators when collapsed
+  // whether to highlight mod conflicts and plugins on collapsed
+  // separators
   //
-  bool collapsibleSeparatorsConflicts() const;
-  void setCollapsibleSeparatorsConflicts(bool b);
+  bool collapsibleSeparatorsHighlightTo() const;
+  void setCollapsibleSeparatorsHighlightTo(bool b);
+
+  // whether to highlight mod conflicts and plugins from separators
+  // when selected but collapsed
+  //
+  bool collapsibleSeparatorsHighlightFrom() const;
+  void setCollapsibleSeparatorsHighlightFrom(bool b);
 
   // whether each profile should have its own expansion state
   //

--- a/src/settings.h
+++ b/src/settings.h
@@ -663,6 +663,11 @@ public:
   bool metaDownloads() const;
   void setMetaDownloads(bool b);
 
+  // whether to hide downloads after installing them
+  //
+  bool hideDownloadsAfterInstallation() const;
+  void setHideDownloadsAfterInstallation(bool b);
+
   // whether the API counter should be hidden
   //
   bool hideAPICounter() const;

--- a/src/settings.h
+++ b/src/settings.h
@@ -638,6 +638,11 @@ public:
   bool collapsibleSeparatorsHighlightFrom() const;
   void setCollapsibleSeparatorsHighlightFrom(bool b);
 
+  // whether to show icons on collapsed separators
+  //
+  bool collapsibleSeparatorsIcons(int column) const;
+  void setCollapsibleSeparatorsIcons(int column, bool show);
+
   // whether each profile should have its own expansion state
   //
   bool collapsibleSeparatorsPerProfile() const;

--- a/src/settingsdialog.ui
+++ b/src/settingsdialog.ui
@@ -311,22 +311,16 @@ If you disable this feature, MO will only display official DLCs this way. Please
               <property name="checked">
                <bool>false</bool>
               </property>
-              <layout class="QVBoxLayout" name="verticalLayout_20">
-               <property name="leftMargin">
-                <number>7</number>
-               </property>
-               <property name="rightMargin">
-                <number>7</number>
-               </property>
-               <item>
-                <widget class="QWidget" name="widget_8" native="true">
+              <layout class="QGridLayout" name="gridLayout_7">
+               <item row="0" column="0">
+                <widget class="QWidget" name="widget_11" native="true">
                  <property name="minimumSize">
                   <size>
                    <width>0</width>
-                   <height>0</height>
+                   <height>50</height>
                   </size>
                  </property>
-                 <layout class="QHBoxLayout" name="horizontalLayout_13">
+                 <layout class="QGridLayout" name="gridLayout_10">
                   <property name="leftMargin">
                    <number>0</number>
                   </property>
@@ -339,99 +333,135 @@ If you disable this feature, MO will only display official DLCs this way. Please
                   <property name="bottomMargin">
                    <number>0</number>
                   </property>
-                  <item>
-                   <widget class="QLabel" name="label_18">
-                    <property name="text">
-                     <string>When sorting by</string>
+                  <item row="0" column="0">
+                   <layout class="QGridLayout" name="gridLayout_9">
+                    <property name="verticalSpacing">
+                     <number>9</number>
                     </property>
-                   </widget>
-                  </item>
-                  <item>
-                   <widget class="QCheckBox" name="collapsibleSeparatorsAscBox">
-                    <property name="text">
-                     <string>ascending priority</string>
-                    </property>
-                    <property name="checked">
-                     <bool>true</bool>
-                    </property>
-                   </widget>
-                  </item>
-                  <item>
-                   <widget class="QCheckBox" name="collapsibleSeparatorsDscBox">
-                    <property name="text">
-                     <string>descending  priority</string>
-                    </property>
-                   </widget>
-                  </item>
-                 </layout>
-                </widget>
-               </item>
-               <item>
-                <widget class="QCheckBox" name="collapsibleSeparatorsPerProfileBox">
-                 <property name="toolTip">
-                  <string>Do not share the collapse/expanded state of separators between profiles.</string>
-                 </property>
-                 <property name="whatsThis">
-                  <string>Do not share the collapse/expanded state of separators between profiles.</string>
-                 </property>
-                 <property name="text">
-                  <string>Profile-specific collapse states for separators</string>
-                 </property>
-                </widget>
-               </item>
-               <item>
-                <widget class="QWidget" name="widget_9" native="true">
-                 <layout class="QHBoxLayout" name="horizontalLayout_12">
-                  <property name="leftMargin">
-                   <number>0</number>
-                  </property>
-                  <property name="topMargin">
-                   <number>0</number>
-                  </property>
-                  <property name="rightMargin">
-                   <number>0</number>
-                  </property>
-                  <property name="bottomMargin">
-                   <number>0</number>
-                  </property>
-                  <item>
-                   <widget class="QLabel" name="label_34">
-                    <property name="text">
-                     <string>Show conflicts and plugins </string>
-                    </property>
-                   </widget>
-                  </item>
-                  <item>
-                   <widget class="QCheckBox" name="collapsibleSeparatorsHighlightToBox">
-                    <property name="toolTip">
-                     <string>Highlight collapsed separators based on conflicts and plugins from mods inside them.</string>
-                    </property>
-                    <property name="whatsThis">
-                     <string>Highlight collapsed separators based on conflicts and plugins from mods inside them.</string>
-                    </property>
-                    <property name="text">
-                     <string>on separators</string>
-                    </property>
-                    <property name="checked">
-                     <bool>true</bool>
-                    </property>
-                   </widget>
-                  </item>
-                  <item>
-                   <widget class="QCheckBox" name="collapsibleSeparatorsHighlightFromBox">
-                    <property name="toolTip">
-                     <string>When selecting a collapsed separator, highlight conflicting mods and plugins from mods inside the separator.</string>
-                    </property>
-                    <property name="whatsThis">
-                     <string>When selecting a collapsed separator, highlight conflicting mods and plugins from mods inside the separator.</string>
-                    </property>
-                    <property name="text">
-                     <string>from separators</string>
-                    </property>
-                    <property name="checked">
-                     <bool>true</bool>
-                    </property>
-                   </widget>
+                    <item row="0" column="0">
+                     <widget class="QLabel" name="label_18">
+                      <property name="text">
+                       <string>When sorting by</string>
+                      </property>
+                     </widget>
+                    </item>
+                    <item row="3" column="0">
+                     <widget class="QLabel" name="label_35">
+                      <property name="text">
+                       <string>Show icons on separators</string>
+                      </property>
+                     </widget>
+                    </item>
+                    <item row="1" column="0" colspan="3">
+                     <widget class="QCheckBox" name="collapsibleSeparatorsPerProfileBox">
+                      <property name="toolTip">
+                       <string>Do not share the collapse/expanded state of separators between profiles.</string>
+                      </property>
+                      <property name="whatsThis">
+                       <string>Do not share the collapse/expanded state of separators between profiles.</string>
+                      </property>
+                      <property name="text">
+                       <string>Profile-specific collapse states for separators</string>
+                      </property>
+                     </widget>
+                    </item>
+                    <item row="3" column="2">
+                     <widget class="QCheckBox" name="collapsibleSeparatorsIconsFlagsBox">
+                      <property name="text">
+                       <string>flags</string>
+                      </property>
+                      <property name="checked">
+                       <bool>true</bool>
+                      </property>
+                     </widget>
+                    </item>
+                    <item row="2" column="0">
+                     <widget class="QLabel" name="label_34">
+                      <property name="text">
+                       <string>Show conflicts and plugins </string>
+                      </property>
+                     </widget>
+                    </item>
+                    <item row="3" column="1">
+                     <widget class="QCheckBox" name="collapsibleSeparatorsIconsConflictsBox">
+                      <property name="text">
+                       <string>conflicts</string>
+                      </property>
+                      <property name="checked">
+                       <bool>true</bool>
+                      </property>
+                     </widget>
+                    </item>
+                    <item row="3" column="3">
+                     <widget class="QCheckBox" name="collapsibleSeparatorsIconsContentsBox">
+                      <property name="text">
+                       <string>content</string>
+                      </property>
+                      <property name="checked">
+                       <bool>true</bool>
+                      </property>
+                     </widget>
+                    </item>
+                    <item row="3" column="4">
+                     <widget class="QCheckBox" name="collapsibleSeparatorsIconsVersionBox">
+                      <property name="text">
+                       <string>version</string>
+                      </property>
+                      <property name="checked">
+                       <bool>true</bool>
+                      </property>
+                     </widget>
+                    </item>
+                    <item row="0" column="1" colspan="2">
+                     <widget class="QCheckBox" name="collapsibleSeparatorsAscBox">
+                      <property name="text">
+                       <string>ascending priority</string>
+                      </property>
+                      <property name="checked">
+                       <bool>true</bool>
+                      </property>
+                     </widget>
+                    </item>
+                    <item row="0" column="3" colspan="2">
+                     <widget class="QCheckBox" name="collapsibleSeparatorsDscBox">
+                      <property name="text">
+                       <string>descending  priority</string>
+                      </property>
+                     </widget>
+                    </item>
+                    <item row="2" column="1" colspan="2">
+                     <widget class="QCheckBox" name="collapsibleSeparatorsHighlightToBox">
+                      <property name="toolTip">
+                       <string>Highlight collapsed separators based on conflicts and plugins from mods inside them.</string>
+                      </property>
+                      <property name="whatsThis">
+                       <string>Highlight collapsed separators based on conflicts and plugins from mods inside them.</string>
+                      </property>
+                      <property name="text">
+                       <string>on separators</string>
+                      </property>
+                      <property name="checked">
+                       <bool>true</bool>
+                      </property>
+                     </widget>
+                    </item>
+                    <item row="2" column="3" colspan="2">
+                     <widget class="QCheckBox" name="collapsibleSeparatorsHighlightFromBox">
+                      <property name="toolTip">
+                       <string>When selecting a collapsed separator, highlight conflicting mods and plugins from mods inside the separator.</string>
+                      </property>
+                      <property name="whatsThis">
+                       <string>When selecting a collapsed separator, highlight conflicting mods and plugins from mods inside the separator.</string>
+                      </property>
+                      <property name="text">
+                       <string>from separators</string>
+                      </property>
+                      <property name="checked">
+                       <bool>true</bool>
+                      </property>
+                     </widget>
+                    </item>
+                   </layout>
                   </item>
                  </layout>
                 </widget>

--- a/src/settingsdialog.ui
+++ b/src/settingsdialog.ui
@@ -367,22 +367,6 @@ If you disable this feature, MO will only display official DLCs this way. Please
                 </widget>
                </item>
                <item>
-                <widget class="QCheckBox" name="collapsibleSeparatorsConflictsBox">
-                 <property name="toolTip">
-                  <string>Display mod conflicts on and from separator when collapsed, and show plugins from collapsed separators.</string>
-                 </property>
-                 <property name="whatsThis">
-                  <string>Display mod conflicts on and from separator when collapsed, and show plugins from collapsed separators.</string>
-                 </property>
-                 <property name="text">
-                  <string>Show conflicts and plugins on separators and from separators</string>
-                 </property>
-                 <property name="checked">
-                  <bool>true</bool>
-                 </property>
-                </widget>
-               </item>
-               <item>
                 <widget class="QCheckBox" name="collapsibleSeparatorsPerProfileBox">
                  <property name="toolTip">
                   <string>Do not share the collapse/expanded state of separators between profiles.</string>
@@ -393,6 +377,63 @@ If you disable this feature, MO will only display official DLCs this way. Please
                  <property name="text">
                   <string>Profile-specific collapse states for separators</string>
                  </property>
+                </widget>
+               </item>
+               <item>
+                <widget class="QWidget" name="widget_9" native="true">
+                 <layout class="QHBoxLayout" name="horizontalLayout_12">
+                  <property name="leftMargin">
+                   <number>0</number>
+                  </property>
+                  <property name="topMargin">
+                   <number>0</number>
+                  </property>
+                  <property name="rightMargin">
+                   <number>0</number>
+                  </property>
+                  <property name="bottomMargin">
+                   <number>0</number>
+                  </property>
+                  <item>
+                   <widget class="QLabel" name="label_34">
+                    <property name="text">
+                     <string>Show conflicts and plugins </string>
+                    </property>
+                   </widget>
+                  </item>
+                  <item>
+                   <widget class="QCheckBox" name="collapsibleSeparatorsHighlightToBox">
+                    <property name="toolTip">
+                     <string>Highlight collapsed separators based on conflicts and plugins from mods inside them.</string>
+                    </property>
+                    <property name="whatsThis">
+                     <string>Highlight collapsed separators based on conflicts and plugins from mods inside them.</string>
+                    </property>
+                    <property name="text">
+                     <string>on separators</string>
+                    </property>
+                    <property name="checked">
+                     <bool>true</bool>
+                    </property>
+                   </widget>
+                  </item>
+                  <item>
+                   <widget class="QCheckBox" name="collapsibleSeparatorsHighlightFromBox">
+                    <property name="toolTip">
+                     <string>When selecting a collapsed separator, highlight conflicting mods and plugins from mods inside the separator.</string>
+                    </property>
+                    <property name="whatsThis">
+                     <string>When selecting a collapsed separator, highlight conflicting mods and plugins from mods inside the separator.</string>
+                    </property>
+                    <property name="text">
+                     <string>from separators</string>
+                    </property>
+                    <property name="checked">
+                     <bool>true</bool>
+                    </property>
+                   </widget>
+                  </item>
+                 </layout>
                 </widget>
                </item>
               </layout>

--- a/src/settingsdialog.ui
+++ b/src/settingsdialog.ui
@@ -521,6 +521,19 @@ If you disable this feature, MO will only display official DLCs this way. Please
              </widget>
             </item>
             <item>
+             <widget class="QCheckBox" name="hideDownloadInstallBox">
+              <property name="toolTip">
+               <string>Automatically hide downloads after successful installation.</string>
+              </property>
+              <property name="whatsThis">
+               <string>Automatically hide downloads after successful installation.</string>
+              </property>
+              <property name="text">
+               <string>Hide downloads after installation</string>
+              </property>
+             </widget>
+            </item>
+            <item>
              <spacer name="verticalSpacer_5">
               <property name="orientation">
                <enum>Qt::Vertical</enum>

--- a/src/settingsdialog.ui
+++ b/src/settingsdialog.ui
@@ -313,7 +313,7 @@ If you disable this feature, MO will only display official DLCs this way. Please
               </property>
               <layout class="QGridLayout" name="gridLayout_7">
                <item row="0" column="0">
-                <widget class="QWidget" name="widget_11" native="true">
+                <widget class="QWidget" name="collapsibleSeparatorsWidget" native="true">
                  <property name="minimumSize">
                   <size>
                    <width>0</width>
@@ -339,7 +339,7 @@ If you disable this feature, MO will only display official DLCs this way. Please
                      <number>9</number>
                     </property>
                     <item row="0" column="0">
-                     <widget class="QLabel" name="label_18">
+                     <widget class="QLabel" name="collapsibleSeparatorsLabel">
                       <property name="text">
                        <string>When sorting by</string>
                       </property>

--- a/src/settingsdialoguserinterface.cpp
+++ b/src/settingsdialoguserinterface.cpp
@@ -19,7 +19,8 @@ UserInterfaceSettingsTab::UserInterfaceSettingsTab(Settings& s, SettingsDialog& 
   // mod list
   ui->displayForeignBox->setChecked(settings().interface().displayForeign());
   ui->colorSeparatorsBox->setChecked(settings().colors().colorSeparatorScrollbar());
-  ui->collapsibleSeparatorsConflictsBox->setChecked(settings().interface().collapsibleSeparatorsConflicts());
+  ui->collapsibleSeparatorsHighlightFromBox->setChecked(settings().interface().collapsibleSeparatorsHighlightFrom());
+  ui->collapsibleSeparatorsHighlightToBox->setChecked(settings().interface().collapsibleSeparatorsHighlightTo());
   ui->collapsibleSeparatorsAscBox->setChecked(settings().interface().collapsibleSeparators(Qt::AscendingOrder));
   ui->collapsibleSeparatorsDscBox->setChecked(settings().interface().collapsibleSeparators(Qt::DescendingOrder));
   ui->collapsibleSeparatorsPerProfileBox->setChecked(settings().interface().collapsibleSeparatorsPerProfile());
@@ -43,7 +44,8 @@ void UserInterfaceSettingsTab::update()
   settings().interface().setDisplayForeign(ui->displayForeignBox->isChecked());
   settings().interface().setCollapsibleSeparators(
     ui->collapsibleSeparatorsAscBox->isChecked(), ui->collapsibleSeparatorsDscBox->isChecked());
-  settings().interface().setCollapsibleSeparatorsConflicts(ui->collapsibleSeparatorsConflictsBox->isChecked());
+  settings().interface().setCollapsibleSeparatorsHighlightFrom(ui->collapsibleSeparatorsHighlightFromBox->isChecked());
+  settings().interface().setCollapsibleSeparatorsHighlightTo(ui->collapsibleSeparatorsHighlightToBox->isChecked());
   settings().interface().setCollapsibleSeparatorsPerProfile(ui->collapsibleSeparatorsPerProfileBox->isChecked());
   settings().interface().setSaveFilters(ui->saveFiltersBox->isChecked());
 
@@ -59,6 +61,7 @@ void UserInterfaceSettingsTab::updateCollapsibleSeparatorsGroup()
 {
   const auto checked = ui->collapsibleSeparatorsAscBox->isChecked() ||
     ui->collapsibleSeparatorsDscBox->isChecked();
-  ui->collapsibleSeparatorsConflictsBox->setEnabled(checked);
+  ui->collapsibleSeparatorsHighlightToBox->setEnabled(checked);
+  ui->collapsibleSeparatorsHighlightFromBox->setEnabled(checked);
   ui->collapsibleSeparatorsPerProfileBox->setEnabled(checked);
 }

--- a/src/settingsdialoguserinterface.cpp
+++ b/src/settingsdialoguserinterface.cpp
@@ -76,7 +76,10 @@ void UserInterfaceSettingsTab::updateCollapsibleSeparatorsGroup()
 {
   const auto checked = ui->collapsibleSeparatorsAscBox->isChecked() ||
     ui->collapsibleSeparatorsDscBox->isChecked();
-  for (auto* checkbox : ui->collapsibleSeparatorsBox->findChildren<QCheckBox*>()) {
-    checkbox->setEnabled(checked);
+  for (auto* widget : ui->collapsibleSeparatorsWidget->findChildren<QWidget*>()) {
+    widget->setEnabled(checked);
   }
+  ui->collapsibleSeparatorsLabel->setEnabled(true);
+  ui->collapsibleSeparatorsAscBox->setEnabled(true);
+  ui->collapsibleSeparatorsDscBox->setEnabled(true);
 }

--- a/src/settingsdialoguserinterface.cpp
+++ b/src/settingsdialoguserinterface.cpp
@@ -3,13 +3,20 @@
 #include "shared/appconfig.h"
 #include "categoriesdialog.h"
 #include "colortable.h"
+#include "modlist.h"
 #include <utility.h>
 #include <questionboxmemory.h>
 
 using namespace MOBase;
 
 UserInterfaceSettingsTab::UserInterfaceSettingsTab(Settings& s, SettingsDialog& d)
-  : SettingsTab(s, d)
+  : SettingsTab(s, d),
+  m_columnToBox{
+    { ModList::COL_CONFLICTFLAGS, ui->collapsibleSeparatorsIconsConflictsBox },
+    { ModList::COL_FLAGS, ui->collapsibleSeparatorsIconsFlagsBox },
+    { ModList::COL_CONTENT, ui->collapsibleSeparatorsIconsContentsBox},
+    { ModList::COL_VERSION, ui->collapsibleSeparatorsIconsVersionBox }
+  }
 {
 
   // connect before setting to trigger
@@ -19,12 +26,16 @@ UserInterfaceSettingsTab::UserInterfaceSettingsTab(Settings& s, SettingsDialog& 
   // mod list
   ui->displayForeignBox->setChecked(settings().interface().displayForeign());
   ui->colorSeparatorsBox->setChecked(settings().colors().colorSeparatorScrollbar());
-  ui->collapsibleSeparatorsHighlightFromBox->setChecked(settings().interface().collapsibleSeparatorsHighlightFrom());
-  ui->collapsibleSeparatorsHighlightToBox->setChecked(settings().interface().collapsibleSeparatorsHighlightTo());
   ui->collapsibleSeparatorsAscBox->setChecked(settings().interface().collapsibleSeparators(Qt::AscendingOrder));
   ui->collapsibleSeparatorsDscBox->setChecked(settings().interface().collapsibleSeparators(Qt::DescendingOrder));
+  ui->collapsibleSeparatorsHighlightFromBox->setChecked(settings().interface().collapsibleSeparatorsHighlightFrom());
+  ui->collapsibleSeparatorsHighlightToBox->setChecked(settings().interface().collapsibleSeparatorsHighlightTo());
   ui->collapsibleSeparatorsPerProfileBox->setChecked(settings().interface().collapsibleSeparatorsPerProfile());
   ui->saveFiltersBox->setChecked(settings().interface().saveFilters());
+
+  for (auto& p : m_columnToBox) {
+    p.second->setChecked(settings().interface().collapsibleSeparatorsIcons(p.first));
+  }
 
   // download list
   ui->compactBox->setChecked(settings().interface().compactDownloads());
@@ -49,6 +60,10 @@ void UserInterfaceSettingsTab::update()
   settings().interface().setCollapsibleSeparatorsPerProfile(ui->collapsibleSeparatorsPerProfileBox->isChecked());
   settings().interface().setSaveFilters(ui->saveFiltersBox->isChecked());
 
+  for (auto& p : m_columnToBox) {
+    settings().interface().setCollapsibleSeparatorsIcons(p.first, p.second->isChecked());
+  }
+
   // download list
   settings().interface().setCompactDownloads(ui->compactBox->isChecked());
   settings().interface().setMetaDownloads(ui->showMetaBox->isChecked());
@@ -61,7 +76,7 @@ void UserInterfaceSettingsTab::updateCollapsibleSeparatorsGroup()
 {
   const auto checked = ui->collapsibleSeparatorsAscBox->isChecked() ||
     ui->collapsibleSeparatorsDscBox->isChecked();
-  ui->collapsibleSeparatorsHighlightToBox->setEnabled(checked);
-  ui->collapsibleSeparatorsHighlightFromBox->setEnabled(checked);
-  ui->collapsibleSeparatorsPerProfileBox->setEnabled(checked);
+  for (auto* checkbox : ui->collapsibleSeparatorsBox->findChildren<QCheckBox*>()) {
+    checkbox->setEnabled(checked);
+  }
 }

--- a/src/settingsdialoguserinterface.cpp
+++ b/src/settingsdialoguserinterface.cpp
@@ -40,6 +40,7 @@ UserInterfaceSettingsTab::UserInterfaceSettingsTab(Settings& s, SettingsDialog& 
   // download list
   ui->compactBox->setChecked(settings().interface().compactDownloads());
   ui->showMetaBox->setChecked(settings().interface().metaDownloads());
+  ui->hideDownloadInstallBox->setChecked(settings().interface().hideDownloadsAfterInstallation());
 
   // colors
   ui->colorTable->load(s);
@@ -67,6 +68,7 @@ void UserInterfaceSettingsTab::update()
   // download list
   settings().interface().setCompactDownloads(ui->compactBox->isChecked());
   settings().interface().setMetaDownloads(ui->showMetaBox->isChecked());
+  settings().interface().setHideDownloadsAfterInstallation(ui->hideDownloadInstallBox->isChecked());
 
   // colors
   ui->colorTable->commitColors();

--- a/src/settingsdialoguserinterface.h
+++ b/src/settingsdialoguserinterface.h
@@ -1,6 +1,8 @@
 #ifndef SETTINGSDIALOGUSERINTERFACE_H
 #define SETTINGSDIALOGUSERINTERFACE_H
 
+#include <QCheckBox>
+
 #include "settingsdialog.h"
 #include "settings.h"
 
@@ -16,6 +18,10 @@ protected slots:
   // enable/disable the collapsible separators group depending on
   // the checkbox states
   void updateCollapsibleSeparatorsGroup();
+
+private:
+
+  const std::map<int, QCheckBox*> m_columnToBox;
 };
 
 #endif // SETTINGSDIALOGGENERAL_H


### PR DESCRIPTION
A few "fixes" and improvements:

- Update the "Create empty mod" and "Create separator" text to better reflect what they do:
  - When using the global menu or the "All mods" context menu when not sorting by priority, just say "Create X".
  - When sorting by priority:
    - For separators, says "Create separator above" and always create the separator above, regardless of the sort order (so not at the same priority depending on the order).
    - For mods, says "Create empty mod above" or "Create empty mod below" depending on the sort order.
      - When clicking on a separator, says "Create empty mod inside" and always create the mod at the end of the separator.
- Update the "Enable all visible" and "Disable all visible" and the confirmation dialogs:
  - If not filtering, the text says "Enable all" / "Disable all".
  - When filtering, the text says "Enable all matching mods" / "Disable all matching mods".
  - The confirmation dialog now display the number of mods that are going to be enabled/disabled.
- Add separate options to highlight conflicts and plugins from and to separators:
  - "To" means that a collapsed separator is highlighted based on its children when other mods are selected.
  - "From" means that when selected, a collapsed separator highlights other mods as if all its children were selected.
- Add settings to disable icons on collapsed separators.
- Add a setting to automatically hide downloads after installation (request from Discord). Disabled by default.
- Update about dialog.
- Update/clean the README.

![image](https://user-images.githubusercontent.com/2393288/104645784-d6539700-56af-11eb-80c0-68a9bdf84104.png)
