### PR TITLE
Support openmw file types

### DIFF
--- a/src/mainwindow.cpp
+++ b/src/mainwindow.cpp
@@ -1930,7 +1930,9 @@ void MainWindow::updateBSAList(const QStringList& defaultArchives,
       m_OrganizerCore.findFiles("", [](const QString& fileName) -> bool {
         return fileName.endsWith(".esp", Qt::CaseInsensitive) ||
                fileName.endsWith(".esm", Qt::CaseInsensitive) ||
-               fileName.endsWith(".esl", Qt::CaseInsensitive);
+               fileName.endsWith(".esl", Qt::CaseInsensitive) ||
+               fileName.endsWith(".omwaddon", Qt::CaseInsensitive) ||
+               fileName.endsWith(".omwscripts", Qt::CaseInsensitive);
       });
 
   auto hasAssociatedPlugin = [&](const QString& bsaName) -> bool {

--- a/src/modinfodialogesps.cpp
+++ b/src/modinfodialogesps.cpp
@@ -217,7 +217,8 @@ void ESPsTab::clear()
 
 bool ESPsTab::feedFile(const QString& rootPath, const QString& fullPath)
 {
-  static const QString extensions[] = {".esp", ".esm", ".esl"};
+  static const QString extensions[] = {".esp", ".esm", ".esl", ".omwaddon",
+                                       ".omwscripts"};
 
   for (const auto& e : extensions) {
     if (fullPath.endsWith(e, Qt::CaseInsensitive)) {

--- a/src/organizercore.cpp
+++ b/src/organizercore.cpp
@@ -1346,6 +1346,41 @@ void OrganizerCore::updateModsActiveState(const QList<unsigned int>& modIndices,
         ++enabled;
       }
     }
+
+    QStringList omwaddons = dir.entryList(QStringList() << "*.omwaddon", QDir::Files);
+    for (const QString& omwaddon : omwaddons) {
+      const FileEntryPtr file = m_DirectoryStructure->findFile(ToWString(omwaddon));
+      if (file.get() == nullptr) {
+        log::warn("failed to activate {}", omwaddon);
+        continue;
+      }
+
+      if (active != m_PluginList.isEnabled(omwaddon) &&
+          file->getAlternatives().empty()) {
+        m_PluginList.blockSignals(true);
+        m_PluginList.enableESP(omwaddon, active);
+        m_PluginList.blockSignals(false);
+        ++enabled;
+      }
+    }
+
+    QStringList omwscripts =
+        dir.entryList(QStringList() << "*.omwscripts", QDir::Files);
+    for (const QString& omwscript : omwscripts) {
+      const FileEntryPtr file = m_DirectoryStructure->findFile(ToWString(omwscript));
+      if (file.get() == nullptr) {
+        log::warn("failed to activate {}", omwscript);
+        continue;
+      }
+
+      if (active != m_PluginList.isEnabled(omwscript) &&
+          file->getAlternatives().empty()) {
+        m_PluginList.blockSignals(true);
+        m_PluginList.enableESP(omwscript, active);
+        m_PluginList.blockSignals(false);
+        ++enabled;
+      }
+    }
   }
   if (active && (enabled > 1)) {
     MessageDialog::showMessage(

--- a/src/pluginlist.cpp
+++ b/src/pluginlist.cpp
@@ -134,7 +134,9 @@ void PluginList::highlightPlugins(const std::vector<unsigned int>& modIndices,
       QDir dir(selectedMod->absolutePath());
       QStringList plugins = dir.entryList(QStringList() << "*.esp"
                                                         << "*.esm"
-                                                        << "*.esl");
+                                                        << "*.esl"
+                                                        << "*.omwaddon"
+                                                        << "*.omwscripts");
       const MOShared::FilesOrigin& origin =
           directoryEntry.getOriginByName(selectedMod->internalName().toStdWString());
       if (plugins.size() > 0) {
@@ -196,7 +198,9 @@ void PluginList::refresh(const QString& profileName,
 
     if (filename.endsWith(".esp", Qt::CaseInsensitive) ||
         filename.endsWith(".esm", Qt::CaseInsensitive) ||
-        filename.endsWith(".esl", Qt::CaseInsensitive)) {
+        filename.endsWith(".esl", Qt::CaseInsensitive) ||
+        filename.endsWith(".omwaddon", Qt::CaseInsensitive) ||
+        filename.endsWith(".omwscripts", Qt::CaseInsensitive)) {
 
       availablePlugins.append(filename);
 


### PR DESCRIPTION
Partial resolution for [MO2 #1609](https://github.com/ModOrganizer2/modorganizer/issues/1609)

Regarding points brought up in this issue:

While the vanilla engine DOES break when feeding it omwaddons, this is primarily caused by the naming convention used. Many omwaddons work perfectly fine in Morrowind.exe when renamed to ESP. Additionally, this is a very common practice on the part of users. TESCS and OpenMW-CS do not create plugins which are distinctive enough for MO2 to distinguish between the two using anything beyond the name. Of course, we know that the file extension is not at all a reliable means to distinguish between the two. Realistically, there is not one, because omwaddons are intended to be nearly the exact same. Additionally, there are [proven cases](https://www.nexusmods.com/morrowind/mods/53320?tab=files) of mods being created as ESP using TESCS and then renamed to omwaddon as well. Some mods have been [created as omwaddon](https://www.nexusmods.com/morrowind/mods/53675) and published under the original format.

The simple fact of the matter is that MO2 can't take responsibility for this, and the user should understand that the mod they are using is not supported in vanilla. This is universally [explained](https://www.nexusmods.com/morrowind/mods/45694/) by the author in some capacity or another. 

Due to OpenMW goals, supported file types are added in the global context and not the per-game one. Additionally, `omwgame` files are explicitly not supported by design as there simply *are* none and would be an entirely different game with its own instance and Nexus category. Since none exist, there's no way to begin an implementation of this. Omwgame should be supported at such a time as there is an omwgame to support.

Additional references:
[Ashlander Architect](https://www.nexusmods.com/morrowind/mods/52879?tab=description)
[Morrowland Uncapped Attributes](https://www.nexusmods.com/morrowind/mods/53694?tab=description)

Activatable BSA files are not a real feature anybody in the Morrowind community needs or wants. While, historically, the main use case for TES3 BSA files has been the Tamriel Rebuilt project, they no longer ship with BSAs. Creators tend not to use them because it complicates the process of creating mods, they don't support all file types used by TES3, MO2 does not support them, and people constantly mess up registering them. 

Additionally, since OpenMW supports later titles (sort of) *and* their associated iteration of BSA files, this will cause additional compatibility problems with every game. You could feed New Vegas or Morrowind an SSE-era compressed BSA file and it will naturally not work. There's no real reason to put any effort into this, as it is just going to complicate the codebase for a feature literally nobody is asking for at this point in time.

This PR does not touch groundcover plugins. I do not have a thorough proposal for this at this time. However, I think it is best to avoid cluttering the main plugin list with additional fields that are morrowind-specific, so perhaps a right-click option `Mark as Groundcover` or something to that effect can be added which exporters hook into. I don't think there's really a nice way to handle that for both engines unless a check *specifically* for MGEXEgui.exe is added. 