### PR TITLE
Fix tutorial stuck on mod info dialog

### DIFF
--- a/src/mainwindow.cpp
+++ b/src/mainwindow.cpp
@@ -512,6 +512,8 @@ void MainWindow::setupModList()
 
   connect(&ui->modList->actions(), &ModListViewActions::overwriteCleared, [=]() { scheduleCheckForProblems(); });
   connect(&ui->modList->actions(), &ModListViewActions::originModified, this, &MainWindow::originModified);
+  connect(&ui->modList->actions(), &ModListViewActions::modInfoDisplayed, this, &MainWindow::modInfoDisplayed);
+
   connect(m_OrganizerCore.modList(), &ModList::modPrioritiesChanged, [&]() { m_ArchiveListWriter.write(); });
 }
 

--- a/src/mainwindow.h
+++ b/src/mainwindow.h
@@ -143,6 +143,9 @@ public slots:
   void refresherProgress(const DirectoryRefreshProgress* p);
 
 signals:
+  // emitted after the information dialog has been closed, used by tutorials
+  //
+  void modInfoDisplayed();
 
   /**
    * @brief emitted when the selected style changes

--- a/src/modlistviewactions.cpp
+++ b/src/modlistviewactions.cpp
@@ -520,6 +520,7 @@ void ModListViewActions::displayModInformation(ModInfo::Ptr modInfo, unsigned in
 
     modInfo->saveMeta();
     m_core.modList()->modInfoChanged(modInfo);
+    emit modInfoDisplayed();
   }
 
   if (m_core.currentProfile()->modEnabled(modIndex) && !modInfo->isForeign()) {

--- a/src/modlistviewactions.h
+++ b/src/modlistviewactions.h
@@ -138,6 +138,10 @@ signals:
   //
   void originModified(int originId) const;
 
+  // emitted when the mod info dialog has been shown and closed
+  //
+  void modInfoDisplayed() const;
+
 private:
 
   // find the priority where to install or create a mod for the


### PR DESCRIPTION
Emit `modInfoDisplayed`, it's required by the tutorial. Since the dialog is shown in `ModListViewActions`, it must emit its own signal which is forwarded to `MainWindow`. Fixes #1419.