### PR TITLE
(Un-)endorse & (un-)track mods from the same source

### DIFF
--- a/src/mainwindow.cpp
+++ b/src/mainwindow.cpp
@@ -3068,12 +3068,14 @@ void MainWindow::nxmEndorsementsAvailable(QVariant userData, QVariant resultData
           ModInfo::getByModID(result->first, result->second.first);
 
       for (auto mod : modsList) {
-        if (result->second.second == "Endorsed")
-          mod->setIsEndorsed(true);
-        else if (result->second.second == "Abstained")
-          mod->setNeverEndorse();
-        else
-          mod->setIsEndorsed(false);
+        if (mod->endorsedState() != EndorsedState::ENDORSED_NEVER) {
+          if (result->second.second == "Endorsed")
+            mod->setIsEndorsed(true);
+          else if (result->second.second == "Abstained")
+            mod->setNeverEndorse();
+          else
+            mod->setIsEndorsed(false);
+        }
       }
 
       if (Settings::instance().nexus().endorsementIntegration()) {


### PR DESCRIPTION
When you (un-)endorse or (un-)track a mod, all mods from the same source (Nexus mod page) are now also updated accordingly. This suggestion was listed in #464.