### PR TITLE
Fix empty loglist after startup.

### DIFF
--- a/src/mainwindow.cpp
+++ b/src/mainwindow.cpp
@@ -1209,8 +1209,12 @@ void MainWindow::showEvent(QShowEvent *event)
     m_WasVisible = true;
     updateProblemsButton();
 
-    // Notify plugin that the MO2 is ready:
+    // notify plugins that the MO2 is ready
     m_PluginContainer.startPlugins(this);
+
+    // forces a log list refresh to display startup logs
+    ui->logList->reset();
+    ui->logList->scrollToBottom();
   }
 }
 

--- a/src/mainwindow.cpp
+++ b/src/mainwindow.cpp
@@ -1213,6 +1213,15 @@ void MainWindow::showEvent(QShowEvent *event)
     m_PluginContainer.startPlugins(this);
 
     // forces a log list refresh to display startup logs
+    //
+    // since the log list is not visible until this point, the automatic
+    // resize of columns seems to break the log list (since Qt 5.15.1 or
+    // 5.15.2), an make the list empty on startup (in debug the list is not
+    // empty because some logs are added after the log list becomes visible)
+    //
+    // the reset() forces a re-computation of the column size, thus properly
+    // the logs that are already in the log model
+    //
     ui->logList->reset();
     ui->logList->scrollToBottom();
   }


### PR DESCRIPTION
Since 2.4a4, the log list is empty after starting MO2 when using log level < debug. Adding a log correctly refreshes the log list.

It's possibly a Qt bug introduced in 5.15.1 or 5.15.2, but this fixes by forcing a refresh of the loglist during the first show event.