### PR TITLE
Disable qml cache

### DIFF
--- a/src/moapplication.cpp
+++ b/src/moapplication.cpp
@@ -160,6 +160,8 @@ MOApplication::MOApplication(int& argc, char** argv)
 {
   TimeThis tt("MOApplication()");
 
+  qputenv("QML_DISABLE_DISK_CACHE", "true");
+
   connect(&m_styleWatcher, &QFileSystemWatcher::fileChanged, [&](auto&& file){
     log::debug("style file '{}' changed, reloading", file);
     updateStyle(file);


### PR DESCRIPTION
This is the cause of the "cache instance" showing up in the instance manager. By default Qt dumps it in the instances folder.