### PR TITLE
Hopefully fix update filter not showing new mod updates.

### DIFF
--- a/src/mainwindow.cpp
+++ b/src/mainwindow.cpp
@@ -2951,7 +2951,6 @@ void MainWindow::nxmModInfoAvailable(QString gameName, int modID, QVariant userD
   }
   std::vector<ModInfo::Ptr> modsList = ModInfo::getByModID(gameNameReal, modID);
   for (auto mod : modsList) {
-    bool foundUpdate = false;
     QDateTime now = QDateTime::currentDateTimeUtc();
     QDateTime updateTarget = mod->getExpires();
     if (now >= updateTarget) {
@@ -2959,7 +2958,6 @@ void MainWindow::nxmModInfoAvailable(QString gameName, int modID, QVariant userD
       // with an older version than the main mod version.
       if (mod->getNexusFileStatus() != 3 && mod->getNexusFileStatus() != 5) {
         mod->setNewestVersion(result["version"].toString());
-        foundUpdate = true;
       }
       // update the LastNexusUpdate time in any case since we did perform the check.
       mod->setLastNexusUpdate(QDateTime::currentDateTimeUtc());

--- a/src/mainwindow.cpp
+++ b/src/mainwindow.cpp
@@ -2979,9 +2979,7 @@ void MainWindow::nxmModInfoAvailable(QString gameName, int modID, QVariant userD
     mod->setNexusLastModified(QDateTime::fromSecsSinceEpoch(result["updated_timestamp"].toInt(), Qt::UTC));
     mod->saveMeta();
 
-    if (foundUpdate) {
-      m_OrganizerCore.modList()->notifyChange(ModInfo::getIndex(mod->name()));
-    }
+    m_OrganizerCore.modList()->notifyChange(ModInfo::getIndex(mod->name()));
   }
 }
 


### PR DESCRIPTION
Notify all the mods that have had their info checked, not just the ones that have been found with an update. This is because Mo2 also shows mods that have had their files deleted or moved to Old as updateAvailable, in which case there is no update but the filter still needs to be notified to include the mod.