### PR TITLE
Make modlist.txt less case sensitive

### DIFF
--- a/src/modinfo.cpp
+++ b/src/modinfo.cpp
@@ -52,7 +52,7 @@ using namespace MOShared;
 const std::set<unsigned int> ModInfo::s_EmptySet;
 std::vector<ModInfo::Ptr> ModInfo::s_Collection;
 ModInfo::Ptr ModInfo::s_Overwrite;
-std::map<QString, unsigned int, ModNameCompare> ModInfo::s_ModsByName;
+std::map<QString, unsigned int, MOBase::FileNameComparator> ModInfo::s_ModsByName;
 std::map<std::pair<QString, int>, std::vector<unsigned int>> ModInfo::s_ModsByModID;
 int ModInfo::s_NextID;
 QMutex ModInfo::s_Mutex(QMutex::Recursive);

--- a/src/modinfo.cpp
+++ b/src/modinfo.cpp
@@ -52,7 +52,7 @@ using namespace MOShared;
 const std::set<unsigned int> ModInfo::s_EmptySet;
 std::vector<ModInfo::Ptr> ModInfo::s_Collection;
 ModInfo::Ptr ModInfo::s_Overwrite;
-std::map<QString, unsigned int> ModInfo::s_ModsByName;
+std::map<QString, unsigned int, ModNameCompare> ModInfo::s_ModsByName;
 std::map<std::pair<QString, int>, std::vector<unsigned int>> ModInfo::s_ModsByModID;
 int ModInfo::s_NextID;
 QMutex ModInfo::s_Mutex(QMutex::Recursive);

--- a/src/modinfo.h
+++ b/src/modinfo.h
@@ -43,6 +43,12 @@ class QDateTime;
 namespace MOBase { class IPluginGame; }
 namespace MOShared { class DirectoryEntry; }
 
+struct ModNameCompare {
+  bool operator()(const QString& lhs, const QString& rhs) const {
+    return QString::compare(lhs, rhs, Qt::CaseInsensitive) < 0;
+  }
+};
+
 /**
  * @brief Represents meta information about a single mod.
  *
@@ -989,7 +995,7 @@ protected:
   static QMutex s_Mutex;
   static std::vector<ModInfo::Ptr> s_Collection;
   static ModInfo::Ptr s_Overwrite;
-  static std::map<QString, unsigned int> s_ModsByName;
+  static std::map<QString, unsigned int, ModNameCompare> s_ModsByName;
   static std::map<std::pair<QString, int>, std::vector<unsigned int>> s_ModsByModID;
   static int s_NextID;
 

--- a/src/modinfo.h
+++ b/src/modinfo.h
@@ -21,6 +21,7 @@ along with Mod Organizer.  If not, see <http://www.gnu.org/licenses/>.
 #define MODINFO_H
 
 #include "imodinterface.h"
+#include "ifiletree.h"
 #include "versioninfo.h"
 
 class OrganizerCore;
@@ -42,12 +43,6 @@ class QDateTime;
 
 namespace MOBase { class IPluginGame; }
 namespace MOShared { class DirectoryEntry; }
-
-struct ModNameCompare {
-  bool operator()(const QString& lhs, const QString& rhs) const {
-    return QString::compare(lhs, rhs, Qt::CaseInsensitive) < 0;
-  }
-};
 
 /**
  * @brief Represents meta information about a single mod.
@@ -995,7 +990,7 @@ protected:
   static QMutex s_Mutex;
   static std::vector<ModInfo::Ptr> s_Collection;
   static ModInfo::Ptr s_Overwrite;
-  static std::map<QString, unsigned int, ModNameCompare> s_ModsByName;
+  static std::map<QString, unsigned int, MOBase::FileNameComparator> s_ModsByName;
   static std::map<std::pair<QString, int>, std::vector<unsigned int>> s_ModsByModID;
   static int s_NextID;
 

--- a/src/profile.cpp
+++ b/src/profile.cpp
@@ -410,18 +410,9 @@ void Profile::refreshModStatus()
       } else {
         namesRead.insert(lookupName);
       }
-      unsigned int modIndex = ModInfo::findMod(
-	  	  [lookupName](ModInfo::Ptr info) { 
-			    return info->name().compare(lookupName, Qt::CaseInsensitive) == 0; 
-			  }
-		  );
+      unsigned int modIndex = ModInfo::getIndex(lookupName);
       if (modIndex != UINT_MAX) {
         ModInfo::Ptr info = ModInfo::getByIndex(modIndex);
-        if (info->name().compare(lookupName) != 0) {
-          // name in modlist.txt doesn't match case of actual folder
-          // need to rewrite the modlist to fix this
-          modStatusModified = true;
-        }
         if ((modIndex < m_ModStatus.size())
             && (info->getFixedPriority() == INT_MIN)) {
           m_ModStatus[modIndex].m_Enabled = enabled;

--- a/src/profile.cpp
+++ b/src/profile.cpp
@@ -382,6 +382,8 @@ void Profile::refreshModStatus()
 
   std::set<QString> namesRead;
 
+  bool warnAboutOverwrite = false;
+
   // load mods from file and update enabled state and priority for them
   int index = 0;
   while (!file.atEnd()) {
@@ -405,6 +407,9 @@ void Profile::refreshModStatus()
     }
     if (modName.size() > 0) {
       QString lookupName = modName;
+      if (modName.compare("overwrite", Qt::CaseInsensitive) == 0) {
+        warnAboutOverwrite = true;
+      }
       if (namesRead.find(lookupName) != namesRead.end()) {
         continue;
       } else {
@@ -486,6 +491,19 @@ void Profile::refreshModStatus()
 
   file.close();
   updateIndices();
+
+  // User has a mod named some variation of "overwrite".  Tell them about it.
+  if (warnAboutOverwrite) {
+    QMessageBox::warning(
+      nullptr,
+      tr("Overwrite mod conflict"),
+      tr("At least one mod named \"overwrite\" was detected, disabled, and moved to the lowest priority on the mod list. "
+         "You may want to rename this mod and enable it again.")
+      );
+    // also, mark the mod-list as changed
+    modStatusModified = true;
+  }
+
   if (modStatusModified) {
     m_ModListWriter.write();
   }

--- a/src/profile.cpp
+++ b/src/profile.cpp
@@ -410,9 +410,18 @@ void Profile::refreshModStatus()
       } else {
         namesRead.insert(lookupName);
       }
-      unsigned int modIndex = ModInfo::getIndex(lookupName);
+      unsigned int modIndex = ModInfo::findMod(
+	  	  [lookupName](ModInfo::Ptr info) { 
+			    return info->name().compare(lookupName, Qt::CaseInsensitive) == 0; 
+			  }
+		  );
       if (modIndex != UINT_MAX) {
         ModInfo::Ptr info = ModInfo::getByIndex(modIndex);
+        if (info->name().compare(lookupName) != 0) {
+          // name in modlist.txt doesn't match case of actual folder
+          // need to rewrite the modlist to fix this
+          modStatusModified = true;
+        }
         if ((modIndex < m_ModStatus.size())
             && (info->getFixedPriority() == INT_MIN)) {
           m_ModStatus[modIndex].m_Enabled = enabled;


### PR DESCRIPTION
This should make it so case doesn't matter when it comes to the
folder names of mods and what's in modlist.txt.  If a mismatch
in case is detected, modlist.txt will be flagged dirty to fix
it at some point.

This handles the foillowing cases:
 * modlist.txt was modified outside MO
 * the mod folder was renamed outside MO