### PR TITLE
Write BOM if original file used one

### DIFF
--- a/src/texteditor.h
+++ b/src/texteditor.h
@@ -130,6 +130,7 @@ private:
   QColor m_highlightBackground;
   QString m_filename;
   QString m_encoding;
+  bool m_needsBOM;
   bool m_dirty;
   bool m_loading;
 


### PR DESCRIPTION
Important for UTF-16 as lots of things can't detect or read UTF-16 without a BOM

Fixes https://github.com/ModOrganizer2/modorganizer/issues/2209