### PR TITLE
Only push directory if we find a MO INI file

### DIFF
--- a/src/instancemanager.cpp
+++ b/src/instancemanager.cpp
@@ -565,15 +565,17 @@ QString InstanceManager::iniPath(const QString& instanceDir) const
 
 std::vector<QString> InstanceManager::globalInstancePaths() const
 {
-  const std::set<QString> ignore = {"cache", "qtwebengine"};
-
   const QDir root(globalInstancesRootPath());
   const auto dirs = root.entryList(QDir::Dirs | QDir::NoDotAndDotDot);
 
   std::vector<QString> list;
 
   for (auto&& d : dirs) {
-    if (!ignore.contains(QFileInfo(d).fileName().toLower())) {
+    const QFileInfo iniFile(QDir(root.filePath(d)), "ModOrganizer.ini");
+    log::debug("Checking for INI at path '{}'", iniFile.absoluteFilePath());
+
+    if (iniFile.exists()) {
+      log::debug("Found INI at path '{}'", iniFile.absoluteFilePath());
       list.push_back(root.filePath(d));
     }
   }


### PR DESCRIPTION
Only push directory if we find a MO INI file.

---

Open points:

- I figured having a debug log here would be useful in troubleshooting
- I could not find any OS-independent way of joining paths via Qt, do we have something like this that I should be using instead of the hardcoded path joining (taken from the same file)
- Do we still want the filter code if this lands?
- I did a compare against case-sensitive `ModOrganizer.ini`, can this possibly cause issues that warrants needing a full path lowercase comparison?