### PR TITLE
Show blueprint master count in plugin counter tooltip, hide unsupported plugin types

### DIFF
--- a/src/pluginlistview.cpp
+++ b/src/pluginlistview.cpp
@@ -7,6 +7,7 @@
 #include <widgetutility.h>
 
 #include "copyeventfilter.h"
+#include "gameplugins.h"
 #include "genericicondelegate.h"
 #include "mainwindow.h"
 #include "modelutils.h"
@@ -59,10 +60,12 @@ void PluginListView::updatePluginCount()
   int activeMasterCount       = 0;
   int activeMediumMasterCount = 0;
   int activeLightMasterCount  = 0;
+  int activeBlueprintCount    = 0;
   int activeRegularCount      = 0;
   int masterCount             = 0;
   int mediumMasterCount       = 0;
   int lightMasterCount        = 0;
+  int blueprintCount          = 0;
   int regularCount            = 0;
   int activeVisibleCount      = 0;
 
@@ -89,37 +92,68 @@ void PluginListView::updatePluginCount()
       activeRegularCount += active;
       activeVisibleCount += visible && active;
     }
+
+    if (list->isBlueprintFlagged(plugin)) {
+      // separate if-statement because blueprint masters are also counted as
+      // (medium/light) masters
+      blueprintCount++;
+      activeBlueprintCount += active;
+    }
   }
 
   int activeCount = activeMasterCount + activeMediumMasterCount +
                     activeLightMasterCount + activeRegularCount;
   int totalCount = masterCount + mediumMasterCount + lightMasterCount + regularCount;
 
-  ui.counter->display(activeVisibleCount);
-  ui.counter->setToolTip(
+  auto toolTip =
       tr("<table cellspacing=\"6\">"
          "<tr><th>Type</th><th>Active      </th><th>Total</th></tr>"
          "<tr><td>All plugins:</td><td align=right>%1    </td><td "
          "align=right>%2</td></tr>"
          "<tr><td>ESMs:</td><td align=right>%3    </td><td align=right>%4</td></tr>"
-         "<tr><td>ESPs:</td><td align=right>%7    </td><td align=right>%8</td></tr>"
-         "<tr><td>ESMs+ESPs:</td><td align=right>%9    </td><td "
-         "align=right>%10</td></tr>"
-         "<tr><td>ESHs:</td><td align=right>%11   </td><td align=right>%12</td></tr>"
-         "<tr><td>ESLs:</td><td align=right>%5    </td><td align=right>%6</td></tr>"
-         "</table>")
+         "<tr><td>ESPs:</td><td align=right>%5    </td><td align=right>%6</td></tr>"
+         "<tr><td>ESMs+ESPs:</td><td align=right>%7    </td><td "
+         "align=right>%8</td></tr>")
           .arg(activeCount)
           .arg(totalCount)
           .arg(activeMasterCount)
           .arg(masterCount)
-          .arg(activeLightMasterCount)
-          .arg(lightMasterCount)
           .arg(activeRegularCount)
           .arg(regularCount)
           .arg(activeMasterCount + activeRegularCount)
-          .arg(masterCount + regularCount)
-          .arg(activeMediumMasterCount)
-          .arg(mediumMasterCount));
+          .arg(masterCount + regularCount);
+
+  auto gamePlugins = m_core->gameFeatures().gameFeature<GamePlugins>();
+  const bool lightPluginsAreSupported =
+      gamePlugins ? gamePlugins->lightPluginsAreSupported() : false;
+  const bool mediumPluginsAreSupported =
+      gamePlugins ? gamePlugins->mediumPluginsAreSupported() : false;
+  const bool blueprintPluginsAreSupported =
+      gamePlugins ? gamePlugins->blueprintPluginsAreSupported() : false;
+
+  if (mediumPluginsAreSupported) {
+    toolTip +=
+        tr("<tr><td>ESHs:</td><td align=right>%1   </td><td align=right>%2</td></tr>")
+            .arg(activeMediumMasterCount)
+            .arg(mediumMasterCount);
+  }
+  if (lightPluginsAreSupported) {
+    toolTip +=
+        tr("<tr><td>ESLs:</td><td align=right>%1    </td><td align=right>%2</td></tr>")
+            .arg(activeLightMasterCount)
+            .arg(lightMasterCount);
+  }
+  if (blueprintPluginsAreSupported) {
+    toolTip += tr("<tr><td>Blueprint masters:</td><td align=right>%1    </td><td "
+                  "align=right>%2</td></tr>")
+                   .arg(activeBlueprintCount)
+                   .arg(blueprintCount);
+  }
+
+  toolTip += "</table>";
+
+  ui.counter->display(activeVisibleCount);
+  ui.counter->setToolTip(toolTip);
 }
 
 void PluginListView::onFilterChanged(const QString& filter)


### PR DESCRIPTION
For Starfield it now looks like this (I don't have the latest version installed):

![image](https://github.com/user-attachments/assets/e921e623-8537-4847-8630-a4169990eba0)

And for Skyrim Special Edition like this (ESH and blueprint masters are hidden):

![image](https://github.com/user-attachments/assets/00aa3322-f411-49ef-a7a5-f015a92f4501)
