### PR TITLE
Switch from fmtlib to std::format.

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -15,6 +15,6 @@ jobs:
         with:
           qt-modules: qtpositioning qtwebchannel qtwebengine qtwebsockets
           mo2-third-parties:
-            7z zlib fmt gtest libbsarch libloot openssl bzip2 python lz4 spdlog
+            7z zlib gtest libbsarch libloot openssl bzip2 python lz4 spdlog
             boost boost-di sip pyqt pybind11 ss licenses explorerpp usvfs
           mo2-dependencies: cmake_common uibase githubpp bsatk esptk archive lootcli game_gamebryo

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -15,6 +15,6 @@ jobs:
         with:
           qt-modules: qtpositioning qtwebchannel qtwebengine qtwebsockets
           mo2-third-parties:
-            7z zlib fmt gtest libbsarch libloot openssl libffi bzip2 python lz4 spdlog
+            7z zlib fmt gtest libbsarch libloot openssl bzip2 python lz4 spdlog
             boost boost-di sip pyqt pybind11 ss licenses explorerpp usvfs
           mo2-dependencies: cmake_common uibase githubpp bsatk esptk archive lootcli game_gamebryo

--- a/src/categories.cpp
+++ b/src/categories.cpp
@@ -74,7 +74,7 @@ void CategoryFactory::loadCategories()
             bool ok  = false;
             int temp = iter->toInt(&ok);
             if (!ok) {
-              log::error(tr("invalid category id {}").toStdString(), iter->constData());
+              log::error(tr("invalid category id {0}"), iter->constData());
             }
             nexusCats.push_back(NexusCategory("Unknown", temp));
           }
@@ -84,8 +84,7 @@ void CategoryFactory::loadCategories()
         int id       = cells[0].toInt(&cell0Ok);
         int parentID = cells[3].trimmed().toInt(&cell3Ok);
         if (!cell0Ok || !cell3Ok) {
-          log::error(tr("invalid category line {}: {}").toStdString(), lineNum,
-                     line.constData());
+          log::error(tr("invalid category line {0}: {1}"), lineNum, line.constData());
         }
         addCategory(id, QString::fromUtf8(cells[1].constData()), nexusCats, parentID);
       } else if (cells.count() == 3) {
@@ -94,14 +93,13 @@ void CategoryFactory::loadCategories()
         int id       = cells[0].toInt(&cell0Ok);
         int parentID = cells[2].trimmed().toInt(&cell3Ok);
         if (!cell0Ok || !cell3Ok) {
-          log::error(tr("invalid category line {}: {}").toStdString(), lineNum,
-                     line.constData());
+          log::error(tr("invalid category line {0}: {1}"), lineNum, line.constData());
         }
 
         addCategory(id, QString::fromUtf8(cells[1].constData()),
                     std::vector<NexusCategory>(), parentID);
       } else {
-        log::error(tr("invalid category line {}: {} ({} cells)").toStdString(), lineNum,
+        log::error(tr("invalid category line {0}: {1} ({2} cells)"), lineNum,
                    line.constData(), cells.count());
       }
     }
@@ -122,19 +120,17 @@ void CategoryFactory::loadCategories()
           bool ok         = false;
           int nexID       = nexCells[2].toInt(&ok);
           if (!ok) {
-            log::error(tr("invalid nexus ID {}").toStdString(),
-                       nexCells[2].constData());
+            log::error(tr("invalid nexus ID {}"), nexCells[2].constData());
           }
           int catID = nexCells[0].toInt(&ok);
           if (!ok) {
-            log::error(tr("invalid category id {}").toStdString(),
-                       nexCells[0].constData());
+            log::error(tr("invalid category id {}"), nexCells[0].constData());
           }
           m_NexusMap.insert_or_assign(nexID, NexusCategory(nexName, nexID));
           m_NexusMap.at(nexID).setCategoryID(catID);
         } else {
-          log::error(tr("invalid nexus category line {}: {} ({} cells)").toStdString(),
-                     lineNum, nexLine.constData(), nexCells.count());
+          log::error(tr("invalid nexus category line {0}: {1} ({2} cells)"), lineNum,
+                     nexLine.constData(), nexCells.count());
         }
       }
     }
@@ -394,7 +390,7 @@ bool CategoryFactory::isDescendantOfImpl(int id, int parentID,
       return isDescendantOfImpl(m_Categories[index].parentID(), parentID, seen);
     }
   } else {
-    log::warn(tr("{} is no valid category id").toStdString(), id);
+    log::warn(tr("{} is no valid category id"), id);
     return false;
   }
 }
@@ -513,11 +509,11 @@ unsigned int CategoryFactory::resolveNexusID(int nexusID) const
   auto result = m_NexusMap.find(nexusID);
   if (result != m_NexusMap.end()) {
     if (m_IDMap.count(result->second.categoryID())) {
-      log::debug(tr("nexus category id {} maps to internal {}").toStdString(), nexusID,
+      log::debug(tr("nexus category id {0} maps to internal {1}"), nexusID,
                  m_IDMap.at(result->second.categoryID()));
       return m_IDMap.at(result->second.categoryID());
     }
   }
-  log::debug(tr("nexus category id {} not mapped").toStdString(), nexusID);
+  log::debug(tr("nexus category id {} not mapped"), nexusID);
   return 0U;
 }

--- a/src/directoryrefresher.cpp
+++ b/src/directoryrefresher.cpp
@@ -138,7 +138,7 @@ void dumpStats(std::vector<DirectoryStats>& stats)
 
   if (run == 0) {
     std::ofstream out(file, std::ios::out | std::ios::trunc);
-    out << fmt::format("what,run,{}", DirectoryStats::csvHeader()) << "\n";
+    out << std::format("what,run,{}", DirectoryStats::csvHeader()) << "\n";
   }
 
   std::sort(stats.begin(), stats.end(), [](auto&& a, auto&& b) {
@@ -150,11 +150,11 @@ void dumpStats(std::vector<DirectoryStats>& stats)
 
   DirectoryStats total;
   for (const auto& s : stats) {
-    out << fmt::format("{},{},{}", s.mod, run, s.toCsv()) << "\n";
+    out << std::format("{},{},{}", s.mod, run, s.toCsv()) << "\n";
     total += s;
   }
 
-  out << fmt::format("total,{},{}", run, total.toCsv()) << "\n";
+  out << std::format("total,{},{}", run, total.toCsv()) << "\n";
 
   ++run;
 }

--- a/src/envshell.cpp
+++ b/src/envshell.cpp
@@ -1,7 +1,11 @@
-#include "envshell.h"
+
+#include <format>
+
 #include <log.h>
 #include <utility.h>
 #include <windowsx.h>
+
+#include "envshell.h"
 
 namespace env
 {
@@ -16,7 +20,7 @@ class MenuFailed : public std::runtime_error
 public:
   MenuFailed(HRESULT r, const std::string& what)
       : runtime_error(
-            fmt::format("{}, {}", what,
+            std::format("{}, {}", what,
                         QString::fromStdWString(formatSystemMessage(r)).toStdString()))
   {}
 };
@@ -478,7 +482,7 @@ void ShellMenu::invoke(const QPoint& p, int cmd)
   const auto r = m_cm->InvokeCommand((CMINVOKECOMMANDINFO*)&info);
 
   if (FAILED(r)) {
-    throw MenuFailed(r, fmt::format("InvokeCommand failed, verb={}", cmd));
+    throw MenuFailed(r, std::format("InvokeCommand failed, verb={}", cmd));
   }
 }
 
@@ -568,7 +572,7 @@ void ShellMenuCollection::exec(const QPoint& pos)
   }
 
   if (!m_active) {
-    log::debug("SMC: command {} selected without active submenu");
+    log::debug("SMC: command {} selected without active submenu", cmd);
     return;
   }
 

--- a/src/organizer_en.ts
+++ b/src/organizer_en.ts
@@ -311,22 +311,22 @@ p, li { white-space: pre-wrap; }
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="categoriesdialog.cpp" line="371"/>
+        <location filename="categoriesdialog.cpp" line="372"/>
         <source>Error %1: Request to Nexus failed: %2</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="categoriesdialog.cpp" line="379"/>
+        <location filename="categoriesdialog.cpp" line="380"/>
         <source>Add</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="categoriesdialog.cpp" line="380"/>
+        <location filename="categoriesdialog.cpp" line="381"/>
         <source>Remove</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="categoriesdialog.cpp" line="382"/>
+        <location filename="categoriesdialog.cpp" line="383"/>
         <source>Remove Nexus Mapping(s)</source>
         <translation type="unfinished"></translation>
     </message>
@@ -334,67 +334,74 @@ p, li { white-space: pre-wrap; }
 <context>
     <name>CategoryFactory</name>
     <message>
-        <location filename="categories.cpp" line="77"/>
-        <location filename="categories.cpp" line="130"/>
+        <location filename="categories.cpp" line="127"/>
         <source>invalid category id {}</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="categories.cpp" line="87"/>
-        <location filename="categories.cpp" line="97"/>
-        <source>invalid category line {}: {}</source>
+        <location filename="categories.cpp" line="96"/>
+        <source>invalid category line {0}: {1}</source>
+        <oldsource>invalid category line {}: {}</oldsource>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="categories.cpp" line="104"/>
-        <source>invalid category line {}: {} ({} cells)</source>
+        <location filename="categories.cpp" line="77"/>
+        <source>invalid category id {0}</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="categories.cpp" line="125"/>
+        <location filename="categories.cpp" line="102"/>
+        <source>invalid category line {0}: {1} ({2} cells)</source>
+        <oldsource>invalid category line {}: {} ({} cells)</oldsource>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="categories.cpp" line="123"/>
         <source>invalid nexus ID {}</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="categories.cpp" line="136"/>
