### PR TITLE
Add onProfileSettingChanged

### DIFF
--- a/src/organizercore.cpp
+++ b/src/organizercore.cpp
@@ -354,6 +354,13 @@ void OrganizerCore::profileRemoved(QString const& profileName)
   m_ProfileRemoved(profileName);
 }
 
+void OrganizerCore::profileSettingChanged(MOBase::IProfile* profile, const QString& settingName,
+                                          const QVariant& oldValue, const QVariant& newValue)
+{
+  m_ProfileSettingChanged(profile, settingName, oldValue, newValue);
+}
+
+
 void OrganizerCore::downloadRequested(QNetworkReply* reply, QString gameName, int modID,
                                       const QString& fileName)
 {
@@ -1201,6 +1208,13 @@ boost::signals2::connection
 OrganizerCore::onProfileChanged(std::function<void(IProfile*, IProfile*)> const& func)
 {
   return m_ProfileChanged.connect(func);
+}
+
+boost::signals2::connection OrganizerCore::onProfileSettingChanged(
+    std::function<void(IProfile*, const QString& key, const QVariant&,
+                       const QVariant&)> const& func)
+{
+  return m_ProfileSettingChanged.connect(func);
 }
 
 boost::signals2::connection OrganizerCore::onPluginSettingChanged(

--- a/src/organizercore.h
+++ b/src/organizercore.h
@@ -95,6 +95,8 @@ private:
   using SignalProfileRemoved = boost::signals2::signal<void(QString const&)>;
   using SignalProfileChanged =
       boost::signals2::signal<void(MOBase::IProfile*, MOBase::IProfile*)>;
+  using SignalProfileSettingChanged = boost::signals2::signal<void(
+      MOBase::IProfile*, const QString& key, const QVariant&, const QVariant&)>;
   using SignalPluginSettingChanged = boost::signals2::signal<void(
       QString const&, const QString& key, const QVariant&, const QVariant&)>;
   using SignalPluginEnabled = boost::signals2::signal<void(const MOBase::IPlugin*)>;
@@ -402,6 +404,9 @@ public:
   onProfileRemoved(std::function<void(QString const&)> const& func);
   boost::signals2::connection onProfileChanged(
       std::function<void(MOBase::IProfile*, MOBase::IProfile*)> const& func);
+  boost::signals2::connection onProfileSettingChanged(
+      std::function<void(MOBase::IProfile*, const QString& key, const QVariant&,
+                         const QVariant&)> const& func);
   boost::signals2::connection onPluginSettingChanged(
       std::function<void(QString const&, const QString& key, const QVariant&,
                          const QVariant&)> const& func);
@@ -452,6 +457,8 @@ public slots:
   void profileRenamed(MOBase::IProfile* profile, QString const& oldName,
                       QString const& newName);
   void profileRemoved(QString const& profileName);
+  void profileSettingChanged(MOBase::IProfile* profile, const QString& settingName,
+                      const QVariant& oldValue, const QVariant& newValue);
 
   bool nexusApi(bool retry = false);
 
@@ -544,6 +551,7 @@ private:
   SignalProfileRenamed m_ProfileRenamed;
   SignalProfileRemoved m_ProfileRemoved;
   SignalProfileChanged m_ProfileChanged;
+  SignalProfileSettingChanged m_ProfileSettingChanged;
   SignalPluginSettingChanged m_PluginSettingChanged;
   SignalPluginEnabled m_PluginEnabled;
   SignalPluginEnabled m_PluginDisabled;

--- a/src/organizerproxy.cpp
+++ b/src/organizerproxy.cpp
@@ -50,6 +50,8 @@ void OrganizerProxy::connectSignals()
       m_Proxied->onProfileRemoved(callSignalIfPluginActive(this, m_ProfileRemoved)));
   m_Connections.push_back(
       m_Proxied->onProfileChanged(callSignalIfPluginActive(this, m_ProfileChanged)));
+  m_Connections.push_back(
+      m_Proxied->onProfileSettingChanged(callSignalIfPluginActive(this, m_ProfileSettingChanged)));
 
   m_Connections.push_back(m_Proxied->onUserInterfaceInitialized(
       callSignalAlways(m_UserInterfaceInitialized)));
@@ -395,6 +397,14 @@ bool OrganizerProxy::onProfileChanged(
 {
   return m_ProfileChanged.connect(func).connected();
 }
+
+bool OrganizerProxy::onProfileSettingChanged(
+    std::function<void(MOBase::IProfile*, const QString& key, const QVariant&,
+                       const QVariant&)> const& func)
+{
+  return m_ProfileSettingChanged.connect(func).connected();
+}
+
 // Always call these one, otherwise plugin cannot detect they are being enabled /
 // disabled:
 bool OrganizerProxy::onPluginSettingChanged(

--- a/src/organizerproxy.h
+++ b/src/organizerproxy.h
@@ -93,6 +93,9 @@ public:  // IOrganizer interface
   onProfileRemoved(std::function<void(QString const&)> const& func) override;
   virtual bool onProfileChanged(
       std::function<void(MOBase::IProfile*, MOBase::IProfile*)> const& func) override;
+  virtual bool onProfileSettingChanged(
+      std::function<void(MOBase::IProfile*, const QString& key, const QVariant&,
+                         const QVariant&)> const& func) override;
 
   // Plugin related:
   virtual bool isPluginEnabled(QString const& pluginName) const override;
@@ -145,6 +148,7 @@ private:
   OrganizerCore::SignalProfileRenamed m_ProfileRenamed;
   OrganizerCore::SignalProfileRemoved m_ProfileRemoved;
   OrganizerCore::SignalProfileChanged m_ProfileChanged;
+  OrganizerCore::SignalProfileSettingChanged m_ProfileSettingChanged;
   OrganizerCore::SignalPluginSettingChanged m_PluginSettingChanged;
   OrganizerCore::SignalPluginEnabled m_PluginEnabled;
   OrganizerCore::SignalPluginEnabled m_PluginDisabled;

--- a/src/profilesdialog.h
+++ b/src/profilesdialog.h
@@ -93,6 +93,12 @@ signals:
    */
   void profileRemoved(QString const& profileName);
 
+  /**
+   * @brief Signal emitted when a profile's setting has been changed.
+   */
+  void profileSettingChanged(Profile* profile, const QString& settingName,
+                             const QVariant& oldValue, const QVariant& newValue);
+
 protected:
   virtual void showEvent(QShowEvent* event);
 


### PR DESCRIPTION
Allows registering a new callback `onProfileSettingChanged `to be called when a profile setting is changed, along with the a new `profileSettingChanged `signal, emitted by the Profiles Dialog checkbox values changing