### PR TITLE
Collapsible separators improvements

### DIFF
--- a/src/modlistbypriorityproxy.cpp
+++ b/src/modlistbypriorityproxy.cpp
@@ -116,8 +116,6 @@ void ModListByPriorityProxy::onModelRowsRemoved(const QModelIndex& parent, int f
 
 void ModListByPriorityProxy::onModelLayoutChanged(const QList<QPersistentModelIndex>&, LayoutChangeHint hint)
 {
-  MOBase::log::debug("LAYOUT");
-
   emit layoutAboutToBeChanged();
   auto persistent = persistentIndexList();
   buildTree();

--- a/src/modlistview.cpp
+++ b/src/modlistview.cpp
@@ -657,10 +657,6 @@ bool ModListView::moveSelection(int key)
   }
 
   m_core->modList()->shiftModsPriority(sourceRows, offset);
-
-  // reset the selection and the index
-  setSelected(cindex, sourceRows);
-
   return true;
 }
 
@@ -682,27 +678,25 @@ void ModListView::updateGroupByProxy()
 {
   int groupIndex = ui.groupBy->currentIndex();
   auto* previousModel = m_sortProxy->sourceModel();
-  QAbstractProxyModel* nextProxy = nullptr;
 
+  QAbstractItemModel* nextModel = m_core->modList();
   if (groupIndex == GroupBy::CATEGORY) {
-    nextProxy = m_byCategoryProxy;
+    nextModel = m_byCategoryProxy;
   }
   else if (groupIndex == GroupBy::NEXUS_ID) {
-    nextProxy = m_byNexusIdProxy;
+    nextModel = m_byNexusIdProxy;
   }
   else if (m_core->settings().interface().collapsibleSeparators(m_sortProxy->sortOrder())
     && m_sortProxy->sortColumn() == ModList::COL_PRIORITY) {
     m_byPriorityProxy->setSortOrder(m_sortProxy->sortOrder());
-    nextProxy = m_byPriorityProxy;
-  }
-
-  QAbstractItemModel* nextModel = m_core->modList();
-  if (nextProxy) {
-    nextProxy->setSourceModel(m_core->modList());
-    nextModel = nextProxy;
+    nextModel = m_byPriorityProxy;
   }
 
   if (nextModel != previousModel) {
+
+    if (auto* proxy = dynamic_cast<QAbstractProxyModel*>(nextModel)) {
+      proxy->setSourceModel(m_core->modList());
+    }
     m_sortProxy->setSourceModel(nextModel);
 
     // reset the source model of the old proxy because we do not want to
@@ -711,17 +705,18 @@ void ModListView::updateGroupByProxy()
     if (auto* proxy = qobject_cast<QAbstractProxyModel*>(previousModel)) {
       proxy->setSourceModel(nullptr);
     }
-  }
 
-  // expand items previously expanded
-  refreshExpandedItems();
+    // expand items previously expanded
+    refreshExpandedItems();
 
-  if (hasCollapsibleSeparators()) {
-    ui.filterSeparators->setCurrentIndex(ModListSortProxy::SeparatorFilter);
-    ui.filterSeparators->setEnabled(false);
-  }
-  else {
-    ui.filterSeparators->setEnabled(true);
+    if (hasCollapsibleSeparators()) {
+      ui.filterSeparators->setCurrentIndex(ModListSortProxy::SeparatorFilter);
+      ui.filterSeparators->setEnabled(false);
+    }
+    else {
+      ui.filterSeparators->setEnabled(true);
+    }
+
   }
 }
 
@@ -1356,17 +1351,10 @@ void ModListView::dropEvent(QDropEvent* event)
   // is no way to deduce this except using dropIndicatorPosition())
   emit dropEntered(event->mimeData(), isExpanded(index), static_cast<DropPosition>(dropIndicatorPosition()));
 
-  ModListDropInfo dropInfo(event->mimeData(), *m_core);
-
   // see selectedIndexes()
