### PR TITLE
Add form and header versions to plugin list tool tips and plugin API and add more columns

### DIFF
--- a/src/pluginlist.cpp
+++ b/src/pluginlist.cpp
@@ -96,6 +96,10 @@ QString PluginList::getColumnName(int column)
     return tr("Mod Index");
   case COL_FLAGS:
     return tr("Flags");
+  case COL_FORMVERSION:
+    return tr("Form Version");
+  case COL_HEADERVERSION:
+    return tr("Header Version");
   default:
     return tr("unknown");
   }
@@ -114,6 +118,10 @@ QString PluginList::getColumnToolTip(int column)
         "overwrites data from plugins with lower priority.");
   case COL_MODINDEX:
     return tr("Determines the formids of objects originating from this mods.");
+  case COL_FORMVERSION:
+    return tr("Form version of the plugin.");
+  case COL_HEADERVERSION:
+    return tr("Header version of the plugin.");
   default:
     return tr("unknown");
   }
@@ -1299,17 +1307,24 @@ QVariant PluginList::data(const QModelIndex& modelIndex, int role) const
 
 QVariant PluginList::displayData(const QModelIndex& modelIndex) const
 {
-  const int index = modelIndex.row();
+  const int index    = modelIndex.row();
+  const auto& plugin = m_ESPs[index];
 
   switch (modelIndex.column()) {
   case COL_NAME:
-    return m_ESPs[index].name;
+    return plugin.name;
 
   case COL_PRIORITY:
-    return QString::number(m_ESPs[index].priority);
+    return QString::number(plugin.priority);
 
   case COL_MODINDEX:
-    return m_ESPs[index].index;
+    return plugin.index;
+
+  case COL_FORMVERSION:
+    return plugin.formVersion != 0 ? QString::number(plugin.formVersion) : QString();
+
+  case COL_HEADERVERSION:
+    return QString::number(plugin.headerVersion);
 
   default:
     return {};

--- a/src/pluginlist.cpp
+++ b/src/pluginlist.cpp
@@ -100,6 +100,10 @@ QString PluginList::getColumnName(int column)
     return tr("Form Version");
   case COL_HEADERVERSION:
     return tr("Header Version");
+  case COL_AUTHOR:
+    return tr("Author");
+  case COL_DESCRIPTION:
+    return tr("Description");
   default:
     return tr("unknown");
   }
@@ -122,6 +126,10 @@ QString PluginList::getColumnToolTip(int column)
     return tr("Form version of the plugin.");
   case COL_HEADERVERSION:
     return tr("Header version of the plugin.");
+  case COL_AUTHOR:
+    return tr("Author of the plugin.");
+  case COL_DESCRIPTION:
+    return tr("Description of the plugin.");
   default:
     return tr("unknown");
   }
@@ -1325,6 +1333,12 @@ QVariant PluginList::displayData(const QModelIndex& modelIndex) const
 
   case COL_HEADERVERSION:
     return QString::number(plugin.headerVersion);
+
+  case COL_AUTHOR:
+    return plugin.author;
+
+  case COL_DESCRIPTION:
+    return plugin.description;
 
   default:
     return {};

--- a/src/pluginlist.cpp
+++ b/src/pluginlist.cpp
@@ -1100,6 +1100,26 @@ bool PluginList::hasNoRecords(const QString& name) const
   }
 }
 
+int PluginList::formVersion(const QString& name) const
+{
+  auto iter = m_ESPsByName.find(name);
+  if (iter == m_ESPsByName.end()) {
+    return -1;
+  } else {
+    return m_ESPs[iter->second].formVersion;
+  }
+}
+
+float PluginList::headerVersion(const QString& name) const
+{
+  auto iter = m_ESPsByName.find(name);
+  if (iter == m_ESPsByName.end()) {
+    return -1;
+  } else {
+    return m_ESPs[iter->second].headerVersion;
+  }
+}
+
 QString PluginList::author(const QString& name) const
 {
   auto iter = m_ESPsByName.find(name);
@@ -1387,6 +1407,15 @@ QVariant PluginList::tooltipData(const QModelIndex& modelIndex) const
     toolTip += "<br><b><i>" +
                tr("This plugin can't be disabled (enforced by the game).") + "</i></b>";
   }