-        <source>invalid nexus category line {}: {} ({} cells)</source>
+        <location filename="categories.cpp" line="132"/>
+        <source>invalid nexus category line {0}: {1} ({2} cells)</source>
+        <oldsource>invalid nexus category line {}: {} ({} cells)</oldsource>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="categories.cpp" line="191"/>
+        <location filename="categories.cpp" line="187"/>
         <source>Failed to save custom categories</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="categories.cpp" line="214"/>
+        <location filename="categories.cpp" line="210"/>
         <source>Failed to save nexus category mappings</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="categories.cpp" line="359"/>
-        <location filename="categories.cpp" line="405"/>
-        <location filename="categories.cpp" line="414"/>
-        <location filename="categories.cpp" line="482"/>
+        <location filename="categories.cpp" line="355"/>
+        <location filename="categories.cpp" line="401"/>
+        <location filename="categories.cpp" line="410"/>
+        <location filename="categories.cpp" line="478"/>
         <source>invalid category index: %1</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="categories.cpp" line="397"/>
+        <location filename="categories.cpp" line="393"/>
         <source>{} is no valid category id</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="categories.cpp" line="492"/>
+        <location filename="categories.cpp" line="488"/>
         <source>invalid category id: %1</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="categories.cpp" line="516"/>
-        <source>nexus category id {} maps to internal {}</source>
+        <location filename="categories.cpp" line="512"/>
+        <source>nexus category id {0} maps to internal {1}</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="categories.cpp" line="521"/>
+        <location filename="categories.cpp" line="517"/>
         <source>nexus category id {} not mapped</source>
         <translation type="unfinished"></translation>
     </message>
@@ -3222,7 +3229,7 @@ Hide: never show separators</oldsource>
     <message>
         <location filename="mainwindow.ui" line="812"/>
         <location filename="mainwindow.ui" line="815"/>
-        <location filename="mainwindow.cpp" line="3047"/>
+        <location filename="mainwindow.cpp" line="3053"/>
         <source>Sort the plugins using LOOT.</source>
         <translation type="unfinished"></translation>
     </message>
@@ -3660,7 +3667,7 @@ Hide: never show separators</oldsource>
     <message>
         <location filename="mainwindow.ui" line="1832"/>
         <location filename="mainwindow.ui" line="1835"/>
-        <location filename="mainwindow.cpp" line="2967"/>
+        <location filename="mainwindow.cpp" line="2973"/>
         <source>Endorse Mod Organizer</source>
         <translation type="unfinished"></translation>
     </message>
@@ -3759,7 +3766,7 @@ Hide: never show separators</oldsource>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="mainwindow.cpp" line="3050"/>
+        <location filename="mainwindow.cpp" line="3056"/>
         <source>There is no supported sort mechanism for this game. You will probably have to use a third-party tool.</source>
         <translation type="unfinished"></translation>
     </message>
@@ -4082,156 +4089,156 @@ As a final option, you can disable Nexus category mapping altogether, which can 
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="mainwindow.cpp" line="2930"/>
+        <location filename="mainwindow.cpp" line="2936"/>
         <source>Update available</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="mainwindow.cpp" line="2968"/>
+        <location filename="mainwindow.cpp" line="2974"/>
         <source>Do you want to endorse Mod Organizer on %1 now?</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="mainwindow.cpp" line="2987"/>
+        <location filename="mainwindow.cpp" line="2993"/>
         <source>Abstain from Endorsing Mod Organizer</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="mainwindow.cpp" line="2988"/>
+        <location filename="mainwindow.cpp" line="2994"/>
         <source>Are you sure you want to abstain from endorsing Mod Organizer 2?
 You will have to visit the mod page on the %1 Nexus site to change your mind.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="mainwindow.cpp" line="3016"/>
+        <location filename="mainwindow.cpp" line="3022"/>
         <source>Thank you for endorsing MO2! :)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="mainwindow.cpp" line="3021"/>
+        <location filename="mainwindow.cpp" line="3027"/>
         <source>Please reconsider endorsing MO2 on Nexus!</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="mainwindow.cpp" line="3147"/>
+        <location filename="mainwindow.cpp" line="3153"/>
         <source>None of your %1 mods appear to have had recent file updates.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="mainwindow.cpp" line="3160"/>
+        <location filename="mainwindow.cpp" line="3166"/>
         <source>All of your mods have been checked recently. We restrict update checks to help preserve your available API requests.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="mainwindow.cpp" line="3390"/>
+        <location filename="mainwindow.cpp" line="3396"/>
         <source>Thank you!</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="mainwindow.cpp" line="3391"/>
+        <location filename="mainwindow.cpp" line="3397"/>
         <source>Thank you for your endorsement!</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="mainwindow.cpp" line="3505"/>
+        <location filename="mainwindow.cpp" line="3511"/>
         <source>Mod ID %1 no longer seems to be available on Nexus.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="mainwindow.cpp" line="3523"/>
+        <location filename="mainwindow.cpp" line="3529"/>
         <source>Error %1: Request to Nexus failed: %2</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="mainwindow.cpp" line="3540"/>
-        <location filename="mainwindow.cpp" line="3613"/>
+        <location filename="mainwindow.cpp" line="3546"/>
+        <location filename="mainwindow.cpp" line="3619"/>
         <source>failed to read %1: %2</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="mainwindow.cpp" line="3553"/>
+        <location filename="mainwindow.cpp" line="3559"/>
         <source>Error</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="mainwindow.cpp" line="3554"/>
+        <location filename="mainwindow.cpp" line="3560"/>
         <source>failed to extract %1 (errorcode %2)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="mainwindow.cpp" line="3588"/>
+        <location filename="mainwindow.cpp" line="3594"/>
         <source>Extract BSA</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="mainwindow.cpp" line="3627"/>
+        <location filename="mainwindow.cpp" line="3633"/>
         <source>This archive contains invalid hashes. Some files may be broken.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="mainwindow.cpp" line="3637"/>
+        <location filename="mainwindow.cpp" line="3643"/>
         <source>Extract...</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="mainwindow.cpp" line="3706"/>
+        <location filename="mainwindow.cpp" line="3712"/>
         <source>Remove &apos;%1&apos; from the toolbar</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="mainwindow.cpp" line="3762"/>
+        <location filename="mainwindow.cpp" line="3768"/>
         <source>Backup of load order created</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="mainwindow.cpp" line="3773"/>
+        <location filename="mainwindow.cpp" line="3779"/>
         <source>Choose backup to restore</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="mainwindow.cpp" line="3790"/>
+        <location filename="mainwindow.cpp" line="3796"/>
         <source>No Backups</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="mainwindow.cpp" line="3791"/>
+        <location filename="mainwindow.cpp" line="3797"/>
         <source>There are no backups to restore</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="mainwindow.cpp" line="3815"/>
-        <location filename="mainwindow.cpp" line="3839"/>
+        <location filename="mainwindow.cpp" line="3821"/>
+        <location filename="mainwindow.cpp" line="3845"/>
         <source>Restore failed</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="mainwindow.cpp" line="3816"/>
-        <location filename="mainwindow.cpp" line="3840"/>
+        <location filename="mainwindow.cpp" line="3822"/>
+        <location filename="mainwindow.cpp" line="3846"/>
         <source>Failed to restore the backup. Errorcode: %1</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="mainwindow.cpp" line="3828"/>
+        <location filename="mainwindow.cpp" line="3834"/>
         <source>Backup of mod list created</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="mainwindow.cpp" line="3908"/>
+        <location filename="mainwindow.cpp" line="3914"/>
         <source>A file with the same name has already been downloaded. What would you like to do?</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="mainwindow.cpp" line="3910"/>
+        <location filename="mainwindow.cpp" line="3916"/>
         <source>Overwrite</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="mainwindow.cpp" line="3911"/>
+        <location filename="mainwindow.cpp" line="3917"/>
         <source>Rename new file</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="mainwindow.cpp" line="3912"/>
+        <location filename="mainwindow.cpp" line="3918"/>
         <source>Ignore file</source>
         <translation type="unfinished"></translation>
     </message>
@@ -5075,7 +5082,7 @@ p, li { white-space: pre-wrap; }
     <message>
         <location filename="modlistcontextmenu.cpp" line="376"/>
         <location filename="modlistcontextmenu.cpp" line="453"/>
-        <location filename="modlistcontextmenu.cpp" line="620"/>
+        <location filename="modlistcontextmenu.cpp" line="622"/>
         <source>Open in Explorer</source>
         <translation type="unfinished"></translation>
     </message>
@@ -5113,25 +5120,25 @@ p, li { white-space: pre-wrap; }
     </message>
     <message>
         <location filename="modlistcontextmenu.cpp" line="429"/>
-        <location filename="modlistcontextmenu.cpp" line="593"/>
+        <location filename="modlistcontextmenu.cpp" line="595"/>
         <source>Ignore missing data</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="modlistcontextmenu.cpp" line="435"/>
-        <location filename="modlistcontextmenu.cpp" line="600"/>
+        <location filename="modlistcontextmenu.cpp" line="602"/>
         <source>Mark as converted/working</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="modlistcontextmenu.cpp" line="441"/>
-        <location filename="modlistcontextmenu.cpp" line="608"/>
+        <location filename="modlistcontextmenu.cpp" line="610"/>
         <source>Visit on Nexus</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="modlistcontextmenu.cpp" line="448"/>
-        <location filename="modlistcontextmenu.cpp" line="615"/>
+        <location filename="modlistcontextmenu.cpp" line="617"/>
         <source>Visit on %1</source>
         <translation type="unfinished"></translation>
     </message>
@@ -5212,22 +5219,22 @@ p, li { white-space: pre-wrap; }
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="modlistcontextmenu.cpp" line="565"/>
+        <location filename="modlistcontextmenu.cpp" line="567"/>
         <source>Remap Category (From Nexus)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="modlistcontextmenu.cpp" line="573"/>
