### PR TITLE
Default profile settings

### DIFF
--- a/src/createinstancedialog.cpp
+++ b/src/createinstancedialog.cpp
@@ -110,6 +110,7 @@ CreateInstanceDialog::CreateInstanceDialog(const PluginContainer& pc, Settings* 
   m_pages.push_back(std::make_unique<GamePage>(*this));
   m_pages.push_back(std::make_unique<VariantsPage>(*this));
   m_pages.push_back(std::make_unique<NamePage>(*this));
+  m_pages.push_back(std::make_unique<ProfilePage>(*this));
   m_pages.push_back(std::make_unique<PathsPage>(*this));
   m_pages.push_back(std::make_unique<NexusPage>(*this));
   m_pages.push_back(std::make_unique<ConfirmationPage>(*this));
@@ -355,6 +356,10 @@ void CreateInstanceDialog::finish()
       s.paths().setOverwrite(ci.paths.overwrite);
     }
 
+    s.setProfileLocalInis(ci.profileSettings.localInis);
+    s.setProfileLocalSaves(ci.profileSettings.localSaves);
+    s.setProfileArchiveInvalidation(ci.profileSettings.archiveInvalidation);
+
     logCreation(tr("Writing %1...").arg(ci.iniPath));
 
     // writing ini
@@ -475,12 +480,13 @@ CreateInstanceDialog::CreationInfo CreateInstanceDialog::rawCreationInfo() const
 
   CreationInfo ci;
 
-  ci.type         = getSelected(&cid::Page::selectedInstanceType);
-  ci.game         = getSelected(&cid::Page::selectedGame);
-  ci.gameLocation = getSelected(&cid::Page::selectedGameLocation);
-  ci.gameVariant  = getSelected(&cid::Page::selectedGameVariant, ci.game);
-  ci.instanceName = getSelected(&cid::Page::selectedInstanceName);
-  ci.paths        = getSelected(&cid::Page::selectedPaths);
+  ci.type            = getSelected(&cid::Page::selectedInstanceType);
+  ci.game            = getSelected(&cid::Page::selectedGame);
+  ci.gameLocation    = getSelected(&cid::Page::selectedGameLocation);
+  ci.gameVariant     = getSelected(&cid::Page::selectedGameVariant, ci.game);
+  ci.instanceName    = getSelected(&cid::Page::selectedInstanceName);
+  ci.profileSettings = getSelected(&cid::Page::profileSettings);
+  ci.paths           = getSelected(&cid::Page::selectedPaths);
 
   if (ci.type == Portable) {
     ci.dataPath = QDir(InstanceManager::singleton().portablePath()).absolutePath();

--- a/src/createinstancedialog.h
+++ b/src/createinstancedialog.h
@@ -66,6 +66,15 @@ public:
     auto operator<=>(const Paths&) const = default;
   };
 
+  struct ProfileSettings
+  {
+    bool localInis;
+    bool localSaves;
+    bool archiveInvalidation;
+
+    auto operator<=>(const ProfileSettings&) const = default;
+  };
+
   // all the info filled in the various pages
   //
   struct CreationInfo
@@ -78,6 +87,7 @@ public:
     QString dataPath;
     QString iniPath;
     Paths paths;
