### PR TITLE
Fix update of data tab after refresh.

### DIFF
--- a/src/datatab.cpp
+++ b/src/datatab.cpp
@@ -128,7 +128,7 @@ void DataTab::doUpdateTree()
     }
   }
 
-  m_needUpdate = true;
+  m_needUpdate = false;
 }
 
 void DataTab::ensureFullyLoaded()

--- a/src/mainwindow.cpp
+++ b/src/mainwindow.cpp
@@ -394,10 +394,9 @@ MainWindow::MainWindow(Settings &settings
 
   connect(&m_PluginContainer, SIGNAL(diagnosisUpdate()), this, SLOT(scheduleCheckForProblems()));
 
-  connect(m_OrganizerCore.directoryRefresher(), &DirectoryRefresher::refreshed, [this] { onDirectoryStructureChanged(); });
-  connect(
-    m_OrganizerCore.directoryRefresher(),
-    &DirectoryRefresher::progress,
+  connect(&m_OrganizerCore, &OrganizerCore::directoryStructureReady,
+    this, &MainWindow::onDirectoryStructureChanged);
+  connect(m_OrganizerCore.directoryRefresher(), &DirectoryRefresher::progress,
     this, &MainWindow::refresherProgress);
   connect(m_OrganizerCore.directoryRefresher(), SIGNAL(error(QString)), this, SLOT(showError(QString)));
 


### PR DESCRIPTION
The old signal/slot connection should have been queued as before (error on my side when refactoring), but then there seems to be some concurrency issue since the `updateTree` call may happen before the organizer core slot, thus the directory structure is not up-to-date. I changed the signal to `directoryStructureReady` to be fix it.