+        <location filename="modlistcontextmenu.cpp" line="575"/>
         <source>Start tracking</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="modlistcontextmenu.cpp" line="578"/>
+        <location filename="modlistcontextmenu.cpp" line="580"/>
         <source>Stop tracking</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="modlistcontextmenu.cpp" line="583"/>
+        <location filename="modlistcontextmenu.cpp" line="585"/>
         <source>Tracked state unknown</source>
         <translation type="unfinished"></translation>
     </message>
@@ -5404,7 +5411,7 @@ Please enter the name:</source>
     </message>
     <message>
         <location filename="modlistviewactions.cpp" line="120"/>
-        <location filename="modlistviewactions.cpp" line="1321"/>
+        <location filename="modlistviewactions.cpp" line="1325"/>
         <source>Create Mod...</source>
         <translation type="unfinished"></translation>
     </message>
@@ -5416,7 +5423,7 @@ Please enter a name:</source>
     </message>
     <message>
         <location filename="modlistviewactions.cpp" line="131"/>
-        <location filename="modlistviewactions.cpp" line="1332"/>
+        <location filename="modlistviewactions.cpp" line="1336"/>
         <source>A mod with this name already exists</source>
         <translation type="unfinished"></translation>
     </message>
@@ -5448,14 +5455,14 @@ Please enter a name:</source>
     </message>
     <message>
         <location filename="modlistviewactions.cpp" line="217"/>
-        <location filename="modlistviewactions.cpp" line="791"/>
-        <location filename="modlistviewactions.cpp" line="1040"/>
+        <location filename="modlistviewactions.cpp" line="793"/>
+        <location filename="modlistviewactions.cpp" line="1042"/>
         <source>Confirm</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="modlistviewactions.cpp" line="240"/>
-        <location filename="modlistviewactions.cpp" line="318"/>
+        <location filename="modlistviewactions.cpp" line="320"/>
         <source>You are not currently authenticated with Nexus. Please do so under Settings -&gt; Nexus.</source>
         <translation type="unfinished"></translation>
     </message>
@@ -5470,247 +5477,247 @@ Please enter a name:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="modlistviewactions.cpp" line="337"/>
+        <location filename="modlistviewactions.cpp" line="339"/>
         <source>Export to csv</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="modlistviewactions.cpp" line="341"/>
+        <location filename="modlistviewactions.cpp" line="343"/>
         <source>CSV (Comma Separated Values) is a format that can be imported in programs like Excel to create a spreadsheet.
 You can also use online editors and converters instead.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="modlistviewactions.cpp" line="346"/>
+        <location filename="modlistviewactions.cpp" line="348"/>
         <source>Select what mods you want export:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="modlistviewactions.cpp" line="347"/>
+        <location filename="modlistviewactions.cpp" line="349"/>
         <source>All installed mods</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="modlistviewactions.cpp" line="349"/>
+        <location filename="modlistviewactions.cpp" line="351"/>
         <source>Only active (checked) mods from your current profile</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="modlistviewactions.cpp" line="351"/>
+        <location filename="modlistviewactions.cpp" line="353"/>
         <source>All currently visible mods in the mod list</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="modlistviewactions.cpp" line="368"/>
+        <location filename="modlistviewactions.cpp" line="370"/>
         <source>Choose what Columns to export:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="modlistviewactions.cpp" line="371"/>
+        <location filename="modlistviewactions.cpp" line="373"/>
         <source>Mod_Priority</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="modlistviewactions.cpp" line="373"/>
+        <location filename="modlistviewactions.cpp" line="375"/>
         <source>Mod_Name</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="modlistviewactions.cpp" line="375"/>
+        <location filename="modlistviewactions.cpp" line="377"/>
         <source>Notes_column</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="modlistviewactions.cpp" line="376"/>
+        <location filename="modlistviewactions.cpp" line="378"/>
         <source>Mod_Status</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="modlistviewactions.cpp" line="378"/>
+        <location filename="modlistviewactions.cpp" line="380"/>
         <source>Primary_Category</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="modlistviewactions.cpp" line="379"/>
+        <location filename="modlistviewactions.cpp" line="381"/>
         <source>Nexus_ID</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="modlistviewactions.cpp" line="380"/>
+        <location filename="modlistviewactions.cpp" line="382"/>
         <source>Mod_Nexus_URL</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="modlistviewactions.cpp" line="381"/>
+        <location filename="modlistviewactions.cpp" line="383"/>
         <source>Mod_Version</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="modlistviewactions.cpp" line="382"/>
+        <location filename="modlistviewactions.cpp" line="384"/>
         <source>Install_Date</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="modlistviewactions.cpp" line="383"/>
+        <location filename="modlistviewactions.cpp" line="385"/>
         <source>Download_File_Name</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="modlistviewactions.cpp" line="510"/>
+        <location filename="modlistviewactions.cpp" line="512"/>
         <source>export failed: %1</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="modlistviewactions.cpp" line="564"/>
+        <location filename="modlistviewactions.cpp" line="566"/>
         <source>Failed to display overwrite dialog: %1</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="modlistviewactions.cpp" line="625"/>
+        <location filename="modlistviewactions.cpp" line="627"/>
         <source>Set Priority</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="modlistviewactions.cpp" line="626"/>
+        <location filename="modlistviewactions.cpp" line="628"/>
         <source>Set the priority of the selected mods</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="modlistviewactions.cpp" line="756"/>
+        <location filename="modlistviewactions.cpp" line="758"/>
         <source>failed to rename mod: %1</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="modlistviewactions.cpp" line="792"/>
+        <location filename="modlistviewactions.cpp" line="794"/>
         <source>Remove the following mods?&lt;br&gt;&lt;ul&gt;%1&lt;/ul&gt;</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="modlistviewactions.cpp" line="809"/>
+        <location filename="modlistviewactions.cpp" line="811"/>
         <source>failed to remove mod: %1</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="modlistviewactions.cpp" line="837"/>
+        <location filename="modlistviewactions.cpp" line="839"/>
         <source>Continue?</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="modlistviewactions.cpp" line="838"/>
+        <location filename="modlistviewactions.cpp" line="840"/>
         <source>The versioning scheme decides which version is considered newer than another.
 This function will guess the versioning scheme under the assumption that the installed version is outdated.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="modlistviewactions.cpp" line="864"/>
+        <location filename="modlistviewactions.cpp" line="866"/>
         <source>Sorry</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="modlistviewactions.cpp" line="865"/>
+        <location filename="modlistviewactions.cpp" line="867"/>
         <source>I don&apos;t know a versioning scheme where %1 is newer than %2.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="modlistviewactions.cpp" line="886"/>
+        <location filename="modlistviewactions.cpp" line="888"/>
         <source>Opening Nexus Links</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="modlistviewactions.cpp" line="887"/>
+        <location filename="modlistviewactions.cpp" line="889"/>
         <source>You are trying to open %1 links to Nexus Mods.  Are you sure you want to do this?</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="modlistviewactions.cpp" line="910"/>
-        <location filename="modlistviewactions.cpp" line="932"/>
+        <location filename="modlistviewactions.cpp" line="912"/>
+        <location filename="modlistviewactions.cpp" line="934"/>
         <source>Opening Web Pages</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="modlistviewactions.cpp" line="911"/>
-        <location filename="modlistviewactions.cpp" line="933"/>
+        <location filename="modlistviewactions.cpp" line="913"/>
+        <location filename="modlistviewactions.cpp" line="935"/>
         <source>You are trying to open %1 Web Pages.  Are you sure you want to do this?</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="modlistviewactions.cpp" line="983"/>
-        <location filename="modlistviewactions.cpp" line="988"/>
-        <location filename="modlistviewactions.cpp" line="999"/>
+        <location filename="modlistviewactions.cpp" line="985"/>
+        <location filename="modlistviewactions.cpp" line="990"/>
+        <location filename="modlistviewactions.cpp" line="1001"/>
         <source>Failed</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="modlistviewactions.cpp" line="984"/>
+        <location filename="modlistviewactions.cpp" line="986"/>
         <source>Installation file no longer exists</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="modlistviewactions.cpp" line="989"/>
+        <location filename="modlistviewactions.cpp" line="991"/>
         <source>Mods installed with old versions of MO can&apos;t be reinstalled in this way.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="modlistviewactions.cpp" line="999"/>
+        <location filename="modlistviewactions.cpp" line="1001"/>
         <source>Failed to create backup.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="modlistviewactions.cpp" line="1041"/>
+        <location filename="modlistviewactions.cpp" line="1043"/>
         <source>Restore all hidden files in the following mods?&lt;br&gt;&lt;ul&gt;%1&lt;/ul&gt;</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="modlistviewactions.cpp" line="267"/>
-        <location filename="modlistviewactions.cpp" line="1074"/>
-        <location filename="modlistviewactions.cpp" line="1391"/>
+        <location filename="modlistviewactions.cpp" line="1076"/>
+        <location filename="modlistviewactions.cpp" line="1395"/>
         <source>Are you sure?</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="modlistviewactions.cpp" line="1075"/>
+        <location filename="modlistviewactions.cpp" line="1077"/>
         <source>About to restore all hidden files in:
 </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="modlistviewactions.cpp" line="1108"/>
+        <location filename="modlistviewactions.cpp" line="1110"/>
         <source>Endorsing multiple mods will take a while. Please wait...</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="modlistviewactions.cpp" line="1273"/>
+        <location filename="modlistviewactions.cpp" line="1277"/>
         <source>Overwrite?</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="modlistviewactions.cpp" line="1274"/>
+        <location filename="modlistviewactions.cpp" line="1278"/>
         <source>This will replace the existing mod &quot;%1&quot;. Continue?</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="modlistviewactions.cpp" line="1278"/>
+        <location filename="modlistviewactions.cpp" line="1282"/>
         <source>failed to remove mod &quot;%1&quot;</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="modlistviewactions.cpp" line="1284"/>
