### PR TITLE
Add/Change IPluginList `hasXExtension` and `isXFlagged` methods

### DIFF
--- a/src/pluginlist.cpp
+++ b/src/pluginlist.cpp
@@ -69,9 +69,9 @@ static bool ByName(const PluginList::ESPInfo& LHS, const PluginList::ESPInfo& RH
 
 static bool ByPriority(const PluginList::ESPInfo& LHS, const PluginList::ESPInfo& RHS)
 {
-  if (LHS.isMaster && !RHS.isMaster) {
+  if (LHS.isMasterFlagged && !RHS.isMasterFlagged) {
     return true;
-  } else if (!LHS.isMaster && RHS.isMaster) {
+  } else if (!LHS.isMasterFlagged && RHS.isMasterFlagged) {
     return false;
   } else {
     return LHS.priority < RHS.priority;
@@ -326,7 +326,7 @@ void PluginList::fixPluginRelationships()
   // Count the types of plugins
   int masterCount = 0;
   for (auto plugin : m_ESPs) {
-    if (plugin.isLight || plugin.isMaster) {
+    if (plugin.isLightFile || plugin.isMasterFlagged) {
       masterCount++;
     }
   }
@@ -334,7 +334,7 @@ void PluginList::fixPluginRelationships()
   // Ensure masters are up top and normal plugins are down below
   for (int i = 0; i < m_ESPs.size(); i++) {
     ESPInfo& plugin = m_ESPs[i];
-    if (plugin.isLight || plugin.isMaster) {
+    if (plugin.isLightFile || plugin.isMasterFlagged) {
       if (plugin.priority > masterCount) {
         int newPriority = masterCount + 1;
         setPluginPriority(i, newPriority);
@@ -923,13 +923,13 @@ int PluginList::loadOrder(const QString &name) const
   }
 }
 
-bool PluginList::isMaster(const QString &name) const
+bool PluginList::isMasterFile(const QString &name) const
 {
   auto iter = m_ESPsByName.find(name);
   if (iter == m_ESPsByName.end()) {
     return false;
   } else {
-    return m_ESPs[iter->second].isMaster;
+    return m_ESPs[iter->second].isMasterFile;
   }
 }
 
@@ -944,13 +944,13 @@ bool PluginList::isMasterFlagged(const QString& name) const
   }
 }
 
-bool PluginList::isLight(const QString &name) const
+bool PluginList::isLightFile(const QString &name) const
 {
   auto iter = m_ESPsByName.find(name);
   if (iter == m_ESPsByName.end()) {
     return false;
   } else {
-    return m_ESPs[iter->second].isLight;
+    return m_ESPs[iter->second].isLightFile;
   }
 }
 
@@ -1049,7 +1049,7 @@ void PluginList::generatePluginIndexes()
       ++numSkipped;
       continue;
     }
-    if (lightPluginsSupported && (m_ESPs[i].isLight || m_ESPs[i].isLightFlagged)) {
+    if (lightPluginsSupported && (m_ESPs[i].isLightFile || m_ESPs[i].isLightFlagged)) {
       int ESLpos = 254 + ((numESLs + 1) / 4096);
       m_ESPs[i].index = QString("%1:%2").arg(ESLpos, 2, 16, QChar('0')).arg((numESLs) % 4096, 3, 16, QChar('0')).toUpper();
       ++numESLs;
@@ -1178,10 +1178,10 @@ QVariant PluginList::fontData(const QModelIndex &modelIndex) const
 
   QFont result;
 
-  if (m_ESPs[index].isMaster) {
+  if (m_ESPs[index].isMasterFile || m_ESPs[index].isMasterFlagged) {
     result.setItalic(true);
     result.setWeight(QFont::Bold);
-  } else if (m_ESPs[index].isLight || m_ESPs[index].isLightFlagged) {
+  } else if (m_ESPs[index].isLightFile || m_ESPs[index].isLightFlagged) {
     result.setItalic(true);
   }
 
@@ -1263,7 +1263,7 @@ QVariant PluginList::tooltipData(const QModelIndex &modelIndex) const
           "be added to your game settings, overwriting in case of conflicts.");
     }
 
-    if (esp.isLightFlagged && !esp.isLight) {
+    if (esp.isLightFlagged && !esp.isLightFile) {
       toolTip +=
         "<br><br>" + tr(
           "This ESP is flagged as an ESL. It will adhere to the ESP load "
@@ -1385,7 +1385,7 @@ QVariant PluginList::iconData(const QModelIndex &modelIndex) const
     result.append(":/MO/gui/archive_conflict_neutral");
   }
 
-  if (esp.isLightFlagged && !esp.isLight) {
+  if (esp.isLightFlagged && !esp.isLightFile) {
     result.append(":/MO/gui/awaiting");
   }
 
@@ -1521,18 +1521,18 @@ void PluginList::setPluginPriority(int row, int &newPriority, bool isForced)
   else if (newPriorityTemp >= static_cast<int>(m_ESPsByPriority.size()))
     newPriorityTemp = static_cast<int>(m_ESPsByPriority.size()) - 1;
 
-  if (!m_ESPs[row].isMaster && !m_ESPs[row].isLight) {
+  if (!m_ESPs[row].isMasterFlagged && !m_ESPs[row].isLightFile) {
     // don't allow esps to be moved above esms
     while ((newPriorityTemp < static_cast<int>(m_ESPsByPriority.size() - 1)) &&
-            (m_ESPs.at(m_ESPsByPriority.at(newPriorityTemp)).isMaster ||
-             m_ESPs.at(m_ESPsByPriority.at(newPriorityTemp)).isLight)) {
+            (m_ESPs.at(m_ESPsByPriority.at(newPriorityTemp)).isMasterFlagged ||
+             m_ESPs.at(m_ESPsByPriority.at(newPriorityTemp)).isLightFile)) {
       ++newPriorityTemp;
     }
   } else {
     // don't allow esms to be moved below esps
     while ((newPriorityTemp > 0) &&
-           !m_ESPs.at(m_ESPsByPriority.at(newPriorityTemp)).isMaster &&
-           !m_ESPs.at(m_ESPsByPriority.at(newPriorityTemp)).isLight) {
+           !m_ESPs.at(m_ESPsByPriority.at(newPriorityTemp)).isMasterFlagged &&
+           !m_ESPs.at(m_ESPsByPriority.at(newPriorityTemp)).isLightFile) {
       --newPriorityTemp;
     }
     // also don't allow "regular" esms to be moved above primary plugins
@@ -1705,9 +1705,9 @@ PluginList::ESPInfo::ESPInfo(const QString &name, bool enabled,
   try {
     ESP::File file(ToWString(fullPath));
     auto extension = name.right(3).toLower();
-    isMaster = (extension == "esm");
+    isMasterFile = (extension == "esm");
     isMasterFlagged = file.isMaster();
-    isLight = lightPluginsAreSupported && (extension == "esl");
+    isLightFile = lightPluginsAreSupported && (extension == "esl");
     isLightFlagged = lightPluginsAreSupported && file.isLight();
 
     author = QString::fromLatin1(file.author().c_str());
@@ -1718,9 +1718,9 @@ PluginList::ESPInfo::ESPInfo(const QString &name, bool enabled,
     }
   } catch (const std::exception &e) {
     log::error("failed to parse plugin file {}: {}", fullPath, e.what());
-    isMaster = false;
+    isMasterFile = false;
     isMasterFlagged = false;
-    isLight = false;
+    isLightFile = false;
     isLightFlagged = false;
   }
 }

--- a/src/pluginlist.cpp
+++ b/src/pluginlist.cpp
@@ -933,6 +933,17 @@ bool PluginList::isMaster(const QString &name) const
   }
 }
 
+bool PluginList::isMasterFlagged(const QString& name) const
+{
+  auto iter = m_ESPsByName.find(name);
+  if (iter == m_ESPsByName.end()) {
+    return false;
+  }
+  else {
+    return m_ESPs[iter->second].isMasterFlagged;
+  }
+}
+
 bool PluginList::isLight(const QString &name) const
 {
   auto iter = m_ESPsByName.find(name);
@@ -1693,8 +1704,9 @@ PluginList::ESPInfo::ESPInfo(const QString &name, bool enabled,
 {
   try {
     ESP::File file(ToWString(fullPath));
-    isMaster = file.isMaster();
     auto extension = name.right(3).toLower();
+    isMaster = (extension == "esm");
+    isMasterFlagged = file.isMaster();
     isLight = lightPluginsAreSupported && (extension == "esl");
     isLightFlagged = lightPluginsAreSupported && file.isLight();
 
@@ -1707,6 +1719,7 @@ PluginList::ESPInfo::ESPInfo(const QString &name, bool enabled,
   } catch (const std::exception &e) {
     log::error("failed to parse plugin file {}: {}", fullPath, e.what());
     isMaster = false;
+    isMasterFlagged = false;
     isLight = false;
     isLightFlagged = false;
   }

--- a/src/pluginlist.h
+++ b/src/pluginlist.h
@@ -233,6 +233,7 @@ public:
   int loadOrder(const QString &name) const;
   bool setPriority(const QString& name, int newPriority);
   bool isMaster(const QString &name) const;
+  bool isMasterFlagged(const QString& name) const;
   bool isLight(const QString &name) const;
   bool isLightFlagged(const QString &name) const;
   QStringList masters(const QString &name) const;
@@ -320,6 +321,7 @@ private:
     FILETIME time;
     QString originName;
     bool isMaster;
+    bool isMasterFlagged;
     bool isLight;
     bool isLightFlagged;
     bool modSelected;

--- a/src/pluginlist.h
+++ b/src/pluginlist.h
@@ -232,13 +232,14 @@ public:
   int priority(const QString &name) const;
   int loadOrder(const QString &name) const;
   bool setPriority(const QString& name, int newPriority);
-  bool isMasterFile(const QString &name) const;
-  bool isMasterFlagged(const QString& name) const;
-  bool isLightFile(const QString &name) const;
-  bool isLightFlagged(const QString &name) const;
   QStringList masters(const QString &name) const;
   QString origin(const QString &name) const;
   void setLoadOrder(const QStringList& pluginList);
+
+  bool hasMasterExtension(const QString& name) const;
+  bool hasLightExtension(const QString& name) const;
+  bool isMasterFlagged(const QString& name) const;
+  bool isLightFlagged(const QString& name) const;
 
   boost::signals2::connection onRefreshed(const std::function<void()>& callback);
   boost::signals2::connection onPluginMoved(const std::function<void(const QString&, int, int)>& func);
@@ -320,9 +321,9 @@ private:
     int loadOrder;
     FILETIME time;
     QString originName;
-    bool isMasterFile;
+    bool hasMasterExtension;
+    bool hasLightExtension;
     bool isMasterFlagged;
-    bool isLightFile;
     bool isLightFlagged;
     bool modSelected;
     QString author;

--- a/src/pluginlist.h
+++ b/src/pluginlist.h
@@ -232,9 +232,9 @@ public:
   int priority(const QString &name) const;
   int loadOrder(const QString &name) const;
   bool setPriority(const QString& name, int newPriority);
-  bool isMaster(const QString &name) const;
+  bool isMasterFile(const QString &name) const;
   bool isMasterFlagged(const QString& name) const;
-  bool isLight(const QString &name) const;
+  bool isLightFile(const QString &name) const;
   bool isLightFlagged(const QString &name) const;
   QStringList masters(const QString &name) const;
   QString origin(const QString &name) const;
@@ -320,9 +320,9 @@ private:
     int loadOrder;
     FILETIME time;
     QString originName;
-    bool isMaster;
+    bool isMasterFile;
     bool isMasterFlagged;
-    bool isLight;
+    bool isLightFile;
     bool isLightFlagged;
     bool modSelected;
     QString author;

--- a/src/pluginlistproxy.cpp
+++ b/src/pluginlistproxy.cpp
@@ -63,9 +63,9 @@ void PluginListProxy::setLoadOrder(const QStringList& pluginList)
   return m_Proxied->setLoadOrder(pluginList);
 }
 
-bool PluginListProxy::isMaster(const QString& name) const
+bool PluginListProxy::isMasterFile(const QString& name) const
 {
-  return m_Proxied->isMaster(name);
+  return m_Proxied->isMasterFile(name);
 }
 
 bool PluginListProxy::isMasterFlagged(const QString& name) const
@@ -73,14 +73,19 @@ bool PluginListProxy::isMasterFlagged(const QString& name) const
   return m_Proxied->isMasterFlagged(name);
 }
 
-bool PluginListProxy::isLight(const QString& name) const
+bool PluginListProxy::isLightFile(const QString& name) const
 {
-  return m_Proxied->isLight(name);
+  return m_Proxied->isLightFile(name);
 }
 
 bool PluginListProxy::isLightFlagged(const QString& name) const
 {
   return m_Proxied->isLightFlagged(name);
+}
+
+bool PluginListProxy::isMaster(const QString& name) const
+{
+  return m_Proxied->isMasterFlagged(name);
 }
 
 QStringList PluginListProxy::masters(const QString& name) const

--- a/src/pluginlistproxy.cpp
+++ b/src/pluginlistproxy.cpp
@@ -68,6 +68,21 @@ bool PluginListProxy::isMaster(const QString& name) const
   return m_Proxied->isMaster(name);
 }
 
+bool PluginListProxy::isMasterFlagged(const QString& name) const
+{
+  return m_Proxied->isMasterFlagged(name);
+}
+
+bool PluginListProxy::isLight(const QString& name) const
+{
+  return m_Proxied->isLight(name);
+}
+
+bool PluginListProxy::isLightFlagged(const QString& name) const
+{
+  return m_Proxied->isLightFlagged(name);
+}
+
 QStringList PluginListProxy::masters(const QString& name) const
 {
   return m_Proxied->masters(name);

--- a/src/pluginlistproxy.cpp
+++ b/src/pluginlistproxy.cpp
@@ -63,26 +63,6 @@ void PluginListProxy::setLoadOrder(const QStringList& pluginList)
   return m_Proxied->setLoadOrder(pluginList);
 }
 
-bool PluginListProxy::isMasterFile(const QString& name) const
-{
-  return m_Proxied->isMasterFile(name);
-}
-
-bool PluginListProxy::isMasterFlagged(const QString& name) const
-{
-  return m_Proxied->isMasterFlagged(name);
-}
-
-bool PluginListProxy::isLightFile(const QString& name) const
-{
-  return m_Proxied->isLightFile(name);
-}
-
-bool PluginListProxy::isLightFlagged(const QString& name) const
-{
-  return m_Proxied->isLightFlagged(name);
-}
-
 bool PluginListProxy::isMaster(const QString& name) const
 {
   return m_Proxied->isMasterFlagged(name);
@@ -111,4 +91,24 @@ bool PluginListProxy::onPluginMoved(const std::function<void(const QString&, int
 bool PluginListProxy::onPluginStateChanged(const std::function<void(const std::map<QString, PluginStates>&)> &func)
 {
   return m_PluginStateChanged.connect(func).connected();
+}
+
+bool PluginListProxy::hasMasterExtension(const QString& name) const
+{
+  return m_Proxied->hasMasterExtension(name);
+}
+
+bool PluginListProxy::hasLightExtension(const QString& name) const
+{
+  return m_Proxied->hasLightExtension(name);
+}
+
+bool PluginListProxy::isMasterFlagged(const QString& name) const
+{
+  return m_Proxied->isMasterFlagged(name);
+}
+
+bool PluginListProxy::isLightFlagged(const QString& name) const
+{
+  return m_Proxied->isLightFlagged(name);
 }

--- a/src/pluginlistproxy.h
+++ b/src/pluginlistproxy.h
@@ -22,6 +22,9 @@ public:
   int loadOrder(const QString& name) const override;
   void setLoadOrder(const QStringList& pluginList) override;
   bool isMaster(const QString& name) const override;
+  bool isMasterFlagged(const QString& name) const override;
+  bool isLight(const QString& name) const override;
+  bool isLightFlagged(const QString& name) const override;
   QStringList masters(const QString& name) const override;
   QString origin(const QString& name) const override;
   bool onRefreshed(const std::function<void()>& callback) override;

--- a/src/pluginlistproxy.h
+++ b/src/pluginlistproxy.h
@@ -21,15 +21,18 @@ public:
   bool setPriority(const QString& name, int newPriority) override;
   int loadOrder(const QString& name) const override;
   void setLoadOrder(const QStringList& pluginList) override;
-  bool isMaster(const QString& name) const override;
+  bool isMasterFile(const QString& name) const override;
   bool isMasterFlagged(const QString& name) const override;
-  bool isLight(const QString& name) const override;
+  bool isLightFile(const QString& name) const override;
   bool isLightFlagged(const QString& name) const override;
   QStringList masters(const QString& name) const override;
   QString origin(const QString& name) const override;
   bool onRefreshed(const std::function<void()>& callback) override;
   bool onPluginMoved(const std::function<void(const QString&, int, int)>& func) override;
   bool onPluginStateChanged(const std::function<void(const std::map<QString, PluginStates>&)>& func) override;
+
+  // DEPRECATED
+  [[deprecated]] bool isMaster(const QString& name) const override;
 
 private:
 

--- a/src/pluginlistproxy.h
+++ b/src/pluginlistproxy.h
@@ -8,7 +8,6 @@ class OrganizerProxy;
 
 class PluginListProxy : public MOBase::IPluginList
 {
-
 public:
 
   PluginListProxy(OrganizerProxy* oproxy, PluginList* pluginlist);
@@ -21,18 +20,18 @@ public:
   bool setPriority(const QString& name, int newPriority) override;
   int loadOrder(const QString& name) const override;
   void setLoadOrder(const QStringList& pluginList) override;
-  bool isMasterFile(const QString& name) const override;
-  bool isMasterFlagged(const QString& name) const override;
-  bool isLightFile(const QString& name) const override;
-  bool isLightFlagged(const QString& name) const override;
+  [[deprecated]] bool isMaster(const QString& name) const override;
   QStringList masters(const QString& name) const override;
   QString origin(const QString& name) const override;
+
   bool onRefreshed(const std::function<void()>& callback) override;
   bool onPluginMoved(const std::function<void(const QString&, int, int)>& func) override;
   bool onPluginStateChanged(const std::function<void(const std::map<QString, PluginStates>&)>& func) override;
 
-  // DEPRECATED
-  [[deprecated]] bool isMaster(const QString& name) const override;
+  bool hasMasterExtension(const QString& name) const override;
+  bool hasLightExtension(const QString& name) const override;
+  bool isMasterFlagged(const QString& name) const override;
+  bool isLightFlagged(const QString& name) const override;
 
 private:
 

--- a/src/pluginlistview.cpp
+++ b/src/pluginlistview.cpp
@@ -76,7 +76,7 @@ void PluginListView::updatePluginCount()
       activeLightMasterCount += active;
       activeVisibleCount += visible && active;
     }
-    else if (list->isMaster(plugin)) {
+    else if (list->isMaster(plugin) || list->isMasterFlagged(plugin)) {
       masterCount++;
       activeMasterCount += active;
       activeVisibleCount += visible && active;

--- a/src/pluginlistview.cpp
+++ b/src/pluginlistview.cpp
@@ -71,12 +71,12 @@ void PluginListView::updatePluginCount()
   for (QString plugin : list->pluginNames()) {
     bool active = list->isEnabled(plugin);
     bool visible = m_sortProxy->filterMatchesPlugin(plugin);
-    if (list->isLightFile(plugin) || list->isLightFlagged(plugin)) {
+    if (list->hasLightExtension(plugin) || list->isLightFlagged(plugin)) {
       lightMasterCount++;
       activeLightMasterCount += active;
       activeVisibleCount += visible && active;
     }
-    else if (list->isMasterFile(plugin) || list->isMasterFlagged(plugin)) {
+    else if (list->hasMasterExtension(plugin) || list->isMasterFlagged(plugin)) {
       masterCount++;
       activeMasterCount += active;
       activeVisibleCount += visible && active;

--- a/src/pluginlistview.cpp
+++ b/src/pluginlistview.cpp
@@ -71,12 +71,12 @@ void PluginListView::updatePluginCount()
   for (QString plugin : list->pluginNames()) {
     bool active = list->isEnabled(plugin);
     bool visible = m_sortProxy->filterMatchesPlugin(plugin);
-    if (list->isLight(plugin) || list->isLightFlagged(plugin)) {
+    if (list->isLightFile(plugin) || list->isLightFlagged(plugin)) {
       lightMasterCount++;
       activeLightMasterCount += active;
       activeVisibleCount += visible && active;
     }
-    else if (list->isMaster(plugin) || list->isMasterFlagged(plugin)) {
+    else if (list->isMasterFile(plugin) || list->isMasterFlagged(plugin)) {
       masterCount++;
       activeMasterCount += active;
       activeVisibleCount += visible && active;


### PR DESCRIPTION
For #1669

`isMaster` was inconsistent with the then `isLight` as it checked the master flag while `isLight` checked the file extension. I've renamed the methods to be more clear, and deprecated the old one. I also tried to make sure the current behavior stays mostly the same, but it's not out of the question that I may have made a mistake somewhere.

I also added them to the proxy primarily for use in python

Related PRs:
https://github.com/ModOrganizer2/modorganizer-uibase/pull/122
https://github.com/ModOrganizer2/modorganizer-plugin_python/pull/100