### PR TITLE
Speedup refresh when archive parsing is enabled and updateBSAList

### DIFF
--- a/src/directoryrefresher.cpp
+++ b/src/directoryrefresher.cpp
@@ -328,7 +328,8 @@ struct ModThread
   int prio = -1;
   std::vector<std::wstring> archives;
   std::set<std::wstring> enabledArchives;
-  DirectoryStats* stats = nullptr;
+  std::vector<std::wstring>* loadOrder = nullptr;
+  DirectoryStats* stats                = nullptr;
   env::DirectoryWalker walker;
 
   std::condition_variable cv;
@@ -356,18 +357,8 @@ struct ModThread
     ds->addFromOrigin(walker, modName, path, prio, *stats);
 
     if (Settings::instance().archiveParsing()) {
-      QStringList loadOrder;
-      auto gamePlugins = gameFeatures->gameFeature<GamePlugins>();
-      if (gamePlugins) {
-        loadOrder = gamePlugins->getLoadOrder();
-      }
-
-      std::vector<std::wstring> lo;
-      for (auto&& s : loadOrder) {
-        lo.push_back(s.toStdWString());
-      }
-
-      ds->addFromAllBSAs(modName, path, prio, archives, enabledArchives, lo, *stats);
+      ds->addFromAllBSAs(modName, path, prio, archives, enabledArchives, *loadOrder,
+                         *stats);
     }
 
     if (progress) {
@@ -399,6 +390,18 @@ void DirectoryRefresher::addMultipleModsFilesToStructure(
 
   log::debug("refresher: using {} threads", m_threadCount);
   g_threads.setMax(m_threadCount);
+
+  std::vector<std::wstring> loadOrder;
+  if (Settings::instance().archiveParsing()) {
+    auto gamePlugins = m_Core.gameFeatures().gameFeature<GamePlugins>();
+    if (gamePlugins) {
+      QStringList lo = gamePlugins->getLoadOrder();
+      loadOrder.reserve(lo.size());
+      for (auto&& s : lo) {
+        loadOrder.push_back(s.toStdWString());
+      }
+    }
+  }
 
   for (std::size_t i = 0; i < entries.size(); ++i) {
     const auto& e  = entries[i];
@@ -436,7 +439,8 @@ void DirectoryRefresher::addMultipleModsFilesToStructure(
           mt.enabledArchives.insert(a.toStdWString());
         }
 
-        mt.stats = &stats[i];
+        mt.loadOrder = &loadOrder;
+        mt.stats     = &stats[i];
 
         mt.wakeup();
       }

--- a/src/mainwindow.cpp
+++ b/src/mainwindow.cpp
@@ -1919,12 +1919,18 @@ void MainWindow::updateBSAList(const QStringList& defaultArchives,
                fileName.endsWith(".esl", Qt::CaseInsensitive);
       });
 
+  QList<std::pair<QString, QString>> pluginNamePairs;
+  pluginNamePairs.reserve(plugins.size());
+  for (const QString& pluginName : plugins) {
+    QFileInfo pluginInfo(pluginName);
+    pluginNamePairs.append(
+        std::make_pair(pluginInfo.completeBaseName(), pluginInfo.fileName()));
+  }
+
   auto hasAssociatedPlugin = [&](const QString& bsaName) -> bool {
-    for (const QString& pluginName : plugins) {
-      QFileInfo pluginInfo(pluginName);
-      if (bsaName.startsWith(QFileInfo(pluginName).completeBaseName(),
-                             Qt::CaseInsensitive) &&
-          (m_OrganizerCore.pluginList()->state(pluginInfo.fileName()) ==
+    for (const auto& [completeBaseName, fileName] : pluginNamePairs) {
+      if (bsaName.startsWith(completeBaseName, Qt::CaseInsensitive) &&
+          (m_OrganizerCore.pluginList()->state(fileName) ==
            IPluginList::STATE_ACTIVE)) {
         return true;
       }


### PR DESCRIPTION
- Speeds up DirectoryRefresher::refresh when archive parsing is enabled by getting the load order only once.
- Speeds up OrganizerCore::refreshBSAList by getting the completeBaseName and fileName for each plugin only once.

The motivation is that some large (a few thousand mods and plugins) Wabbajack lists I have installed came with archive parsing enabled. These changes should give a significant speedup when refreshing such lists.