### PR TITLE
Better refresh of override markers and conflicts.

### DIFF
--- a/src/modinfo.h
+++ b/src/modinfo.h
@@ -897,11 +897,6 @@ public: // Conflicts
   //
   virtual const std::set<unsigned int>& getModArchiveLooseOverwritten() const { return s_EmptySet; }
 
-  /**
-   * @brief Update conflict information.
-   */
-  virtual void doConflictCheck() const {}
-
 public slots:
 
   /**

--- a/src/modinfowithconflictinfo.h
+++ b/src/modinfowithconflictinfo.h
@@ -54,14 +54,12 @@ public:
    */
   void clearCaches() override;
 
-  const std::set<unsigned int>& getModOverwrite() const override { return m_OverwriteList; }
-  const std::set<unsigned int>& getModOverwritten() const override { return m_OverwrittenList; }
-  const std::set<unsigned int>& getModArchiveOverwrite() const override { return m_ArchiveOverwriteList; }
-  const std::set<unsigned int>& getModArchiveOverwritten() const override { return m_ArchiveOverwrittenList; }
-  const std::set<unsigned int>& getModArchiveLooseOverwrite() const override { return m_ArchiveLooseOverwriteList; }
-  const std::set<unsigned int>& getModArchiveLooseOverwritten() const override { return m_ArchiveLooseOverwrittenList; }
-
-  void doConflictCheck() const override;
+  const std::set<unsigned int>& getModOverwrite() const override { return m_Conflicts.value().m_OverwriteList; }
+  const std::set<unsigned int>& getModOverwritten() const override { return m_Conflicts.value().m_OverwrittenList; }
+  const std::set<unsigned int>& getModArchiveOverwrite() const override { return m_Conflicts.value().m_ArchiveOverwriteList; }
+  const std::set<unsigned int>& getModArchiveOverwritten() const override { return m_Conflicts.value().m_ArchiveOverwrittenList; }
+  const std::set<unsigned int>& getModArchiveLooseOverwrite() const override { return m_Conflicts.value().m_ArchiveLooseOverwriteList; }
+  const std::set<unsigned int>& getModArchiveLooseOverwritten() const override { return m_Conflicts.value().m_ArchiveLooseOverwrittenList; }
 
 public slots:
 
@@ -72,11 +70,8 @@ public slots:
 
 protected:
 
