### PR TITLE
Fix initial launch of forced load dialog

### DIFF
--- a/src/editexecutablesdialog.cpp
+++ b/src/editexecutablesdialog.cpp
@@ -141,9 +141,10 @@ void EditExecutablesDialog::loadForcedLibraries()
   const auto* p = m_organizerCore.currentProfile();
 
   for (const auto& e : m_executablesList) {
-    if (p->forcedLibrariesEnabled(e.title())) {
-      m_forcedLibraries.set(e.title(), true, p->determineForcedLibraries(e.title()));
-    }
+    m_forcedLibraries.set(
+      e.title(),
+      p->forcedLibrariesEnabled(e.title()),
+      p->determineForcedLibraries(e.title()));
   }
 }
 
@@ -242,8 +243,8 @@ bool EditExecutablesDialog::commitChanges()
     }
 
     if (auto libraryList=m_forcedLibraries.find(e.title())) {
-      if (libraryList && libraryList->enabled && !libraryList->value.empty()) {
-        profile->setForcedLibrariesEnabled(e.title(), true);
+      if (libraryList && !libraryList->value.empty()) {
+        profile->setForcedLibrariesEnabled(e.title(), libraryList->enabled);
         profile->storeForcedLibraries(e.title(), libraryList->value);
       }
     }


### PR DESCRIPTION
Previously, the first time the "configure libraries" button
was pressed for an executable, the forced libraries defined
by the game plugin would be missing.  The user would have to
add a row, save everything, and then go back for things to
display properly.

Now the forced libraries are built into the dialog so they
will always be displayed.