### PR TITLE
Do not sort categories table while adding rows

### DIFF
--- a/src/categoriesdialog.cpp
+++ b/src/categoriesdialog.cpp
@@ -254,12 +254,14 @@ void CategoriesDialog::fillTable()
     }
   }
 
+  table->setSortingEnabled(true);
   refreshIDs();
 }
 
 void CategoriesDialog::addCategory_clicked()
 {
   int row = m_ContextRow >= 0 ? m_ContextRow : 0;
+  ui->categoriesTable->setSortingEnabled(false);
   ui->categoriesTable->insertRow(row);
   ui->categoriesTable->setVerticalHeaderItem(row, new QTableWidgetItem("  "));
   ui->categoriesTable->setItem(row, 0,
@@ -267,6 +269,7 @@ void CategoriesDialog::addCategory_clicked()
   ui->categoriesTable->setItem(row, 1, new QTableWidgetItem("new"));
   ui->categoriesTable->setItem(row, 2, new QTableWidgetItem("0"));
   ui->categoriesTable->setItem(row, 3, new QTableWidgetItem(""));
+  ui->categoriesTable->setSortingEnabled(true);
 }
 
 void CategoriesDialog::removeCategory_clicked()
@@ -300,6 +303,7 @@ void CategoriesDialog::nexusImport_clicked()
       m_HighestID = 0;
     }
     int row = 0;
+    table->setSortingEnabled(false);
     for (int i = 0; i < list->count(); ++i) {
       QString name = list->item(i)->data(Qt::DisplayRole).toString();
       int nexusID  = list->item(i)->data(Qt::UserRole).toInt();
@@ -344,6 +348,7 @@ void CategoriesDialog::nexusImport_clicked()
         }
       }
     }
+    table->setSortingEnabled(true);
     refreshIDs();
   }
 }

--- a/src/categoriesdialog.ui
+++ b/src/categoriesdialog.ui
@@ -79,9 +79,6 @@
      <property name="gridStyle">
       <enum>Qt::DashLine</enum>
      </property>
-     <property name="sortingEnabled">
-      <bool>true</bool>
-     </property>
      <property name="wordWrap">
       <bool>false</bool>
      </property>


### PR DESCRIPTION
This addresses an issue where items were being placed in an unexpected row. The documentation for QTableWidget::setItem shows that the row will be sorted if the item is in the active sort column, and that sorting can be disabled before setting multiple items of a row and enabled afterwards. So, this enables sorting after the initial table is filled, disables sorting before multiple items are set in the same row, and enables sorting after multiple items are set. It should solve #2226.

https://doc.qt.io/qt-6/qtablewidget.html#setItem