### PR TITLE
Fixes for stylesheets that use transparent backgrounds

### DIFF
--- a/src/modinfodialogimages.cpp
+++ b/src/modinfodialogimages.cpp
@@ -76,7 +76,10 @@ ImagesTab::ImagesTab(ModInfoDialogTabContext cx)
   ui->imagesShowDDS->setEnabled(m_ddsAvailable);
 
   ui->imagesThumbnails->setAutoFillBackground(false);
-  ui->imagesThumbnails->setAttribute(Qt::WA_OpaquePaintEvent, true);
+
+  if (ui->imagesThumbnails->palette().color(QPalette::Base) != Qt::transparent) {
+    ui->imagesThumbnails->setAttribute(Qt::WA_OpaquePaintEvent, true);
+  }
 
   {
     auto list = std::make_unique<QListWidget>();

--- a/src/problemsdialog.cpp
+++ b/src/problemsdialog.cpp
@@ -56,7 +56,6 @@ void ProblemsDialog::runDiagnosis()
       m_hasProblems = true;
 
       if (diagnose->hasGuidedFix(key)) {
-        newItem->setText(1, tr("Fix"));
         QPushButton* fixButton = new QPushButton(tr("Fix"));
         fixButton->setProperty("fix",
                                QVariant::fromValue(reinterpret_cast<void*>(diagnose)));


### PR DESCRIPTION
This addresses a couple issues noticed by using the 1809 Dark Mode stylesheet, related to using transparent backgrounds. First, I have removed a redundant "Fix" text when a guided fix is available in the problems dialog. Second, only apply the Qt::WA_OpaquePaintEvent attribute when the imagesThumbnails widget does not have a transparent background. Qt::WA_OpaquePaintEvent is used for optimization and does not erase the background before painting. This means text would overlap when scrolling and text from other tabs would be visible when switching to the images tab.