### PR TITLE
Replace spaces with ? wildcard for #1605

### DIFF
--- a/src/settingsdialogpaths.cpp
+++ b/src/settingsdialogpaths.cpp
@@ -199,9 +199,14 @@ void PathsSettingsTab::on_browseGameDirBtn_clicked()
 {
   QFileInfo oldGameExe(ui->managedGameDirEdit->text());
 
-  QString temp =
-      QFileDialog::getOpenFileName(&dialog(), QObject::tr("Select game executable"),
-                                   oldGameExe.absolutePath(), oldGameExe.fileName());
+  // this gets the name of the game executable
+  //
+  // spaces in the name are interpreted as separators ";" in the filter,
+  // so we replace them with the single character matching wildcard "?"
+  //
+  QString temp = QFileDialog::getOpenFileName(
+      &dialog(), QObject::tr("Select game executable"), oldGameExe.absolutePath(),
+      oldGameExe.fileName().replace(QRegularExpression(" "), "?"));
 
   if (temp.isEmpty()) {
     return;


### PR DESCRIPTION
Replaces spaces in the filter with ? wildcards. This works around the mentioned issue and allows us to see 'Stardew Valley.exe' when browsing.