+        <location filename="modlistviewactions.cpp" line="1288"/>
         <source>failed to rename &quot;%1&quot; to &quot;%2&quot;</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="modlistviewactions.cpp" line="1303"/>
+        <location filename="modlistviewactions.cpp" line="1307"/>
         <source>Move successful.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="modlistviewactions.cpp" line="1322"/>
+        <location filename="modlistviewactions.cpp" line="1326"/>
         <source>This will move all files from overwrite into a new, regular mod.
 Please enter a name:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="modlistviewactions.cpp" line="1392"/>
+        <location filename="modlistviewactions.cpp" line="1396"/>
         <source>About to recursively delete:
 </source>
         <translation type="unfinished"></translation>
@@ -6322,97 +6329,97 @@ Continue?</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="pluginlist.cpp" line="1272"/>
+        <location filename="pluginlist.cpp" line="1270"/>
         <source>Origin</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="pluginlist.cpp" line="1276"/>
+        <location filename="pluginlist.cpp" line="1274"/>
         <source>This plugin can&apos;t be disabled or moved (enforced by the game).</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="pluginlist.cpp" line="1282"/>
+        <location filename="pluginlist.cpp" line="1280"/>
         <source>This plugin can&apos;t be disabled (enforced by the game).</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="pluginlist.cpp" line="1286"/>
+        <location filename="pluginlist.cpp" line="1284"/>
         <source>Author</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="pluginlist.cpp" line="1291"/>
+        <location filename="pluginlist.cpp" line="1289"/>
         <source>Description</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="pluginlist.cpp" line="1296"/>
+        <location filename="pluginlist.cpp" line="1294"/>
         <source>Missing Masters</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="pluginlist.cpp" line="1308"/>
+        <location filename="pluginlist.cpp" line="1306"/>
         <source>Enabled Masters</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="pluginlist.cpp" line="1319"/>
+        <location filename="pluginlist.cpp" line="1317"/>
         <source>Loads Archives</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="pluginlist.cpp" line="1320"/>
+        <location filename="pluginlist.cpp" line="1318"/>
         <source>There are Archives connected to this plugin. Their assets will be added to your game, overwriting in case of conflicts following the plugin order. Loose files will always overwrite assets from Archives. (This flag only checks for Archives from the same mod as the plugin)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="pluginlist.cpp" line="1328"/>
+        <location filename="pluginlist.cpp" line="1326"/>
         <source>Loads INI settings</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="pluginlist.cpp" line="1331"/>
+        <location filename="pluginlist.cpp" line="1329"/>
         <source>There is an ini file connected to this plugin. Its settings will be added to your game settings, overwriting in case of conflicts.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="pluginlist.cpp" line="1338"/>
+        <location filename="pluginlist.cpp" line="1336"/>
         <source>This %1 is flagged as an ESL. It will adhere to the %1 load order but the records will be loaded in ESL space.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="pluginlist.cpp" line="1355"/>
+        <location filename="pluginlist.cpp" line="1353"/>
         <source>This is a dummy plugin. It contains no records and is typically used to load a paired archive file.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="pluginlist.cpp" line="1360"/>
+        <location filename="pluginlist.cpp" line="1358"/>
         <source>This game does not currently permit custom plugin loading. There may be manual workarounds.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="pluginlist.cpp" line="1391"/>
+        <location filename="pluginlist.cpp" line="1389"/>
         <source>Incompatible with %1</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="pluginlist.cpp" line="1397"/>
+        <location filename="pluginlist.cpp" line="1395"/>
         <source>Depends on missing %1</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="pluginlist.cpp" line="1405"/>
+        <location filename="pluginlist.cpp" line="1403"/>
         <source>Warning</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="pluginlist.cpp" line="1409"/>
+        <location filename="pluginlist.cpp" line="1407"/>
         <source>Error</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="pluginlist.cpp" line="1688"/>
+        <location filename="pluginlist.cpp" line="1690"/>
         <source>failed to restore load order for %1</source>
         <translation type="unfinished"></translation>
     </message>
@@ -7013,57 +7020,57 @@ p, li { white-space: pre-wrap; }
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="categories.cpp" line="425"/>
+        <location filename="categories.cpp" line="421"/>
         <source>Active</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="categories.cpp" line="428"/>
+        <location filename="categories.cpp" line="424"/>
         <source>Update available</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="categories.cpp" line="431"/>
+        <location filename="categories.cpp" line="427"/>
         <source>Has category</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="categories.cpp" line="434"/>
+        <location filename="categories.cpp" line="430"/>
         <source>Conflicted</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="categories.cpp" line="437"/>
+        <location filename="categories.cpp" line="433"/>
         <source>Has hidden files</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="categories.cpp" line="440"/>
+        <location filename="categories.cpp" line="436"/>
         <source>Endorsed</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="categories.cpp" line="443"/>
+        <location filename="categories.cpp" line="439"/>
         <source>Has backup</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="categories.cpp" line="446"/>
+        <location filename="categories.cpp" line="442"/>
         <source>Managed</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="categories.cpp" line="449"/>
+        <location filename="categories.cpp" line="445"/>
         <source>Has valid game data</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="categories.cpp" line="452"/>
+        <location filename="categories.cpp" line="448"/>
         <source>Has Nexus ID</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="categories.cpp" line="455"/>
+        <location filename="categories.cpp" line="451"/>
         <source>Tracked on Nexus</source>
         <translation type="unfinished"></translation>
     </message>
@@ -7234,13 +7241,13 @@ p, li { white-space: pre-wrap; }
         <location filename="settingsdialognexus.cpp" line="270"/>
         <location filename="settingsdialognexus.cpp" line="277"/>
         <location filename="settingsdialogworkarounds.cpp" line="142"/>
-        <location filename="spawn.cpp" line="194"/>
-        <location filename="spawn.cpp" line="218"/>
-        <location filename="spawn.cpp" line="293"/>
-        <location filename="spawn.cpp" line="316"/>
-        <location filename="spawn.cpp" line="343"/>
-        <location filename="spawn.cpp" line="367"/>
-        <location filename="spawn.cpp" line="398"/>
+        <location filename="spawn.cpp" line="182"/>
+        <location filename="spawn.cpp" line="206"/>
+        <location filename="spawn.cpp" line="281"/>
+        <location filename="spawn.cpp" line="304"/>
+        <location filename="spawn.cpp" line="331"/>
+        <location filename="spawn.cpp" line="355"/>
+        <location filename="spawn.cpp" line="386"/>
         <location filename="uilocker.cpp" line="349"/>
         <source>Cancel</source>
         <translation type="unfinished"></translation>
@@ -7395,12 +7402,12 @@ p, li { white-space: pre-wrap; }
         </translation>
     </message>
     <message>
-        <location filename="envshell.cpp" line="303"/>
+        <location filename="envshell.cpp" line="307"/>
         <source>No menu available</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="envshell.cpp" line="342"/>
+        <location filename="envshell.cpp" line="346"/>
         <source>Selected files must be in the same directory</source>
         <translation type="unfinished"></translation>
     </message>
@@ -7614,7 +7621,7 @@ Destination:<byte value="xd"/>
     </message>
     <message>
         <location filename="mainwindow.cpp" line="1825"/>
-        <location filename="mainwindow.cpp" line="2902"/>
+        <location filename="mainwindow.cpp" line="2908"/>
         <source>&lt;Manage...&gt;</source>
         <translation type="unfinished"></translation>
     </message>
@@ -8026,12 +8033,13 @@ Example:
     </message>
     <message>
         <location filename="shared/fileregister.cpp" line="77"/>
-        <source>invalid file index for remove: {}</source>
+        <source>invalid file index for remove</source>
+        <oldsource>invalid file index for remove: {}</oldsource>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="shared/fileregister.cpp" line="99"/>
-        <source>invalid file index for remove (for origin): {}</source>
+        <location filename="shared/fileregister.cpp" line="98"/>
+        <source>invalid file index for remove (for origin)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
@@ -8041,200 +8049,201 @@ Example:
     </message>
     <message>
         <location filename="shared/originconnection.cpp" line="101"/>
-        <source>failed to change name lookup from {} to {}</source>
+        <source>failed to change name lookup from {0} to {1}</source>
+        <oldsource>failed to change name lookup from {} to {}</oldsource>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="spawn.cpp" line="152"/>
+        <location filename="spawn.cpp" line="140"/>
         <source>This error typically happens because an antivirus has deleted critical files from Mod Organizer&apos;s installation folder or has made them generally inaccessible. Add an exclusion for Mod Organizer&apos;s installation folder in your antivirus, reinstall Mod Organizer and try again.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="spawn.cpp" line="159"/>
+        <location filename="spawn.cpp" line="147"/>
         <source>This error typically happens because an antivirus is preventing Mod Organizer from starting programs. Add an exclusion for Mod Organizer&apos;s installation folder in your antivirus and try again.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="spawn.cpp" line="164"/>
+        <location filename="spawn.cpp" line="152"/>
         <source>The file &apos;%1&apos; does not exist.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="spawn.cpp" line="168"/>
+        <location filename="spawn.cpp" line="156"/>
         <source>The working directory &apos;%1&apos; does not exist.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="spawn.cpp" line="185"/>
-        <location filename="spawn.cpp" line="186"/>
-        <location filename="spawn.cpp" line="211"/>
-        <location filename="spawn.cpp" line="212"/>
+        <location filename="spawn.cpp" line="173"/>
+        <location filename="spawn.cpp" line="174"/>
+        <location filename="spawn.cpp" line="199"/>
+        <location filename="spawn.cpp" line="200"/>
         <source>Cannot start Steam</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="spawn.cpp" line="188"/>
+        <location filename="spawn.cpp" line="176"/>
         <source>The path to the Steam executable cannot be found. You might try reinstalling Steam.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="spawn.cpp" line="192"/>
