### PR TITLE
A few fixes for RC 1

### DIFF
--- a/src/modlist.cpp
+++ b/src/modlist.cpp
@@ -208,7 +208,7 @@ QVariant ModList::data(const QModelIndex& modelIndex, int role) const
       if (modInfo->hasAutomaticPriority()) {
         return QVariant();  // hide priority for mods where it's fixed
       } else {
-        return m_Profile->getModPriority(modIndex);
+        return QString::number(m_Profile->getModPriority(modIndex));
       }
     } else if (column == COL_MODID) {
       int modID = modInfo->nexusId();

--- a/src/modlistcontextmenu.cpp
+++ b/src/modlistcontextmenu.cpp
@@ -561,7 +561,9 @@ void ModListContextMenu::addRegularActions(ModInfo::Ptr mod)
     }
   }
 
-  if (mod->nexusId() > 0 && !mod->installationFile().isEmpty()) {
+  if (mod->nexusId() > 0 &&
+      (mod->getNexusCategory() > 0 || !mod->installationFile().isEmpty()) &&
+      !mod->isSeparator()) {
     addAction(tr("Remap Category (From Nexus)"), [=]() {
       m_actions.remapCategory(m_selected);
     });

--- a/src/modlistviewactions.cpp
+++ b/src/modlistviewactions.cpp
@@ -279,7 +279,9 @@ void ModListViewActions::assignCategories() const
   }
   for (auto mod : m_core.modList()->allMods()) {
     ModInfo::Ptr modInfo = ModInfo::getByName(mod);
-    int nexusCategory    = modInfo->getNexusCategory();
+    if (modInfo->isSeparator())
+      continue;
+    int nexusCategory = modInfo->getNexusCategory();
     if (!nexusCategory) {
       QSettings downloadMeta(m_core.downloadsPath() + "/" +
                                  modInfo->installationFile() + ".meta",
@@ -1125,6 +1127,8 @@ void ModListViewActions::remapCategory(const QModelIndexList& indices) const
 {
   for (auto& idx : indices) {
     ModInfo::Ptr modInfo = ModInfo::getByIndex(idx.data(ModList::IndexRole).toInt());
+    if (modInfo->isSeparator())
+      continue;
 
     int categoryID = modInfo->getNexusCategory();
     if (!categoryID) {

--- a/src/pluginlist.cpp
+++ b/src/pluginlist.cpp
@@ -1185,7 +1185,7 @@ QVariant PluginList::displayData(const QModelIndex& modelIndex) const
     return m_ESPs[index].name;
 
   case COL_PRIORITY:
-    return m_ESPs[index].priority;
+    return QString::number(m_ESPs[index].priority);
 
   case COL_MODINDEX:
     return m_ESPs[index].index;

--- a/src/version.rc
+++ b/src/version.rc
@@ -4,7 +4,7 @@
 // Otherwise, if letters are used in VER_FILEVERSION_STR, uses the full MOBase::VersionInfo parser
 // Otherwise, uses the numbers from VER_FILEVERSION and sets the release type as pre-alpha
 #define VER_FILEVERSION     2,5,0
-#define VER_FILEVERSION_STR "2.5.0-rc1\0"
+#define VER_FILEVERSION_STR "2.5.0rc2\0"
 
 VS_VERSION_INFO VERSIONINFO
 FILEVERSION     VER_FILEVERSION


### PR DESCRIPTION
* Convert the priority index to a string as Windows appears to be converting these to localized numerals
* Skip separators when assigning categories
* Update the context menu requirements for displaying the auto-assign option
* Bump to RC 2