### PR TITLE
WIP: Plugin sorting updates

### DIFF
--- a/src/mainwindow.cpp
+++ b/src/mainwindow.cpp
@@ -371,12 +371,7 @@ MainWindow::MainWindow(Settings& settings, OrganizerCore& organizerCore,
   ui->groupCombo->installEventFilter(noWheel);
   ui->profileBox->installEventFilter(noWheel);
 
-  if (organizerCore.managedGame()->sortMechanism() ==
-      MOBase::IPluginGame::SortMechanism::NONE) {
-    ui->sortButton->setDisabled(true);
-    ui->sortButton->setToolTip(tr("There is no supported sort mechanism for this game. "
-                                  "You will probably have to use a third-party tool."));
-  }
+  updateSortButton();
 
   connect(&m_PluginContainer, SIGNAL(diagnosisUpdate()), this,
           SLOT(scheduleCheckForProblems()));
@@ -399,6 +394,9 @@ MainWindow::MainWindow(Settings& settings, OrganizerCore& organizerCore,
           SLOT(updateAvailable()));
   connect(m_OrganizerCore.updater(), SIGNAL(motdAvailable(QString)), this,
           SLOT(motdReceived(QString)));
+  connect(&m_OrganizerCore, &OrganizerCore::refreshTriggered, this, [this]() {
+    updateSortButton();
+  });
 
   connect(&NexusInterface::instance(), SIGNAL(requestNXMDownload(QString)),
           &m_OrganizerCore, SLOT(downloadRequestedNXM(QString)));
@@ -2766,6 +2764,8 @@ void MainWindow::on_actionSettings_triggered()
 
   m_OrganizerCore.refreshLists();
 
+  updateSortButton();
+
   if (settings.paths().profiles() != oldProfilesDirectory) {
     refreshProfiles();
   }
@@ -3031,6 +3031,19 @@ void MainWindow::toggleUpdateAction()
 {
   const auto& s = m_OrganizerCore.settings();
   ui->actionUpdate->setVisible(s.checkForUpdates());
+}
+
+void MainWindow::updateSortButton()
+{
+  if (m_OrganizerCore.managedGame()->sortMechanism() !=
+      IPluginGame::SortMechanism::NONE) {
+    ui->sortButton->setEnabled(true);
+    ui->sortButton->setToolTip(tr("Sort the plugins using LOOT."));
+  } else {
+    ui->sortButton->setDisabled(true);
+    ui->sortButton->setToolTip(tr("There is no supported sort mechanism for this game. "
+                                  "You will probably have to use a third-party tool."));
+  }
 }
 
 void MainWindow::nxmEndorsementsAvailable(QVariant userData, QVariant resultData, int)

--- a/src/mainwindow.h
+++ b/src/mainwindow.h
@@ -243,6 +243,8 @@ private:
   void toggleMO2EndorseState();
   void toggleUpdateAction();
 
+  void updateSortButton();
+
   // update info
   struct NxmUpdateInfoData
   {

--- a/src/organizercore.cpp
+++ b/src/organizercore.cpp
@@ -1220,6 +1220,8 @@ void OrganizerCore::refresh(bool saveChanges)
   m_ModList.notifyChange(-1);
 
   refreshDirectoryStructure();
+
+  emit refreshTriggered();
 }
 
 void OrganizerCore::refreshESPList(bool force)

--- a/src/organizercore.h
+++ b/src/organizercore.h
@@ -471,6 +471,9 @@ signals:
   // Use queued connections
   void directoryStructureReady();
 
+  // Notify of a general UI refresh
+  void refreshTriggered();
+
 private:
   std::pair<unsigned int, ModInfo::Ptr> doInstall(const QString& archivePath,
                                                   MOBase::GuessedValue<QString> modName,

--- a/src/pluginlist.cpp
+++ b/src/pluginlist.cpp
@@ -176,6 +176,7 @@ void PluginList::refresh(const QString& profileName,
   ChangeBracket<PluginList> layoutChange(this);
 
   QStringList primaryPlugins = m_GamePlugin->primaryPlugins();
+  QStringList enabledPlugins = m_GamePlugin->enabledPlugins();
   GamePlugins* gamePlugins   = m_GamePlugin->feature<GamePlugins>();
   const bool lightPluginsAreSupported =
       gamePlugins ? gamePlugins->lightPluginsAreSupported() : false;
@@ -204,7 +205,8 @@ void PluginList::refresh(const QString& profileName,
       }
 
       bool forceEnabled = Settings::instance().game().forceEnableCoreFiles() &&
-                          primaryPlugins.contains(filename, Qt::CaseInsensitive);
+                          (primaryPlugins.contains(filename, Qt::CaseInsensitive) ||
+                           enabledPlugins.contains(filename, Qt::CaseInsensitive));
       bool forceDisabled =
           m_GamePlugin->loadOrderMechanism() == IPluginGame::LoadOrderMechanism::None &&
           !forceEnabled;

--- a/src/pluginlist.h
+++ b/src/pluginlist.h
@@ -313,13 +313,15 @@ signals:
 private:
   struct ESPInfo
   {
-    ESPInfo(const QString& name, bool enabled, bool forceDisabled,
-            const QString& originName, const QString& fullPath, bool hasIni,
-            std::set<QString> archives, bool lightSupported, bool overrideSupported);
+    ESPInfo(const QString& name, bool forceLoaded, bool forceEnabled,
+            bool forceDisabled, const QString& originName, const QString& fullPath,
+            bool hasIni, std::set<QString> archives, bool lightSupported,
+            bool overrideSupported);
 
     QString name;
     QString fullPath;
     bool enabled;
+    bool forceLoaded;
     bool forceEnabled;
     bool forceDisabled;
     int priority;


### PR DESCRIPTION
- Add enabledPlugins for core plugins which are enabled but NOT auto-loaded (may need to be written to plugins.txt or have an ambiguous load order position)
- General Starfield updates
  - Add enabledPlugins for "BlueprintShips-Starfield.esm"
  - Disable plugin management if sTestFile is in use (also applies to FO4)
  - Write the enabledPlugins to plugins.txt to enforce base game load order
  - Allow for LOOT sorting (dynamic based on settings)
- Incorporate enabledPlugins into force enabled plugins in plugin list
- Update various interface layers

TODO: Fix sort button to dynamically update if status changes
TODO: Auto refresh lists if the INI Editor is closed