### PR TITLE
DownloadListView improvements

### DIFF
--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -63,7 +63,7 @@ add_filter(NAME src/dialogs GROUPS
 
 add_filter(NAME src/downloads GROUPS
 	downloadlist
-	downloadlistwidget
+	downloadlistview
 	downloadmanager
 )
 

--- a/src/downloadlistview.cpp
+++ b/src/downloadlistview.cpp
@@ -266,17 +266,17 @@ void DownloadListView::onCustomContextMenu(const QPoint &point)
     // display download-specific actions
   }
 
-  menu.addAction(tr("Delete Installed Downloads..."), this, SLOT(issueDeleteCompleted()));
-  menu.addAction(tr("Delete Uninstalled Downloads..."), this, SLOT(issueDeleteUninstalled()));
-  menu.addAction(tr("Delete All Downloads..."), this, SLOT(issueDeleteAll()));
+  menu.addAction(tr("Delete Installed Downloads..."), [=] { issueDeleteCompleted(); });
+  menu.addAction(tr("Delete Uninstalled Downloads..."), [=] { issueDeleteUninstalled(); });
+  menu.addAction(tr("Delete All Downloads..."), [=] { issueDeleteAll(); });
 
   menu.addSeparator();
   if (!hidden) {
-    menu.addAction(tr("Hide Installed..."), this, SLOT(issueRemoveFromViewCompleted()));
-    menu.addAction(tr("Hide Uninstalled..."), this, SLOT(issueRemoveFromViewUninstalled()));
-    menu.addAction(tr("Hide All..."), this, SLOT(issueRemoveFromViewAll()));
+    menu.addAction(tr("Hide Installed..."), [=] { issueRemoveFromViewCompleted(); });
+    menu.addAction(tr("Hide Uninstalled..."), [=] { issueRemoveFromViewUninstalled(); });
+    menu.addAction(tr("Hide All..."), [=] { issueRemoveFromViewAll(); });
   } else {
-    menu.addAction(tr("Un-Hide All..."), this, SLOT(issueRestoreToViewAll()));
+    menu.addAction(tr("Un-Hide All..."), [=] { issueRestoreToViewAll(); } );
   }
 
   menu.exec(viewport()->mapToGlobal(point));

--- a/src/downloadlistview.h
+++ b/src/downloadlistview.h
@@ -90,6 +90,9 @@ signals:
   void openMetaFile(int index);
   void openInDownloadsFolder(int index);
 
+protected:
+  void keyPressEvent(QKeyEvent* event) override;
+
 private slots:
   void onDoubleClick(const QModelIndex& index);
   void onCustomContextMenu(const QPoint& point);

--- a/src/downloadlistview.h
+++ b/src/downloadlistview.h
@@ -32,24 +32,24 @@ along with Mod Organizer.  If not, see <http://www.gnu.org/licenses/>.
 
 
 namespace Ui {
-  class DownloadListWidget;
+  class DownloadListView;
 }
 
-class DownloadListWidget;
+class DownloadListView;
 
 class DownloadProgressDelegate : public QStyledItemDelegate
 {
   Q_OBJECT
 
 public:
-  DownloadProgressDelegate(DownloadManager* manager, DownloadListWidget* list);
+  DownloadProgressDelegate(DownloadManager* manager, DownloadListView* list);
 
   void paint(QPainter *painter, const QStyleOptionViewItem &option,
     const QModelIndex &index) const override;
 
 private:
   DownloadManager* m_Manager;
-  DownloadListWidget* m_List;
+  DownloadListView* m_List;
 };
 
 class DownloadListHeader : public QHeaderView
@@ -64,13 +64,13 @@ private:
   void mouseReleaseEvent(QMouseEvent *event) override;
 };
 
-class DownloadListWidget : public QTreeView
+class DownloadListView : public QTreeView
 {
   Q_OBJECT
 
 public:
-  explicit DownloadListWidget(QWidget *parent = 0);
-  ~DownloadListWidget();
+  explicit DownloadListView(QWidget *parent = 0);
+  ~DownloadListView();
 
   void setManager(DownloadManager *manager);
   void setSourceModel(DownloadList *sourceModel);
@@ -91,34 +91,34 @@ signals:
   void openInDownloadsFolder(int index);
 
 private slots:
-  void onDoubleClick(const QModelIndex &index);
-  void onCustomContextMenu(const QPoint &point);
-  void onHeaderCustomContextMenu(const QPoint &point);
-  void issueInstall();
-  void issueDelete();
-  void issueRemoveFromView();
-  void issueRestoreToView();
+  void onDoubleClick(const QModelIndex& index);
+  void onCustomContextMenu(const QPoint& point);
+  void onHeaderCustomContextMenu(const QPoint& point);
+
+  void issueInstall(int index);
+  void issueDelete(int index);
+  void issueRemoveFromView(int index);
+  void issueRestoreToView(int index);
   void issueRestoreToViewAll();
-  void issueVisitOnNexus();
-  void issueOpenFile();
-  void issueOpenMetaFile();
-  void issueOpenInDownloadsFolder();
-  void issueCancel();
-  void issuePause();
-  void issueResume();
+  void issueVisitOnNexus(int index);
+  void issueOpenFile(int index);
+  void issueOpenMetaFile(int index);
+  void issueOpenInDownloadsFolder(int index);
+  void issueCancel(int index);
+  void issuePause(int index);
+  void issueResume(int index);
   void issueDeleteAll();
   void issueDeleteCompleted();
   void issueDeleteUninstalled();
   void issueRemoveFromViewAll();
   void issueRemoveFromViewCompleted();
   void issueRemoveFromViewUninstalled();
-  void issueQueryInfo();
-  void issueQueryInfoMd5();
+  void issueQueryInfo(int index);
+  void issueQueryInfoMd5(int index);
 
 private:
   DownloadManager *m_Manager;
   DownloadList *m_SourceModel = 0;
-  int m_ContextRow;
 
   void resizeEvent(QResizeEvent *event);
 };

