### PR TITLE
Send to last conflict

### DIFF
--- a/src/modlistcontextmenu.cpp
+++ b/src/modlistcontextmenu.cpp
@@ -266,8 +266,8 @@ void ModListContextMenu::addSendToContextMenu()
 
   QMenu* menu = new QMenu(m_view);
   menu->setTitle(tr("Send to... "));
-  menu->addAction(tr("Highest priority"), [this] { m_actions.sendModsToTop(m_selected); });
-  menu->addAction(tr("Lowest priority"), [this] { m_actions.sendModsToBottom(m_selected); });
+  menu->addAction(tr("Lowest priority"), [this] { m_actions.sendModsToTop(m_selected); });
+  menu->addAction(tr("Highest priority"), [this] { m_actions.sendModsToBottom(m_selected); });
   menu->addAction(tr("Priority..."), [this] { m_actions.sendModsToPriority(m_selected); });
   menu->addAction(tr("Separator..."), [this] { m_actions.sendModsToSeparator(m_selected); });
   if (overwritten) {

--- a/src/modlistcontextmenu.cpp
+++ b/src/modlistcontextmenu.cpp
@@ -247,7 +247,12 @@ void ModListContextMenu::addSendToContextMenu()
     ModInfo::EConflictFlag::FLAG_CONFLICT_REDUNDANT
   };
 
-  bool overwritten = false;
+  static const std::vector overwrite_flags{
+    ModInfo::EConflictFlag::FLAG_CONFLICT_MIXED,
+    ModInfo::EConflictFlag::FLAG_CONFLICT_OVERWRITE
+  };
+
+  bool overwrite = false, overwritten = false;
   for (auto& idx : m_selected) {
     auto index = idx.data(ModList::IndexRole);
     if (index.isValid()) {
@@ -256,7 +261,10 @@ void ModListContextMenu::addSendToContextMenu()
       if (std::find_first_of(flags.begin(), flags.end(),
         overwritten_flags.begin(), overwritten_flags.end()) != flags.end()) {
         overwritten = true;
-        break;
+      }
+      if (std::find_first_of(flags.begin(), flags.end(),
+        overwrite_flags.begin(), overwrite_flags.end()) != flags.end()) {
+        overwrite = true;
       }
     }
   }
@@ -267,6 +275,9 @@ void ModListContextMenu::addSendToContextMenu()
   menu->addAction(tr("Highest priority"), [this] { m_actions.sendModsToBottom(m_selected); });
   menu->addAction(tr("Priority..."), [this] { m_actions.sendModsToPriority(m_selected); });
   menu->addAction(tr("Separator..."), [this] { m_actions.sendModsToSeparator(m_selected); });
+  if (overwrite) {
+    menu->addAction(tr("First conflict"), [this] { m_actions.sendModsToFirstConflict(m_selected); });
+  }
   if (overwritten) {
     menu->addAction(tr("Last conflict"), [this] { m_actions.sendModsToLastConflict(m_selected); });
   }

--- a/src/modlistcontextmenu.cpp
+++ b/src/modlistcontextmenu.cpp
@@ -244,10 +244,7 @@ void ModListContextMenu::addSendToContextMenu()
   static const std::vector overwritten_flags{
     ModInfo::EConflictFlag::FLAG_CONFLICT_MIXED,
     ModInfo::EConflictFlag::FLAG_CONFLICT_OVERWRITTEN,
-    ModInfo::EConflictFlag::FLAG_CONFLICT_REDUNDANT,
-    ModInfo::EConflictFlag::FLAG_ARCHIVE_LOOSE_CONFLICT_OVERWRITTEN,
-    ModInfo::EConflictFlag::FLAG_ARCHIVE_CONFLICT_OVERWRITTEN,
-    ModInfo::EConflictFlag::FLAG_ARCHIVE_CONFLICT_MIXED
+    ModInfo::EConflictFlag::FLAG_CONFLICT_REDUNDANT
   };
 
   bool overwritten = false;