-        <location filename="spawn.cpp" line="216"/>
-        <location filename="spawn.cpp" line="314"/>
+        <location filename="spawn.cpp" line="180"/>
+        <location filename="spawn.cpp" line="204"/>
+        <location filename="spawn.cpp" line="302"/>
         <source>Continue without starting Steam</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="spawn.cpp" line="193"/>
-        <location filename="spawn.cpp" line="217"/>
+        <location filename="spawn.cpp" line="181"/>
+        <location filename="spawn.cpp" line="205"/>
         <source>The program may fail to launch.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="spawn.cpp" line="227"/>
+        <location filename="spawn.cpp" line="215"/>
         <source>Cannot launch program</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="spawn.cpp" line="229"/>
-        <location filename="spawn.cpp" line="253"/>
-        <location filename="spawn.cpp" line="271"/>
+        <location filename="spawn.cpp" line="217"/>
+        <location filename="spawn.cpp" line="241"/>
+        <location filename="spawn.cpp" line="259"/>
         <source>Cannot start %1</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="spawn.cpp" line="251"/>
+        <location filename="spawn.cpp" line="239"/>
         <source>Cannot launch helper</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="spawn.cpp" line="269"/>
-        <location filename="spawn.cpp" line="324"/>
+        <location filename="spawn.cpp" line="257"/>
+        <location filename="spawn.cpp" line="312"/>
         <source>Elevation required</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="spawn.cpp" line="273"/>
+        <location filename="spawn.cpp" line="261"/>
         <source>This program is requesting to run as administrator but Mod Organizer itself is not running as administrator. Running programs as administrator is typically unnecessary as long as the game and Mod Organizer have been installed outside &quot;Program Files&quot;.<byte value="xd"/>
 <byte value="xd"/>
 You can restart Mod Organizer as administrator and try launching the program again.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="spawn.cpp" line="289"/>
-        <location filename="spawn.cpp" line="338"/>
+        <location filename="spawn.cpp" line="277"/>
+        <location filename="spawn.cpp" line="326"/>
         <source>Restart Mod Organizer as administrator</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="spawn.cpp" line="290"/>
-        <location filename="spawn.cpp" line="339"/>
+        <location filename="spawn.cpp" line="278"/>
+        <location filename="spawn.cpp" line="327"/>
         <source>You must allow &quot;helper.exe&quot; to make changes to the system.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="spawn.cpp" line="302"/>
+        <location filename="spawn.cpp" line="290"/>
         <source>Launch Steam</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="spawn.cpp" line="303"/>
+        <location filename="spawn.cpp" line="291"/>
         <source>This program requires Steam</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="spawn.cpp" line="304"/>
+        <location filename="spawn.cpp" line="292"/>
         <source>Mod Organizer has detected that this program likely requires Steam to be running to function properly.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="spawn.cpp" line="313"/>
+        <location filename="spawn.cpp" line="301"/>
         <source>Start Steam</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="spawn.cpp" line="315"/>
-        <location filename="spawn.cpp" line="341"/>
+        <location filename="spawn.cpp" line="303"/>
+        <location filename="spawn.cpp" line="329"/>
         <source>The program might fail to run.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="spawn.cpp" line="325"/>
+        <location filename="spawn.cpp" line="313"/>
         <source>Steam is running as administrator</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="spawn.cpp" line="326"/>
+        <location filename="spawn.cpp" line="314"/>
         <source>Running Steam as administrator is typically unnecessary and can cause problems when Mod Organizer itself is not running as administrator.<byte value="xd"/>
 <byte value="xd"/>
 You can restart Mod Organizer as administrator and try launching the program again.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="spawn.cpp" line="341"/>
-        <location filename="spawn.cpp" line="365"/>
-        <location filename="spawn.cpp" line="395"/>
+        <location filename="spawn.cpp" line="329"/>
+        <location filename="spawn.cpp" line="353"/>
+        <location filename="spawn.cpp" line="383"/>
         <source>Continue</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="spawn.cpp" line="351"/>
+        <location filename="spawn.cpp" line="339"/>
         <source>Event Log not running</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="spawn.cpp" line="352"/>
+        <location filename="spawn.cpp" line="340"/>
         <source>The Event Log service is not running</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="spawn.cpp" line="353"/>
+        <location filename="spawn.cpp" line="341"/>
         <source>The Windows Event Log service is not running. This can prevent USVFS from running properly and your mods may not be recognized by the program being launched.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="spawn.cpp" line="365"/>
-        <location filename="spawn.cpp" line="396"/>
+        <location filename="spawn.cpp" line="353"/>
+        <location filename="spawn.cpp" line="384"/>
         <source>Your mods might not work.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="spawn.cpp" line="376"/>
+        <location filename="spawn.cpp" line="364"/>
         <source>Blacklisted program</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="spawn.cpp" line="378"/>
+        <location filename="spawn.cpp" line="366"/>
         <source>The program %1 is blacklisted</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="spawn.cpp" line="379"/>
+        <location filename="spawn.cpp" line="367"/>
         <source>The program you are attempting to launch is blacklisted in the virtual filesystem. This will likely prevent it from seeing any mods, INI files or any other virtualized files.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="spawn.cpp" line="397"/>
+        <location filename="spawn.cpp" line="385"/>
         <source>Change the blacklist</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="spawn.cpp" line="618"/>
+        <location filename="spawn.cpp" line="606"/>
         <source>Waiting</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="spawn.cpp" line="619"/>
+        <location filename="spawn.cpp" line="607"/>
         <source>Please press OK once you&apos;re logged into steam.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="spawn.cpp" line="907"/>
+        <location filename="spawn.cpp" line="895"/>
         <source>Select binary</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="spawn.cpp" line="908"/>
+        <location filename="spawn.cpp" line="896"/>
         <source>Binary</source>
         <translation type="unfinished"></translation>
     </message>
@@ -8310,17 +8319,17 @@ You can restart Mod Organizer as administrator and try launching the program aga
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../game_gamebryo/src/gamebryo/gamebryosavegame.cpp" line="109"/>
-        <source>wrong file format - expected %1 got %2</source>
+        <location filename="../../game_gamebryo/src/gamebryo/gamebryosavegame.cpp" line="110"/>
+        <source>wrong file format - expected %1 got &apos;%2&apos; for %3</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../game_gamebryo/src/gamebryo/gamegamebryo.cpp" line="319"/>
+        <location filename="../../game_gamebryo/src/gamebryo/gamegamebryo.cpp" line="325"/>
         <source>failed to query registry path (preflight): %1</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../game_gamebryo/src/gamebryo/gamegamebryo.cpp" line="327"/>
+        <location filename="../../game_gamebryo/src/gamebryo/gamegamebryo.cpp" line="333"/>
         <source>failed to query registry path (read): %1</source>
         <translation type="unfinished"></translation>
     </message>
@@ -8417,90 +8426,90 @@ You can restart Mod Organizer as administrator and try launching the program aga
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../uibase/src/utility.cpp" line="61"/>
+        <location filename="../../uibase/src/utility.cpp" line="62"/>
         <source>removal of &quot;%1&quot; failed: %2</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../uibase/src/utility.cpp" line="70"/>
+        <location filename="../../uibase/src/utility.cpp" line="71"/>
         <source>removal of &quot;%1&quot; failed</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../uibase/src/utility.cpp" line="74"/>
+        <location filename="../../uibase/src/utility.cpp" line="75"/>
         <source>&quot;%1&quot; doesn&apos;t exist (remove)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../uibase/src/utility.cpp" line="349"/>
+        <location filename="../../uibase/src/utility.cpp" line="350"/>
         <source>Error %1</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../uibase/src/utility.cpp" line="533"/>
-        <location filename="../../uibase/src/utility.cpp" line="556"/>
+        <location filename="../../uibase/src/utility.cpp" line="534"/>
+        <location filename="../../uibase/src/utility.cpp" line="557"/>
         <source>You have an invalid custom browser command in the settings.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../uibase/src/utility.cpp" line="672"/>
-        <location filename="../../uibase/src/utility.cpp" line="701"/>
+        <location filename="../../uibase/src/utility.cpp" line="673"/>
+        <location filename="../../uibase/src/utility.cpp" line="702"/>
         <source>failed to create directory &quot;%1&quot;</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../uibase/src/utility.cpp" line="681"/>
-        <location filename="../../uibase/src/utility.cpp" line="708"/>
+        <location filename="../../uibase/src/utility.cpp" line="682"/>
+        <location filename="../../uibase/src/utility.cpp" line="709"/>
         <source>failed to copy &quot;%1&quot; to &quot;%2&quot;</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../uibase/src/utility.cpp" line="1115"/>
+        <location filename="../../uibase/src/utility.cpp" line="1108"/>
         <source>%1 B</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../uibase/src/utility.cpp" line="1115"/>
+        <location filename="../../uibase/src/utility.cpp" line="1108"/>
         <source>%1 KB</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../uibase/src/utility.cpp" line="1116"/>
+        <location filename="../../uibase/src/utility.cpp" line="1109"/>
         <source>%1 MB</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../uibase/src/utility.cpp" line="1116"/>
+        <location filename="../../uibase/src/utility.cpp" line="1109"/>
         <source>%1 GB</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../uibase/src/utility.cpp" line="1117"/>
+        <location filename="../../uibase/src/utility.cpp" line="1110"/>
         <source>%1 TB</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../uibase/src/utility.cpp" line="1122"/>
+        <location filename="../../uibase/src/utility.cpp" line="1115"/>
         <source>%1 B/s</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../uibase/src/utility.cpp" line="1122"/>
+        <location filename="../../uibase/src/utility.cpp" line="1115"/>
         <source>%1 KB/s</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../uibase/src/utility.cpp" line="1123"/>
+        <location filename="../../uibase/src/utility.cpp" line="1116"/>
         <source>%1 MB/s</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../uibase/src/utility.cpp" line="1123"/>