+    ProfileSettings profileSettings;
   };
 
   CreateInstanceDialog(const PluginContainer& pc, Settings* s,

--- a/src/createinstancedialog.ui
+++ b/src/createinstancedialog.ui
@@ -34,7 +34,6 @@
         <property name="font">
          <font>
           <pointsize>14</pointsize>
-          <weight>75</weight>
           <bold>true</bold>
          </font>
         </property>
@@ -294,7 +293,7 @@
                   <x>0</x>
                   <y>0</y>
                   <width>455</width>
-                  <height>286</height>
+                  <height>275</height>
                  </rect>
                 </property>
                 <layout class="QVBoxLayout" name="verticalLayout_26">
@@ -430,7 +429,7 @@
                <x>0</x>
                <y>0</y>
                <width>455</width>
-               <height>278</height>
+               <height>265</height>
               </rect>
              </property>
              <layout class="QVBoxLayout" name="verticalLayout_17">
@@ -530,6 +529,90 @@
           </item>
           <item>
            <spacer name="verticalSpacer_2">
+            <property name="orientation">
+             <enum>Qt::Vertical</enum>
+            </property>
+            <property name="sizeHint" stdset="0">
+             <size>
+              <width>20</width>
+              <height>40</height>
+             </size>
+            </property>
+           </spacer>
+          </item>
+         </layout>
+        </widget>
+       </item>
+      </layout>
+     </widget>
+     <widget class="QWidget" name="page">
+      <layout class="QVBoxLayout" name="verticalLayout_31">
+       <item>
+        <widget class="QWidget" name="widget_24" native="true">
+         <layout class="QHBoxLayout" name="horizontalLayout_8">
+          <property name="leftMargin">
+           <number>0</number>
+          </property>
+          <property name="topMargin">
+           <number>0</number>
+          </property>
+          <property name="rightMargin">
+           <number>0</number>
+          </property>
+          <property name="bottomMargin">
+           <number>0</number>
+          </property>
+          <item>
+           <widget class="QLabel" name="profileSettingsLabel">
+            <property name="text">
+             <string>&lt;h3&gt;Configure your profile settings.&lt;/h3&gt;</string>
+            </property>
+            <property name="wordWrap">
+             <bool>true</bool>
+            </property>
+           </widget>
+          </item>
+         </layout>
+        </widget>
+       </item>
+       <item>
+        <widget class="QWidget" name="widget_25" native="true">
+         <layout class="QVBoxLayout" name="verticalLayout_28">
+          <item>
+           <widget class="QCheckBox" name="profileInisCheckbox">
+            <property name="toolTip">
+             <string extracomment="Enabling this will copy your game's INI files into each profile, which will override the default INI settings"/>
+            </property>
+            <property name="text">
+             <string>Use profile-specific game INI files</string>
+            </property>
+           </widget>
+          </item>
+          <item>
+           <widget class="QCheckBox" name="profileSavesCheckbox">
+            <property name="toolTip">
+             <string extracomment="Enabling this will redirect the game's save files into your active profile, allowing you to separate your saves between profiles"/>
+            </property>
+            <property name="text">
+             <string>Use profile-specific save games</string>
+            </property>
+           </widget>
+          </item>
+          <item>
+           <widget class="QCheckBox" name="archiveInvalidationCheckbox">
+            <property name="toolTip">
+             <string extracomment="Enabling this will allow MO2 to automatically run necessary INI edits or other steps to allow file overrides in the game."/>
+            </property>
+            <property name="text">
+             <string>Automatic archive invalidation</string>
+            </property>
+            <property name="checked">
+             <bool>true</bool>
+            </property>
+           </widget>
+          </item>
+          <item>
+           <spacer name="verticalSpacer_7">
             <property name="orientation">
              <enum>Qt::Vertical</enum>
             </property>
@@ -1242,7 +1325,6 @@
   <tabstop>showAllGames</tabstop>
   <tabstop>gamesFilter</tabstop>
   <tabstop>scrollArea_2</tabstop>
-  <tabstop>instanceName</tabstop>
   <tabstop>location</tabstop>
   <tabstop>browseLocation</tabstop>
   <tabstop>advancedPathOptions</tabstop>

--- a/src/createinstancedialogpages.cpp
+++ b/src/createinstancedialogpages.cpp
@@ -937,9 +937,7 @@ bool NamePage::checkName(QString parentDir, QString name)
   return okay;
 }
 
-ProfilePage::ProfilePage(CreateInstanceDialog& dlg)
-  : Page(dlg)
-{}
+ProfilePage::ProfilePage(CreateInstanceDialog& dlg) : Page(dlg) {}
 
 bool ProfilePage::ready() const
 {

--- a/src/createinstancedialogpages.cpp
+++ b/src/createinstancedialogpages.cpp
@@ -143,6 +143,12 @@ CreateInstanceDialog::Paths Page::selectedPaths() const
   return {};
 }
 