--- a/src/modlistview.cpp
+++ b/src/modlistview.cpp
@@ -1358,12 +1358,17 @@ void ModListView::dropEvent(QDropEvent* event)
   // is no way to deduce this except using dropIndicatorPosition())
   emit dropEntered(event->mimeData(), isExpanded(index), static_cast<DropPosition>(dropIndicatorPosition()));
 
+  ModListDropInfo dropInfo(event->mimeData(), *m_core);
+
   // see selectedIndexes()
   auto [current, selected] = this->selected();
   m_inDragMoveEvent = true;
   QTreeView::dropEvent(event);
   m_inDragMoveEvent = false;
-  setSelected(current, selected);
+
+  if (dropInfo.isModDrop()) {
+    setSelected(current, selected);
+  }
 }
 
 void ModListView::timerEvent(QTimerEvent* event)

--- a/src/modlistview.cpp
+++ b/src/modlistview.cpp
@@ -906,6 +906,19 @@ void ModListView::drawBranches(QPainter* painter, const QRect& rect, const QMode
   QTreeView::drawBranches(painter, r, index);
 }
 
+void ModListView::commitData(QWidget* editor)
+{
+  // maintain the selection when changing priority
+  if (currentIndex().column() == ModList::COL_PRIORITY) {
+    auto [current, selected] = this->selected();
+    QTreeView::commitData(editor);
+    setSelected(current, selected);
+  }
+  else {
+    QTreeView::commitData(editor);
+  }
+}
+
 QModelIndexList ModListView::selectedIndexes() const
 {
   // during drag&drop events, we fake the return value of selectedIndexes()

--- a/src/modlistview.cpp
+++ b/src/modlistview.cpp
@@ -1095,7 +1095,7 @@ QColor ModListView::markerColor(const QModelIndex& index) const
   bool highligth = m_markers.highlight.find(modIndex) != m_markers.highlight.end();
   bool overwrite = m_markers.overwrite.find(modIndex) != m_markers.overwrite.end();
   bool archiveOverwrite = m_markers.archiveOverwrite.find(modIndex) != m_markers.archiveOverwrite.end();
-  bool archiveLooseOverwrite = m_markers.archiveOverwritten.find(modIndex) != m_markers.archiveOverwritten.end();
+  bool archiveLooseOverwrite = m_markers.archiveLooseOverwrite.find(modIndex) != m_markers.archiveLooseOverwrite.end();
   bool overwritten = m_markers.overwritten.find(modIndex) != m_markers.overwritten.end();
   bool archiveOverwritten = m_markers.archiveOverwritten.find(modIndex) != m_markers.archiveOverwritten.end();
   bool archiveLooseOverwritten = m_markers.archiveLooseOverwritten.find(modIndex) != m_markers.archiveLooseOverwritten.end();

--- a/src/modlistview.cpp
+++ b/src/modlistview.cpp
@@ -397,10 +397,22 @@ void ModListView::setSelected(const QModelIndex& current, const QModelIndexList&
 
 void ModListView::scrollToAndSelect(const QModelIndex& index)
 {
+  scrollToAndSelect(QModelIndexList{index});
+}
+
+void ModListView::scrollToAndSelect(const QModelIndexList& indexes, const QModelIndex& current)
+{
   // focus, scroll to and select
-  scrollTo(index);
-  setCurrentIndex(index);
-  selectionModel()->select(index, QItemSelectionModel::SelectCurrent | QItemSelectionModel::Rows);
+  if (!current.isValid() && indexes.isEmpty()) {
+    return;
+  }
+  scrollTo(current.isValid() ? current : indexes.first());
+  setCurrentIndex(current.isValid() ? current : indexes.first());
+  QItemSelection selection;
+  for (auto& idx : indexes) {
+    selection.select(idx, idx);
+  }
+  selectionModel()->select(selection, QItemSelectionModel::Select | QItemSelectionModel::Rows);
   QTimer::singleShot(50, [=] { setFocus(); });
 }
 

--- a/src/modlistview.cpp
+++ b/src/modlistview.cpp
@@ -89,14 +89,13 @@ public:
     // but the mod list view uses alternate color so we need to find the
     // right color
     auto bg = opt.palette.base().color();
-    auto vrow = (opt.rect.y() - m_view->verticalOffset()) / opt.rect.height();
-    if (vrow % 2 == 1) {
+    if (opt.features & QStyleOptionViewItem::Alternate) {
       bg = opt.palette.alternateBase().color();
     }
 
     // compute ideal foreground color for some rows
     if (color.isValid()) {
-      if ((index.column() == ModList::COL_NAME
+      if (((index.column() == ModList::COL_NAME || index.column() == ModList::COL_PRIORITY)
         && ModInfo::getByIndex(index.data(ModList::IndexRole).toInt())->isSeparator())
         || index.column() == ModList::COL_NOTES) {
 

--- a/src/modlistview.cpp
+++ b/src/modlistview.cpp
@@ -451,34 +451,31 @@ void ModListView::onModPrioritiesChanged(const QModelIndexList& indices)
   m_core->currentProfile()->writeModlist();
   m_core->directoryStructure()->getFileRegister()->sortOrigins();
 
-  { // refresh selection
-    QModelIndex current = currentIndex();
-    if (current.isValid()) {
-      ModInfo::Ptr modInfo = ModInfo::getByIndex(current.data(ModList::IndexRole).toInt());
-      // clear caches on all mods conflicting with the moved mod
-      for (int i : modInfo->getModOverwrite()) {
-        ModInfo::getByIndex(i)->clearCaches();
-      }
-      for (int i : modInfo->getModOverwritten()) {
-        ModInfo::getByIndex(i)->clearCaches();
-      }
-      for (int i : modInfo->getModArchiveOverwrite()) {
-        ModInfo::getByIndex(i)->clearCaches();
-      }
-      for (int i : modInfo->getModArchiveOverwritten()) {
-        ModInfo::getByIndex(i)->clearCaches();
-      }
-      for (int i : modInfo->getModArchiveLooseOverwrite()) {
-        ModInfo::getByIndex(i)->clearCaches();
-      }
-      for (int i : modInfo->getModArchiveLooseOverwritten()) {
-        ModInfo::getByIndex(i)->clearCaches();
-      }
-      // update conflict check on the moved mod
-      modInfo->doConflictCheck();
-      setOverwriteMarkers(selectionModel()->selectedRows());
+  for (auto& idx : indices) {
+    ModInfo::Ptr modInfo = ModInfo::getByIndex(idx.data(ModList::IndexRole).toInt());
+    // clear caches on all mods conflicting with the moved mod
+    for (int i : modInfo->getModOverwrite()) {
+      ModInfo::getByIndex(i)->clearCaches();
     }
+    for (int i : modInfo->getModOverwritten()) {
+      ModInfo::getByIndex(i)->clearCaches();
+    }
+    for (int i : modInfo->getModArchiveOverwrite()) {
+      ModInfo::getByIndex(i)->clearCaches();
+    }
+    for (int i : modInfo->getModArchiveOverwritten()) {
+      ModInfo::getByIndex(i)->clearCaches();
+    }
+    for (int i : modInfo->getModArchiveLooseOverwrite()) {
+      ModInfo::getByIndex(i)->clearCaches();
+    }
+    for (int i : modInfo->getModArchiveLooseOverwritten()) {
+      ModInfo::getByIndex(i)->clearCaches();
+    }
+    // update conflict check on the moved mod
+    modInfo->doConflictCheck();
   }
+  setOverwriteMarkers(selectionModel()->selectedRows());
 }
 
 void ModListView::onModInstalled(const QString& modName)
@@ -1349,9 +1346,11 @@ void ModListView::dropEvent(QDropEvent* event)
   emit dropEntered(event->mimeData(), isExpanded(index), static_cast<DropPosition>(dropIndicatorPosition()));
 
   // see selectedIndexes()
+  auto [current, selected] = this->selected();
   m_inDragMoveEvent = true;
   QTreeView::dropEvent(event);
   m_inDragMoveEvent = false;
+  setSelected(current, selected);
 }
 
 void ModListView::timerEvent(QTimerEvent* event)

--- a/src/modlistview.h
+++ b/src/modlistview.h
@@ -89,6 +89,7 @@ public:
   // focus the view, select the given index and scroll to it
   //
   void scrollToAndSelect(const QModelIndex& index);
+  void scrollToAndSelect(const QModelIndexList& indexes, const QModelIndex& current = QModelIndex());
 
   // refresh the view (to call when settings have been changed)
   //

--- a/src/modlistview.h
+++ b/src/modlistview.h
@@ -182,6 +182,8 @@ protected slots:
   void onFiltersCriteria(const std::vector<ModListSortProxy::Criteria>& filters);
   void onProfileChanged(Profile* oldProfile, Profile* newProfile);
 
+  void commitData(QWidget* editor) override;
+
 private:
 
   friend class ModConflictIconDelegate;

--- a/src/modlistviewactions.cpp
+++ b/src/modlistviewactions.cpp
@@ -591,8 +591,6 @@ void ModListViewActions::sendModsToLastConflict(const QModelIndexList& indexes) 
     }
     auto info = ModInfo::getByIndex(idx.data(ModList::IndexRole).toInt());
     conflicts.insert(info->getModOverwritten().begin(), info->getModOverwritten().end());
-    conflicts.insert(info->getModArchiveOverwritten().begin(), info->getModArchiveOverwritten().end());
-    conflicts.insert(info->getModArchiveLooseOverwritten().begin(), info->getModArchiveLooseOverwritten().end());
   }
 
   std::set<int> priorities;

--- a/src/modlistviewactions.h
+++ b/src/modlistviewactions.h
@@ -62,6 +62,7 @@ public:
   void sendModsToBottom(const QModelIndexList& index) const;
   void sendModsToPriority(const QModelIndexList& index) const;
   void sendModsToSeparator(const QModelIndexList& index) const;
+  void sendModsToLastConflict(const QModelIndexList& index) const;
 
   // actions for most regular mods
   //

--- a/src/modlistviewactions.h
+++ b/src/modlistviewactions.h
@@ -62,6 +62,7 @@ public:
   void sendModsToBottom(const QModelIndexList& index) const;
   void sendModsToPriority(const QModelIndexList& index) const;
   void sendModsToSeparator(const QModelIndexList& index) const;
+  void sendModsToFirstConflict(const QModelIndexList& index) const;
   void sendModsToLastConflict(const QModelIndexList& index) const;
 
   // actions for most regular mods
@@ -144,6 +145,11 @@ private:
   // check the given mods from update, the map should map game names to nexus ID
   //
   void checkModsForUpdates(std::multimap<QString, int> const& IDs) const;
+
+  // set the priorities of the given mods while maintaining the
+  // mod list selection (which may be different from the list of mods)
+  //
+  void setModsPriority(const QModelIndexList& indexes, int priority) const;
 
 private:
 


### PR DESCRIPTION
Closes https://github.com/ModOrganizer2/modorganizer/issues/697

---

- Rename "Send to Top" and "Send to Bottom" to "Send to lowest priority" and "Send to highest priority" (send to top/bottom does not make sense in reverse priority or when sorting by something other than priority).
- Add "Send to first conflict" and "Send to last conflict" that sends all the selected mods before/after the first/last conflict of the selected mods.
  - Maintain selection when changing priority (send to, drag&drop, click the column priority).
  - Fix update of icons and highlights of mods after changing priority of a mod (was not updating immediately, and it's much more visible with the selection maintained).
  - Fix one of the marker for archive/loose files conflict that was incorrect.
- Small color fix for separators.

I've not implemented the "automatically scroll to" from the issue because I'm not sure it's a good idea to always automatically scroll.