### PR TITLE
Ignore Qt-created 'cache' directory

### DIFF
--- a/src/instancemanager.cpp
+++ b/src/instancemanager.cpp
@@ -565,7 +565,7 @@ QString InstanceManager::iniPath(const QString& instanceDir) const
 
 std::vector<QString> InstanceManager::globalInstancePaths() const
 {
-  const std::set<QString> ignore = {"qtwebengine"};
+  const std::set<QString> ignore = {"cache", "qtwebengine"};
 
   const QDir root(globalInstancesRootPath());
   const auto dirs = root.entryList(QDir::Dirs | QDir::NoDotAndDotDot);


### PR DESCRIPTION
Ignore Qt-created 'cache' directory, which currently pops up in the instance overview window.