-  /**
-   * @brief Check if the content of this mod is valid.
-   *
-   * @return true if the content is valid, false otherwise.
-   **/
+  // check if the content of this mod is valid
+  //
   virtual bool doIsValid() const;
 
   /**
@@ -136,23 +131,27 @@ protected:
 
 private:
 
+  struct Conflicts {
+    EConflictType m_CurrentConflictState = CONFLICT_NONE;
+    EConflictType m_ArchiveConflictState = CONFLICT_NONE;
+    EConflictType m_ArchiveConflictLooseState = CONFLICT_NONE;
+    bool m_HasLooseOverwrite = false;
+    bool m_HasHiddenFiles = false;
+
+    std::set<unsigned int> m_OverwriteList;   // indices of mods overritten by this mod
+    std::set<unsigned int> m_OverwrittenList; // indices of mods overwriting this mod
+    std::set<unsigned int> m_ArchiveOverwriteList;   // indices of mods with archive files overritten by this mod
+    std::set<unsigned int> m_ArchiveOverwrittenList; // indices of mods with archive files overwriting this mod
+    std::set<unsigned int> m_ArchiveLooseOverwriteList; // indices of mods with archives being overwritten by this mod's loose files
+    std::set<unsigned int> m_ArchiveLooseOverwrittenList; // indices of mods with loose files overwriting this mod's archive files
+  };
+
+  Conflicts doConflictCheck() const;
+
   MOBase::MemoizedLocked<std::shared_ptr<const MOBase::IFileTree>> m_FileTree;
   MOBase::MemoizedLocked<bool> m_Valid;
   MOBase::MemoizedLocked<std::set<int>> m_Contents;
-
-  mutable EConflictType m_CurrentConflictState;
-  mutable EConflictType m_ArchiveConflictState;
-  mutable EConflictType m_ArchiveConflictLooseState;
-  mutable bool m_HasLooseOverwrite;
-  mutable bool m_HasHiddenFiles;
-  mutable QTime m_LastConflictCheck;
-
-  mutable std::set<unsigned int> m_OverwriteList;   // indices of mods overritten by this mod
-  mutable std::set<unsigned int> m_OverwrittenList; // indices of mods overwriting this mod
-  mutable std::set<unsigned int> m_ArchiveOverwriteList;   // indices of mods with archive files overritten by this mod
-  mutable std::set<unsigned int> m_ArchiveOverwrittenList; // indices of mods with archive files overwriting this mod
-  mutable std::set<unsigned int> m_ArchiveLooseOverwriteList; // indices of mods with archives being overwritten by this mod's loose files
-  mutable std::set<unsigned int> m_ArchiveLooseOverwrittenList; // indices of mods with loose files overwriting this mod's archive files
+  MOBase::MemoizedLocked<Conflicts> m_Conflicts;
 
 };
 

--- a/src/modlist.cpp
+++ b/src/modlist.cpp
@@ -549,7 +549,6 @@ bool ModList::setData(const QModelIndex &index, const QVariant &value, int role)
       m_Profile->setModEnabled(modID, enabled);
       m_Modified = true;
       m_LastCheck.restart();
-      emit modStatesChanged({ index });
       emit tutorialModlistUpdate();
     }
     result = true;
@@ -997,11 +996,15 @@ void ModList::notifyModRemoved(QString const& modName) const
 
 void ModList::notifyModStateChanged(QList<unsigned int> modIndices) const
 {
+  QModelIndexList indices;
   std::map<QString, IModList::ModStates> mods;
   for (auto modIndex : modIndices) {
+    indices.append(index(modIndex, 0));
     ModInfo::Ptr modInfo = ModInfo::getByIndex(modIndex);
     mods.emplace(modInfo->name(), state(modIndex));
   }
+
+  emit modStatesChanged(indices);
   m_ModStateChanged(mods);
 }
 
@@ -1404,7 +1407,6 @@ bool ModList::toggleState(const QModelIndexList& indices)
 
   m_Profile->setModsEnabled(modsToEnable, modsToDisable);
 
-  emit modStatesChanged(indices);
   emit tutorialModlistUpdate();
 
   m_Modified = true;
@@ -1430,6 +1432,4 @@ void ModList::setActive(const QModelIndexList& indices, bool active)
   else {
     m_Profile->setModsEnabled({}, mods);
   }
-
-  emit modStatesChanged(indices);
 }

--- a/src/modlist.h
+++ b/src/modlist.h
@@ -258,11 +258,11 @@ signals:
   // the sorting of the list can only be manually changed if the list is sorted by priority
   // in which case the move is intended to change the priority of a mod.
   //
-  void modPrioritiesChanged(const QModelIndexList& indices);
+  void modPrioritiesChanged(const QModelIndexList& indices) const;
 
   // emitted when the state (active/inactive) of one or multiple mods have changed
   //
-  void modStatesChanged(const QModelIndexList& indices);
+  void modStatesChanged(const QModelIndexList& indices) const;
 
   /**
    * @brief emitted when the model wants a text to be displayed by the UI

--- a/src/modlistview.cpp
+++ b/src/modlistview.cpp
@@ -689,7 +689,10 @@ void ModListView::setup(OrganizerCore& core, CategoryFactory& factory, MainWindo
   connect(m_core, &OrganizerCore::profileChanged, this, &ModListView::onProfileChanged);
   connect(core.modList(), &ModList::modPrioritiesChanged, [=](auto&& indices) { onModPrioritiesChanged(indices); });
   connect(core.modList(), &ModList::clearOverwrite, [=] { m_actions->clearOverwrite(); });
-  connect(core.modList(), &ModList::modStatesChanged, [=] { updateModCount(); });
+  connect(core.modList(), &ModList::modStatesChanged, [=] {
+    updateModCount();
+    setOverwriteMarkers(selectionModel()->selectedRows());
+  });
   connect(core.modList(), &ModList::modelReset, [=] { clearOverwriteMarkers(); });
 
   // proxy for various group by

--- a/src/organizercore.h
+++ b/src/organizercore.h
@@ -405,6 +405,11 @@ private:
   void updateModActiveState(int index, bool active);
   void updateModsActiveState(const QList<unsigned int> &modIndices, bool active);
 
+  // clear the conflict caches of all the given mods, and the mods in conflict
+  // with the given mods
+  //
+  void clearCaches(std::vector<unsigned int> const& indices) const;
+
   bool createDirectory(const QString &path);
 
   QString oldMO1HookDll() const;


### PR DESCRIPTION
Multiple fixes to avoid markers and conflict icons not being updated properly when doing some operations (in particular enabling/disabling mods):
- switch from a timer to a `MemoizedLock` for conflicts in `ModInfoWithConflicts`,
- clear caches of conflicting mods when enabling/disabling mods.