### PR TITLE
Refresh Callback (+ Extra for AboutToRun)

### DIFF
--- a/src/mainwindow.cpp
+++ b/src/mainwindow.cpp
@@ -1803,7 +1803,9 @@ void MainWindow::on_profileBox_currentIndexChanged(int index)
       m_OrganizerCore.managedGame()->feature<BSAInvalidation>();
   if (invalidation != nullptr) {
     if (invalidation->prepareProfile(m_OrganizerCore.currentProfile())) {
-      QTimer::singleShot(5, &m_OrganizerCore, SLOT(profileRefresh()));
+      QTimer::singleShot(5, [this] {
+        m_OrganizerCore.refresh();
+      });
     }
   }
 }
@@ -2395,7 +2397,9 @@ void MainWindow::on_actionAdd_Profile_triggered()
       m_OrganizerCore.managedGame()->feature<BSAInvalidation>();
   if (invalidation != nullptr) {
     if (invalidation->prepareProfile(m_OrganizerCore.currentProfile())) {
-      QTimer::singleShot(5, &m_OrganizerCore, SLOT(profileRefresh()));
+      QTimer::singleShot(5, [this] {
+        m_OrganizerCore.refresh();
+      });
     }
   }
 }
@@ -2555,7 +2559,7 @@ void MainWindow::setWindowEnabled(bool enabled)
 
 void MainWindow::refreshProfile_activated()
 {
-  m_OrganizerCore.profileRefresh();
+  m_OrganizerCore.refresh();
 }
 
 void MainWindow::saveArchiveList()
@@ -2782,7 +2786,7 @@ void MainWindow::on_actionSettings_triggered()
 
   if ((settings.paths().mods() != oldModDirectory) ||
       (settings.interface().displayForeign() != oldDisplayForeign)) {
-    m_OrganizerCore.profileRefresh();
+    m_OrganizerCore.refresh();
   }
 
   const auto state = settings.archiveParsing();

--- a/src/modlistcontextmenu.cpp
+++ b/src/modlistcontextmenu.cpp
@@ -97,7 +97,7 @@ void ModListGlobalContextMenu::populate(OrganizerCore& core, ModListView* view,
   addAction(tr("Auto assign categories"), [=]() {
     view->actions().assignCategories();
   });
-  addAction(tr("Refresh"), &core, &OrganizerCore::profileRefresh);
+  addAction(tr("Refresh"), &core, &OrganizerCore::refresh);
   addAction(tr("Export to csv..."), [=]() {
     view->actions().exportModListCSV();
   });

--- a/src/organizercore.cpp
+++ b/src/organizercore.cpp
@@ -1934,7 +1934,6 @@ bool OrganizerCore::beforeRun(
     m_CurrentProfile->writeModlistNow(true);
   }
 
-  // TODO: should also pass arguments
   if (!m_AboutToRun(binary.absoluteFilePath(), cwd, arguments)) {
     log::debug("start of \"{}\" cancelled by plugin", binary.absoluteFilePath());
     return false;

--- a/src/organizercore.cpp
+++ b/src/organizercore.cpp
@@ -1197,9 +1197,9 @@ OrganizerCore::onPluginDisabled(std::function<void(const IPlugin*)> const& func)
 
 boost::signals2::connection
 OrganizerCore::onNextRefresh(std::function<void()> const& func,
-                             RefreshCallbackGroup group, bool immediateIfPossible)
+                             RefreshCallbackGroup group, RefreshCallbackMode mode)
 {
-  if (!immediateIfPossible || m_DirectoryUpdate) {
+  if (m_DirectoryUpdate || mode == RefreshCallbackMode::FORCE_WAIT_FOR_REFRESH) {
     return m_OnNextRefreshCallbacks.connect(static_cast<int>(group), func);
   } else {
     func();
@@ -1238,7 +1238,7 @@ void OrganizerCore::refreshESPList(bool force)
           reportError(tr("Failed to refresh list of esps: %1").arg(e.what()));
         }
       },
-      RefreshCallbackGroup::CORE);
+      RefreshCallbackGroup::CORE, RefreshCallbackMode::RUN_NOW_IF_POSSIBLE);
 }
 
 void OrganizerCore::refreshBSAList()
@@ -1894,7 +1894,7 @@ void OrganizerCore::savePluginList()
         m_PluginList.saveTo(m_CurrentProfile->getLockedOrderFileName());
         m_PluginList.saveLoadOrder(*m_DirectoryStructure);
       },
-      RefreshCallbackGroup::CORE);
+      RefreshCallbackGroup::CORE, RefreshCallbackMode::RUN_NOW_IF_POSSIBLE);
 }
 
 void OrganizerCore::saveCurrentProfile()

