### PR TITLE
Broken plugins blacklist

### DIFF
--- a/src/plugincontainer.cpp
+++ b/src/plugincontainer.cpp
@@ -953,8 +953,12 @@ void PluginContainer::reloadPlugin(QString const& filepath)
 void PluginContainer::unloadPlugins()
 {
   if (m_Organizer) {
-    // clearPlugins() must be called before loadPlugins() since it actually
-    // loads the blacklist
+    // this will clear several structures that can hold on to pointers to
+    // plugins, as well as read the plugin blacklist from the ini file, which
+    // is used in loadPlugins() below to skip plugins
+    //
+    // note that the first thing loadPlugins() does is call unloadPlugins(),
+    // so this makes sure the blacklist is always available
     m_Organizer->settings().plugins().clearPlugins();
   }
 

--- a/src/plugincontainer.cpp
+++ b/src/plugincontainer.cpp
@@ -952,6 +952,12 @@ void PluginContainer::reloadPlugin(QString const& filepath)
 
 void PluginContainer::unloadPlugins()
 {
+  if (m_Organizer) {
+    // clearPlugins() must be called before loadPlugins() since it actually
+    // loads the blacklist
+    m_Organizer->settings().plugins().clearPlugins();
+  }
+
   bf::for_each(m_Plugins, [](auto& t) { t.second.clear(); });
   bf::for_each(m_AccessPlugins, [](auto& t) { t.second.clear(); });
   m_Requirements.clear();


### PR DESCRIPTION
`clearPlugins()` actually loads the blacklist and so must be called before `loadPlugins()` or the list will be empty