### PR TITLE
 Notify mod installation to plugins after directory structure is ready. 

### DIFF
--- a/src/organizercore.h
+++ b/src/organizercore.h
@@ -10,6 +10,7 @@
 #include "downloadmanager.h"
 #include "executableslist.h"
 #include "usvfsconnector.h"
+#include "guessedvalue.h"
 #include "moshortcut.h"
 #include "memoizedlock.h"
 #include "processrunner.h"
@@ -399,6 +400,9 @@ signals:
   void directoryStructureReady();
 
 private:
+
+  std::pair<unsigned int, ModInfo::Ptr> doInstall(const QString& archivePath,
+    MOBase::GuessedValue<QString> modName, ModInfo::Ptr currentMod, int priority, bool reinstallation);
 
   void saveCurrentProfile();
   void storeSettings();


### PR DESCRIPTION
This is actually a pretty small change that add the following before calling `refresh()` (and remove the call to `notifyModInstalled` afterward):

```cpp
connect(this, &OrganizerCore::directoryStructureReady, this, [=] {
  const int modIndex = ModInfo::getIndex(modName);
  if (modIndex != UINT_MAX) {
    const auto modInfo = ModInfo::getByIndex(modIndex);
    m_ModList.notifyModInstalled(modInfo.get());
  }
  }, Qt::SingleShotConnection);
```

Most of the changes are trying to have a single function called by both `installDownload()` and `installArchive()` instead of having two almost identical functions.