### PR TITLE
Add settings to not check update on mod install and to auto-collapse on hover

### DIFF
--- a/src/mainwindow.cpp
+++ b/src/mainwindow.cpp
@@ -2191,6 +2191,10 @@ void MainWindow::directory_refreshed()
 
 void MainWindow::modInstalled(const QString &modName)
 {
+  if (!m_OrganizerCore.settings().interface().checkUpdateAfterInstallation()) {
+    return;
+  }
+
   unsigned int index = ModInfo::getIndex(modName);
 
   if (index == UINT_MAX) {

--- a/src/modlistview.cpp
+++ b/src/modlistview.cpp
@@ -1377,7 +1377,7 @@ void ModListView::timerEvent(QTimerEvent* event)
     if (state() == QAbstractItemView::DraggingState
       && viewport()->rect().contains(pos)) {
       QModelIndex index = indexAt(pos);
-      setExpanded(index, true);
+      setExpanded(index, !m_core->settings().interface().autoCollapseOnHover() || !isExpanded(index));
     }
     m_openTimer.stop();
   }

--- a/src/settings.cpp
+++ b/src/settings.cpp
@@ -2238,6 +2238,16 @@ void InterfaceSettings::setSaveFilters(bool b)
   set(m_Settings, "Settings", "save_filters", b);
 }
 
+bool InterfaceSettings::checkUpdateAfterInstallation() const
+{
+  return get<bool>(m_Settings, "Settings", "autocheck_update_install", true);
+}
+
+void InterfaceSettings::setCheckUpdateAfterInstallation(bool b)
+{
+  set(m_Settings, "Settings", "autocheck_update_install", b);
+}
+
 bool InterfaceSettings::compactDownloads() const
 {
   return get<bool>(m_Settings, "Settings", "compact_downloads", false);

--- a/src/settings.cpp
+++ b/src/settings.cpp
@@ -2238,6 +2238,16 @@ void InterfaceSettings::setSaveFilters(bool b)
   set(m_Settings, "Settings", "save_filters", b);
 }
 
