### PR TITLE
Do not return previous value in env::set and env::setPath.

### DIFF
--- a/src/env.cpp
+++ b/src/env.cpp
@@ -418,9 +418,9 @@ QString prependToPath(const QString& s)
   return old;
 }
 
-QString setPath(const QString& s)
+void setPath(const QString& s)
 {
-  return set("PATH", s);
+  set("PATH", s);
 }
 
 QString get(const QString& name)
@@ -457,11 +457,9 @@ QString get(const QString& name)
   return QString::fromWCharArray(buffer.get(), realSize);
 }
 
-QString set(const QString& n, const QString& v)
+void set(const QString& n, const QString& v)
 {
-  auto old = get(n);
   ::SetEnvironmentVariableW(n.toStdWString().c_str(), v.toStdWString().c_str());
-  return old;
 }
 
 

--- a/src/env.h
+++ b/src/env.h
@@ -233,12 +233,12 @@ private:
 // environment variables
 //
 QString get(const QString& name);
-QString set(const QString& name, const QString& value);
+void set(const QString& name, const QString& value);
 
 QString path();
 QString appendToPath(const QString& s);
 QString prependToPath(const QString& s);
-QString setPath(const QString& s);
+void setPath(const QString& s);
 
 
 class Service


### PR DESCRIPTION
To avoid log error when the previous value does not exist. The return value was not used anywhere.