### PR TITLE
Match capitilization of "Hidden files" in data tab with downloads tab

### DIFF
--- a/src/mainwindow.ui
+++ b/src/mainwindow.ui
@@ -1192,7 +1192,7 @@
                   <string>Filter the list so that hidden files are shown.</string>
                  </property>
                  <property name="text">
-                  <string>Hidden Files</string>
+                  <string>Hidden files</string>
                  </property>
                  <property name="checked">
                   <bool>true</bool>


### PR DESCRIPTION
This fixes a small oversight in #2136: the F in "files" was capitalized in the data tab while it isn't in the downloads tab.