### PR TITLE
Mass Metadata Parsing

### DIFF
--- a/src/downloadmanager.cpp
+++ b/src/downloadmanager.cpp
@@ -440,6 +440,26 @@ void DownloadManager::refreshList()
   }
 }
 
+void DownloadManager::queryDownloadListInfo()
+{
+  TimeThis tt("DownloadManager::queryDownloadListInfos()");
+
+  startDisableDirWatcher();
+
+  log::info("Retrieving infos from every download (if possible)...");
+
+  // Just go through all active downloads to query infos
+  for (size_t i = 0; i < m_ActiveDownloads.size(); i++) {
+    if (isInfoIncomplete(i)) {
+      queryInfoMd5(i);
+    }
+  }
+
+  log::info("Files infos have been retrived successfully!");
+
+  endDisableDirWatcher();
+}
+
 bool DownloadManager::addDownload(const QStringList& URLs, QString gameName, int modID,
                                   int fileID, const ModRepositoryFileInfo* fileInfo)
 {

--- a/src/downloadmanager.cpp
+++ b/src/downloadmanager.cpp
@@ -444,7 +444,7 @@ void DownloadManager::queryDownloadListInfo()
 {
   TimeThis tt("DownloadManager::queryDownloadListInfos()");
 
-  log::info("Retrieving infos from every download (if possible)...");
+  log::info("Retrieving data from every download (if possible)...");
 
   int incompleteInfos = 0;
 
@@ -467,8 +467,8 @@ void DownloadManager::queryDownloadListInfo()
   } else {
 
     // Warn the user if the number of incomplete infos is over 5
-    QString message = tr("There %1 incomplete download meta files.\n\n"
-                         "Do you want to fetch metadata for all incomplete downloads?\n"
+    QString message = tr("There are %1 incomplete download meta files.\n\n"
+                         "Do you want to fetch all incomplete metadata?\n"
                          "API uses will be consumed, and Mod Organizer may stutter.");
     message         = message.arg(incompleteInfos);
     if (QMessageBox::question(m_ParentWidget, tr("Incomplete Download Infos"), message,
@@ -485,7 +485,7 @@ void DownloadManager::queryDownloadListInfo()
     return;
   }
 
-  log::info("Files infos have been retrieved successfully!");
+  log::info("Metadata has been retrieved successfully!");
 }
 
 bool DownloadManager::addDownload(const QStringList& URLs, QString gameName, int modID,

--- a/src/downloadmanager.cpp
+++ b/src/downloadmanager.cpp
@@ -455,8 +455,18 @@ void DownloadManager::queryDownloadListInfo()
     }
   }
 
-  // Warn the user if the number of incomplete infos is over 5
-  if (incompleteInfos > 5) {
+  if (incompleteInfos <= 5) {
+    // Fetch metadata for incomplete download infos
+    startDisableDirWatcher();
+    for (size_t i = 0; i < m_ActiveDownloads.size(); i++) {
+      if (isInfoIncomplete(i)) {
+        queryInfoMd5(i);
+      }
+    }
+    endDisableDirWatcher();
+  } else {
+
+    // Warn the user if the number of incomplete infos is over 5
     QString message = tr("There %1 incomplete download meta files.\n\n"
                          "Do you want to fetch metadata for all incomplete downloads?\n"
                          "API uses will be consumed, and Mod Organizer may stutter.");

--- a/src/downloadmanager.h
+++ b/src/downloadmanager.h
@@ -402,6 +402,11 @@ public:
    */
   void refreshList();
 
+  /**
+   * @brief Query infos for every download in the list
+   */
+  void queryDownloadListInfo();
+
 public:  // IDownloadManager interface:
   int startDownloadURLs(const QStringList& urls);
   int startDownloadNexusFile(int modID, int fileID);

--- a/src/downloadstab.cpp
+++ b/src/downloadstab.cpp
@@ -5,7 +5,7 @@
 #include "ui_mainwindow.h"
 
 DownloadsTab::DownloadsTab(OrganizerCore& core, Ui::MainWindow* mwui)
-    : m_core(core), ui{mwui->btnRefreshDownloads, mwui->downloadView,
+    : m_core(core), ui{mwui->btnRefreshDownloads, mwui->btnQueryDownloadsInfo, mwui->downloadView,
                        mwui->showHiddenBox, mwui->downloadFilterEdit}
 {
   DownloadList* sourceModel = new DownloadList(m_core, ui.list);
@@ -25,6 +25,9 @@ DownloadsTab::DownloadsTab(OrganizerCore& core, Ui::MainWindow* mwui)
 
   connect(ui.refresh, &QPushButton::clicked, [&] {
     refresh();
+  });
+  connect(ui.queryInfos, &QPushButton::clicked, [&] {
+    queryInfos(); 
   });
   connect(ui.list, SIGNAL(installDownload(int)), &m_core, SLOT(installDownload(int)));
   connect(ui.list, SIGNAL(queryInfo(int)), m_core.downloadManager(),
@@ -78,6 +81,11 @@ void DownloadsTab::update()
 void DownloadsTab::refresh()
 {
   m_core.downloadManager()->refreshList();
+}
+
+void DownloadsTab::queryInfos() 
+{
+  m_core.downloadManager()->queryDownloadListInfo();
 }
 
 void DownloadsTab::resumeDownload(int downloadIndex)

--- a/src/downloadstab.cpp
+++ b/src/downloadstab.cpp
@@ -5,8 +5,9 @@
 #include "ui_mainwindow.h"
 
 DownloadsTab::DownloadsTab(OrganizerCore& core, Ui::MainWindow* mwui)
-    : m_core(core), ui{mwui->btnRefreshDownloads, mwui->btnQueryDownloadsInfo, mwui->downloadView,
-                       mwui->showHiddenBox, mwui->downloadFilterEdit}
+    : m_core(core),
+      ui{mwui->btnRefreshDownloads, mwui->btnQueryDownloadsInfo, mwui->downloadView,
+         mwui->showHiddenBox, mwui->downloadFilterEdit}
 {
   DownloadList* sourceModel = new DownloadList(m_core, ui.list);
 
@@ -27,7 +28,7 @@ DownloadsTab::DownloadsTab(OrganizerCore& core, Ui::MainWindow* mwui)
     refresh();
   });
   connect(ui.queryInfos, &QPushButton::clicked, [&] {
-    queryInfos(); 
+    queryInfos();
   });
   connect(ui.list, SIGNAL(installDownload(int)), &m_core, SLOT(installDownload(int)));
   connect(ui.list, SIGNAL(queryInfo(int)), m_core.downloadManager(),
@@ -83,7 +84,7 @@ void DownloadsTab::refresh()
   m_core.downloadManager()->refreshList();
 }
 
-void DownloadsTab::queryInfos() 
+void DownloadsTab::queryInfos()
 {
   m_core.downloadManager()->queryDownloadListInfo();
 }

--- a/src/downloadstab.h
+++ b/src/downloadstab.h
@@ -23,6 +23,7 @@ private:
   struct DownloadsTabUi
   {
     QPushButton* refresh;
+    QPushButton* queryInfos;
     DownloadListView* list;
     QCheckBox* showHidden;
     QLineEdit* filter;
@@ -33,6 +34,12 @@ private:
   MOBase::FilterWidget m_filter;
 
   void refresh();
+
+  /**
+   * @brief Handle click on the "Query infos" button
+   **/
+  void queryInfos();
+
   void resumeDownload(int downloadIndex);
 };
 

--- a/src/mainwindow.ui
+++ b/src/mainwindow.ui
@@ -1326,6 +1326,26 @@
                  </property>
                 </spacer>
                </item>
+               <item>
+                <widget class="QPushButton" name="btnQueryDownloadsInfo">
+                 <property name="sizePolicy">
+                  <sizepolicy hsizetype="Minimum" vsizetype="Fixed">
+                   <horstretch>0</horstretch>
+                   <verstretch>0</verstretch>
+                  </sizepolicy>
+                 </property>
+                 <property name="contextMenuPolicy">
+                  <enum>Qt::ContextMenuPolicy::DefaultContextMenu</enum>
+                 </property>
+                 <property name="text">
+                  <string>Query Metadata</string>
+                 </property>
+                 <property name="icon">
+                  <iconset resource="resources.qrc">
+                   <normaloff>:/MO/gui/resources/system-search.png</normaloff>:/MO/gui/resources/system-search.png</iconset>
+                 </property>
+                </widget>
+               </item>
               </layout>
              </item>
              <item>


### PR DESCRIPTION
I liked the idea of #1861, but could not get it built. Fixed up and implemented the functionality started over there. Adds a button opposite the Refresh button in the Downloads tab that queries every mod in the Downloads list that does not have a .meta file associated with it. 