### PR TITLE
Portable instance loop

### DIFF
--- a/src/main.cpp
+++ b/src/main.cpp
@@ -80,7 +80,8 @@ int run(int argc, char *argv[])
   // stuff that's done only once, even if MO restarts in the loop below
   app.firstTimeSetup(multiProcess);
 
-  // force the "Select instance" dialog on startup (only for first loop)
+  // force the "Select instance" dialog on startup, only for first loop or when
+  // the current instance cannot be used
   bool pick = cl.pick();
 
   // MO runs in a loop because it can be restarted in several ways, such as
@@ -105,12 +106,16 @@ int run(int argc, char *argv[])
         const auto r = app.setup(multiProcess, pick);
         pick = false;
 
-        if (r == RestartExitCode) {
+        if (r == RestartExitCode || r == ReselectExitCode) {
           // resets things when MO is "restarted"
           app.resetForRestart();
 
           // don't reprocess command line
           cl.clear();
+
+          if (r == ReselectExitCode) {
+            pick = true;
+          }
 
           continue;
         } else if (r != 0) {

--- a/src/moapplication.cpp
+++ b/src/moapplication.cpp
@@ -492,7 +492,7 @@ std::optional<int> MOApplication::setupInstanceLoop(
       continue;
     } else if (setupResult == SetupInstanceResults::SelectAnother) {
       InstanceManager::singleton().clearCurrentInstance();
-      return RestartExitCode;
+      return ReselectExitCode;
     } else {
       return 1;
     }

--- a/src/shared/util.h
+++ b/src/shared/util.h
@@ -74,6 +74,7 @@ enum class Exit
 };
 
 const int RestartExitCode = INT_MAX;
+const int ReselectExitCode = INT_MAX - 1;
 
 using ExitFlags = QFlags<Exit>;
 Q_DECLARE_OPERATORS_FOR_FLAGS(ExitFlags);


### PR DESCRIPTION
Example: a portable instance exists, its game has moved, the game selection dialog is shown, user cancels, MO clears the instance name to force the instance selection to show, MO "restarts", sees no instance name, sees a portable instance exists, picks it, goto top.

This would need a bit of a refactor, because it's not the first time I've had problems with portable instances being empty names. A separate flag or a special instance name in the registry like `__mo_portable` or something would be really helpful.

In any case, this is a very late fix for 2.4, so I tried changing as little as I could. I'm reusing Holt's pick flag to force selection and added a new return value constant `ReselectExitCode` to set it.