### PR TITLE
Use primary game source for categories if defined

### DIFF
--- a/src/mainwindow.cpp
+++ b/src/mainwindow.cpp
@@ -2842,8 +2842,14 @@ void MainWindow::refreshNexusCategories(CategoriesDialog* dialog)
 {
   NexusInterface& nexus = NexusInterface::instance();
   nexus.setPluginContainer(&m_PluginContainer);
-  nexus.requestGameInfo(Settings::instance().game().plugin()->gameShortName(), dialog,
-                        QVariant(), QString());
+  if (!Settings::instance().game().plugin()->primarySources().isEmpty()) {
+    nexus.requestGameInfo(
+        Settings::instance().game().plugin()->primarySources().first(), dialog,
+        QVariant(), QString());
+  } else {
+    nexus.requestGameInfo(Settings::instance().game().plugin()->gameShortName(), dialog,
+                          QVariant(), QString());
+  }
 }
 
 void MainWindow::categoriesSaved()


### PR DESCRIPTION
Rather than setting the nexus info on games with no direct 'nexus game', we can use the existing 'primary source' properties to determine what actual game to fetch category info from.

(The assumption being that the primary source will only be set if direct nexus info is unavailable, which is currently the case.)

Setting nexus info on these games causes alternate issues as these games are then interpreted as being valid nexus sources which can throw off version checking for existing installed mods.