### PR TITLE
Add filter checkbox to data tab to show/hide hidden files

### DIFF
--- a/src/datatab.cpp
+++ b/src/datatab.cpp
@@ -22,7 +22,8 @@ DataTab::DataTab(OrganizerCore& core, PluginContainer& pc, QWidget* parent,
          mwui->dataTabRefresh,
          mwui->dataTree,
          mwui->dataTabShowOnlyConflicts,
-         mwui->dataTabShowFromArchives},
+         mwui->dataTabShowFromArchives,
+         mwui->dataTabShowHiddenFiles},
       m_needUpdate(true)
 {
   m_filetree.reset(new FileTree(core, m_pluginContainer, ui.tree));
@@ -52,6 +53,10 @@ DataTab::DataTab(OrganizerCore& core, PluginContainer& pc, QWidget* parent,
     onArchives();
   });
 
+  connect(ui.hiddenFiles, &QCheckBox::toggled, [&] {
+    onHiddenFiles();
+  });
+
   connect(m_filetree.get(), &FileTree::executablesChanged, this,
           &DataTab::executablesChanged);
 
@@ -66,6 +71,7 @@ void DataTab::saveState(Settings& s) const
   s.geometry().saveState(ui.tree->header());
   s.widgets().saveChecked(ui.conflicts);
   s.widgets().saveChecked(ui.archives);
+  s.widgets().saveChecked(ui.hiddenFiles);
 }
 
 void DataTab::restoreState(const Settings& s)
@@ -78,6 +84,7 @@ void DataTab::restoreState(const Settings& s)
 
   s.widgets().restoreChecked(ui.conflicts);
   s.widgets().restoreChecked(ui.archives);
+  s.widgets().restoreChecked(ui.hiddenFiles);
 }
 
 void DataTab::activated()
@@ -146,6 +153,11 @@ void DataTab::onArchives()
   updateOptions();
 }
 
+void DataTab::onHiddenFiles()
+{
+  updateOptions();
+}
+
 void DataTab::updateOptions()
 {
   using M = FileTreeModel;
@@ -158,6 +170,10 @@ void DataTab::updateOptions()
 
   if (ui.archives->isChecked()) {
     flags |= M::Archives;
+  }
+
+  if (ui.hiddenFiles->isChecked()) {
+    flags |= M::HiddenFiles;
   }
 
   m_filetree->model()->setFlags(flags);

--- a/src/datatab.h
+++ b/src/datatab.h
@@ -54,6 +54,7 @@ private:
     QTreeView* tree;
     QCheckBox* conflicts;
     QCheckBox* archives;
+    QCheckBox* hiddenFiles;
   };
 
   OrganizerCore& m_core;
@@ -69,6 +70,7 @@ private:
   void onItemExpanded(QTreeWidgetItem* item);
   void onConflicts();
   void onArchives();
+  void onHiddenFiles();
   void updateOptions();
   void ensureFullyLoaded();
   bool isActive() const;

--- a/src/filetreemodel.cpp
+++ b/src/filetreemodel.cpp
@@ -182,8 +182,8 @@ void* makeInternalPointer(FileTreeItem* item)
 
 FileTreeModel::FileTreeModel(OrganizerCore& core, QObject* parent)
     : QAbstractItemModel(parent), m_core(core), m_enabled(true),
-      m_root(FileTreeItem::createDirectory(this, nullptr, L"", L"")), m_flags(NoFlags),
-      m_fullyLoaded(false), m_sortingEnabled(true)
+      m_root(FileTreeItem::createDirectory(this, nullptr, L"", L"")),
+      m_flags(HiddenFiles), m_fullyLoaded(false), m_sortingEnabled(true)
 {
   m_root->setExpanded(true);
   m_sortTimer.setSingleShot(true);
@@ -267,6 +267,11 @@ const FileTreeModel::SortInfo& FileTreeModel::sortInfo() const
 bool FileTreeModel::showArchives() const
 {
   return (m_flags.testFlag(Archives) && m_core.settings().archiveParsing());
+}
+
+bool FileTreeModel::showHiddenFiles() const
+{
+  return m_flags.testAnyFlag(HiddenFiles);
 }
 
 QModelIndex FileTreeModel::index(int row, int col, const QModelIndex& parentIndex) const
@@ -971,6 +976,11 @@ bool FileTreeModel::shouldShowFile(const FileEntry& file) const
 
   if (!showArchives() && file.isFromArchive()) {
     // files from archives shouldn't be shown, but this file is from an archive
+    return false;
+  }
+
+  if (!showHiddenFiles() && file.getName().ends_with(L".mohidden")) {
+    // hidden files shouldn't be shown, but this file is hidden
     return false;
   }
 

--- a/src/filetreemodel.h
+++ b/src/filetreemodel.h
@@ -18,7 +18,8 @@ public:
     NoFlags          = 0x00,
     ConflictsOnly    = 0x01,
     Archives         = 0x02,
-    PruneDirectories = 0x04
+    PruneDirectories = 0x04,
+    HiddenFiles      = 0x08
   };
 
   enum Columns
@@ -101,6 +102,8 @@ private:
   bool showConflictsOnly() const { return (m_flags & ConflictsOnly); }
 
   bool showArchives() const;
+
+  bool showHiddenFiles() const;
 
   // for `forFetching`, see top of filetreemodel.cpp
   void update(FileTreeItem& parentItem, const MOShared::DirectoryEntry& parentEntry,

--- a/src/mainwindow.ui
+++ b/src/mainwindow.ui
@@ -1181,6 +1181,25 @@
                 </widget>
                </item>
                <item>
+                <widget class="QCheckBox" name="dataTabShowHiddenFiles">
+                 <property name="toolTip">
+                  <string>Filter the list so that hidden files are shown.</string>
+                 </property>
+                 <property name="statusTip">
+                  <string/>
+                 </property>
+                 <property name="whatsThis">
+                  <string>Filter the list so that hidden files are shown.</string>
+                 </property>
+                 <property name="text">
+                  <string>Hidden Files</string>
+                 </property>
+                 <property name="checked">
+                  <bool>true</bool>
+                 </property>
+                </widget>
+               </item>
+               <item>
                 <widget class="QLineEdit" name="dataTabFilter">
                  <property name="toolTip">
                   <string>Filter the Data tree.</string>


### PR DESCRIPTION
This suggestion was listed in #464. I made it checked (show hidden files) by default since that's the current behavior, but maybe it makes more sense to hide them by default. I'll change that if necessary.

![image](https://github.com/user-attachments/assets/f105a7d5-5ed4-4ed5-9ea5-2200fd961dc2)
