### PR TITLE
Display savegame name and filepath in saves tab.

### DIFF
--- a/src/mainwindow.cpp
+++ b/src/mainwindow.cpp
@@ -351,6 +351,7 @@ MainWindow::MainWindow(Settings &settings
   }
 
   settings.geometry().restoreState(ui->downloadView->header());
+  settings.geometry().restoreState(ui->savegameList->header());
 
   ui->splitter->setStretchFactor(0, 3);
   ui->splitter->setStretchFactor(1, 2);
@@ -2005,6 +2006,7 @@ void MainWindow::storeSettings()
 
   s.geometry().saveState(ui->espList->header());
   s.geometry().saveState(ui->downloadView->header());
+  s.geometry().saveState(ui->savegameList->header());
 
   s.widgets().saveIndex(ui->executablesListBox);
   s.widgets().saveIndex(ui->tabWidget);

--- a/src/mainwindow.ui
+++ b/src/mainwindow.ui
@@ -1199,7 +1199,7 @@ p, li { white-space: pre-wrap; }
               <number>0</number>
              </property>
              <item>
-              <widget class="QListWidget" name="savegameList">
+              <widget class="QTreeWidget" name="savegameList">
                <property name="contextMenuPolicy">
                 <enum>Qt::CustomContextMenu</enum>
                </property>
@@ -1215,6 +1215,9 @@ p, li { white-space: pre-wrap; }
 &lt;p style=&quot;-qt-paragraph-type:empty; margin-top:0px; margin-bottom:0px; margin-left:0px; margin-right:0px; -qt-block-indent:0; text-indent:0px; font-size:8pt;&quot;&gt;&lt;/p&gt;
 &lt;p style=&quot; margin-top:0px; margin-bottom:0px; margin-left:0px; margin-right:0px; -qt-block-indent:0; text-indent:0px;&quot;&gt;&lt;span style=&quot; font-size:8pt;&quot;&gt;If you click &amp;quot;Fix Mods...&amp;quot; in the context menu, MO will try to activate all mods and esps to fix those missing esps. It will not disable anything!&lt;/span&gt;&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
                </property>
+               <property name="sizeAdjustPolicy">
+                <enum>QAbstractScrollArea::AdjustIgnored</enum>
+               </property>
                <property name="alternatingRowColors">
                 <bool>true</bool>
                </property>
@@ -1224,9 +1227,43 @@ p, li { white-space: pre-wrap; }
                <property name="selectionBehavior">
                 <enum>QAbstractItemView::SelectRows</enum>
                </property>
-               <property name="uniformItemSizes">
+               <property name="indentation">
+                <number>0</number>
+               </property>
+               <property name="rootIsDecorated">
+                <bool>false</bool>
+               </property>
+               <property name="uniformRowHeights">
                 <bool>true</bool>
                </property>
+               <property name="sortingEnabled">
+                <bool>false</bool>
+               </property>
+               <property name="columnCount">
+                <number>2</number>
+               </property>
+               <attribute name="headerCascadingSectionResizes">
+                <bool>false</bool>
+               </attribute>
+               <attribute name="headerStretchLastSection">
+                <bool>false</bool>
+               </attribute>
+               <column>
+                <property name="text">
+                 <string>Name</string>
+                </property>
+                <property name="textAlignment">
+                 <set>AlignLeading|AlignVCenter</set>
+                </property>
+               </column>
+               <column>
+                <property name="text">
+                 <string>File</string>
+                </property>
+                <property name="textAlignment">
+                 <set>AlignLeading|AlignVCenter</set>
+                </property>
+               </column>
               </widget>
              </item>
             </layout>

--- a/src/savestab.h
+++ b/src/savestab.h
@@ -24,7 +24,7 @@ public:
   SavesTab(QWidget* window, OrganizerCore& core, Ui::MainWindow* ui);
 
   void refreshSaveList();
-  void displaySaveGameInfo(QListWidgetItem *newItem);
+  void displaySaveGameInfo(QTreeWidgetItem *newItem);
 
   QDir currentSavesDir() const;
 
