### PR TITLE
Move Qt plugins to dlls folder

### DIFF
--- a/src/qt.conf
+++ b/src/qt.conf
@@ -1,3 +1,4 @@
 [Paths]
 Prefix=.
 Plugins=dlls
+Qml2Imports=dlls


### PR DESCRIPTION
Starting off small this time, only Qt dlls.

Related commits:
https://github.com/ModOrganizer2/cmake_common/pull/17
https://github.com/ModOrganizer2/modorganizer-nxmhandler/pull/17
https://github.com/ModOrganizer2/modorganizer-Installer/pull/27