### PR TITLE
Add error checking to lockedorder.txt processing

### DIFF
--- a/src/pluginlist.cpp
+++ b/src/pluginlist.cpp
@@ -524,7 +524,7 @@ void PluginList::readLockedOrderFrom(const QString &fileName)
       m_LockedOrder[pluginName] = priority;
       continue;
     }
-    int pluginIndex = it->second; //TODO: uh.... check this
+    int pluginIndex = it->second;
 
     // Do not allow locking forced plugins
     if (m_ESPs[pluginIndex].forceEnabled)

--- a/src/pluginlist.cpp
+++ b/src/pluginlist.cpp
@@ -540,8 +540,8 @@ void PluginList::readLockedOrderFrom(const QString &fileName)
     }
 
     // These are some helper functions for figuring out what is already locked
-    static auto findLocked = [&](const std::pair<QString, int>& a) { return a.second == priority; };
-    static auto alreadyLocked = [&](){ return std::find_if(m_LockedOrder.begin(), m_LockedOrder.end(), findLocked) != m_LockedOrder.end(); };
+    auto findLocked = [&](const std::pair<QString, int>& a) { return a.second == priority; };
+    auto alreadyLocked = [&](){ return std::find_if(m_LockedOrder.begin(), m_LockedOrder.end(), findLocked) != m_LockedOrder.end(); };
 
     // See if we can just set the given priority
     if (!m_ESPs[priority].forceEnabled && !alreadyLocked())

--- a/src/pluginlist.cpp
+++ b/src/pluginlist.cpp
@@ -486,58 +486,88 @@ void PluginList::readLockedOrderFrom(const QString &fileName)
   }
 
   file.open(QIODevice::ReadOnly);
-
   int lineNumber = 0;
-  while (!file.atEnd()) {
-    ++lineNumber;
+  while (!file.atEnd())
+  {
     QByteArray line = file.readLine();
-    if ((line.size() > 0) && (line.at(0) != '#')) {
-      QList<QByteArray> fields = line.split('|');
-      if (fields.count() == 2) {
-        int priority = fields.at(1).trimmed().toInt();
-        QString name = QString::fromUtf8(fields.at(0));
-        int pluginIndex = 0;
-        try {
-          pluginIndex = m_ESPsByName.at(name);
-        }
-        catch (...) {
-		  // Plugin does not exist anymore.  Go ahead and set it as locked.
-          m_LockedOrder[name] = priority;
-          continue;
-        }
-        // Avoid locking a force-enabled plugin or invalid priorities
-        if (!m_ESPs[pluginIndex].forceEnabled && priority >= 0) {
-		  // Is the priority off the charts?
-          if (priority < m_ESPsByPriority.size()) {
-            // Is this an open and unclaimed priority?
-            if (m_ESPs[m_ESPsByPriority.at(priority)].forceEnabled ||
-               std::find_if(m_LockedOrder.begin(), m_LockedOrder.end(), [&](const std::pair<QString, int> &a) { return a.second == priority; }) != m_LockedOrder.end()) {
-              // Attempt to find a priority but step over force-enabled plugins and already-set locks
-              int calcPriority = priority;
-              do {
-                ++calcPriority;
-              } while (calcPriority < m_ESPsByPriority.size() && (m_ESPs[m_ESPsByPriority.at(calcPriority)].forceEnabled &&
-                       std::find_if(m_LockedOrder.begin(), m_LockedOrder.end(), [&](const std::pair<QString, int> &a) { return a.second == calcPriority; }) != m_LockedOrder.end()));
-              // If we have a match, we can reassign the priority...
-              if (calcPriority < m_ESPsByPriority.size())
-                m_LockedOrder[name] = calcPriority;
-            } else {
-              m_LockedOrder[name] = priority;
-            }
-          }
-          else {
-		    // Priority is larger than the plugin list.  Go ahead set it as locked at that priority.
-			// It'll be added to the end of the priority list later on.
-            m_LockedOrder[name] = priority;
-          }
-        }
-      } else {
-        log::error("locked order file: invalid line #{} '{}'", lineNumber, QString::fromUtf8(line));
-        reportError(tr("The file containing locked plugin indices is broken"));
+    ++lineNumber;
+
+    // Skip empty lines or commented out lines (#)
+    if ((line.size() <= 0) || (line.at(0) == '#'))
+    {
+      continue;
+    }
+
+    QList<QByteArray> fields = line.split('|');
+    if (fields.count() != 2)
+    {
+      // Don't know how to parse this so run away
+      log::error("locked order file: invalid line #{}: {}", lineNumber, QString::fromUtf8(line).trimmed());
+      continue;
+    }
+
+    // Read the plugin name and priority
+    QString pluginName = QString::fromUtf8(fields.at(0));
+    int priority = fields.at(1).trimmed().toInt();
+    if (priority < 0)
+    {
+      // WTF do you mean a negative priority?
+      log::error("locked order file: invalid line #{}: {}", lineNumber, QString::fromUtf8(line).trimmed());
+      continue;
+    }
+
+    // Determine the index of the plugin
+    auto it = m_ESPsByName.find(pluginName);
+    if (it == m_ESPsByName.end())
+    {
+      // Plugin does not exist in the current set of plugins
+      m_LockedOrder[pluginName] = priority;
+      continue;
+    }
+    int pluginIndex = it->second; //TODO: uh.... check this
+
+    // Do not allow locking forced plugins
+    if (m_ESPs[pluginIndex].forceEnabled)
+    {
+      continue;
+    }
+
+    // If the priority is larger than the number of plugins, just keep it locked
+    if (priority >= m_ESPsByPriority.size())
+    {
+      m_LockedOrder[pluginName] = priority;
+      continue;
+    }
+
+    // These are some helper functions for figuring out what is already locked
+    static auto findLocked = [&](const std::pair<QString, int>& a) { return a.second == priority; };
+    static auto alreadyLocked = [&](){ return std::find_if(m_LockedOrder.begin(), m_LockedOrder.end(), findLocked) != m_LockedOrder.end(); };
+
+    // See if we can just set the given priority
+    if (!m_ESPs[priority].forceEnabled && !alreadyLocked())
+    {
+      m_LockedOrder[pluginName] = priority;
+      continue;
+    }
+
+    // Find the next higher priority we can set the plugin to
+    while (++priority < m_ESPs.size())
+    {
+      if (!m_ESPs[priority].forceEnabled && !alreadyLocked())
+      {
+        m_LockedOrder[pluginName] = priority;
         break;
       }
     }
-  }
+
+    // See if we walked off the end of the plugin list
+    if (priority >= m_ESPs.size())
+    {
+      // I guess go ahead and lock it here at the end of the list?
+      m_LockedOrder[pluginName] = priority;
+      continue;
+    }
+  } /* while (!file.atEnd()) */
   file.close();
 }
 


### PR DESCRIPTION
Errors now checked:
1. Plugin listed in lockedorder.txt does not exist
2. Priority in lockedorder.txt is negative
3. Priority in lockedorder.txt is greater than the total number of plugins

Note that lockedorder.txt is not rewritten after these errors occur as
that seems most likely to be the desired behavior...?  That is, preserving
the state of lockedorder.txt is more important than anything making sense.
Though negative priorities don't make sense and never will so just get rid
of that if the lockedorder.txt is written to at some point.