@@ -40,7 +40,7 @@ private:
   {
     QTabWidget* mainTabs;
     QWidget* tab;
-    QListWidget* list;
+    QTreeWidget* list;
   };
 
   QWidget* m_window;
@@ -55,7 +55,7 @@ private:
 
   void onContextMenu(const QPoint &pos);
   void deleteSavegame();
-  void saveSelectionChanged(QListWidgetItem *newItem);
+  void saveSelectionChanged(QTreeWidgetItem *newItem);
   void fixMods(SaveGameInfo::MissingAssets const &missingAssets);
   void refreshSavesIfOpen();
   void openInExplorer();

--- a/src/stylesheets/skyrim.qss
+++ b/src/stylesheets/skyrim.qss
@@ -47,7 +47,8 @@ QTreeView::item {
 #modList::item,
 #settingsTree::item,
 #pluginSettingsList::item,
-#espList::item {
+#espList::item,
+#savegameList::item {
   min-height: 34px;
   padding: 0; }
   #modList::item QComboBox,

--- a/src/stylesheets/vs15 Dark-Green.qss
+++ b/src/stylesheets/vs15 Dark-Green.qss
@@ -43,6 +43,7 @@ QListView::item:disabled,
 #bsaList::item,
 #dataTree::item,
 QTreeView#modList::item,
+#savegameList::item,
 QTreeWidget#categoriesTree::item,
 #tabConflicts QTreeWidget::item {
   padding: 0.3em 0; }

--- a/src/stylesheets/vs15 Dark-Orange.qss
+++ b/src/stylesheets/vs15 Dark-Orange.qss
@@ -44,6 +44,7 @@ QListView::item:disabled,
 #bsaList::item,
 #dataTree::item,
 QTreeView#modList::item,
+#savegameList::item,
 QTreeWidget#categoriesTree::item,
 #tabConflicts QTreeWidget::item {
   padding: 0.3em 0; }

--- a/src/stylesheets/vs15 Dark-Purple.qss
+++ b/src/stylesheets/vs15 Dark-Purple.qss
@@ -44,6 +44,7 @@ QListView::item:disabled,
 #bsaList::item,
 #dataTree::item,
 QTreeView#modList::item,
+#savegameList::item,
 QTreeWidget#categoriesTree::item,
 #tabConflicts QTreeWidget::item {
   padding: 0.3em 0; }

--- a/src/stylesheets/vs15 Dark-Red.qss
+++ b/src/stylesheets/vs15 Dark-Red.qss
@@ -44,6 +44,7 @@ QListView::item:disabled,
 #bsaList::item,
 #dataTree::item,
 QTreeView#modList::item,
+#savegameList::item,
 QTreeWidget#categoriesTree::item,
 #tabConflicts QTreeWidget::item {
   padding: 0.3em 0; }

--- a/src/stylesheets/vs15 Dark-Yellow.qss
+++ b/src/stylesheets/vs15 Dark-Yellow.qss
@@ -43,6 +43,7 @@ QListView::item:disabled,
 #bsaList::item,
 #dataTree::item,
 QTreeView#modList::item,
+#savegameList::item,
 QTreeWidget#categoriesTree::item,
 #tabConflicts QTreeWidget::item {
   padding: 0.3em 0; }

--- a/src/stylesheets/vs15 Dark.qss
+++ b/src/stylesheets/vs15 Dark.qss
@@ -44,6 +44,7 @@ QListView::item:disabled,
 #dataTree::item,
 QTreeView#modList::item,
 QTreeWidget#categoriesTree::item,
+#savegameList::item,
 #tabConflicts QTreeWidget::item {
   padding: 0.3em 0; }
 


### PR DESCRIPTION
Fixes #1430 and replaces #1434

This is a temporary change for 2.4.1 before moving to a dedicated model for saves in 2.5 (hopefully).

- The saves list now has two columns "Name" and "File" displaying the name and the relative path to the file.
- I've updated the theme that needed updating. I've tested with all the other themes (including the one we do not manage) and all seemed ok.