### PR TITLE
Add option to ignore root meta.ini when creating IFileTree for QDir.

### DIFF
--- a/src/qdirfiletree.cpp
+++ b/src/qdirfiletree.cpp
@@ -7,10 +7,6 @@ using namespace MOBase;
 class QDirFileTreeImpl : public QDirFileTree {
 public:
 
-
-  /**
-   *
-   */
   QDirFileTreeImpl(std::shared_ptr<const IFileTree> parent, QDir dir) :
     FileTreeEntry(parent, dir.dirName()), QDirFileTree(), qDir(dir) { }
 
@@ -25,7 +21,8 @@ protected:
   std::shared_ptr<FileTreeEntry> makeFile(std::shared_ptr<const IFileTree> parent, QString name) const override { return nullptr; }
   std::shared_ptr<IFileTree> makeDirectory(std::shared_ptr<const IFileTree> parent, QString name) const override { return nullptr; }
 
-  bool doPopulate(std::shared_ptr<const IFileTree> parent, std::vector<std::shared_ptr<FileTreeEntry>>& entries) const override {
+  bool doPopulate(std::shared_ptr<const IFileTree> parent, std::vector<std::shared_ptr<FileTreeEntry>>& entries) const override
+  {
     auto infoList = qDir.entryInfoList(qDir.filter() | QDir::NoDotAndDotDot, QDir::Name | QDir::DirsFirst | QDir::IgnoreCase);
     for (auto& info : infoList) {
       if (info.isDir()) {
@@ -40,18 +37,59 @@ protected:
     return true;
   }
 
-  std::shared_ptr<IFileTree> QDirFileTree::doClone() const {
+  std::shared_ptr<IFileTree> QDirFileTree::doClone() const
+  {
     return std::make_shared<QDirFileTreeImpl>(nullptr, qDir);
   }
 
-private:
+protected:
   QDir qDir;
+
+};
+
+// subclass of QDirFileTreeImpl that ignores meta.ini
+//
+// only used for the root folder, subdirectories are actually QDirFileTreeImpl
+class QDirRootFileTreeImpl : public QDirFileTreeImpl {
+public:
+
+
+  QDirRootFileTreeImpl(QDir dir) : FileTreeEntry(nullptr, dir.dirName()), QDirFileTreeImpl(nullptr, dir) { }
+
+protected:
+
+  bool doPopulate(std::shared_ptr<const IFileTree> parent, std::vector<std::shared_ptr<FileTreeEntry>>& entries) const override
+  {
+    auto infoList = qDir.entryInfoList(qDir.filter() | QDir::NoDotAndDotDot, QDir::Name | QDir::DirsFirst | QDir::IgnoreCase);
+    for (auto& info : infoList) {
+      if (info.isDir()) {
+        entries.push_back(std::make_shared<QDirFileTreeImpl>(parent, QDir(info.absoluteFilePath())));
+      }
+      else if (info.fileName().compare("meta.ini", Qt::CaseInsensitive) != 0) {
+        entries.push_back(createFileEntry(parent, info.fileName()));
+      }
+    }
+
+    // Vector is already sorted:
+    return true;
+  }
+
+  std::shared_ptr<IFileTree> QDirFileTree::doClone() const
+  {
+    return std::make_shared<QDirRootFileTreeImpl>(qDir);
+  }
 
 };
 
 /**
  *
  */
-std::shared_ptr<const QDirFileTree> QDirFileTree::makeTree(QDir directory) {
-  return std::make_shared<QDirFileTreeImpl>(nullptr, directory);
+std::shared_ptr<const QDirFileTree> QDirFileTree::makeTree(QDir directory, bool ignoreRootMeta)
+{
+  if (ignoreRootMeta) {
+    return std::make_shared<QDirRootFileTreeImpl>(directory);
+  }
+  else {
+    return std::make_shared<QDirFileTreeImpl>(nullptr, directory);
+  }
 }

--- a/src/qdirfiletree.h
+++ b/src/qdirfiletree.h
@@ -41,10 +41,12 @@ public:
    * @brief Create a new file tree representing the given directory.
    *
    * @param directory Directory to represent.
+   * @param ignoreRootMeta If true, the meta.ini file in the root folder will
+   *   be ignored.
    *
    * @return a file tree representing the given directory.
    */
-  static std::shared_ptr<const QDirFileTree> makeTree(QDir directory);
+  static std::shared_ptr<const QDirFileTree> makeTree(QDir directory, bool ignoreRootMeta = true);
 
 protected:
 


### PR DESCRIPTION
Closes #1522 