### PR TITLE
Resize columns to contents in notifications window

### DIFF
--- a/src/problemsdialog.cpp
+++ b/src/problemsdialog.cpp
@@ -16,6 +16,7 @@ ProblemsDialog::ProblemsDialog(const PluginContainer& pluginContainer, QWidget* 
       m_hasProblems(false)
 {
   ui->setupUi(this);
+  ui->problemsWidget->header()->setSectionResizeMode(QHeaderView::ResizeToContents);
 
   runDiagnosis();
 


### PR DESCRIPTION
This PR changes the resize behavior of the columns in the notifications window to always resize to the contents to give them more appropriate sizes.

Before:

![notifications-before](https://github.com/user-attachments/assets/cc60e74f-905d-4828-b937-a0d966fca1f9)

After:

![notifications-after](https://github.com/user-attachments/assets/36dfb2ea-e6d9-440b-9cc2-a7ae309430ab)

The code I added is outside of the auto-generated `setupUi` method because as far as I can tell, there is no accessible `sectionResizeMode` property in the `QTreeWidget`'s header in Qt Designer. To allow users to manually resize the columns, the header row must be set to visible, which we probably don't want.