--- a/src/downloadstab.cpp
+++ b/src/downloadstab.cpp
@@ -1,6 +1,6 @@
 #include "downloadstab.h"
 #include "downloadlist.h"
-#include "downloadlistwidget.h"
+#include "downloadlistview.h"
 #include "organizercore.h"
 #include "ui_mainwindow.h"
 
@@ -37,7 +37,7 @@ DownloadsTab::DownloadsTab(OrganizerCore& core, Ui::MainWindow* mwui)
   connect(ui.list, SIGNAL(restoreDownload(int)), m_core.downloadManager(), SLOT(restoreDownload(int)));
   connect(ui.list, SIGNAL(cancelDownload(int)), m_core.downloadManager(), SLOT(cancelDownload(int)));
   connect(ui.list, SIGNAL(pauseDownload(int)), m_core.downloadManager(), SLOT(pauseDownload(int)));
-  connect(ui.list, &DownloadListWidget::resumeDownload, [&](int i){ resumeDownload(i); });
+  connect(ui.list, &DownloadListView::resumeDownload, [&](int i){ resumeDownload(i); });
 }
 
 void DownloadsTab::update()
@@ -50,10 +50,10 @@ void DownloadsTab::update()
   // set the view attribute and default row sizes
   if (m_core.settings().interface().compactDownloads()) {
     ui.list->setProperty("downloadView", "compact");
-    ui.list->setStyleSheet("DownloadListWidget::item { padding: 4px 2px; }");
+    ui.list->setStyleSheet("DownloadListView::item { padding: 4px 2px; }");
   } else {
     ui.list->setProperty("downloadView", "standard");
-    ui.list->setStyleSheet("DownloadListWidget::item { padding: 16px 4px; }");
+    ui.list->setStyleSheet("DownloadListView::item { padding: 16px 4px; }");
   }
 
   ui.list->setMetaDisplay(m_core.settings().interface().metaDownloads());

--- a/src/downloadstab.h
+++ b/src/downloadstab.h
@@ -5,7 +5,7 @@
 
 namespace Ui { class MainWindow; }
 class OrganizerCore;
-class DownloadListWidget;
+class DownloadListView;
 
 class DownloadsTab : public QObject
 {
@@ -20,7 +20,7 @@ private:
   struct DownloadsTabUi
   {
     QPushButton* refresh;
-    DownloadListWidget* list;
+    DownloadListView* list;
     QCheckBox* showHidden;
     QLineEdit* filter;
   };

--- a/src/mainwindow.cpp
+++ b/src/mainwindow.cpp
@@ -46,7 +46,6 @@ along with Mod Organizer.  If not, see <http://www.gnu.org/licenses/>.
 #include "categoriesdialog.h"
 #include "overwriteinfodialog.h"
 #include "downloadlist.h"
-#include "downloadlistwidget.h"
 #include "messagedialog.h"
 #include "installationmanager.h"
 #include "motddialog.h"

--- a/src/mainwindow.ui
+++ b/src/mainwindow.ui
@@ -1282,7 +1282,7 @@ p, li { white-space: pre-wrap; }
              <item>
               <layout class="QVBoxLayout" name="downloadLayout">
                <item>
-                <widget class="DownloadListWidget" name="downloadView">
+                <widget class="DownloadListView" name="downloadView">
                  <property name="minimumSize">
                   <size>
                    <width>320</width>
@@ -1942,11 +1942,6 @@ p, li { white-space: pre-wrap; }
    <header>lcdnumber.h</header>
   </customwidget>
   <customwidget>
-   <class>DownloadListWidget</class>
-   <extends>QTreeView</extends>
-   <header>downloadlistwidget.h</header>
-  </customwidget>
-  <customwidget>
    <class>MOBase::SortableTreeWidget</class>
    <extends>QWidget</extends>
    <header>sortabletreewidget.h</header>
@@ -1960,6 +1955,11 @@ p, li { white-space: pre-wrap; }
    <class>StatusBar</class>
    <extends>QStatusBar</extends>
    <header>statusbar.h</header>
+  </customwidget>
+  <customwidget>
+   <class>DownloadListView</class>
+   <extends>QTreeView</extends>
+   <header>downloadlistview.h</header>
   </customwidget>
  </customwidgets>
  <resources>


### PR DESCRIPTION
Closes https://github.com/ModOrganizer2/modorganizer/issues/924

---

- Rename `DownloadListWidget` to `DownloadListView` to be consistent with other view (`ModListView`, `PluginListView`, etc.).
- Clean the context menu code by removing the `m_ContextRow` attribute and use new-style slots for actions.
- Handle multiple key events:
  - enter: install
  - delete: remove or cancel (if downloading)
  - space: pause / resume downloads