### PR TITLE
Highlight mods that contain selected files in data tab

### DIFF
--- a/src/colortable.cpp
+++ b/src/colortable.cpp
@@ -233,12 +233,12 @@ void ColorTable::load(Settings& s)
       });
 
   addColor(
-      QObject::tr("Mod contains selected plugin"), QColor(0, 0, 255, 64),
+      QObject::tr("Mod contains selected file"), QColor(0, 0, 255, 64),
       [this] {
-        return m_settings->colors().modlistContainsPlugin();
+        return m_settings->colors().modlistContainsFile();
       },
       [this](auto&& v) {
-        m_settings->colors().setModlistContainsPlugin(v);
+        m_settings->colors().setModlistContainsFile(v);
       });
 
   addColor(

--- a/src/mainwindow.cpp
+++ b/src/mainwindow.cpp
@@ -2240,6 +2240,7 @@ void MainWindow::on_tabWidget_currentChanged(int index)
   QWidget* currentWidget = ui->tabWidget->widget(index);
   if (currentWidget == ui->espTab) {
     m_OrganizerCore.refreshESPList();
+    ui->espList->activated();
   } else if (currentWidget == ui->bsaTab) {
     m_OrganizerCore.refreshBSAList();
   } else if (currentWidget == ui->dataTab) {

--- a/src/modlistview.h
+++ b/src/modlistview.h
@@ -138,7 +138,7 @@ public slots:
 
   // set highligth markers
   //
-  void setHighlightedMods(const std::vector<unsigned int>& pluginIndices);
+  void setHighlightedMods(const std::set<QString>& modNames);
 
 protected:
   // map from/to the view indexes to the model
@@ -215,7 +215,7 @@ private:  // private structures
     QPushButton* clearFilters;
     QComboBox* filterSeparators;
 
-    // the plugin list (for highligths)
+    // the plugin list (for highlights)
     PluginListView* pluginList;
   };
 
@@ -265,7 +265,7 @@ private:  // private functions
   void onModInstalled(const QString& modName);
   void onModFilterActive(bool filterActive);
 
-  // refresh the overwrite markers and the highligthed plugins from
+  // refresh the overwrite markers and the highlighted plugins from
   // the current selection
   //
   void refreshMarkersAndPlugins();

--- a/src/pluginlist.cpp
+++ b/src/pluginlist.cpp
@@ -161,15 +161,14 @@ void PluginList::highlightPlugins(const std::vector<unsigned int>& modIndices,
                                                   this->columnCount() - 1));
 }
 
-void PluginList::highlightMasters(
-    const std::vector<unsigned int>& selectedPluginIndices)
+void PluginList::highlightMasters(const QModelIndexList& selectedPluginIndices)
 {
   for (auto& esp : m_ESPs) {
     esp.isMasterOfSelectedPlugin = false;
   }
 
   for (const auto& pluginIndex : selectedPluginIndices) {
-    const ESPInfo& plugin = m_ESPs[pluginIndex];
+    const ESPInfo& plugin = m_ESPs[pluginIndex.row()];
     for (const auto& master : plugin.masters) {
       const auto iter = m_ESPsByName.find(master);
       if (iter != m_ESPsByName.end()) {

--- a/src/pluginlist.h
+++ b/src/pluginlist.h
@@ -222,7 +222,7 @@ public:
   void highlightPlugins(const std::vector<unsigned int>& modIndices,
                         const MOShared::DirectoryEntry& directoryEntry);
 
-  void highlightMasters(const std::vector<unsigned int>& selectedPluginIndices);
+  void highlightMasters(const QModelIndexList& selectedPluginIndices);
 
   void refreshLoadOrder();
 

--- a/src/pluginlistview.h
+++ b/src/pluginlistview.h
@@ -21,6 +21,7 @@ class PluginListView : public QTreeView
 public:
   explicit PluginListView(QWidget* parent = nullptr);
 
+  void activated();
   void setup(OrganizerCore& core, MainWindow* mw, Ui::MainWindow* mwui);
 
   // the column by which the plugin list is currently sorted

--- a/src/settings.cpp
+++ b/src/settings.cpp
@@ -1265,15 +1265,15 @@ void ColorSettings::setModlistOverwritingArchive(const QColor& c)
   set(m_Settings, "Settings", "overwritingArchiveFilesColor", c);
 }
 
-QColor ColorSettings::modlistContainsPlugin() const
+QColor ColorSettings::modlistContainsFile() const
 {
-  return get<QColor>(m_Settings, "Settings", "containsPluginColor",
+  return get<QColor>(m_Settings, "Settings", "containsFileColor",
                      QColor(0, 0, 255, 64));
 }
 
-void ColorSettings::setModlistContainsPlugin(const QColor& c)
+void ColorSettings::setModlistContainsFile(const QColor& c)
 {
-  set(m_Settings, "Settings", "containsPluginColor", c);
+  set(m_Settings, "Settings", "containsFileColor", c);
 }
 
 QColor ColorSettings::pluginListContained() const

--- a/src/settings.h
+++ b/src/settings.h
@@ -251,8 +251,8 @@ public:
   QColor modlistOverwritingArchive() const;
   void setModlistOverwritingArchive(const QColor& c);
 
-  QColor modlistContainsPlugin() const;
-  void setModlistContainsPlugin(const QColor& c);
+  QColor modlistContainsFile() const;
+  void setModlistContainsFile(const QColor& c);
 
   QColor pluginListContained() const;
   void setPluginListContained(const QColor& c);


### PR DESCRIPTION
The highlight color is the same as when highlighting mods from selected plugins in the plugins tab, so I updated the description of that color in the color table accordingly. This includes the name of the setting in ModOrganizer.ini, so if the user changed that color before updating, they'll probably need to set it again. Resolves #1530.