### PR TITLE
Refresh the esp/bsa lists after closing settings

### DIFF
--- a/src/mainwindow.cpp
+++ b/src/mainwindow.cpp
@@ -2764,6 +2764,8 @@ void MainWindow::on_actionSettings_triggered()
   ui->modList->refreshFilters();
   ui->modList->refresh();
 
+  m_OrganizerCore.refreshLists();
+
   if (settings.paths().profiles() != oldProfilesDirectory) {
     refreshProfiles();
   }


### PR DESCRIPTION
- Should resolve issues with certain settings not 'applying' immediately
- For example: Starfield 'enable plugin management' setting