### PR TITLE
Prevent crash when opening NXM link before selecting instance

### DIFF
--- a/src/moapplication.cpp
+++ b/src/moapplication.cpp
@@ -390,8 +390,14 @@ void MOApplication::externalMessage(const QString& message)
       }
     }
   } else if (isNxmLink(message)) {
-    MessageDialog::showMessage(tr("Download started"), qApp->activeWindow(), false);
-    m_core->downloadRequestedNXM(message);
+    if (InstanceManager::singleton().currentInstance()->gamePlugin() == nullptr) {
+      // This can happen if MO2 is started with the --pick option and no instance has
+      // been selected yet, in which case m_core will be null.
+      reportError(tr("No instance has been selected. Cannot download mod."));
+    } else {
+      MessageDialog::showMessage(tr("Download started"), qApp->activeWindow(), false);
+      m_core->downloadRequestedNXM(message);
+    }
   } else {
     cl::CommandLine cl;
 

--- a/src/moapplication.cpp
+++ b/src/moapplication.cpp
@@ -393,7 +393,7 @@ void MOApplication::externalMessage(const QString& message)
     if (InstanceManager::singleton().currentInstance()->gamePlugin() == nullptr) {
       // This can happen if MO2 is started with the --pick option and no instance has
       // been selected yet, in which case m_core will be null.
-      reportError(tr("No instance has been selected. Cannot download mod."));
+      reportError(tr("You need to select an instance before trying to download mods."));
     } else {
       MessageDialog::showMessage(tr("Download started"), qApp->activeWindow(), false);
       m_core->downloadRequestedNXM(message);


### PR DESCRIPTION
Fixes #2121. Implementing #1531 would be more complicated, since we'd have to consider more edge cases (e.g. what to do when there are multiple instances found for the game from the downloaded mod).