### PR TITLE
Nexus archived support

### DIFF
--- a/src/downloadmanager.cpp
+++ b/src/downloadmanager.cpp
@@ -1223,6 +1223,7 @@ QString DownloadManager::getFileTypeString(int fileType)
     case 4: return tr("Old");
     case 5: return tr("Miscellaneous");
     case 6: return tr("Deleted");
+    case 7: return tr("Archived");
     default: return tr("Unknown");
   }
 }
@@ -1723,7 +1724,8 @@ void DownloadManager::nxmFilesAvailable(QString, int, QVariant userData, QVarian
         {return lhs.toMap()["uploaded_timestamp"].toInt() > rhs.toMap()["uploaded_timestamp"].toInt();});
       for (QVariant file : files) {
         QVariantMap fileInfo = file.toMap();
-        if (fileInfo["category_id"].toInt() != 6)
+        if (fileInfo["category_id"].toInt() != NexusInterface::FileStatus::REMOVED &&
+          fileInfo["category_id"].toInt() != NexusInterface::FileStatus::ARCHIVED)
           selection.addChoice(fileInfo["file_name"].toString(), "", file);
       }
       if (selection.exec() == QDialog::Accepted) {
@@ -1958,7 +1960,8 @@ void DownloadManager::nxmFileInfoFromMd5Available(QString gameName, QVariant use
       auto results = resultlist[i].toMap();
       auto fileDetails = results["file_details"].toMap();
 
-      if (fileDetails["category_id"].toInt() != 6) { //6 = deleted
+      if (fileDetails["category_id"].toInt() != NexusInterface::FileStatus::REMOVED &&
+          fileDetails["category_id"].toInt() != NexusInterface::FileStatus::ARCHIVED) {
         if (chosenIdx < 0) {
           chosenIdx = i; //intentional to not break in order to check other results
         } else {

--- a/src/modlist.cpp
+++ b/src/modlist.cpp
@@ -441,10 +441,12 @@ QVariant ModList::data(const QModelIndex &modelIndex, int role) const
                           "(i.e. due to a bug) or the author uses a non-standard versioning scheme and that newest version is actually newer. "
                           "Either way you may want to \"upgrade\".");
       }
-      if (modInfo->getNexusFileStatus() == 4) {
+      if (modInfo->getNexusFileStatus() == NexusInterface::FileStatus::OLD_VERSION) {
         text += "<br>" + tr("This file has been marked as \"Old\". There is most likely an updated version of this file available.");
       }
-      else if (modInfo->getNexusFileStatus() == 6) {
+      else if (modInfo->getNexusFileStatus() == NexusInterface::FileStatus::REMOVED ||
+               modInfo->getNexusFileStatus() == NexusInterface::FileStatus::ARCHIVED || 
+               modInfo->getNexusFileStatus() == NexusInterface::FileStatus::ARCHIVED_HIDDEN) {
         text += "<br>" + tr("This file has been marked as \"Deleted\"! You may want to check for an update or remove the nexus ID from this mod!");
       }
       if (modInfo->nexusId() > 0) {

--- a/src/nexusinterface.h
+++ b/src/nexusinterface.h
@@ -148,6 +148,18 @@ public:
     MONTH
   };
 
+  // Nexus file category IDs (MAIN, OLD etc), not to be confused with mod categories (Armors, Texture etc).
+  enum FileStatus {
+    MAIN = 1,
+    UPDATE = 2,
+    OPTIONAL_FILE = 3,  // actual string version is "OPTIONAL", but that is already defined as a macro in minwindef.h
+    OLD_VERSION = 4,
+    MISCELLANEOUS = 5,
+    REMOVED = 6,
+    ARCHIVED = 7,
+    ARCHIVED_HIDDEN = 1000 // Archived files can be hidden by authors so if they aren't listed we can assume they were hidden.
+  };
+
 public:
   static APILimits defaultAPILimits();
   static APILimits parseLimits(const QNetworkReply* reply);


### PR DESCRIPTION
- Added enum for nexus mod file status (main, update, etc).
- Added ARCHIVED support for nexus update check and download query.
- Use FileStatus enum instead of scattered int literals.
- Re-wrote the update check code