+        <location filename="../../uibase/src/utility.cpp" line="1116"/>
         <source>%1 GB/s</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../uibase/src/utility.cpp" line="1124"/>
+        <location filename="../../uibase/src/utility.cpp" line="1117"/>
         <source>%1 TB/s</source>
         <translation type="unfinished"></translation>
     </message>
@@ -10466,19 +10475,19 @@ Please open the &quot;Nexus&quot; tab.</source>
 <context>
     <name>uibase</name>
     <message>
-        <location filename="../../uibase/src/utility.cpp" line="1186"/>
+        <location filename="../../uibase/src/utility.cpp" line="1179"/>
         <source>h</source>
         <extracomment>Time remaining hours</extracomment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../uibase/src/utility.cpp" line="1189"/>
+        <location filename="../../uibase/src/utility.cpp" line="1182"/>
         <source>m</source>
         <extracomment>Time remaining minutes</extracomment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../uibase/src/utility.cpp" line="1192"/>
+        <location filename="../../uibase/src/utility.cpp" line="1185"/>
         <source>s</source>
         <extracomment>Time remaining seconds</extracomment>
         <translation type="unfinished"></translation>

--- a/src/organizer_en.ts
+++ b/src/organizer_en.ts
@@ -6319,107 +6319,112 @@ Continue?</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="pluginlist.cpp" line="248"/>
+        <location filename="pluginlist.cpp" line="251"/>
         <source>failed to update esp info for file %1 (source id: %2), error: %3</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="pluginlist.cpp" line="408"/>
+        <location filename="pluginlist.cpp" line="411"/>
         <source>Plugin not found: %1</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="pluginlist.cpp" line="1270"/>
+        <location filename="pluginlist.cpp" line="1273"/>
         <source>Origin</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="pluginlist.cpp" line="1274"/>
+        <location filename="pluginlist.cpp" line="1277"/>
         <source>This plugin can&apos;t be disabled or moved (enforced by the game).</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="pluginlist.cpp" line="1280"/>
+        <location filename="pluginlist.cpp" line="1283"/>
         <source>This plugin can&apos;t be disabled (enforced by the game).</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="pluginlist.cpp" line="1284"/>
+        <location filename="pluginlist.cpp" line="1287"/>
         <source>Author</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="pluginlist.cpp" line="1289"/>
+        <location filename="pluginlist.cpp" line="1292"/>
         <source>Description</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="pluginlist.cpp" line="1294"/>
+        <location filename="pluginlist.cpp" line="1297"/>
         <source>Missing Masters</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="pluginlist.cpp" line="1306"/>
+        <location filename="pluginlist.cpp" line="1309"/>
         <source>Enabled Masters</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="pluginlist.cpp" line="1317"/>
+        <location filename="pluginlist.cpp" line="1320"/>
         <source>Loads Archives</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="pluginlist.cpp" line="1318"/>
+        <location filename="pluginlist.cpp" line="1321"/>
         <source>There are Archives connected to this plugin. Their assets will be added to your game, overwriting in case of conflicts following the plugin order. Loose files will always overwrite assets from Archives. (This flag only checks for Archives from the same mod as the plugin)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="pluginlist.cpp" line="1326"/>
+        <location filename="pluginlist.cpp" line="1329"/>
         <source>Loads INI settings</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="pluginlist.cpp" line="1329"/>
+        <location filename="pluginlist.cpp" line="1332"/>
         <source>There is an ini file connected to this plugin. Its settings will be added to your game settings, overwriting in case of conflicts.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="pluginlist.cpp" line="1336"/>
+        <location filename="pluginlist.cpp" line="1339"/>
         <source>This %1 is flagged as an ESL. It will adhere to the %1 load order but the records will be loaded in ESL space.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="pluginlist.cpp" line="1353"/>
+        <location filename="pluginlist.cpp" line="1356"/>
         <source>This is a dummy plugin. It contains no records and is typically used to load a paired archive file.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="pluginlist.cpp" line="1358"/>
+        <location filename="pluginlist.cpp" line="1363"/>
+        <source>Light plugins (ESL) are not supported by this game.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="pluginlist.cpp" line="1365"/>
         <source>This game does not currently permit custom plugin loading. There may be manual workarounds.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="pluginlist.cpp" line="1389"/>
+        <location filename="pluginlist.cpp" line="1397"/>
         <source>Incompatible with %1</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="pluginlist.cpp" line="1395"/>
+        <location filename="pluginlist.cpp" line="1403"/>
         <source>Depends on missing %1</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="pluginlist.cpp" line="1403"/>
+        <location filename="pluginlist.cpp" line="1411"/>
         <source>Warning</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="pluginlist.cpp" line="1407"/>
+        <location filename="pluginlist.cpp" line="1415"/>
         <source>Error</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="pluginlist.cpp" line="1690"/>
+        <location filename="pluginlist.cpp" line="1698"/>
         <source>failed to restore load order for %1</source>
         <translation type="unfinished"></translation>
     </message>
@@ -6635,17 +6640,16 @@ p, li { white-space: pre-wrap; }
     </message>
     <message>
         <location filename="problemsdialog.cpp" line="59"/>
-        <location filename="problemsdialog.cpp" line="60"/>
         <source>Fix</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="problemsdialog.cpp" line="67"/>
+        <location filename="problemsdialog.cpp" line="66"/>
         <source>No guided fix</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="problemsdialog.cpp" line="75"/>
+        <location filename="problemsdialog.cpp" line="74"/>
         <source>(There are no notifications)</source>
         <translation type="unfinished"></translation>
     </message>
@@ -7015,7 +7019,7 @@ p, li { white-space: pre-wrap; }
     </message>
     <message>
         <location filename="apiuseraccount.cpp" line="14"/>
-        <location filename="settingsdialogdiagnostics.cpp" line="83"/>
+        <location filename="settingsdialogdiagnostics.cpp" line="86"/>
         <source>None</source>
         <translation type="unfinished"></translation>
     </message>
@@ -7241,13 +7245,13 @@ p, li { white-space: pre-wrap; }
         <location filename="settingsdialognexus.cpp" line="270"/>
         <location filename="settingsdialognexus.cpp" line="277"/>
         <location filename="settingsdialogworkarounds.cpp" line="142"/>
-        <location filename="spawn.cpp" line="182"/>
-        <location filename="spawn.cpp" line="206"/>
-        <location filename="spawn.cpp" line="281"/>
-        <location filename="spawn.cpp" line="304"/>
-        <location filename="spawn.cpp" line="331"/>
-        <location filename="spawn.cpp" line="355"/>
-        <location filename="spawn.cpp" line="386"/>
+        <location filename="spawn.cpp" line="180"/>
+        <location filename="spawn.cpp" line="204"/>
+        <location filename="spawn.cpp" line="279"/>
+        <location filename="spawn.cpp" line="302"/>
+        <location filename="spawn.cpp" line="329"/>
+        <location filename="spawn.cpp" line="353"/>
+        <location filename="spawn.cpp" line="384"/>
         <location filename="uilocker.cpp" line="349"/>
         <source>Cancel</source>
         <translation type="unfinished"></translation>
@@ -7492,8 +7496,8 @@ Destination:<byte value="xd"/>
         <location filename="loglist.cpp" line="384"/>
         <location filename="loot.cpp" line="396"/>
         <location filename="organizercore.cpp" line="389"/>
-        <location filename="settingsdialogdiagnostics.cpp" line="37"/>
-        <location filename="settingsdialogdiagnostics.cpp" line="63"/>
+        <location filename="settingsdialogdiagnostics.cpp" line="40"/>
+        <location filename="settingsdialogdiagnostics.cpp" line="66"/>
         <location filename="settingsdialogpaths.cpp" line="100"/>
         <location filename="settingsdialogpaths.cpp" line="236"/>
         <location filename="../../uibase/src/report.cpp" line="65"/>
@@ -7544,8 +7548,8 @@ Destination:<byte value="xd"/>
     </message>
     <message>
         <location filename="loot.cpp" line="401"/>
-        <location filename="settingsdialogdiagnostics.cpp" line="36"/>
-        <location filename="settingsdialogdiagnostics.cpp" line="62"/>
+        <location filename="settingsdialogdiagnostics.cpp" line="39"/>
+        <location filename="settingsdialogdiagnostics.cpp" line="65"/>
         <source>Warning</source>
         <translation type="unfinished"></translation>
     </message>
@@ -7774,12 +7778,12 @@ Destination:<byte value="xd"/>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="pluginlist.cpp" line="712"/>
+        <location filename="pluginlist.cpp" line="715"/>
         <source>failed to access %1</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="pluginlist.cpp" line="726"/>
+        <location filename="pluginlist.cpp" line="729"/>
         <source>failed to set file time %1</source>
         <translation type="unfinished"></translation>
     </message>
@@ -7849,34 +7853,34 @@ This program is known to cause issues with Mod Organizer, such as freezing or bl
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="settingsdialogdiagnostics.cpp" line="34"/>
-        <location filename="settingsdialogdiagnostics.cpp" line="60"/>
+        <location filename="settingsdialogdiagnostics.cpp" line="37"/>
+        <location filename="settingsdialogdiagnostics.cpp" line="63"/>
         <source>Debug</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="settingsdialogdiagnostics.cpp" line="35"/>
-        <location filename="settingsdialogdiagnostics.cpp" line="61"/>
+        <location filename="settingsdialogdiagnostics.cpp" line="38"/>
+        <location filename="settingsdialogdiagnostics.cpp" line="64"/>
         <source>Info (recommended)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="settingsdialogdiagnostics.cpp" line="59"/>
+        <location filename="settingsdialogdiagnostics.cpp" line="62"/>
         <source>Trace</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="settingsdialogdiagnostics.cpp" line="84"/>
