### PR TITLE
Prevent undefined behavior when using QString::chopped

### DIFF
--- a/src/downloadlist.cpp
+++ b/src/downloadlist.cpp
@@ -221,7 +221,8 @@ QVariant DownloadList::data(const QModelIndex& index, int role) const
             .arg(info->modName)
             .arg(m_manager.getModID(index.row()))
             .arg(info->version.canonicalString())
-            .arg(info->description.chopped(4096));
+            .arg(info->description.size() > 4096 ? info->description.chopped(4096)
+                                                 : info->description);
       }
       return text;
     }


### PR DESCRIPTION
This small change is based on a note in the Qt documentation for [`QString::chopped`](https://doc.qt.io/qt-6/qstring.html#chopped-1) which states _"The behavior is undefined if len is negative or greater than size()."_ I did not see any other instance of chopped in the codebase that needs changed.