### PR TITLE
Add new contributors to the about dialog

### DIFF
--- a/src/aboutdialog.ui
+++ b/src/aboutdialog.ui
@@ -266,6 +266,16 @@
                 <string notr="true">Qudix</string>
                </property>
               </item>
+              <item>
+               <property name="text">
+                <string notr="true">RJ</string>
+               </property>
+              </item>
+              <item>
+               <property name="text">
+                <string notr="true">Jonathan Feenstra</string>
+               </property>
+              </item>
              </widget>
             </item>
            </layout>
@@ -402,7 +412,7 @@
               </item>
               <item>
                <property name="text">
-                <string>zDas (Portuguese)</string>
+                <string>Dasinho (Portuguese)</string>
                </property>
               </item>
               <item>
@@ -632,6 +642,21 @@
               <item>
                <property name="text">
                 <string notr="true">z929669</string>
+               </property>
+              </item>
+              <item>
+               <property name="text">
+                <string notr="true">Eddoursul</string>
+               </property>
+              </item>
+              <item>
+               <property name="text">
+                <string notr="true">Twinki</string>
+               </property>
+              </item>
+              <item>
+               <property name="text">
+                <string notr="true">ashemedai</string>
                </property>
               </item>
              </widget>


### PR DESCRIPTION
The last time the about dialog was updated with new contributors was [18 December 2021](https://github.com/ModOrganizer2/modorganizer/commit/8d08d7f6ba0f52ab7c204617a1e14e12fb5b5d01), so anyone who contributed after that isn't listed yet. In the Git history of this repository's master branch, I found the following new code contributors since then (besides myself):

- @Liderate (credited as "RJ")
- @eddoursul (credited as "Eddoursul")
- @Twinki14 / @TWiNki (credited as "Twinki")
- @ashemedai (credited as "ashemedai")

I also updated @Dasinhoo's old username (zDas) to "Dasinho". If anyone I listed prefers to be credited under a different name, please let me know.

I don't know if there are others that need to be added that haven't made any commits in this repository (new translators or contributors in our other repositories).