### PR TITLE
Switch back to invalidating filter when receiving mod updates.

### DIFF
--- a/src/mainwindow.cpp
+++ b/src/mainwindow.cpp
@@ -2819,41 +2819,37 @@ void MainWindow::nxmUpdateInfoAvailable(QString gameName, QVariant userData, QVa
   }
   QVariantList resultList = resultData.toList();
 
-  QFutureWatcher<std::pair<QString, std::set<QSharedPointer<ModInfo>>>> *watcher = new QFutureWatcher<std::pair<QString, std::set<QSharedPointer<ModInfo>>>>();
-  QObject::connect(watcher, &QFutureWatcher<std::set<QSharedPointer<ModInfo>>>::finished, this, &MainWindow::finishUpdateInfo);
-  QFuture<std::pair<QString, std::set<QSharedPointer<ModInfo>>>> future = QtConcurrent::run([=]() -> std::pair<QString, std::set<QSharedPointer<ModInfo>>> {
-    return std::make_pair(gameNameReal, ModInfo::filteredMods(gameNameReal, resultList, userData.toBool(), true));
+  auto* watcher = new QFutureWatcher<NxmUpdateInfoData>();
+  QObject::connect(watcher, &QFutureWatcher<NxmUpdateInfoData>::finished, [this, watcher]() {
+    finishUpdateInfo(watcher->result());
+    watcher->deleteLater();
+  });
+  auto future = QtConcurrent::run([=]() {
+    return NxmUpdateInfoData{ gameNameReal, ModInfo::filteredMods(gameNameReal, resultList, userData.toBool(), true) };
   });
   watcher->setFuture(future);
+  ui->modList->invalidateFilter();
 }
 
-void MainWindow::finishUpdateInfo()
+void MainWindow::finishUpdateInfo(const NxmUpdateInfoData& data)
 {
-  QFutureWatcher<std::pair<QString, std::set<QSharedPointer<ModInfo>>>> *watcher = static_cast<QFutureWatcher<std::pair<QString, std::set<QSharedPointer<ModInfo>>>> *>(sender());
-
-  QString game = watcher->result().first;
-  auto finalMods = watcher->result().second;
-
-  if (finalMods.empty()) {
-    log::info("{}", tr("None of your %1 mods appear to have had recent file updates.").arg(game));
+  if (data.finalMods.empty()) {
+    log::info("{}", tr("None of your %1 mods appear to have had recent file updates.").arg(data.game));
   }
 
   std::set<std::pair<QString, int>> organizedGames;
-  for (auto mod : finalMods) {
+  for (auto& mod : data.finalMods) {
     if (mod->canBeUpdated()) {
       organizedGames.insert(std::make_pair<QString, int>(mod->gameName().toLower(), mod->nexusId()));
     }
-    m_OrganizerCore.modList()->notifyChange(ModInfo::getIndex(mod->name()));
   }
 
-  if (!finalMods.empty() && organizedGames.empty())
+  if (!data.finalMods.empty() && organizedGames.empty())
     log::warn("{}", tr("All of your mods have been checked recently. We restrict update checks to help preserve your available API requests."));
 
-  for (auto game : organizedGames)
+  for (const auto& game : organizedGames) {
     NexusInterface::instance().requestUpdates(game.second, this, QVariant(), game.first, QString());
-
-  disconnect(sender());
-  delete sender();
+  }
 }
 
 void MainWindow::nxmUpdatesAvailable(QString gameName, int modID, QVariant userData, QVariant resultData, int requestID)
@@ -2928,12 +2924,14 @@ void MainWindow::nxmUpdatesAvailable(QString gameName, int modID, QVariant userD
     if (foundUpdate) {
       // Just get the standard data updates for endorsements and descriptions
       mod->setLastNexusUpdate(QDateTime::currentDateTimeUtc());
-      m_OrganizerCore.modList()->notifyChange(ModInfo::getIndex(mod->name()));
     } else {
       // Scrape mod data here so we can use the mod version if no file update was located
       requiresInfo = true;
     }
   }
+
+  // invalidate the filter to display mods with an update
+  ui->modList->invalidateFilter();
 
   if (requiresInfo)
     NexusInterface::instance().requestModInfo(gameNameReal, modID, this, QVariant(), QString());

--- a/src/mainwindow.h
+++ b/src/mainwindow.h
@@ -224,6 +224,13 @@ private:
   void toggleMO2EndorseState();
   void toggleUpdateAction();
 
+  // update info
+  struct NxmUpdateInfoData {
+    QString game;
+    std::set<ModInfo::Ptr> finalMods;
+  };
+  void finishUpdateInfo(const NxmUpdateInfoData& data);
+
 private:
 
   static const char *PATTERN_BACKUP_GLOB;
@@ -331,10 +338,10 @@ private slots:
 
   void modInstalled(const QString &modName);
 
-  void finishUpdateInfo();
+  // update info
+  void nxmUpdateInfoAvailable(QString gameName, QVariant userData, QVariant resultData, int requestID);
 
   void nxmEndorsementsAvailable(QVariant userData, QVariant resultData, int);
-  void nxmUpdateInfoAvailable(QString gameName, QVariant userData, QVariant resultData, int requestID);
   void nxmUpdatesAvailable(QString gameName, int modID, QVariant userData, QVariant resultData, int requestID);
   void nxmModInfoAvailable(QString gameName, int modID, QVariant userData, QVariant resultData, int requestID);
   void nxmEndorsementToggled(QString, int, QVariant, QVariant resultData, int);

--- a/src/modlistview.cpp
+++ b/src/modlistview.cpp
@@ -299,6 +299,11 @@ std::optional<unsigned int> ModListView::prevMod(unsigned int  modIndex) const
   return {};
 }
 
+void ModListView::invalidateFilter()
+{
+  m_sortProxy->invalidate();
+}
+
 void ModListView::setFilterCriteria(const std::vector<ModListSortProxy::Criteria>& criteria)
 {
   m_sortProxy->setCriteria(criteria);

--- a/src/modlistview.h
+++ b/src/modlistview.h
@@ -112,6 +112,10 @@ signals:
 
 public slots:
 
+  // invalidate (refresh) the filter (similar to a layout changed event)
+  //
+  void invalidateFilter();
+
   // set the filter criteria/options for mods
   //
   void setFilterCriteria(const std::vector<ModListSortProxy::Criteria>& criteria);


### PR DESCRIPTION
1. I clean a bit the NXM-update slots because I did not like that sender stuff, so I just used a lambda.
    - The signal was incorrect (the template type of `QFutureWatcher` did not match), but I guess that was partially fine... 
2. I switched back to invalidate in some cases, but I only invalidate at the end (there is no point invalidating for all mods).
    - I removed `invalidate` initially because it was breaking selection, etc., which was annoying. Now it does not, (probably) because I modified the by-priority proxy to not reset the model when not required.

I have no clue if this actually will fix the issue some users are experiencing because I still cannot reproduce it.