### PR TITLE
Reduce log level of harmless failures

### DIFF
--- a/src/envmodule.cpp
+++ b/src/envmodule.cpp
@@ -130,7 +130,7 @@ Module::FileInfo Module::getFileInfo() const
       return {};
     }
 
-    log::error(
+    log::debug(
       "GetFileVersionInfoSizeW() failed on '{}', {}",
       m_path, formatSystemMessage(e));
 
@@ -268,7 +268,7 @@ QDateTime Module::getTimestamp(const VS_FIXEDFILEINFO& fi) const
     if (h.get() == INVALID_HANDLE_VALUE) {
       const auto e = GetLastError();
 
-      log::error(
+      log::debug(
         "can't open file '{}' for timestamp, {}",
         m_path, formatSystemMessage(e));
 


### PR DESCRIPTION
These two messages (along with their glaring red X icons) are cluttering up the log on linux/wine systems, misleading people who are trying to diagnose real problems. Let's reduce their log priority to make it clear that they're harmless.

As mentioned here:
https://github.com/ModOrganizer2/modorganizer/issues/372#issuecomment-575231673