--- a/src/organizercore.h
+++ b/src/organizercore.h
@@ -83,7 +83,8 @@ private:
 
 private:
   using SignalAboutToRunApplication =
-      boost::signals2::signal<bool(const QString&), SignalCombinerAnd>;
+      boost::signals2::signal<bool(const QString&, const QDir&, const QString&),
+                              SignalCombinerAnd>;
   using SignalFinishedRunApplication =
       boost::signals2::signal<void(const QString&, unsigned int)>;
   using SignalUserInterfaceInitialized = boost::signals2::signal<void(QMainWindow*)>;
@@ -269,8 +270,8 @@ public:
 
   ProcessRunner processRunner();
 
-  bool beforeRun(const QFileInfo& binary, const QString& profileName,
-                 const QString& customOverwrite,
+  bool beforeRun(const QFileInfo& binary, const QDir& cwd, const QString& arguments,
+                 const QString& profileName, const QString& customOverwrite,
                  const QList<MOBase::ExecutableForcedLoadSetting>& forcedLibraries);
 
   void afterRun(const QFileInfo& binary, DWORD exitCode);
@@ -356,8 +357,8 @@ public:
   ModList* modList();
   void refresh(bool saveChanges = true);
 
-  boost::signals2::connection
-  onAboutToRun(const std::function<bool(const QString&)>& func);
+  boost::signals2::connection onAboutToRun(
+      const std::function<bool(const QString&, const QDir&, const QString&)>& func);
   boost::signals2::connection
   onFinishedRun(const std::function<void(const QString&, unsigned int)>& func);
   boost::signals2::connection
@@ -387,8 +388,6 @@ public:  // IPluginDiagnose interface
   virtual void startGuidedFix(unsigned int key) const;
 
 public slots:
-
-  void profileRefresh();
 
   void syncOverwrite();
 
@@ -472,7 +471,7 @@ private:
 
 private slots:
 
-  void directory_refreshed();
+  void onDirectoryRefreshed();
   void downloadRequested(QNetworkReply* reply, QString gameName, int modID,
                          const QString& fileName);
   void removeOrigin(const QString& name);

--- a/src/organizercore.h
+++ b/src/organizercore.h
@@ -212,6 +212,17 @@ public:
     friend class OrganizerCore;
   };
 
+  // enumeration for the mode when adding refresh callbacks
+  //
+  enum class RefreshCallbackMode : int
+  {
+    // run the callbacks immediately if no refresh is running
+    RUN_NOW_IF_POSSIBLE = 0,
+
+    // wait for the next refresh if none is running
+    FORCE_WAIT_FOR_REFRESH = 1
+  };
+
   // enumeration for the groups where refresh callbacks can be put
   //
   enum class RefreshCallbackGroup : int
@@ -222,8 +233,8 @@ public:
     // internal MO2 callbacks
     INTERNAL = 1,
 
-    // plugins callbacks
-    PLUGIN = 2
+    // external callbacks, typically MO2 plugins
+    EXTERNAL = 2
   };
 
 public:
@@ -399,10 +410,9 @@ public:
   // - group to add the function to
   // - if immediateIfReady is true, the function will be called immediately if no
   //   directory update is running
-  boost::signals2::connection
-  onNextRefresh(std::function<void()> const& func,
-                RefreshCallbackGroup group = RefreshCallbackGroup::INTERNAL,
-                bool immediateIfReady      = true);
+  boost::signals2::connection onNextRefresh(std::function<void()> const& func,
+                                            RefreshCallbackGroup group,
+                                            RefreshCallbackMode mode);
 
 public:  // IPluginDiagnose interface
   virtual std::vector<unsigned int> activeProblems() const;

--- a/src/organizerproxy.cpp
+++ b/src/organizerproxy.cpp
@@ -357,9 +357,12 @@ bool OrganizerProxy::onUserInterfaceInitialized(
 bool OrganizerProxy::onNextRefresh(const std::function<void()>& func,
                                    bool immediateIfPossible)
 {
+  using enum OrganizerCore::RefreshCallbackMode;
   return m_Proxied
       ->onNextRefresh(MOShared::callIfPluginActive(this, func),
-                      OrganizerCore::RefreshCallbackGroup::PLUGIN, immediateIfPossible)
+                      OrganizerCore::RefreshCallbackGroup::EXTERNAL,
+                      immediateIfPossible ? RUN_NOW_IF_POSSIBLE
+                                          : FORCE_WAIT_FOR_REFRESH)
       .connected();
 }
 

