### PR TITLE
Fix file sizes in the data tab

### DIFF
--- a/src/filetreeitem.h
+++ b/src/filetreeitem.h
@@ -150,12 +150,12 @@ public:
 
   void setFileSize(uint64_t size)
   {
-    m_fileSize.override(size);
+    m_fileSize.set(size);
   }
 
   void setCompressedFileSize(uint64_t compressedSize)
   {
-    m_compressedFileSize.override(compressedSize);
+    m_compressedFileSize.set(compressedSize);
   }
 
   const QString& realPath() const
@@ -243,7 +243,6 @@ private:
   {
     std::optional<T> value;
     bool failed = false;
-    bool overridden = false;
 
     bool empty() const
     {
@@ -254,29 +253,18 @@ private:
     {
       value = std::move(t);
       failed = false;
-      overridden = false;
-    }
-
-    void override(T t)
-    {
-      value = std::move(t);
-      failed = false;
-      overridden = true;
     }
 
     void fail()
     {
       value = {};
       failed = true;
-      overridden = false;
     }
 
     void reset()
     {
-      if (!overridden) {
-        value = {};
-        failed = false;
-      }
+      value = {};
+      failed = false;
     }
   };
 

--- a/src/shared/directoryentry.cpp
+++ b/src/shared/directoryentry.cpp
@@ -675,7 +675,17 @@ void DirectoryEntry::onDirectoryEnd(Context* cx, std::wstring_view path)
 void DirectoryEntry::onFile(Context* cx, std::wstring_view path, FILETIME ft)
 {
   elapsed(cx->stats.fileTimes, [&]{
-    cx->current.top()->insert(path, cx->origin, ft, L"", -1, cx->stats);
+    auto f = cx->current.top()->insert(path, cx->origin, ft, L"", -1, cx->stats);
+
+    if (f) {
+      // the file might already be in the register and it might have come from
+      // an archive, which sets the file size if it's available (see addFiles()
+      // just below)
+      //
+      // so the file size might be stale here because the file is being
+      // overridden by another mod, make sure to clear it
+      f->setFileSize(FileEntry::NoFileSize, FileEntry::NoFileSize);
+    }
   });
 }
 


### PR DESCRIPTION
The bug was that if a file had an origin from an archive, the size from the archive was always shown even if the conflict was won by another mod.

When a file from disk is added for the first time to the register (in `DirectoryEntry::onFile()`), its file size is `NoFileSize` by default because it's not available. This is forwarded to the Data tab, which will get the size on disk of the file the first time it's shown in the tree. However, if one of the origins of the file is from an _archive_, bsatk helpfully gives the size, so that's added to the register (see [`DirectoryEntry::addFiles()`](https://github.com/isanae/modorganizer/blob/81413e6a2f2b171b3a7efa93d18c496da7c14a7e/src/shared/directoryentry.cpp#L705), not in diff below).

The problem was that if another origin was added that has a higher prio, that file size from the BSA was never cleared to `NoFileSize`, which prevented the Data tab from getting the size on disk and always displayed the size from the BSA.

So the file size is now set to `NoFileSize` when adding a file from the disk. This clears whatever size might be have been set if a previous origin was from an archive.

I also removed `Cached::override()`, I'm not sure what the purpose was (yes, I wrote it). It looks like it was to prevent fetching the file size again if it was available from a BSA, but it makes no sense and would prevent the file size from being updated ever again even if the winning origin of a file changed. So that's gone too.