### PR TITLE
Fixes for the update dialog window

### DIFF
--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -18,6 +18,7 @@ add_filter(NAME src/application GROUPS
 	multiprocess
 	sanitychecks
 	selfupdater
+	updatedialog
 )
 
 add_filter(NAME src/browser GROUPS

--- a/src/organizer.pro
+++ b/src/organizer.pro
@@ -83,6 +83,7 @@ SOURCES += \
     modflagicondelegate.cpp \
     genericicondelegate.cpp \
     organizerproxy.cpp \
+    updatedialog.cpp \
     viewmarkingscrollbar.cpp \
     plugincontainer.cpp \
     organizercore.cpp \
@@ -161,6 +162,7 @@ HEADERS  += \
     modflagicondelegate.h \
     genericicondelegate.h \
     organizerproxy.h \
+    updatedialog.h \
     viewmarkingscrollbar.h \
     plugincontainer.h \
     organizercore.h \
@@ -203,7 +205,8 @@ FORMS    += \
     aboutdialog.ui \
     listdialog.ui \
     forcedloaddialog.ui \
-    forcedloaddialogwidget.ui
+    forcedloaddialogwidget.ui \
+    updatedialog.ui
 
 RESOURCES += \
     resources.qrc \

--- a/src/selfupdater.cpp
+++ b/src/selfupdater.cpp
@@ -129,7 +129,7 @@ void SelfUpdater::testForUpdate(const Settings& settings)
         auto lastKey = mreleases.begin()->first;
         if (lastKey > this->m_MOVersion) {
 
-          // Fill m_UpdateCandidates with version strictly greater than the 
+          // Fill m_UpdateCandidates with version strictly greater than the
           // current version:
           m_UpdateCandidates.clear();
           for (auto p : mreleases) {
@@ -182,7 +182,7 @@ void SelfUpdater::startUpdate()
     }
 
     // Stop including pre-release as soon as we find a non-prerelease:
-    if (!release["prelease"].toBool()) {
+    if (!release["prerelease"].toBool()) {
       includePreRelease = false;
     }
 

--- a/src/selfupdater.cpp
+++ b/src/selfupdater.cpp
@@ -188,7 +188,7 @@ void SelfUpdater::startUpdate()
       includePreRelease = false;
     }
 
-    details += "\n## " + release["tag_name"].toString() + "\n---\n";
+    details += "\n## " + release["name"].toString() + "\n---\n";
     details += release["body"].toString();
   }
 

--- a/src/selfupdater.cpp
+++ b/src/selfupdater.cpp
@@ -165,9 +165,11 @@ void SelfUpdater::startUpdate()
 
   auto latestRelease = m_UpdateCandidates.begin()->second;
 
-  UpdateDialog dialog(m_Parent, tr("New update available (%1 -> %2)")
-                                .arg(MOShared::createVersionInfo().displayString(3))
-                                .arg(latestRelease["tag_name"].toString()));
+  UpdateDialog dialog(m_Parent);
+  dialog.setVersions(
+    MOShared::createVersionInfo().displayString(3),
+    latestRelease["tag_name"].toString()
+  );
 
   // We concatenate release details. We only include pre-release if those are
   // the latest release:

--- a/src/updatedialog.cpp
+++ b/src/updatedialog.cpp
@@ -6,12 +6,11 @@
 
 using namespace MOBase;
 
-UpdateDialog::UpdateDialog(QWidget* parent, const QString& title) :
+UpdateDialog::UpdateDialog(QWidget* parent) :
   QDialog(parent, Qt::WindowMaximizeButtonHint | Qt::WindowCloseButtonHint), ui(new Ui::UpdateDialog)
 {
   // Basic UI stuff
   ui->setupUi(this);
-  setWindowTitle(title);
   connect(ui->installButton, &QPushButton::pressed, this, [&]{ done(QDialog::Accepted); });
   connect(ui->cancelButton, &QPushButton::pressed, this, [&]{ done(QDialog::Rejected); });
 
@@ -56,4 +55,13 @@ UpdateDialog::~UpdateDialog() = default;
 void UpdateDialog::setChangeLogs(const QString& text)
 {
   m_changeLogs.setText(text);
+}
+
+void UpdateDialog::setVersions(const QString& oldVersion, const QString& newVersion)
+{
+  ui->updateLabel->setText(
+    tr("Mod Organizer %1 is available.  The current version is %2.  Updating will not affect your mods or profiles.")
+    .arg(newVersion)
+    .arg(oldVersion)
+  );
 }

--- a/src/updatedialog.cpp
+++ b/src/updatedialog.cpp
@@ -1,0 +1,59 @@
+#include "updatedialog.h"
+#include "ui_updatedialog.h"
+
+#include "lootdialog.h" // for MarkdownPage
+#include <QWebChannel>
+
+using namespace MOBase;
+
+UpdateDialog::UpdateDialog(QWidget* parent, const QString& title) :
+  QDialog(parent, Qt::WindowMaximizeButtonHint | Qt::WindowCloseButtonHint), ui(new Ui::UpdateDialog)
+{
+  // Basic UI stuff
+  ui->setupUi(this);
+  setWindowTitle(title);
+  connect(ui->installButton, &QPushButton::pressed, this, [&]{ done(QDialog::Accepted); });
+  connect(ui->cancelButton, &QPushButton::pressed, this, [&]{ done(QDialog::Rejected); });
+
+  // Replace a label with an icon
+  QIcon icon = style()->standardIcon(QStyle::SP_MessageBoxQuestion);
+  QPixmap pixmap = icon.pixmap(QSize(32, 32));
+  ui->iconLabel->setPixmap(pixmap);
+  ui->iconLabel->setScaledContents(true);
+
+  // Setting up the Markdown stuff
+  auto* page = new MarkdownPage(this);
+  ui->detailsWebView->setPage(page);
+
+  auto* channel = new QWebChannel(this);
+  channel->registerObject("content", &m_changeLogs);
+  page->setWebChannel(channel);
+
+  const QString path = QApplication::applicationDirPath() + "/resources/markdown.html";
+  QFile f(path);
+
+  if (f.open(QFile::ReadOnly)) {
+    const QString html = f.readAll();
+    if (!html.isEmpty()) {
+      ui->detailsWebView->setHtml(html);
+    } else {
+      log::error("failed to read '{}', {}", path, f.errorString());
+    }
+  } else {
+    log::error("can't open '{}', {}", path, f.errorString());
+  }
+
+  // Setting up the expander
+  m_expander.set(ui->detailsButton, ui->detailsWidget);
+  connect(&m_expander, &ExpanderWidget::toggled, this, [&]{ adjustSize(); });
+
+  // Adjust sizes after the expander hides stuff
+  adjustSize();
+}
+
+UpdateDialog::~UpdateDialog() = default;
+
+void UpdateDialog::setChangeLogs(const QString& text)
+{
+  m_changeLogs.setText(text);
+}

--- a/src/updatedialog.h
+++ b/src/updatedialog.h
@@ -1,0 +1,27 @@
+#ifndef MODORGANIZER_UPDATEDIALOG_H
+#define MODORGANIZER_UPDATEDIALOG_H
+
+#include <QDialog>
+
+#include <expanderwidget.h>
+#include "lootdialog.h" // for MarkdownDocument
+
+namespace Ui { class UpdateDialog; }
+
+class UpdateDialog : public QDialog
+{
+  Q_OBJECT;
+
+public:
+  UpdateDialog(QWidget* parent, const QString& title);
+  ~UpdateDialog();
+
+  void setChangeLogs(const QString& text);
+
+private:
+  std::unique_ptr<Ui::UpdateDialog> ui;
+  MOBase::ExpanderWidget m_expander;
+  MarkdownDocument m_changeLogs;
+};
+
+#endif // MODORGANIZER_UPDATEDIALOG_H

--- a/src/updatedialog.h
+++ b/src/updatedialog.h
@@ -13,10 +13,11 @@ class UpdateDialog : public QDialog
   Q_OBJECT;
 
 public:
-  UpdateDialog(QWidget* parent, const QString& title);
+  UpdateDialog(QWidget* parent);
   ~UpdateDialog();
 
   void setChangeLogs(const QString& text);
+  void setVersions(const QString& oldVersion, const QString& newVersion);
 
 private:
   std::unique_ptr<Ui::UpdateDialog> ui;

--- a/src/updatedialog.ui
+++ b/src/updatedialog.ui
@@ -17,7 +17,7 @@
    </size>
   </property>
   <property name="windowTitle">
-   <string notr="true">New update available (xxxx)</string>
+   <string notr="true">Update available</string>
   </property>
   <property name="sizeGripEnabled">
    <bool>true</bool>
@@ -27,7 +27,7 @@
   </property>
   <layout class="QVBoxLayout" name="verticalLayout_2" stretch="0,0,1">
    <item>
-    <layout class="QHBoxLayout" name="horizontalLayout_2" stretch="0,0,1,0">
+    <layout class="QHBoxLayout" name="horizontalLayout_2" stretch="0,0,1">
      <property name="spacing">
       <number>0</number>
      </property>
@@ -80,39 +80,13 @@
      </item>
      <item>
       <widget class="QLabel" name="updateLabel">
-       <property name="minimumSize">
-        <size>
-         <width>400</width>
-         <height>0</height>
-        </size>
-       </property>
-       <property name="maximumSize">
-        <size>
-         <width>400</width>
-         <height>16777215</height>
-        </size>
-       </property>
        <property name="text">
-        <string>Do you want to install the update?  All your mods and setup will be left untouched.
-Select Show Details option to see the full change-log.</string>
+        <string notr="true">Update text placeholder</string>
        </property>
        <property name="wordWrap">
         <bool>true</bool>
        </property>
       </widget>
-     </item>
-     <item>
-      <spacer name="horizontalSpacer_2">
-       <property name="orientation">
-        <enum>Qt::Horizontal</enum>
-       </property>
-       <property name="sizeHint" stdset="0">
-        <size>
-         <width>20</width>
-         <height>20</height>
-        </size>
-       </property>
-      </spacer>
      </item>
     </layout>
    </item>
@@ -121,7 +95,7 @@ Select Show Details option to see the full change-log.</string>
      <item>
       <widget class="QToolButton" name="detailsButton">
        <property name="text">
-        <string>Show Details...</string>
+        <string>Changelog</string>
        </property>
       </widget>
      </item>

--- a/src/updatedialog.ui
+++ b/src/updatedialog.ui
@@ -1,0 +1,237 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<ui version="4.0">
+ <class>UpdateDialog</class>
+ <widget class="QDialog" name="UpdateDialog">
+  <property name="geometry">
+   <rect>
+    <x>0</x>
+    <y>0</y>
+    <width>578</width>
+    <height>539</height>
+   </rect>
+  </property>
+  <property name="minimumSize">
+   <size>
+    <width>460</width>
+    <height>0</height>
+   </size>
+  </property>
+  <property name="windowTitle">
+   <string notr="true">New update available (xxxx)</string>
+  </property>
+  <property name="sizeGripEnabled">
+   <bool>true</bool>
+  </property>
+  <property name="modal">
+   <bool>true</bool>
+  </property>
+  <layout class="QVBoxLayout" name="verticalLayout_2" stretch="0,0,1">
+   <item>
+    <layout class="QHBoxLayout" name="horizontalLayout_2" stretch="0,0,1,0">
+     <property name="spacing">
+      <number>0</number>
+     </property>
+     <property name="leftMargin">
+      <number>9</number>
+     </property>
+     <property name="rightMargin">
+      <number>9</number>
+     </property>
+     <item>
+      <widget class="QLabel" name="iconLabel">
+       <property name="minimumSize">
+        <size>
+         <width>32</width>
+         <height>32</height>
+        </size>
+       </property>
+       <property name="maximumSize">
+        <size>
+         <width>32</width>
+         <height>32</height>
+        </size>
+       </property>
+       <property name="text">
+        <string notr="true">&lt;?&gt;</string>
+       </property>
+       <property name="alignment">
+        <set>Qt::AlignCenter</set>
+       </property>
+       <property name="margin">
+        <number>0</number>
+       </property>
+      </widget>
+     </item>
+     <item>
+      <spacer name="horizontalSpacer_3">
+       <property name="orientation">
+        <enum>Qt::Horizontal</enum>
+       </property>
+       <property name="sizeType">
+        <enum>QSizePolicy::Fixed</enum>
+       </property>
+       <property name="sizeHint" stdset="0">
+        <size>
+         <width>10</width>
+         <height>20</height>
+        </size>
+       </property>
+      </spacer>
+     </item>
+     <item>
+      <widget class="QLabel" name="updateLabel">
+       <property name="minimumSize">
+        <size>
+         <width>400</width>
+         <height>0</height>
+        </size>
+       </property>
+       <property name="maximumSize">
+        <size>
+         <width>400</width>
+         <height>16777215</height>
+        </size>
+       </property>
+       <property name="text">
+        <string>Do you want to install the update?  All your mods and setup will be left untouched.
+Select Show Details option to see the full change-log.</string>
+       </property>
+       <property name="wordWrap">
+        <bool>true</bool>
+       </property>
+      </widget>
+     </item>
+     <item>
+      <spacer name="horizontalSpacer_2">
+       <property name="orientation">
+        <enum>Qt::Horizontal</enum>
+       </property>
+       <property name="sizeHint" stdset="0">
+        <size>
+         <width>20</width>
+         <height>20</height>
+        </size>
+       </property>
+      </spacer>
+     </item>
+    </layout>
+   </item>
+   <item>
+    <layout class="QHBoxLayout" name="horizontalLayout">
+     <item>
+      <widget class="QToolButton" name="detailsButton">
+       <property name="text">
+        <string>Show Details...</string>
+       </property>
+      </widget>
+     </item>
+     <item>
+      <spacer name="horizontalSpacer">
+       <property name="orientation">
+        <enum>Qt::Horizontal</enum>
+       </property>
+       <property name="sizeHint" stdset="0">
+        <size>
+         <width>40</width>
+         <height>20</height>
+        </size>
+       </property>
+      </spacer>
+     </item>
+     <item>
+      <widget class="QPushButton" name="installButton">
+       <property name="text">
+        <string>Install</string>
+       </property>
+       <property name="default">
+        <bool>true</bool>
+       </property>
+      </widget>
+     </item>
+     <item>
+      <widget class="QPushButton" name="cancelButton">
+       <property name="text">
+        <string>Cancel</string>
+       </property>
+       <property name="autoDefault">
+        <bool>false</bool>
+       </property>
+      </widget>
+     </item>
+    </layout>
+   </item>
+   <item>
+    <widget class="QWidget" name="detailsWidget" native="true">
+     <layout class="QVBoxLayout" name="verticalLayout" stretch="0">
+      <property name="spacing">
+       <number>0</number>
+      </property>
+      <property name="leftMargin">
+       <number>0</number>
+      </property>
+      <property name="topMargin">
+       <number>0</number>
+      </property>
+      <property name="rightMargin">
+       <number>0</number>
+      </property>
+      <property name="bottomMargin">
+       <number>0</number>
+      </property>
+      <item>
+       <widget class="QFrame" name="frame">
+        <property name="frameShape">
+         <enum>QFrame::StyledPanel</enum>
+        </property>
+        <property name="frameShadow">
+         <enum>QFrame::Raised</enum>
+        </property>
+        <layout class="QVBoxLayout" name="verticalLayout_3" stretch="0">
+         <property name="spacing">
+          <number>0</number>
+         </property>
+         <property name="leftMargin">
+          <number>0</number>
+         </property>
+         <property name="topMargin">
+          <number>0</number>
+         </property>
+         <property name="rightMargin">
+          <number>0</number>
+         </property>
+         <property name="bottomMargin">
+          <number>0</number>
+         </property>
+         <item>
+          <widget class="QWebEngineView" name="detailsWebView" native="true">
+           <property name="minimumSize">
+            <size>
+             <width>650</width>
+             <height>450</height>
+            </size>
+           </property>
+           <property name="url" stdset="0">
+            <url>
+             <string>about:blank</string>
+            </url>
+           </property>
+          </widget>
+         </item>
+        </layout>
+       </widget>
+      </item>
+     </layout>
+    </widget>
+   </item>
+  </layout>
+ </widget>
+ <customwidgets>
+  <customwidget>
+   <class>QWebEngineView</class>
+   <extends>QWidget</extends>
+   <header location="global">QtWebEngineWidgets/QWebEngineView</header>
+  </customwidget>
+ </customwidgets>
+ <resources/>
+ <connections/>
+</ui>


### PR DESCRIPTION
Fix: Properly concatenate pre-release logs
Fix: Allow resizing of window and change default size for readability
Side effects: It's a different color with a different markdown renderer.
New feature: Includes the version being updated from.