### PR TITLE
Starfield Updates: Shattered Space & Blueprint Support

### DIFF
--- a/src/pluginlist.cpp
+++ b/src/pluginlist.cpp
@@ -1931,8 +1931,10 @@ PluginList::ESPInfo::ESPInfo(const QString& name, bool forceLoaded, bool forceEn
     isMasterFlagged    = file.isMaster();
     isLightFlagged     = lightSupported && file.isLight(mediumSupported);
     isMediumFlagged    = mediumSupported && file.isMedium();
-    isBlueprintFlagged = blueprintSupported && isMasterFlagged && file.isBlueprint();
-    hasNoRecords       = file.isDummy();
+    isBlueprintFlagged = blueprintSupported &&
+                         (isMasterFlagged || hasMasterExtension || hasLightExtension) &&
+                         file.isBlueprint();
+    hasNoRecords = file.isDummy();
 
     author      = QString::fromLatin1(file.author().c_str());
     description = QString::fromLatin1(file.description().c_str());

--- a/src/pluginlist.cpp
+++ b/src/pluginlist.cpp
@@ -1931,7 +1931,7 @@ PluginList::ESPInfo::ESPInfo(const QString& name, bool forceLoaded, bool forceEn
     isMasterFlagged    = file.isMaster();
     isLightFlagged     = lightSupported && file.isLight(mediumSupported);
     isMediumFlagged    = mediumSupported && file.isMedium();
-    isBlueprintFlagged = blueprintSupported && file.isBlueprint();
+    isBlueprintFlagged = blueprintSupported && isMasterFlagged && file.isBlueprint();
     hasNoRecords       = file.isDummy();
 
     author      = QString::fromLatin1(file.author().c_str());

--- a/src/pluginlist.h
+++ b/src/pluginlist.h
@@ -242,6 +242,7 @@ public:
   bool isMasterFlagged(const QString& name) const;
   bool isMediumFlagged(const QString& name) const;
   bool isLightFlagged(const QString& name) const;
+  bool isBlueprintFlagged(const QString& name) const;
   bool hasNoRecords(const QString& name) const;
 
   boost::signals2::connection onRefreshed(const std::function<void()>& callback);
@@ -317,7 +318,7 @@ private:
     ESPInfo(const QString& name, bool forceLoaded, bool forceEnabled,
             bool forceDisabled, const QString& originName, const QString& fullPath,
             bool hasIni, std::set<QString> archives, bool lightSupported,
-            bool mediumSupported);
+            bool mediumSupported, bool blueprintSupported);
 
     QString name;
     QString fullPath;
@@ -335,6 +336,7 @@ private:
     bool isMasterFlagged;
     bool isMediumFlagged;
     bool isLightFlagged;
+    bool isBlueprintFlagged;
     bool hasNoRecords;
     bool modSelected;
     QString author;

--- a/src/pluginlistproxy.cpp
+++ b/src/pluginlistproxy.cpp
@@ -124,6 +124,11 @@ bool PluginListProxy::isLightFlagged(const QString& name) const
   return m_Proxied->isLightFlagged(name);
 }
 
+bool PluginListProxy::isBlueprintFlagged(const QString& name) const
+{
+  return m_Proxied->isBlueprintFlagged(name);
+}
+
 bool PluginListProxy::hasNoRecords(const QString& name) const
 {
   return m_Proxied->hasNoRecords(name);

--- a/src/pluginlistproxy.h
+++ b/src/pluginlistproxy.h
@@ -34,6 +34,7 @@ public:
   bool isMasterFlagged(const QString& name) const override;
   bool isMediumFlagged(const QString& name) const override;
   bool isLightFlagged(const QString& name) const override;
+  bool isBlueprintFlagged(const QString& name) const override;
   bool hasNoRecords(const QString& name) const override;
 
   QString author(const QString& name) const override;


### PR DESCRIPTION
This is a suite of updates both to support the latest Shattered Space core plugins and load order mechanics as well as adding 'blueprint flag' support to MO2.

Related PRs:
https://github.com/ModOrganizer2/modorganizer-uibase/pull/162
https://github.com/ModOrganizer2/modorganizer-esptk/pull/14
https://github.com/ModOrganizer2/modorganizer-game_starfield/pull/32
https://github.com/ModOrganizer2/modorganizer-game_gamebryo/pull/59
https://github.com/ModOrganizer2/modorganizer-plugin_python/pull/136