+CreateInstanceDialog::ProfileSettings Page::profileSettings() const
+{
+  // no-op
+  return {};
+}
+
 IntroPage::IntroPage(CreateInstanceDialog& dlg)
     : Page(dlg), m_skip(GlobalSettings::hideCreateInstanceIntro())
 {
@@ -931,6 +937,24 @@ bool NamePage::checkName(QString parentDir, QString name)
   return okay;
 }
 
+ProfilePage::ProfilePage(CreateInstanceDialog& dlg)
+  : Page(dlg)
+{}
+
+bool ProfilePage::ready() const
+{
+  return true;
+}
+
+CreateInstanceDialog::ProfileSettings ProfilePage::profileSettings() const
+{
+  CreateInstanceDialog::ProfileSettings profileSettings;
+  profileSettings.localInis           = ui->profileInisCheckbox->isChecked();
+  profileSettings.localSaves          = ui->profileSavesCheckbox->isChecked();
+  profileSettings.archiveInvalidation = ui->archiveInvalidationCheckbox->isChecked();
+  return profileSettings;
+}
+
 PathsPage::PathsPage(CreateInstanceDialog& dlg)
     : Page(dlg), m_lastType(CreateInstanceDialog::NoType), m_label(ui->pathsLabel),
       m_simpleExists(ui->locationExists), m_simpleInvalid(ui->locationInvalid),
@@ -1214,6 +1238,17 @@ QString ConfirmationPage::makeReview() const
   if (ci.type != CreateInstanceDialog::Portable) {
     lines.push_back(QObject::tr("Instance name: %1").arg(ci.instanceName));
   }
+
+  lines.push_back(QObject::tr("Profile settings:"));
+  lines.push_back(
+      QObject::tr("  Local INIs: %1")
+          .arg(ci.profileSettings.localInis ? QObject::tr("yes") : QObject::tr("no")));
+  lines.push_back(
+      QObject::tr("  Local Saves: %1")
+          .arg(ci.profileSettings.localSaves ? QObject::tr("yes") : QObject::tr("no")));
+  lines.push_back(QObject::tr("  Automatic Archive Invalidation: %1")
+                      .arg(ci.profileSettings.archiveInvalidation ? QObject::tr("yes")
+                                                                  : QObject::tr("no")));
 
   if (ci.paths.downloads.isEmpty()) {
     // simple settings

--- a/src/createinstancedialogpages.h
+++ b/src/createinstancedialogpages.h
@@ -110,6 +110,10 @@ public:
   //
   virtual CreateInstanceDialog::Paths selectedPaths() const;
 
+  // returns the profile settings
+  //
+  virtual CreateInstanceDialog::ProfileSettings profileSettings() const;
+
 protected:
   Ui::CreateInstanceDialog* ui;
   CreateInstanceDialog& m_dlg;
@@ -556,6 +560,26 @@ private:
   //
   void setIfEmpty(QLineEdit* e, const QString& path, bool force);
 };
+
+
+// default settings for profiles page; allow the user to set their preferred
+// defaults for the profile options
+//
+class ProfilePage : public Page
+{
+public:
+  ProfilePage(CreateInstanceDialog& dlg);
+
+  // always returns true, options are boolean
+  //
+  bool ready() const override;
+
+  CreateInstanceDialog::ProfileSettings profileSettings() const override;
+
+protected:
+
+};
+
 
 // nexus connection page; this reuses the ui found in the settings dialog and
 // is skipped if there's already an api key in the credentials manager

--- a/src/createinstancedialogpages.h
+++ b/src/createinstancedialogpages.h
@@ -561,7 +561,6 @@ private:
   void setIfEmpty(QLineEdit* e, const QString& path, bool force);
 };
 
-
 // default settings for profiles page; allow the user to set their preferred
 // defaults for the profile options
 //
