### PR TITLE
Change the "Visit Nexus" button to support alternate sources

### DIFF
--- a/src/mainwindow.h
+++ b/src/mainwindow.h
@@ -187,7 +187,7 @@ private:
   void setToolbarButtonStyle(Qt::ToolButtonStyle s);
 
   void registerModPage(MOBase::IPluginModPage* modPage);
-  void registerNexusPages(const QStringList& gamePluginNames);
+  bool registerNexusPage(const QString& gameName);
   void registerPluginTool(MOBase::IPluginTool* tool, QString name = QString(), QMenu* menu = nullptr);
 
   void updateToolbarMenu();

--- a/src/mainwindow.h
+++ b/src/mainwindow.h
@@ -187,6 +187,7 @@ private:
   void setToolbarButtonStyle(Qt::ToolButtonStyle s);
 
   void registerModPage(MOBase::IPluginModPage* modPage);
+  void registerNexusPages(const QStringList& gamePluginNames);
   void registerPluginTool(MOBase::IPluginTool* tool, QString name = QString(), QMenu* menu = nullptr);
 
   void updateToolbarMenu();


### PR DESCRIPTION
If a game plugin supports more than one Nexus site for downloads,
the "Visit Nexus" button will be turned into a drop-down that
lets you select each site.

![image](https://user-images.githubusercontent.com/7862539/115991243-80c73a00-a57c-11eb-80a1-acb7646d8728.png)

![image](https://user-images.githubusercontent.com/7862539/115991245-83299400-a57c-11eb-9ce8-b647313ef385.png)
