### PR TITLE
Use case-insensitive data structure in plugin list.

### DIFF
--- a/src/pluginlist.cpp
+++ b/src/pluginlist.cpp
@@ -159,7 +159,7 @@ void PluginList::highlightPlugins(
             if (std::find_if(alternatives.begin(), alternatives.end(), [&](const FileAlternative& element) { return element.originID() == origin.getID(); }) == alternatives.end())
               continue;
           }
-          std::map<QString, int>::iterator iter = m_ESPsByName.find(plugin.toLower());
+          std::map<QString, int>::iterator iter = m_ESPsByName.find(plugin);
           if (iter != m_ESPsByName.end()) {
             m_ESPs[iter->second].modSelected = true;
           }
@@ -205,15 +205,14 @@ void PluginList::refresh(const QString &profileName
 
     if ((extension == "esp") || (extension == "esm") || (extension == "esl")) {
 
-      availablePlugins.append(filename.toLower());
+      availablePlugins.append(filename);
 
-      if (m_ESPsByName.find(filename.toLower()) != m_ESPsByName.end()) {
+      if (m_ESPsByName.find(filename) != m_ESPsByName.end()) {
         continue;
       }
 
       bool forceEnabled = Settings::instance().game().forceEnableCoreFiles() &&
         primaryPlugins.contains(filename, Qt::CaseInsensitive);
-        //(std::find(primaryPlugins.begin(), primaryPlugins.end(), filename.toLower()) != primaryPlugins.end());
 
       bool archive = false;
       try {
@@ -251,7 +250,7 @@ void PluginList::refresh(const QString &profileName
   }
 
   for (const auto &espName : m_ESPsByName) {
-    if (!availablePlugins.contains(espName.first)) {
+    if (!availablePlugins.contains(espName.first, Qt::CaseInsensitive)) {
       m_ESPs[espName.second].name = "";
     }
   }
@@ -311,12 +310,12 @@ void PluginList::fixPriorities()
 
 void PluginList::enableESP(const QString &name, bool enable)
 {
-  std::map<QString, int>::iterator iter = m_ESPsByName.find(name.toLower());
+  std::map<QString, int>::iterator iter = m_ESPsByName.find(name);
 
   if (iter != m_ESPsByName.end()) {
     auto enabled = m_ESPs[iter->second].enabled;
     m_ESPs[iter->second].enabled =
-        enable | m_ESPs[iter->second].forceEnabled;
+        enable || m_ESPs[iter->second].forceEnabled;
 
     emit writePluginsList();
     if (enabled != m_ESPs[iter->second].enabled) {
@@ -425,7 +424,7 @@ void PluginList::toggleState(const QModelIndexList& indices)
 
 bool PluginList::isEnabled(const QString &name)
 {
-  std::map<QString, int>::iterator iter = m_ESPsByName.find(name.toLower());
+  std::map<QString, int>::iterator iter = m_ESPsByName.find(name);
 
   if (iter != m_ESPsByName.end()) {
     return m_ESPs[iter->second].enabled;
@@ -436,10 +435,10 @@ bool PluginList::isEnabled(const QString &name)
 
 void PluginList::clearInformation(const QString &name)
 {
-  std::map<QString, int>::iterator iter = m_ESPsByName.find(name.toLower());
+  std::map<QString, int>::iterator iter = m_ESPsByName.find(name);
 
   if (iter != m_ESPsByName.end()) {
-    m_AdditionalInfo[name.toLower()].messages.clear();
+    m_AdditionalInfo[name].messages.clear();
   }
 }
 
@@ -450,10 +449,10 @@ void PluginList::clearAdditionalInformation()
 
 void PluginList::addInformation(const QString &name, const QString &message)
 {
-  std::map<QString, int>::iterator iter = m_ESPsByName.find(name.toLower());
+  std::map<QString, int>::iterator iter = m_ESPsByName.find(name);
 
   if (iter != m_ESPsByName.end()) {
-    m_AdditionalInfo[name.toLower()].messages.append(message);
+    m_AdditionalInfo[name].messages.append(message);
   } else {
     log::warn("failed to associate message for \"{}\"", name);
   }
@@ -461,10 +460,10 @@ void PluginList::addInformation(const QString &name, const QString &message)
 
 void PluginList::addLootReport(const QString& name, Loot::Plugin plugin)
 {
-  auto iter = m_ESPsByName.find(name.toLower());
+  auto iter = m_ESPsByName.find(name);
 
   if (iter != m_ESPsByName.end()) {
-    m_AdditionalInfo[name.toLower()].loot = std::move(plugin);
+    m_AdditionalInfo[name].loot = std::move(plugin);
   } else {
     log::warn("failed to associate loot report for \"{}\"", name);
   }
@@ -663,18 +662,18 @@ QString PluginList::getIndexPriority(int index) const
 
 bool PluginList::isESPLocked(int index) const
 {
-  return m_LockedOrder.find(m_ESPs.at(index).name.toLower()) != m_LockedOrder.end();
+  return m_LockedOrder.find(m_ESPs.at(index).name) != m_LockedOrder.end();
 }
 
 void PluginList::lockESPIndex(int index, bool lock)
 {
   if (lock) {
     if (!m_ESPs.at(index).forceEnabled)
-      m_LockedOrder[getName(index).toLower()] = m_ESPs.at(index).loadOrder;
+      m_LockedOrder[getName(index)] = m_ESPs.at(index).loadOrder;
     else
       return;
   } else {
-    auto iter = m_LockedOrder.find(getName(index).toLower());
+    auto iter = m_LockedOrder.find(getName(index));
     if (iter != m_LockedOrder.end()) {
       m_LockedOrder.erase(iter);
     }
@@ -710,7 +709,7 @@ void PluginList::refreshLoadOrder()
   bool savePluginsList = false;
   // this is guaranteed to iterate from lowest key (load order) to highest
   for (auto iter = lockedLoadOrder.begin(); iter != lockedLoadOrder.end(); ++iter) {
-    auto nameIter = m_ESPsByName.find(iter->second.toLower());
+    auto nameIter = m_ESPsByName.find(iter->second);
     if (nameIter != m_ESPsByName.end()) {
       // locked esp exists
 
@@ -763,7 +762,7 @@ QStringList PluginList::pluginNames() const
 
 IPluginList::PluginStates PluginList::state(const QString &name) const
 {
-  auto iter = m_ESPsByName.find(name.toLower());
+  auto iter = m_ESPsByName.find(name);
   if (iter == m_ESPsByName.end()) {
     return IPluginList::STATE_MISSING;
   } else {
@@ -772,7 +771,7 @@ IPluginList::PluginStates PluginList::state(const QString &name) const
 }
 
 void PluginList::setState(const QString &name, PluginStates state) {
-  auto iter = m_ESPsByName.find(name.toLower());
+  auto iter = m_ESPsByName.find(name);
   if (iter != m_ESPsByName.end()) {
     m_ESPs[iter->second].enabled = (state == IPluginList::STATE_ACTIVE) ||
                                      m_ESPs[iter->second].forceEnabled;
@@ -788,7 +787,7 @@ void PluginList::setLoadOrder(const QStringList &pluginList)
   }
   int maxPriority = 0;
   for (const QString &plugin : pluginList) {
-    auto iter = m_ESPsByName.find(plugin.toLower());
+    auto iter = m_ESPsByName.find(plugin);
     if (iter !=m_ESPsByName.end()) {
       m_ESPs[iter->second].priority = maxPriority++;
     }
@@ -805,7 +804,7 @@ void PluginList::setLoadOrder(const QStringList &pluginList)
 
 int PluginList::priority(const QString &name) const
 {
-  auto iter = m_ESPsByName.find(name.toLower());
+  auto iter = m_ESPsByName.find(name);
   if (iter == m_ESPsByName.end()) {
     return -1;
   } else {
@@ -838,7 +837,7 @@ bool PluginList::setPriority(const QString& name, int newPriority) {
 
 int PluginList::loadOrder(const QString &name) const
 {
-  auto iter = m_ESPsByName.find(name.toLower());
+  auto iter = m_ESPsByName.find(name);
   if (iter == m_ESPsByName.end()) {
     return -1;
   } else {
@@ -848,7 +847,7 @@ int PluginList::loadOrder(const QString &name) const
 
 bool PluginList::isMaster(const QString &name) const
 {
-  auto iter = m_ESPsByName.find(name.toLower());
+  auto iter = m_ESPsByName.find(name);
   if (iter == m_ESPsByName.end()) {
     return false;
   } else {
@@ -858,7 +857,7 @@ bool PluginList::isMaster(const QString &name) const
 
 bool PluginList::isLight(const QString &name) const
 {
-  auto iter = m_ESPsByName.find(name.toLower());
+  auto iter = m_ESPsByName.find(name);
   if (iter == m_ESPsByName.end()) {
     return false;
   } else {
@@ -868,7 +867,7 @@ bool PluginList::isLight(const QString &name) const
 
 bool PluginList::isLightFlagged(const QString &name) const
 {
-  auto iter = m_ESPsByName.find(name.toLower());
+  auto iter = m_ESPsByName.find(name);
   if (iter == m_ESPsByName.end()) {
     return false;
   } else {
@@ -878,7 +877,7 @@ bool PluginList::isLightFlagged(const QString &name) const
 
 QStringList PluginList::masters(const QString &name) const
 {
-  auto iter = m_ESPsByName.find(name.toLower());
+  auto iter = m_ESPsByName.find(name);
   if (iter == m_ESPsByName.end()) {
     return QStringList();
   } else {
@@ -892,7 +891,7 @@ QStringList PluginList::masters(const QString &name) const
 
 QString PluginList::origin(const QString &name) const
 {
-  auto iter = m_ESPsByName.find(name.toLower());
+  auto iter = m_ESPsByName.find(name);
   if (iter == m_ESPsByName.end()) {
     return QString();
   } else {
@@ -939,7 +938,7 @@ void PluginList::updateIndices()
       log::error("invalid plugin priority: {}", m_ESPs[i].priority);
       continue;
     }
-    m_ESPsByName[m_ESPs[i].name.toLower()] = i;
+    m_ESPsByName[m_ESPs[i].name] = i;
     m_ESPsByPriority.at(static_cast<size_t>(m_ESPs[i].priority)) = i;
   }
 
@@ -988,10 +987,10 @@ int PluginList::columnCount(const QModelIndex &) const
 
 void PluginList::testMasters()
 {
-  std::set<QString> enabledMasters;
+  std::set<QString, FileNameComparator> enabledMasters;
   for (const auto& iter: m_ESPs) {
     if (iter.enabled) {
-      enabledMasters.insert(iter.name.toLower());
+      enabledMasters.insert(iter.name);
     }
   }
 
@@ -999,7 +998,7 @@ void PluginList::testMasters()
     iter.masterUnset.clear();
     if (iter.enabled) {
       for (const auto& master: iter.masters) {
-        if (enabledMasters.find(master.toLower()) == enabledMasters.end()) {
+        if (enabledMasters.find(master) == enabledMasters.end()) {
           iter.masterUnset.insert(master);
         }
       }
@@ -1141,7 +1140,7 @@ QVariant PluginList::tooltipData(const QModelIndex &modelIndex) const
     if (esp.masterUnset.size() > 0) {
       toolTip +=
         "<br><b>" + tr("Missing Masters") + "</b>: " +
-        "<b>" + TruncateString(SetJoin(esp.masterUnset, ", ")) + "</b>";
+        "<b>" + TruncateString(QStringList(esp.masterUnset.begin(), esp.masterUnset.end()).join(", ")) + "</b>";
     }
 
     std::set<QString> enabledMasters;
@@ -1158,7 +1157,7 @@ QVariant PluginList::tooltipData(const QModelIndex &modelIndex) const
     if (!esp.archives.empty()) {
       toolTip +=
         "<br><b>" + tr("Loads Archives") + "</b>: " +
-        TruncateString(SetJoin(esp.archives, ", ")) +
+        TruncateString(QStringList(esp.archives.begin(), esp.archives.end()).join(", ")) +
         "<br>" + tr(
           "There are Archives connected to this plugin. Their assets will be "
           "added to your game, overwriting in case of conflicts following the "
@@ -1185,7 +1184,7 @@ QVariant PluginList::tooltipData(const QModelIndex &modelIndex) const
 
 
   // additional info
-  auto itor = m_AdditionalInfo.find(esp.name.toLower());
+  auto itor = m_AdditionalInfo.find(esp.name);
 
   if (itor != m_AdditionalInfo.end()) {
     if (!itor->second.messages.isEmpty()) {
@@ -1269,9 +1268,8 @@ QVariant PluginList::iconData(const QModelIndex &modelIndex) const
   QVariantList result;
 
   const auto& esp = m_ESPs[index];
-  const QString nameLower = esp.name.toLower();
 
-  auto infoItor = m_AdditionalInfo.find(nameLower);
+  auto infoItor = m_AdditionalInfo.find(esp.name);
 
   const AdditionalInfo* info = nullptr;
   if (infoItor != m_AdditionalInfo.end()) {
@@ -1282,7 +1280,7 @@ QVariant PluginList::iconData(const QModelIndex &modelIndex) const
     result.append(":/MO/gui/warning");
   }
 
-  if (m_LockedOrder.find(nameLower) != m_LockedOrder.end()) {
+  if (m_LockedOrder.find(esp.name) != m_LockedOrder.end()) {
     result.append(":/MO/gui/locked");
   }
 
@@ -1583,7 +1581,7 @@ PluginList::ESPInfo::ESPInfo(const QString &name, bool enabled,
                              bool hasIni, std::set<QString> archives, bool lightPluginsAreSupported)
   : name(name), fullPath(fullPath), enabled(enabled), forceEnabled(enabled),
     priority(0), loadOrder(-1), originName(originName), hasIni(hasIni),
-    archives(archives), modSelected(false)
+    archives(archives.begin(), archives.end()), modSelected(false)
 {
   try {
     ESP::File file(ToWString(fullPath));

--- a/src/pluginlist.h
+++ b/src/pluginlist.h
@@ -20,6 +20,7 @@ along with Mod Organizer.  If not, see <http://www.gnu.org/licenses/>.
 #ifndef PLUGINLIST_H
 #define PLUGINLIST_H
 
+#include <ifiletree.h>
 #include <ipluginlist.h>
 #include "profile.h"
 #include "loot.h"
@@ -325,9 +326,9 @@ private:
     QString author;
     QString description;
     bool hasIni;
-    std::set<QString> archives;
-    std::set<QString> masters;
-    mutable std::set<QString> masterUnset;
+    std::set<QString, MOBase::FileNameComparator> archives;
+    std::set<QString, MOBase::FileNameComparator> masters;
+    mutable std::set<QString, MOBase::FileNameComparator> masterUnset;
 
     bool operator < (const ESPInfo& str) const
     {
@@ -377,12 +378,12 @@ private:
   std::vector<ESPInfo> m_ESPs;
   mutable std::map<QString, QByteArray> m_LastSaveHash;
 
-  std::map<QString, int> m_ESPsByName;
+  std::map<QString, int, MOBase::FileNameComparator> m_ESPsByName;
   std::vector<int> m_ESPsByPriority;
 
-  std::map<QString, int> m_LockedOrder;
+  std::map<QString, int, MOBase::FileNameComparator> m_LockedOrder;
 
-  std::map<QString, AdditionalInfo> m_AdditionalInfo; // maps esp names to boss information
+  std::map<QString, AdditionalInfo, MOBase::FileNameComparator> m_AdditionalInfo; // maps esp names to boss information
 
   QString m_CurrentProfile;
   QFontMetrics m_FontMetrics;


### PR DESCRIPTION
Use sets with case-insensitive comparators in `PluginList`. This avoids having to call `toLower()` every time or forgetting to use it... This does not fix https://github.com/ModOrganizer2/modorganizer/issues/1309 yet (see the gamebryo PR).