+        <location filename="settingsdialogdiagnostics.cpp" line="87"/>
         <source>Mini (recommended)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="settingsdialogdiagnostics.cpp" line="85"/>
+        <location filename="settingsdialogdiagnostics.cpp" line="88"/>
         <source>Data</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="settingsdialogdiagnostics.cpp" line="86"/>
+        <location filename="settingsdialogdiagnostics.cpp" line="89"/>
         <source>Full</source>
         <translation type="unfinished"></translation>
     </message>
@@ -8054,196 +8058,196 @@ Example:
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="spawn.cpp" line="140"/>
+        <location filename="spawn.cpp" line="138"/>
         <source>This error typically happens because an antivirus has deleted critical files from Mod Organizer&apos;s installation folder or has made them generally inaccessible. Add an exclusion for Mod Organizer&apos;s installation folder in your antivirus, reinstall Mod Organizer and try again.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="spawn.cpp" line="147"/>
+        <location filename="spawn.cpp" line="145"/>
         <source>This error typically happens because an antivirus is preventing Mod Organizer from starting programs. Add an exclusion for Mod Organizer&apos;s installation folder in your antivirus and try again.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="spawn.cpp" line="152"/>
+        <location filename="spawn.cpp" line="150"/>
         <source>The file &apos;%1&apos; does not exist.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="spawn.cpp" line="156"/>
+        <location filename="spawn.cpp" line="154"/>
         <source>The working directory &apos;%1&apos; does not exist.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="spawn.cpp" line="173"/>
-        <location filename="spawn.cpp" line="174"/>
-        <location filename="spawn.cpp" line="199"/>
-        <location filename="spawn.cpp" line="200"/>
+        <location filename="spawn.cpp" line="171"/>
+        <location filename="spawn.cpp" line="172"/>
+        <location filename="spawn.cpp" line="197"/>
+        <location filename="spawn.cpp" line="198"/>
         <source>Cannot start Steam</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="spawn.cpp" line="176"/>
+        <location filename="spawn.cpp" line="174"/>
         <source>The path to the Steam executable cannot be found. You might try reinstalling Steam.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="spawn.cpp" line="180"/>
-        <location filename="spawn.cpp" line="204"/>
-        <location filename="spawn.cpp" line="302"/>
+        <location filename="spawn.cpp" line="178"/>
+        <location filename="spawn.cpp" line="202"/>
+        <location filename="spawn.cpp" line="300"/>
         <source>Continue without starting Steam</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="spawn.cpp" line="181"/>
-        <location filename="spawn.cpp" line="205"/>
+        <location filename="spawn.cpp" line="179"/>
+        <location filename="spawn.cpp" line="203"/>
         <source>The program may fail to launch.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="spawn.cpp" line="215"/>
+        <location filename="spawn.cpp" line="213"/>
         <source>Cannot launch program</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="spawn.cpp" line="217"/>
-        <location filename="spawn.cpp" line="241"/>
-        <location filename="spawn.cpp" line="259"/>
+        <location filename="spawn.cpp" line="215"/>
+        <location filename="spawn.cpp" line="239"/>
+        <location filename="spawn.cpp" line="257"/>
         <source>Cannot start %1</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="spawn.cpp" line="239"/>
+        <location filename="spawn.cpp" line="237"/>
         <source>Cannot launch helper</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="spawn.cpp" line="257"/>
-        <location filename="spawn.cpp" line="312"/>
+        <location filename="spawn.cpp" line="255"/>
+        <location filename="spawn.cpp" line="310"/>
         <source>Elevation required</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="spawn.cpp" line="261"/>
+        <location filename="spawn.cpp" line="259"/>
         <source>This program is requesting to run as administrator but Mod Organizer itself is not running as administrator. Running programs as administrator is typically unnecessary as long as the game and Mod Organizer have been installed outside &quot;Program Files&quot;.<byte value="xd"/>
 <byte value="xd"/>
 You can restart Mod Organizer as administrator and try launching the program again.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="spawn.cpp" line="277"/>
-        <location filename="spawn.cpp" line="326"/>
+        <location filename="spawn.cpp" line="275"/>
+        <location filename="spawn.cpp" line="324"/>
         <source>Restart Mod Organizer as administrator</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="spawn.cpp" line="278"/>
-        <location filename="spawn.cpp" line="327"/>
+        <location filename="spawn.cpp" line="276"/>
+        <location filename="spawn.cpp" line="325"/>
         <source>You must allow &quot;helper.exe&quot; to make changes to the system.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="spawn.cpp" line="290"/>
+        <location filename="spawn.cpp" line="288"/>
         <source>Launch Steam</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="spawn.cpp" line="291"/>
+        <location filename="spawn.cpp" line="289"/>
         <source>This program requires Steam</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="spawn.cpp" line="292"/>
+        <location filename="spawn.cpp" line="290"/>
         <source>Mod Organizer has detected that this program likely requires Steam to be running to function properly.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="spawn.cpp" line="301"/>
+        <location filename="spawn.cpp" line="299"/>
         <source>Start Steam</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="spawn.cpp" line="303"/>
-        <location filename="spawn.cpp" line="329"/>
+        <location filename="spawn.cpp" line="301"/>
+        <location filename="spawn.cpp" line="327"/>
         <source>The program might fail to run.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="spawn.cpp" line="313"/>
+        <location filename="spawn.cpp" line="311"/>
         <source>Steam is running as administrator</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="spawn.cpp" line="314"/>
+        <location filename="spawn.cpp" line="312"/>
         <source>Running Steam as administrator is typically unnecessary and can cause problems when Mod Organizer itself is not running as administrator.<byte value="xd"/>
 <byte value="xd"/>
 You can restart Mod Organizer as administrator and try launching the program again.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="spawn.cpp" line="329"/>
-        <location filename="spawn.cpp" line="353"/>
-        <location filename="spawn.cpp" line="383"/>
+        <location filename="spawn.cpp" line="327"/>
+        <location filename="spawn.cpp" line="351"/>
+        <location filename="spawn.cpp" line="381"/>
         <source>Continue</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="spawn.cpp" line="339"/>
+        <location filename="spawn.cpp" line="337"/>
         <source>Event Log not running</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="spawn.cpp" line="340"/>
+        <location filename="spawn.cpp" line="338"/>
         <source>The Event Log service is not running</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="spawn.cpp" line="341"/>
+        <location filename="spawn.cpp" line="339"/>
         <source>The Windows Event Log service is not running. This can prevent USVFS from running properly and your mods may not be recognized by the program being launched.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="spawn.cpp" line="353"/>
-        <location filename="spawn.cpp" line="384"/>
+        <location filename="spawn.cpp" line="351"/>
+        <location filename="spawn.cpp" line="382"/>
         <source>Your mods might not work.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="spawn.cpp" line="364"/>
+        <location filename="spawn.cpp" line="362"/>
         <source>Blacklisted program</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="spawn.cpp" line="366"/>
+        <location filename="spawn.cpp" line="364"/>
         <source>The program %1 is blacklisted</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="spawn.cpp" line="367"/>
+        <location filename="spawn.cpp" line="365"/>
         <source>The program you are attempting to launch is blacklisted in the virtual filesystem. This will likely prevent it from seeing any mods, INI files or any other virtualized files.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="spawn.cpp" line="385"/>
+        <location filename="spawn.cpp" line="383"/>
         <source>Change the blacklist</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="spawn.cpp" line="606"/>
+        <location filename="spawn.cpp" line="604"/>
         <source>Waiting</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="spawn.cpp" line="607"/>
+        <location filename="spawn.cpp" line="605"/>
         <source>Please press OK once you&apos;re logged into steam.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="spawn.cpp" line="895"/>
+        <location filename="spawn.cpp" line="893"/>
         <source>Select binary</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="spawn.cpp" line="896"/>
+        <location filename="spawn.cpp" line="894"/>
         <source>Binary</source>
         <translation type="unfinished"></translation>
     </message>
@@ -8324,12 +8328,12 @@ You can restart Mod Organizer as administrator and try launching the program aga
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../game_gamebryo/src/gamebryo/gamegamebryo.cpp" line="325"/>
+        <location filename="../../game_gamebryo/src/gamebryo/gamegamebryo.cpp" line="323"/>
         <source>failed to query registry path (preflight): %1</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../game_gamebryo/src/gamebryo/gamegamebryo.cpp" line="333"/>
+        <location filename="../../game_gamebryo/src/gamebryo/gamegamebryo.cpp" line="331"/>
         <source>failed to query registry path (read): %1</source>
         <translation type="unfinished"></translation>
     </message>
@@ -9591,7 +9595,8 @@ For the other games this is not a sufficient replacement for AI!</source>
     </message>
     <message>
         <location filename="settingsdialog.ui" line="2211"/>
-        <source>Hint: right click link and copy link location</source>
+        <source>Click a link to open the location</source>
+        <oldsource>Hint: right click link and copy link location</oldsource>
         <translation type="unfinished"></translation>
     </message>
     <message>

--- a/src/organizercore.cpp
+++ b/src/organizercore.cpp
@@ -1564,7 +1564,7 @@ void OrganizerCore::onDirectoryRefreshed()
   // needs to be done before post refresh tasks
   m_DirectoryUpdate = false;
 
-  log::debug("running {} post refresh tasks");
+  log::debug("running post refresh tasks");
   m_OnNextRefreshCallbacks();
   m_OnNextRefreshCallbacks.disconnect_all_slots();
 
