### PR TITLE
Open logs and crashDumps folders from diagnostics settings

### DIFF
--- a/src/settingsdialog.ui
+++ b/src/settingsdialog.ui
@@ -2208,7 +2208,7 @@ For the other games this is not a sufficient replacement for AI!</string>
        <item>
         <widget class="LinkLabel" name="diagnosticsExplainedLabel">
          <property name="toolTip">
-          <string>Hint: right click link and copy link location</string>
+          <string>Click a link to open the location</string>
          </property>
          <property name="text">
           <string>

--- a/src/settingsdialogdiagnostics.cpp
+++ b/src/settingsdialogdiagnostics.cpp
@@ -15,15 +15,18 @@ DiagnosticsSettingsTab::DiagnosticsSettingsTab(Settings& s, SettingsDialog& d)
 
   ui->dumpsMaxEdit->setValue(settings().diagnostics().maxCoreDumps());
 
-  QString logsPath = qApp->property("dataPath").toString() + "/" +
-                     QString::fromStdWString(AppConfig::logPath());
+  QString logsPath = QUrl::fromLocalFile(qApp->property("dataPath").toString() + "/" +
+                                         QString::fromStdWString(AppConfig::logPath()))
+                         .toString();
 
   ui->diagnosticsExplainedLabel->setText(
       ui->diagnosticsExplainedLabel->text()
           .replace("LOGS_FULL_PATH", logsPath)
           .replace("LOGS_DIR", QString::fromStdWString(AppConfig::logPath()))
           .replace("DUMPS_FULL_PATH",
-                   QString::fromStdWString(OrganizerCore::getGlobalCoreDumpPath()))
+                   QUrl::fromLocalFile(
+                       QString::fromStdWString(OrganizerCore::getGlobalCoreDumpPath()))
+                       .toString())
           .replace("DUMPS_DIR", QString::fromStdWString(AppConfig::dumpsDir())));
 }
 


### PR DESCRIPTION
This allows clicking the logs and crashDumps links in the diagnostics settings to open those locations. This was inspired by issue #1995 