-  auto [current, selected] = this->selected();
   m_inDragMoveEvent = true;
   QTreeView::dropEvent(event);
   m_inDragMoveEvent = false;
-
-  if (dropInfo.isModDrop()) {
-    setSelected(current, selected);
-  }
 }
 
 void ModListView::timerEvent(QTimerEvent* event)

--- a/src/modlistview.cpp
+++ b/src/modlistview.cpp
@@ -657,6 +657,11 @@ bool ModListView::moveSelection(int key)
   }
 
   m_core->modList()->shiftModsPriority(sourceRows, offset);
+
+  auto current = indexModelToView(key == Qt::Key_Up ? sourceRows.first() : sourceRows.last());
+  selectionModel()->setCurrentIndex(current, QItemSelectionModel::NoUpdate);
+  scrollTo(current);
+
   return true;
 }
 

--- a/src/modlistviewactions.cpp
+++ b/src/modlistviewactions.cpp
@@ -530,21 +530,14 @@ void ModListViewActions::displayModInformation(ModInfo::Ptr modInfo, unsigned in
   }
 }
 
-void ModListViewActions::setModsPriority(const QModelIndexList& indexes, int priority) const
-{
-  auto [current, selected] = m_view->selected();
-  m_core.modList()->changeModsPriority(indexes, priority);
-  m_view->setSelected(current, selected);
-}
-
 void ModListViewActions::sendModsToTop(const QModelIndexList& indexes) const
 {
-  setModsPriority(indexes, 0);
+  m_core.modList()->changeModsPriority(indexes, 0);
 }
 
 void ModListViewActions::sendModsToBottom(const QModelIndexList& indexes) const
 {
-  setModsPriority(indexes, std::numeric_limits<int>::max());
+  m_core.modList()->changeModsPriority(indexes, std::numeric_limits<int>::max());
 }
 
 void ModListViewActions::sendModsToPriority(const QModelIndexList& indexes) const
@@ -555,7 +548,7 @@ void ModListViewActions::sendModsToPriority(const QModelIndexList& indexes) cons
     0, 0, std::numeric_limits<int>::max(), 1, &ok);
   if (!ok) return;
 
-  setModsPriority(indexes, priority);
+  m_core.modList()->changeModsPriority(indexes, priority);
 }
 
 void ModListViewActions::sendModsToSeparator(const QModelIndexList& indexes) const
@@ -599,7 +592,7 @@ void ModListViewActions::sendModsToSeparator(const QModelIndexList& indexes) con
         --newPriority;
       }
 
-      setModsPriority(indexes, newPriority);
+      m_core.modList()->changeModsPriority(indexes, newPriority);
     }
   }
 }
@@ -622,7 +615,7 @@ void ModListViewActions::sendModsToFirstConflict(const QModelIndexList& indexes)
   });
 
   if (!priorities.empty()) {
-    setModsPriority(indexes, *priorities.begin());
+    m_core.modList()->changeModsPriority(indexes, *priorities.begin());
   }
 }
 
@@ -644,7 +637,7 @@ void ModListViewActions::sendModsToLastConflict(const QModelIndexList& indexes) 
   });
 
   if (!priorities.empty()) {
-    setModsPriority(indexes, *priorities.rbegin());
+    m_core.modList()->changeModsPriority(indexes, *priorities.rbegin());
   }
 }
 

--- a/src/modlistviewactions.h
+++ b/src/modlistviewactions.h
@@ -150,11 +150,6 @@ private:
   //
   void checkModsForUpdates(std::multimap<QString, int> const& IDs) const;
 
-  // set the priorities of the given mods while maintaining the
-  // mod list selection (which may be different from the list of mods)
-  //
-  void setModsPriority(const QModelIndexList& indexes, int priority) const;
-
 private:
 
   OrganizerCore& m_core;


### PR DESCRIPTION
Basically, this changes the way the collapsible separators proxy react to `layoutChanged` events from the mod list to avoid losing the selection every time the priority of a mod is changed.
