### PR TITLE
Fix update checking for files not installed from the downloads

### DIFF
--- a/src/mainwindow.cpp
+++ b/src/mainwindow.cpp
@@ -2939,7 +2939,7 @@ void MainWindow::nxmUpdatesAvailable(QString gameName, int modID, QVariant userD
   for (auto mod : modsList) {
     QString validNewVersion;
     int newModStatus = -1;
-    QString installedFile = mod->installationFile();
+    QString installedFile = QFileInfo(mod->installationFile()).fileName();
 
     if (!installedFile.isEmpty()) {
       QVariantMap foundFileData;


### PR DESCRIPTION
This is the difference between "D:\Downloads\USSEP.7z" and
"USSEP.7z".