--- a/src/organizerproxy.cpp
+++ b/src/organizerproxy.cpp
@@ -347,6 +347,22 @@ bool OrganizerProxy::onFinishedRun(
   return m_Proxied->onFinishedRun(MOShared::callIfPluginActive(this, func)).connected();
 }
 
+bool OrganizerProxy::onUserInterfaceInitialized(
+    std::function<void(QMainWindow*)> const& func)
+{
+  // Always call this one to allow plugin to initialize themselves even when not active:
+  return m_UserInterfaceInitialized.connect(func).connected();
+}
+
+bool OrganizerProxy::onNextRefresh(const std::function<void()>& func,
+                                   bool immediateIfPossible)
+{
+  return m_Proxied
+      ->onNextRefresh(MOShared::callIfPluginActive(this, func),
+                      OrganizerCore::RefreshCallbackGroup::PLUGIN, immediateIfPossible)
+      .connected();
+}
+
 bool OrganizerProxy::onProfileCreated(std::function<void(IProfile*)> const& func)
 {
   return m_ProfileCreated.connect(func).connected();
@@ -368,14 +384,6 @@ bool OrganizerProxy::onProfileChanged(
 {
   return m_ProfileChanged.connect(func).connected();
 }
-
-bool OrganizerProxy::onUserInterfaceInitialized(
-    std::function<void(QMainWindow*)> const& func)
-{
-  // Always call this one to allow plugin to initialize themselves even when not active:
-  return m_UserInterfaceInitialized.connect(func).connected();
-}
-
 // Always call these one, otherwise plugin cannot detect they are being enabled /
 // disabled:
 bool OrganizerProxy::onPluginSettingChanged(

--- a/src/organizerproxy.cpp
+++ b/src/organizerproxy.cpp
@@ -324,6 +324,19 @@ MOBase::IPluginGame const* OrganizerProxy::managedGame() const
 
 bool OrganizerProxy::onAboutToRun(const std::function<bool(const QString&)>& func)
 {
+  return m_Proxied
+      ->onAboutToRun(MOShared::callIfPluginActive(
+          this,
+          [func](const QString& binary, const QDir&, const QString&) {
+            return func(binary);
+          },
+          true))
+      .connected();
+}
+
+bool OrganizerProxy::onAboutToRun(
+    const std::function<bool(const QString&, const QDir&, const QString&)>& func)
+{
   return m_Proxied->onAboutToRun(MOShared::callIfPluginActive(this, func, true))
       .connected();
 }

--- a/src/organizerproxy.h
+++ b/src/organizerproxy.h
@@ -73,6 +73,8 @@ public:  // IOrganizer interface
   virtual void refresh(bool saveChanges);
 
   virtual bool onAboutToRun(const std::function<bool(const QString&)>& func) override;
+  virtual bool onAboutToRun(const std::function<bool(const QString&, const QDir&,
+                                                     const QString&)>& func) override;
   virtual bool
   onFinishedRun(const std::function<void(const QString&, unsigned int)>& func) override;
   virtual bool

--- a/src/organizerproxy.h
+++ b/src/organizerproxy.h
@@ -79,6 +79,8 @@ public:  // IOrganizer interface
   onFinishedRun(const std::function<void(const QString&, unsigned int)>& func) override;
   virtual bool
   onUserInterfaceInitialized(std::function<void(QMainWindow*)> const& func) override;
+  virtual bool onNextRefresh(const std::function<void()>& func,
+                             bool immediateIfPossible) override;
   virtual bool
   onProfileCreated(std::function<void(MOBase::IProfile*)> const& func) override;
   virtual bool onProfileRenamed(

--- a/src/processrunner.cpp
+++ b/src/processrunner.cpp
@@ -768,8 +768,8 @@ std::optional<ProcessRunner::Results> ProcessRunner::runBinary()
   // saves profile, sets up usvfs, notifies plugins, etc.; can return false if
   // a plugin doesn't want the program to run (such as when checkFNIS fails to
   // run FNIS and the user clicks cancel)
-  if (!m_core.beforeRun(m_sp.binary, m_profileName, m_customOverwrite,
-                        m_forcedLibraries)) {
+  if (!m_core.beforeRun(m_sp.binary, m_sp.currentDirectory, m_sp.arguments,
+                        m_profileName, m_customOverwrite, m_forcedLibraries)) {
     return Error;
   }
 


### PR DESCRIPTION
- Pass working directory and arguments to callback in AboutToRun - Optional to be backward compatible.
- Add a new callback to be called after a refresh.

The goal of the new callback is to fix issues plugin developers have when doing stuff in `onFinishedRun` (or whatever the name is). Now they should be able to wrap what they do with `onNextRefresh` and hopefully avoid these problems.

This is to be tested, which is why it's WIP.