@@ -1947,7 +1947,7 @@ bool OrganizerCore::beforeRun(
     m_USVFS.updateMapping(fileMapping(profileName, customOverwrite));
     m_USVFS.updateForcedLibraries(forcedLibraries);
   } catch (const UsvfsConnectorException& e) {
-    log::debug(e.what());
+    log::debug("{}", e.what());
     return false;
   } catch (const std::exception& e) {
     QWidget* w = nullptr;

--- a/src/shared/directoryentry.cpp
+++ b/src/shared/directoryentry.cpp
@@ -414,7 +414,7 @@ const FileEntryPtr DirectoryEntry::searchFile(const std::wstring& path,
 
     if (temp != nullptr) {
       if (len >= path.size()) {
-        log::error(QObject::tr("unexpected end of path").toStdString());
+        log::error("{}", QObject::tr("unexpected end of path"));
         return FileEntryPtr();
       }
 
@@ -905,7 +905,7 @@ void DirectoryEntry::dump(const std::wstring& file) const
     auto e       = _wfopen_s(&f, file.c_str(), L"wb");
 
     if (e != 0 || !f) {
-      throw DumpFailed(fmt::format("failed to open, {} ({})", std::strerror(e), e));
+      throw DumpFailed(std::format("failed to open, {} ({})", std::strerror(e), e));
     }
 
     Guard g([&] {
@@ -943,7 +943,7 @@ void DirectoryEntry::dump(std::FILE* f, const std::wstring& parentPath) const
 
       if (std::fwrite(lineu8.data(), lineu8.size(), 1, f) != 1) {
         const auto e = errno;
-        throw DumpFailed(fmt::format("failed to write, {} ({})", std::strerror(e), e));
+        throw DumpFailed(std::format("failed to write, {} ({})", std::strerror(e), e));
       }
     }
   }

--- a/src/shared/fileregister.cpp
+++ b/src/shared/fileregister.cpp
@@ -74,7 +74,7 @@ bool FileRegister::removeFile(FileIndex index)
     }
   }
 
-  log::error(QObject::tr("invalid file index for remove: {}").toStdString(), index);
+  log::error("{}: {}", QObject::tr("invalid file index for remove"), index);
   return false;
 }
 
@@ -95,9 +95,8 @@ void FileRegister::removeOrigin(FileIndex index, OriginID originID)
     }
   }
 
-  log::error(
-      QObject::tr("invalid file index for remove (for origin): {}").toStdString(),
-      index);
+  log::error("{}: {}", QObject::tr("invalid file index for remove (for origin)"),
+             index);
 }
 
 void FileRegister::removeOriginMulti(std::set<FileIndex> indices, OriginID originID)

--- a/src/shared/originconnection.cpp
+++ b/src/shared/originconnection.cpp
@@ -98,8 +98,8 @@ void OriginConnection::changeNameLookup(const std::wstring& oldName,
     m_OriginsNameMap.erase(iter);
     m_OriginsNameMap[newName] = idx;
   } else {
-    log::error(QObject::tr("failed to change name lookup from {} to {}").toStdString(),
-               oldName, newName);
+    log::error(QObject::tr("failed to change name lookup from {0} to {1}"), oldName,
+               newName);
   }
 }
 

--- a/src/spawn.cpp
+++ b/src/spawn.cpp
@@ -108,40 +108,28 @@ QString makeDetails(const SpawnParameters& sp, DWORD code, const QString& more =
     elevated = L"(not available)";
   }
 
-  std::wstring f = L"Error {code} {codename}{more}: {error}\n"
-                   L" . binary: '{bin}'\n"
-                   L" . owner: {owner}\n"
-                   L" . rights: {rights}\n"
-                   L" . arguments: '{args}'\n"
-                   L" . cwd: '{cwd}'{cwdexists}\n"
-                   L" . stdout: {stdout}, stderr: {stderr}, hooked: {hooked}\n"
-                   L" . MO elevated: {elevated}";
+  auto s = std::format(L"Error {} {}{}: {}\n"
+                       L" . binary: '{}'\n"
+                       L" . owner: {}\n"
+                       L" . rights: {}\n"
+                       L" . arguments: '{}'\n"
+                       L" . cwd: '{}'{}\n"
+                       L" . stdout: {}, stderr: {}, hooked: {}\n"
+                       L" . MO elevated: {}",
+                       code, errorCodeName(code), (more.isEmpty() ? more : ", " + more),
+                       formatSystemMessage(code),
+                       QDir::toNativeSeparators(sp.binary.absoluteFilePath()), owner,
+                       rights, sp.arguments,
+                       QDir::toNativeSeparators(sp.currentDirectory.absolutePath()),
+                       (cwdExists ? L"" : L" (not found)"),
+                       (sp.stdOut == INVALID_HANDLE_VALUE ? L"no" : L"yes"),
+                       (sp.stdErr == INVALID_HANDLE_VALUE ? L"no" : L"yes"),
+                       (sp.hooked ? L"yes" : L"no"), elevated);
 
   if (sp.hooked) {
-    f += L"\n . usvfs x86:{x86_dll} x64:{x64_dll} proxy_x86:{x86_proxy} "
-         L"proxy_x64:{x64_proxy}";
+    s += std::format(L"\n . usvfs x86:{} x64:{} proxy_x86:{} proxy_x64:{}",
+                     usvfs_x86_dll, usvfs_x64_dll, usvfs_x86_proxy, usvfs_x64_proxy);
   }
-
-  const std::wstring wmore = (more.isEmpty() ? L"" : (", " + more).toStdWString());
-
-  const auto s = fmt::format(
-      f, fmt::arg(L"code", code), fmt::arg(L"codename", errorCodeName(code)),
-      fmt::arg(L"more", wmore),
-      fmt::arg(L"bin",
-               QDir::toNativeSeparators(sp.binary.absoluteFilePath()).toStdWString()),
-      fmt::arg(L"owner", owner), fmt::arg(L"rights", rights),
-      fmt::arg(L"error", formatSystemMessage(code)),
-      fmt::arg(L"args", sp.arguments.toStdWString()),
-      fmt::arg(
-          L"cwd",
-          QDir::toNativeSeparators(sp.currentDirectory.absolutePath()).toStdWString()),
-      fmt::arg(L"cwdexists", (cwdExists ? L"" : L" (not found)")),
-      fmt::arg(L"stdout", (sp.stdOut == INVALID_HANDLE_VALUE ? L"no" : L"yes")),
-      fmt::arg(L"stderr", (sp.stdErr == INVALID_HANDLE_VALUE ? L"no" : L"yes")),
-      fmt::arg(L"hooked", (sp.hooked ? L"yes" : L"no")),
-      fmt::arg(L"x86_dll", usvfs_x86_dll), fmt::arg(L"x64_dll", usvfs_x64_dll),
-      fmt::arg(L"x86_proxy", usvfs_x86_proxy), fmt::arg(L"x64_proxy", usvfs_x64_proxy),
-      fmt::arg(L"elevated", elevated));
 
   return QString::fromStdWString(s);
 }
@@ -993,7 +981,7 @@ bool helperExec(QWidget* parent, const std::wstring& moDirectory,
 bool backdateBSAs(QWidget* parent, const std::wstring& moPath,
                   const std::wstring& dataPath)
 {
-  const std::wstring commandLine = fmt::format(L"backdateBSA \"{}\"", dataPath);
+  const std::wstring commandLine = std::format(L"backdateBSA \"{}\"", dataPath);
 
   return helperExec(parent, moPath, commandLine, FALSE);
 }
@@ -1001,7 +989,7 @@ bool backdateBSAs(QWidget* parent, const std::wstring& moPath,
 bool adminLaunch(QWidget* parent, const std::wstring& moPath,
                  const std::wstring& moFile, const std::wstring& workingDir)
 {
-  const std::wstring commandLine = fmt::format(
+  const std::wstring commandLine = std::format(
       L"adminLaunch {} \"{}\" \"{}\"", ::GetCurrentProcessId(), moFile, workingDir);
 
   return helperExec(parent, moPath, commandLine, true);

--- a/src/spawn.cpp
+++ b/src/spawn.cpp
@@ -34,8 +34,6 @@ along with Mod Organizer.  If not, see <http://www.gnu.org/licenses/>.
 #include <QtDebug>
 #include <Shellapi.h>
 #include <errorcodes.h>
-#include <fmt/format.h>
-#include <fmt/xchar.h>
 #include <log.h>
 #include <report.h>
 #include <usvfs.h>

--- a/src/transfersavesdialog.cpp
+++ b/src/transfersavesdialog.cpp
@@ -245,7 +245,7 @@ bool TransferSavesDialog::transferCharacters(
     QString const& character, char const* message, QDir const& sourceDirectory,
     SaveList& saves, QDir const& destination,
     const std::function<bool(const QString&, const QString&)>& method,
-    char const* errmsg)
+    std::format_string<QString, QString> errmsg)
 {
   if (QMessageBox::question(this, tr("Confirm"), tr(message).arg(character),
                             QMessageBox::Yes | QMessageBox::No) != QMessageBox::Yes) {
@@ -270,7 +270,7 @@ bool TransferSavesDialog::transferCharacters(
       }
 
       if (!method(sourceFile.absoluteFilePath(), destinationFile)) {
-        log::error(errmsg, sourceFile.absoluteFilePath(), destinationFile);
+        log::error(errmsg, sourceFile.absoluteFilePath(), std::move(destinationFile));
       }
     }
   }

--- a/src/transfersavesdialog.h
+++ b/src/transfersavesdialog.h
@@ -109,7 +109,7 @@ private:
   transferCharacters(QString const& character, char const* message,
                      QDir const& sourceDirectory, SaveList& saves, QDir const& dest,
                      const std::function<bool(const QString&, const QString&)>& method,
-                     char const* errmsg);
+                     std::format_string<QString, QString> errmsg);
 };
 
 #endif  // TRANSFERSAVESDIALOG_H


### PR DESCRIPTION
See https://github.com/ModOrganizer2/modorganizer-uibase/pull/143

I removed all the manual call to `toStdString()` after `tr`, that's on purpose - Since `std::string` is convertible to `std::format_string`, that would trigger the `format_string` overload, but since the expression would not be compile time, fail.

Supersedes #2027 

**Others:**

- Remove libffi from dependencies in Github action.