@@ -575,11 +574,7 @@ public:
   bool ready() const override;
 
   CreateInstanceDialog::ProfileSettings profileSettings() const override;
-
-protected:
-
 };
-
 
 // nexus connection page; this reuses the ui found in the settings dialog and
 // is skipped if there's already an api key in the credentials manager

--- a/src/profile.cpp
+++ b/src/profile.cpp
@@ -177,8 +177,7 @@ void Profile::findProfileSettings()
     }
   }
 
-  if (setting("", "LocalSettings") ==
-      QVariant()) {
+  if (setting("", "LocalSettings") == QVariant()) {
     QString backupFile = getIniFileName() + "_";
     if (m_Directory.exists(backupFile)) {
       storeSetting("", "LocalSettings", true);

--- a/src/settings.cpp
+++ b/src/settings.cpp
@@ -214,6 +214,36 @@ void Settings::setUsePrereleases(bool b)
   set(m_Settings, "Settings", "use_prereleases", b);
 }
 
+bool Settings::profileLocalInis() const
+{
+  return get<bool>(m_Settings, "Settings", "profile_local_inis", true);
+}
+
+void Settings::setProfileLocalInis(bool b)
+{
+  set(m_Settings, "Settings", "profile_local_inis", b);
+}
+
+bool Settings::profileLocalSaves() const
+{
+  return get<bool>(m_Settings, "Settings", "profile_local_saves", false);
+}
+
+void Settings::setProfileLocalSaves(bool b)
+{
+  set(m_Settings, "Settings", "profile_local_saves", b);
+}
+
+bool Settings::profileArchiveInvalidation() const
+{
+  return get<bool>(m_Settings, "Settings", "profile_archive_invalidation", false);
+}
+
+void Settings::setProfileArchiveInvalidation(bool b)
+{
+  set(m_Settings, "Settings", "profile_archive_invalidation", b);
+}
+
 bool Settings::useSplash() const
 {
   return get<bool>(m_Settings, "Settings", "use_splash", true);

--- a/src/settings.h
+++ b/src/settings.h
@@ -810,6 +810,21 @@ public:
   bool usePrereleases() const;
   void setUsePrereleases(bool b);
 
+  // whether profiles should default to local INIs
+  //
+  bool profileLocalInis() const;
+  void setProfileLocalInis(bool b);
+
+  // whether profiles should default to local saves
+  //
+  bool profileLocalSaves() const;
+  void setProfileLocalSaves(bool b);
+
+  // whether profiles should default to automatic archive invalidation
+  //
+  bool profileArchiveInvalidation() const;
+  void setProfileArchiveInvalidation(bool b);
+
   // whether to use spascreen or not
   //
   bool useSplash() const;

--- a/src/settingsdialog.ui
+++ b/src/settingsdialog.ui
@@ -23,7 +23,7 @@
       <attribute name="title">
        <string>General</string>
       </attribute>
-      <layout class="QGridLayout" name="gridLayout" rowstretch="0,0,0">
+      <layout class="QGridLayout" name="gridLayout" rowstretch="0">
        <item row="0" column="0">
         <widget class="QScrollArea" name="generalScrollArea">
          <property name="styleSheet">
@@ -44,8 +44,8 @@
            <rect>
             <x>0</x>
             <y>0</y>
-            <width>780</width>
-            <height>502</height>
+            <width>761</width>
+            <height>550</height>
            </rect>
           </property>
           <property name="autoFillBackground">
@@ -198,6 +198,36 @@
                 </property>
                 <property name="text">
                  <string>Update to beta versions</string>
+                </property>
+               </widget>
+              </item>
+             </layout>
+            </widget>
+           </item>
+           <item>
+            <widget class="QGroupBox" name="groupBox_8">
+             <property name="title">
+              <string>Profile Defaults</string>
+             </property>
+             <layout class="QVBoxLayout" name="verticalLayout_11">
+              <item>
+               <widget class="QCheckBox" name="localINIs">
+                <property name="text">
+                 <string>Local INIs</string>
+                </property>
+               </widget>
+              </item>
+              <item>
+               <widget class="QCheckBox" name="localSaves">
+                <property name="text">
+                 <string>Local Saves</string>
+                </property>
+               </widget>
+              </item>
+              <item>
+               <widget class="QCheckBox" name="automaticArchiveInvalidation">
+                <property name="text">
+                 <string>Automatic Archive Invalidation</string>
                 </property>
                </widget>
               </item>
@@ -1022,8 +1052,8 @@ If you disable this feature, MO will only display official DLCs this way. Please
            <rect>
             <x>0</x>
             <y>0</y>
-            <width>780</width>
-            <height>502</height>
+            <width>778</width>
+            <height>497</height>
            </rect>
           </property>
           <property name="autoFillBackground">
@@ -1702,8 +1732,8 @@ If you disable this feature, MO will only display official DLCs this way. Please
            <rect>
             <x>0</x>
             <y>0</y>
-            <width>780</width>
-            <height>483</height>
+            <width>778</width>
+            <height>475</height>
            </rect>
           </property>
           <property name="autoFillBackground">

--- a/src/settingsdialoggeneral.cpp
+++ b/src/settingsdialoggeneral.cpp
@@ -72,7 +72,8 @@ void GeneralSettingsTab::update()
   // profile defaults
   settings().setProfileLocalInis(ui->localINIs->isChecked());
   settings().setProfileLocalSaves(ui->localSaves->isChecked());
-  settings().setProfileArchiveInvalidation(ui->automaticArchiveInvalidation->isChecked());
+  settings().setProfileArchiveInvalidation(
+      ui->automaticArchiveInvalidation->isChecked());
 
   // miscellaneous
   settings().geometry().setCenterDialogs(ui->centerDialogs->isChecked());

--- a/src/settingsdialoggeneral.cpp
+++ b/src/settingsdialoggeneral.cpp
@@ -25,6 +25,11 @@ GeneralSettingsTab::GeneralSettingsTab(Settings& s, SettingsDialog& d)
   ui->checkForUpdates->setChecked(settings().checkForUpdates());
   ui->usePrereleaseBox->setChecked(settings().usePrereleases());
 
+  // profile defaults
+  ui->localINIs->setChecked(settings().profileLocalInis());
+  ui->localSaves->setChecked(settings().profileLocalSaves());
+  ui->automaticArchiveInvalidation->setChecked(settings().profileArchiveInvalidation());
+
   // miscellaneous
   ui->centerDialogs->setChecked(settings().geometry().centerDialogs());
   ui->changeGameConfirmation->setChecked(
@@ -63,6 +68,11 @@ void GeneralSettingsTab::update()
   // updates
   settings().setCheckForUpdates(ui->checkForUpdates->isChecked());
   settings().setUsePrereleases(ui->usePrereleaseBox->isChecked());
+
+  // profile defaults
+  settings().setProfileLocalInis(ui->localINIs->isChecked());
+  settings().setProfileLocalSaves(ui->localSaves->isChecked());
+  settings().setProfileArchiveInvalidation(ui->automaticArchiveInvalidation->isChecked());
 
   // miscellaneous
   settings().geometry().setCenterDialogs(ui->centerDialogs->isChecked());


### PR DESCRIPTION
This is a fairly contained change which adds a set to the instance creation dialog and general settings to set up defaults for the profile settings. (profile INIs, saves, and automatic archive invalidation)

There's a lot of confusion generated when profile INIs are enabled by default but not archive invalidation. People think they've modified the INIs but now the game is loading a different copy they didn't know about. As much as it is a user knowledge issue, it's also a pain point for people learning the application.

The current default during instance creation is just to enable archive invalidation. Most people will probably leave it alone, and the people who know what they are can choose their preference. I've tried to test a few different ways. Once the settings get saved to the profile config, it should be sticky. Only new profiles should pick up the defaults. But it's worth more testing.