### PR TITLE
Plugin updates (python rework)

### DIFF
--- a/src/organizer_en.ts
+++ b/src/organizer_en.ts
@@ -5909,48 +5909,48 @@ Continue?</source>
 <context>
     <name>PluginContainer</name>
     <message>
-        <location filename="plugincontainer.cpp" line="1010"/>
+        <location filename="plugincontainer.cpp" line="1013"/>
         <source>Plugin error</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="plugincontainer.cpp" line="1011"/>
+        <location filename="plugincontainer.cpp" line="1014"/>
         <source>Mod Organizer failed to load the plugin &apos;%1&apos; last time it was started.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="plugincontainer.cpp" line="1014"/>
+        <location filename="plugincontainer.cpp" line="1017"/>
         <source>The plugin can be skipped for this session, blacklisted, or loaded normally, in which case it might fail again. Blacklisted plugins can be re-enabled later in the settings.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="plugincontainer.cpp" line="1019"/>
+        <location filename="plugincontainer.cpp" line="1022"/>
         <source>Skip this plugin</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="plugincontainer.cpp" line="1020"/>
+        <location filename="plugincontainer.cpp" line="1023"/>
         <source>Blacklist this plugin</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="plugincontainer.cpp" line="1021"/>
+        <location filename="plugincontainer.cpp" line="1024"/>
         <source>Load this plugin</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="plugincontainer.cpp" line="1118"/>
+        <location filename="plugincontainer.cpp" line="1121"/>
         <source>Some plugins could not be loaded</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="plugincontainer.cpp" line="1121"/>
-        <location filename="plugincontainer.cpp" line="1139"/>
+        <location filename="plugincontainer.cpp" line="1124"/>
+        <location filename="plugincontainer.cpp" line="1142"/>
         <source>Description missing</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="plugincontainer.cpp" line="1130"/>
+        <location filename="plugincontainer.cpp" line="1133"/>
         <source>The following plugins could not be loaded. The reason may be missing dependencies (i.e. python) or an outdated version:</source>
         <translation type="unfinished"></translation>
     </message>
@@ -7413,7 +7413,7 @@ Destination:<byte value="xd"/>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="plugincontainer.cpp" line="796"/>
+        <location filename="plugincontainer.cpp" line="797"/>
         <source>failed to initialize plugin %1: %2</source>
         <translation type="unfinished"></translation>
     </message>

--- a/src/organizer_en.ts
+++ b/src/organizer_en.ts
@@ -5909,48 +5909,48 @@ Continue?</source>
 <context>
     <name>PluginContainer</name>
     <message>
-        <location filename="plugincontainer.cpp" line="1013"/>
+        <location filename="plugincontainer.cpp" line="1046"/>
         <source>Plugin error</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="plugincontainer.cpp" line="1014"/>
+        <location filename="plugincontainer.cpp" line="1047"/>
         <source>Mod Organizer failed to load the plugin &apos;%1&apos; last time it was started.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="plugincontainer.cpp" line="1017"/>
+        <location filename="plugincontainer.cpp" line="1050"/>
         <source>The plugin can be skipped for this session, blacklisted, or loaded normally, in which case it might fail again. Blacklisted plugins can be re-enabled later in the settings.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="plugincontainer.cpp" line="1022"/>
+        <location filename="plugincontainer.cpp" line="1055"/>
         <source>Skip this plugin</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="plugincontainer.cpp" line="1023"/>
+        <location filename="plugincontainer.cpp" line="1056"/>
         <source>Blacklist this plugin</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="plugincontainer.cpp" line="1024"/>
+        <location filename="plugincontainer.cpp" line="1057"/>
         <source>Load this plugin</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="plugincontainer.cpp" line="1121"/>
+        <location filename="plugincontainer.cpp" line="1157"/>
         <source>Some plugins could not be loaded</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="plugincontainer.cpp" line="1124"/>
-        <location filename="plugincontainer.cpp" line="1142"/>
+        <location filename="plugincontainer.cpp" line="1160"/>
+        <location filename="plugincontainer.cpp" line="1178"/>
         <source>Description missing</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="plugincontainer.cpp" line="1133"/>
+        <location filename="plugincontainer.cpp" line="1169"/>
         <source>The following plugins could not be loaded. The reason may be missing dependencies (i.e. python) or an outdated version:</source>
         <translation type="unfinished"></translation>
     </message>

--- a/src/plugincontainer.cpp
+++ b/src/plugincontainer.cpp
@@ -467,8 +467,8 @@ IPlugin* PluginContainer::registerPlugin(QObject *plugin, const QString& filepat
       }
     }
     else {
-      log::warn("Trying to register two plugins with the name '{}', the second one will not be registered.",
-        pluginObj->name());
+      log::warn("Trying to register two plugins with the name '{}' (from {} and {}), the second one will not be registered.",
+        pluginObj->name(), this->filepath(other), QDir::cleanPath(filepath));
       return nullptr;
     }
   }
@@ -481,6 +481,7 @@ IPlugin* PluginContainer::registerPlugin(QObject *plugin, const QString& filepat
   bf::at_key<QObject>(m_Plugins).push_back(plugin);
 
   plugin->setProperty("filepath", QDir::cleanPath(filepath));
+  plugin->setParent(this);
 
   if (m_Organizer) {
     m_Organizer->settings().plugins().registerPlugin(pluginObj);
@@ -920,6 +921,8 @@ void PluginContainer::unloadPlugin(MOBase::IPlugin* plugin, QObject* object)
     }
 
   }
+
+  object->deleteLater();
 
   // Do this at the end.
   m_Requirements.erase(plugin);

--- a/src/plugincontainer.h
+++ b/src/plugincontainer.h
@@ -396,6 +396,16 @@ private:
   // Load the Qt plugin from the given file.
   QObject* loadQtPlugin(const QString& filepath);
 
+  // check if a plugin is folder containing a Qt plugin, it is, return the path to the
+  // DLL containing the plugin in the folder, otherwise return an empty optional
+  //
+  // a Qt plugin folder is a folder with a DLL containing a library (not in a subdirectory),
+  // if multiple plugins are present, only the first one is returned
+  //
+  // extra DLLs are ignored by Qt so can be present in the folder
+  //
+  std::optional<QString> isQtPluginFolder(const QString& filepath) const;
+
   // See startPlugins for more details. This is simply an intermediate function
   // that can be used when loading plugins after initialization. This uses the
   // user interface in m_UserInterface.


### PR DESCRIPTION
Updates that go with the Python rework (pybind11, etc.):

- Better lifetime handling for plugins - the lifetime of the plugins is tied (via `setParent()`) to the lifetime of the container. Before, most Python plugins would still lie around after many MO2 restarts.
- Allow C++ plugins in sub-folder, similar to Python ones. A C++ plugin folder is simply a folder with at least (and at most) one DLL containing a Qt plugin.