+bool InterfaceSettings::autoCollapseOnHover() const
+{
+  return get<bool>(m_Settings, "Settings", "auto_collapse_on_hover", false);
+}
+
+void InterfaceSettings::setAutoCollapseOnHover(bool b)
+{
+  set(m_Settings, "Settings", "auto_collapse_on_hover", b);
+}
+
 bool InterfaceSettings::checkUpdateAfterInstallation() const
 {
   return get<bool>(m_Settings, "Settings", "autocheck_update_install", true);

--- a/src/settings.h
+++ b/src/settings.h
@@ -653,6 +653,11 @@ public:
   bool saveFilters() const;
   void setSaveFilters(bool b);
 
+  // whether to check for update after installing a mod
+  //
+  bool checkUpdateAfterInstallation() const;
+  void setCheckUpdateAfterInstallation(bool b);
+
   // whether to show compact downloads
   //
   bool compactDownloads() const;

--- a/src/settings.h
+++ b/src/settings.h
@@ -653,6 +653,12 @@ public:
   bool saveFilters() const;
   void setSaveFilters(bool b);
 
+  // whether to collapse groups (separators, categories, ...) after
+  // a delay when hovering (similar to auto-expand)
+  //
+  bool autoCollapseOnHover() const;
+  void setAutoCollapseOnHover(bool b);
+
   // whether to check for update after installing a mod
   //
   bool checkUpdateAfterInstallation() const;

--- a/src/settingsdialog.ui
+++ b/src/settingsdialog.ui
@@ -298,6 +298,19 @@ If you disable this feature, MO will only display official DLCs this way. Please
              </widget>
             </item>
             <item>
+             <widget class="QCheckBox" name="autoCollapseDelayBox">
+              <property name="toolTip">
+               <string>Automatically collapse separators, categories or nexus ids after a delay when hovering them during drag.</string>
+              </property>
+              <property name="whatsThis">
+               <string>Automatically collapse separators, categories or nexus ids after a delay when hovering them during drag.</string>
+              </property>
+              <property name="text">
+               <string>Automatically collapse items during drag on hover</string>
+              </property>
+             </widget>
+            </item>
+            <item>
              <spacer name="verticalSpacer_9">
               <property name="orientation">
                <enum>Qt::Vertical</enum>
@@ -365,19 +378,6 @@ If you disable this feature, MO will only display official DLCs this way. Please
                      <widget class="QLabel" name="label_35">
                       <property name="text">
                        <string>Show icons on separators</string>
-                      </property>
-                     </widget>
-                    </item>
-                    <item row="1" column="0" colspan="3">
-                     <widget class="QCheckBox" name="collapsibleSeparatorsPerProfileBox">
-                      <property name="toolTip">
-                       <string>Do not share the collapse/expanded state of separators between profiles.</string>
-                      </property>
-                      <property name="whatsThis">
-                       <string>Do not share the collapse/expanded state of separators between profiles.</string>
-                      </property>
-                      <property name="text">
-                       <string>Profile-specific collapse states for separators</string>
                       </property>
                      </widget>
                     </item>
@@ -474,6 +474,19 @@ If you disable this feature, MO will only display official DLCs this way. Please
                       </property>
                       <property name="checked">
                        <bool>true</bool>
+                      </property>
+                     </widget>
+                    </item>
+                    <item row="1" column="0" colspan="5">
+                     <widget class="QCheckBox" name="collapsibleSeparatorsPerProfileBox">
+                      <property name="toolTip">
+                       <string>Do not share the collapse/expanded state of separators between profiles.</string>
+                      </property>
+                      <property name="whatsThis">
+                       <string>Do not share the collapse/expanded state of separators between profiles.</string>
+                      </property>
+                      <property name="text">
+                       <string>Profile-specific collapse states for separators</string>
                       </property>
                      </widget>
                     </item>

--- a/src/settingsdialog.ui
+++ b/src/settingsdialog.ui
@@ -282,6 +282,22 @@ If you disable this feature, MO will only display official DLCs this way. Please
              </widget>
             </item>
             <item>
+             <widget class="QCheckBox" name="checkUpdateInstallBox">
+              <property name="toolTip">
+               <string>Check if updates iare available for mods after installing them.</string>
+              </property>
+              <property name="whatsThis">
+               <string>Check if updates iare available for mods after installing them.</string>
+              </property>
+              <property name="text">
+               <string>Check for updates when installing mods</string>
+              </property>
+              <property name="checked">
+               <bool>true</bool>
+              </property>
+             </widget>
+            </item>
+            <item>
              <spacer name="verticalSpacer_9">
               <property name="orientation">
                <enum>Qt::Vertical</enum>

--- a/src/settingsdialog.ui
+++ b/src/settingsdialog.ui
@@ -284,10 +284,10 @@ If you disable this feature, MO will only display official DLCs this way. Please
             <item>
              <widget class="QCheckBox" name="checkUpdateInstallBox">
               <property name="toolTip">
-               <string>Check if updates iare available for mods after installing them.</string>
+               <string>Check if updates are available for mods after installing them.</string>
               </property>
               <property name="whatsThis">
-               <string>Check if updates iare available for mods after installing them.</string>
+               <string>Check if updates are available for mods after installing them.</string>
               </property>
               <property name="text">
                <string>Check for updates when installing mods</string>

--- a/src/settingsdialoguserinterface.cpp
+++ b/src/settingsdialoguserinterface.cpp
@@ -32,6 +32,7 @@ UserInterfaceSettingsTab::UserInterfaceSettingsTab(Settings& s, SettingsDialog& 
   ui->collapsibleSeparatorsHighlightToBox->setChecked(settings().interface().collapsibleSeparatorsHighlightTo());
   ui->collapsibleSeparatorsPerProfileBox->setChecked(settings().interface().collapsibleSeparatorsPerProfile());
   ui->saveFiltersBox->setChecked(settings().interface().saveFilters());
+  ui->autoCollapseDelayBox->setChecked(settings().interface().autoCollapseOnHover());
   ui->checkUpdateInstallBox->setChecked(settings().interface().checkUpdateAfterInstallation());
 
   for (auto& p : m_columnToBox) {
@@ -61,6 +62,7 @@ void UserInterfaceSettingsTab::update()
   settings().interface().setCollapsibleSeparatorsHighlightTo(ui->collapsibleSeparatorsHighlightToBox->isChecked());
   settings().interface().setCollapsibleSeparatorsPerProfile(ui->collapsibleSeparatorsPerProfileBox->isChecked());
   settings().interface().setSaveFilters(ui->saveFiltersBox->isChecked());
+  settings().interface().setAutoCollapseOnHover(ui->autoCollapseDelayBox->isChecked());
   settings().interface().setCheckUpdateAfterInstallation(ui->checkUpdateInstallBox->isChecked());
 
   for (auto& p : m_columnToBox) {

--- a/src/settingsdialoguserinterface.cpp
+++ b/src/settingsdialoguserinterface.cpp
@@ -32,6 +32,7 @@ UserInterfaceSettingsTab::UserInterfaceSettingsTab(Settings& s, SettingsDialog& 
   ui->collapsibleSeparatorsHighlightToBox->setChecked(settings().interface().collapsibleSeparatorsHighlightTo());
   ui->collapsibleSeparatorsPerProfileBox->setChecked(settings().interface().collapsibleSeparatorsPerProfile());
   ui->saveFiltersBox->setChecked(settings().interface().saveFilters());
+  ui->checkUpdateInstallBox->setChecked(settings().interface().checkUpdateAfterInstallation());
 
   for (auto& p : m_columnToBox) {
     p.second->setChecked(settings().interface().collapsibleSeparatorsIcons(p.first));
@@ -60,6 +61,7 @@ void UserInterfaceSettingsTab::update()
   settings().interface().setCollapsibleSeparatorsHighlightTo(ui->collapsibleSeparatorsHighlightToBox->isChecked());
   settings().interface().setCollapsibleSeparatorsPerProfile(ui->collapsibleSeparatorsPerProfileBox->isChecked());
   settings().interface().setSaveFilters(ui->saveFiltersBox->isChecked());
+  settings().interface().setCheckUpdateAfterInstallation(ui->checkUpdateInstallBox->isChecked());
 
   for (auto& p : m_columnToBox) {
     settings().interface().setCollapsibleSeparatorsIcons(p.first, p.second->isChecked());


### PR DESCRIPTION
Adds two new settings to:

- Check for updates after installing a mod (default enabled).
- Auto-collapse separators, categories or nexus ID on hover during drag (default disabled).

Closes #1039