### PR TITLE
Don't look for mods with -1 as mod ID when suggesting names

### DIFF
--- a/src/organizercore.cpp
+++ b/src/organizercore.cpp
@@ -744,7 +744,7 @@ ModInfo::Ptr OrganizerCore::installDownload(int index, int priority)
     GuessedValue<QString> modName;
 
     // see if there already are mods with the specified mod id
-    if (modID != 0) {
+    if (modID > 0) {
       std::vector<ModInfo::Ptr> modInfo = ModInfo::getByModID(gameName, modID);
       for (auto iter = modInfo.begin(); iter != modInfo.end(); ++iter) {
         std::vector<ModInfo::EFlag> flags = (*iter)->getFlags();


### PR DESCRIPTION
Downloads usually have 0 as mod id, but if the user tried to Query info and cancelled both dialogs asking to put in the ID, it becomes -1 internally. 