+
+  if (esp.formVersion != 0) {
+    // Oblivion-style plugin headers don't have a form version
+    toolTip +=
+        "<br><b>" + tr("Form Version") + "</b>: " + QString::number(esp.formVersion);
+  }
+
+  toolTip +=
+      "<br><b>" + tr("Header Version") + "</b>: " + QString::number(esp.headerVersion);
 
   if (!esp.author.isEmpty()) {
     toolTip += "<br><b>" + tr("Author") + "</b>: " + TruncateString(esp.author);
@@ -1960,8 +1989,10 @@ PluginList::ESPInfo::ESPInfo(const QString& name, bool forceLoaded, bool forceEn
                          file.isBlueprint();
     hasNoRecords = file.isDummy();
 
-    author      = QString::fromLatin1(file.author().c_str());
-    description = QString::fromLatin1(file.description().c_str());
+    formVersion   = file.formVersion();
+    headerVersion = file.headerVersion();
+    author        = QString::fromLatin1(file.author().c_str());
+    description   = QString::fromLatin1(file.description().c_str());
 
     for (auto&& m : file.masters()) {
       masters.insert(QString::fromStdString(m));

--- a/src/pluginlist.h
+++ b/src/pluginlist.h
@@ -95,8 +95,10 @@ public:
     COL_MODINDEX,
     COL_FORMVERSION,
     COL_HEADERVERSION,
+    COL_AUTHOR,
+    COL_DESCRIPTION,
 
-    COL_LASTCOLUMN = COL_HEADERVERSION,
+    COL_LASTCOLUMN = COL_DESCRIPTION,
   };
 
   using PluginStates = MOBase::IPluginList::PluginStates;
@@ -212,6 +214,8 @@ public:
 
   QString getName(int index) const { return m_ESPs.at(index).name; }
   int getPriority(int index) const { return m_ESPs.at(index).priority; }
+  QString getAuthor(int index) const { return m_ESPs.at(index).author; }
+  QString getDescription(int index) const { return m_ESPs.at(index).description; }
   QString getIndexPriority(int index) const;
   bool isESPLocked(int index) const;
   void lockESPIndex(int index, bool lock);

--- a/src/pluginlist.h
+++ b/src/pluginlist.h
@@ -247,6 +247,8 @@ public:
   bool isBlueprintFlagged(const QString& name) const;
   bool hasNoRecords(const QString& name) const;
 
+  int formVersion(const QString& name) const;
+  float headerVersion(const QString& name) const;
   QString author(const QString& name) const;
   QString description(const QString& name) const;
 
@@ -345,6 +347,8 @@ private:
     bool hasNoRecords;
     bool modSelected;
     bool isMasterOfSelectedPlugin;
+    int formVersion;
+    float headerVersion;
     QString author;
     QString description;
     bool hasIni;

--- a/src/pluginlist.h
+++ b/src/pluginlist.h
@@ -93,8 +93,10 @@ public:
     COL_FLAGS,
     COL_PRIORITY,
     COL_MODINDEX,
+    COL_FORMVERSION,
+    COL_HEADERVERSION,
 
-    COL_LASTCOLUMN = COL_MODINDEX
+    COL_LASTCOLUMN = COL_HEADERVERSION,
   };
 
   using PluginStates = MOBase::IPluginList::PluginStates;

--- a/src/pluginlistproxy.cpp
+++ b/src/pluginlistproxy.cpp
@@ -134,6 +134,16 @@ bool PluginListProxy::hasNoRecords(const QString& name) const
   return m_Proxied->hasNoRecords(name);
 }
 
+int PluginListProxy::formVersion(const QString& name) const
+{
+  return m_Proxied->formVersion(name);
+}
+
+float PluginListProxy::headerVersion(const QString& name) const
+{
+  return m_Proxied->headerVersion(name);
+}
+
 QString PluginListProxy::author(const QString& name) const
 {
   return m_Proxied->author(name);

--- a/src/pluginlistproxy.h
+++ b/src/pluginlistproxy.h
@@ -37,6 +37,8 @@ public:
   bool isBlueprintFlagged(const QString& name) const override;
   bool hasNoRecords(const QString& name) const override;
 
+  int formVersion(const QString& name) const override;
+  float headerVersion(const QString& name) const override;
   QString author(const QString& name) const override;
   QString description(const QString& name) const override;
 

--- a/src/pluginlistsortproxy.cpp
+++ b/src/pluginlistsortproxy.cpp
@@ -83,6 +83,15 @@ bool PluginListSortProxy::lessThan(const QModelIndex& left,
     QString rightVal = plugins->getIndexPriority(right.row());
     return leftVal < rightVal;
   } break;
+  case PluginList::COL_AUTHOR: {
+    return QString::compare(plugins->getAuthor(left.row()),
+                            plugins->getAuthor(right.row()), Qt::CaseInsensitive) < 0;
+  } break;
+  case PluginList::COL_DESCRIPTION: {
+    return QString::compare(plugins->getDescription(left.row()),
+                            plugins->getDescription(right.row()),
+                            Qt::CaseInsensitive) < 0;
+  } break;
   default: {
     return plugins->getPriority(left.row()) < plugins->getPriority(right.row());
   } break;


### PR DESCRIPTION
The header version info in the plugin list tool tip was requested on Discord by @Darkladylexy and adding the form version to the plugin API could be useful for our own [Form 43 checker plugin](https://github.com/ModOrganizer2/modorganizer-form43_checker).

![image](https://github.com/user-attachments/assets/010a110c-9ff2-43c0-934c-c9e727c9079a)

I also added some new columns:

![image](https://github.com/user-attachments/assets/6901698f-ca87-42b0-a798-5693e4e5204b)

Requires https://github.com/ModOrganizer2/modorganizer-uibase/pull/165 and https://github.com/ModOrganizer2/modorganizer-esptk/pull/15

Also related: https://github.com/ModOrganizer2/modorganizer-plugin_python/pull/139