### PR TITLE
Oblivion Remastered Meta PR

### DIFF
--- a/src/directoryrefresher.cpp
+++ b/src/directoryrefresher.cpp
@@ -179,10 +179,13 @@ void DirectoryRefresher::setMods(
 
   m_Mods.clear();
   for (auto mod = mods.begin(); mod != mods.end(); ++mod) {
-    QString name      = std::get<0>(*mod);
-    ModInfo::Ptr info = ModInfo::getByIndex(ModInfo::getIndex(name));
-    m_Mods.push_back(EntryInfo(name, std::get<1>(*mod), info->stealFiles(),
-                               info->archives(), std::get<2>(*mod)));
+    QString name       = std::get<0>(*mod);
+    ModInfo::Ptr info  = ModInfo::getByIndex(ModInfo::getIndex(name));
+    QString path       = std::get<1>(*mod);
+    QString modDataDir = m_Core.managedGame()->modDataDirectory();
+    path               = modDataDir.isEmpty() ? path : path + "/" + modDataDir;
+    m_Mods.push_back(
+        EntryInfo(name, path, info->stealFiles(), info->archives(), std::get<2>(*mod)));
   }
 
   m_EnabledArchives = managedArchives;

--- a/src/mainwindow.cpp
+++ b/src/mainwindow.cpp
@@ -2910,8 +2910,11 @@ void MainWindow::originModified(int originID)
   origin.enable(false);
 
   DirectoryStats dummy;
+  QString path       = QString::fromStdWString(origin.getPath());
+  QString modDataDir = m_OrganizerCore.managedGame()->modDataDirectory();
+  path               = modDataDir.isEmpty() ? path : path + "/" + modDataDir;
   m_OrganizerCore.directoryStructure()->addFromOrigin(
-      origin.getName(), origin.getPath(), origin.getPriority(), dummy);
+      origin.getName(), path.toStdWString(), origin.getPriority(), dummy);
 
   DirectoryRefresher::cleanStructure(m_OrganizerCore.directoryStructure());
 }

--- a/src/moapplication.cpp
+++ b/src/moapplication.cpp
@@ -287,6 +287,7 @@ int MOApplication::setup(MOMultiProcess& multiProcess, bool forceSelect)
   // setting up organizer core
   m_core->setManagedGame(m_instance->gamePlugin());
   m_core->createDefaultProfile();
+  m_core->createOverwriteDirectories();
 
   log::info("using game plugin '{}' ('{}', variant {}, steam id '{}') at {}",
             m_instance->gamePlugin()->gameName(),

--- a/src/modinfodialog.cpp
+++ b/src/modinfodialog.cpp
@@ -571,25 +571,30 @@ void ModInfoDialog::updateTabs(bool becauseOriginChanged)
 
 void ModInfoDialog::feedFiles(std::vector<TabInfo*>& interestedTabs)
 {
-  const auto rootPath = m_mod->absolutePath();
+  const auto rootPath =
+      m_mod->absolutePath() + (m_core.managedGame()->modDataDirectory().isEmpty()
+                                   ? ""
+                                   : "/" + m_core.managedGame()->modDataDirectory());
   if (rootPath.isEmpty()) {
     return;
   }
 
-  const fs::path fsPath(rootPath.toStdWString());
+  if (fs::exists(rootPath.toStdWString())) {
+    const fs::path fsPath(rootPath.toStdWString());
 
-  for (const auto& entry : fs::recursive_directory_iterator(fsPath)) {
-    if (!entry.is_regular_file()) {
-      // skip directories
-      continue;
-    }
+    for (const auto& entry : fs::recursive_directory_iterator(fsPath)) {
+      if (!entry.is_regular_file()) {
+        // skip directories
+        continue;
+      }
 
-    const auto filePath = QString::fromStdWString(entry.path().native());
+      const auto filePath = QString::fromStdWString(entry.path().native());
 
-    // for each tab
-    for (auto* tabInfo : interestedTabs) {
-      if (tabInfo->tab->feedFile(rootPath, filePath)) {
-        break;
+      // for each tab
+      for (auto* tabInfo : interestedTabs) {
+        if (tabInfo->tab->feedFile(rootPath, filePath)) {
+          break;
+        }
       }
     }
   }

--- a/src/modinfooverwrite.cpp
+++ b/src/modinfooverwrite.cpp
@@ -3,9 +3,9 @@
 #include "settings.h"
 #include "shared/appconfig.h"
 
+#include "organizercore.h"
 #include <QApplication>
 #include <QDirIterator>
-#include "organizercore.h"
 
 ModInfoOverwrite::ModInfoOverwrite(OrganizerCore& core) : ModInfoWithConflictInfo(core)
 {}
@@ -31,7 +31,7 @@ bool ModInfoOverwrite::isEmpty() const
     if (iter.fileInfo().isFile() && iter.fileName() != "meta.ini")
       return false;
   }
-  
+
   return true;
 }
 

--- a/src/modinfooverwrite.cpp
+++ b/src/modinfooverwrite.cpp
@@ -5,6 +5,7 @@
 
 #include <QApplication>
 #include <QDirIterator>
+#include "organizercore.h"
 
 ModInfoOverwrite::ModInfoOverwrite(OrganizerCore& core) : ModInfoWithConflictInfo(core)
 {}
@@ -14,10 +15,24 @@ bool ModInfoOverwrite::isEmpty() const
   QDirIterator iter(absolutePath(), QDir::NoDotAndDotDot | QDir::Files | QDir::Dirs);
   if (!iter.hasNext())
     return true;
-  iter.next();
-  if ((iter.fileName() == "meta.ini") && !iter.hasNext())
-    return true;
-  return false;
+  while (iter.hasNext()) {
+    iter.next();
+    if (iter.fileInfo().isDir() &&
+        !m_Core.managedGame()->getModMappings().keys().contains(iter.fileName(),
+                                                                Qt::CaseInsensitive))
+      return false;
+    if (iter.fileInfo().isDir() &&
+        m_Core.managedGame()->getModMappings().keys().contains(iter.fileName(),
+                                                               Qt::CaseInsensitive)) {
+      if (QDir(iter.filePath()).count() > 2) {
+        return false;
+      }
+    }
+    if (iter.fileInfo().isFile() && iter.fileName() != "meta.ini")
+      return false;
+  }
+  
+  return true;
 }
 
 QString ModInfoOverwrite::absolutePath() const

--- a/src/modlist.cpp
+++ b/src/modlist.cpp
@@ -1044,7 +1044,8 @@ bool ModList::dropLocalFiles(const ModListDropInfo& dropInfo, int row,
               auto entry         = dirIter.nextFileInfo();
               QString sourceFile = entry.canonicalFilePath();
 
-              QFileInfo targetInfo(modDir.absoluteFilePath(overDir.relativeFilePath(entry.absoluteFilePath())));
+              QFileInfo targetInfo(modDir.absoluteFilePath(
+                  overDir.relativeFilePath(entry.absoluteFilePath())));
               sourceList << sourceFile;
               targetList << targetInfo.absoluteFilePath();
               relativePathList << QPair<QString, QString>(localUrl.relativePath,

--- a/src/modlist.cpp
+++ b/src/modlist.cpp
@@ -1030,11 +1030,13 @@ bool ModList::dropLocalFiles(const ModListDropInfo& dropInfo, int row,
   for (auto localUrl : dropInfo.localUrls()) {
     QFileInfo sourceInfo(localUrl.url.toLocalFile());
     if (localUrl.originName.compare("overwrite", Qt::CaseInsensitive) == 0) {
+      bool needsMove = true;
       if (sourceInfo.isDir()) {
         for (auto dir : m_Organizer->managedGame()->getModMappings().keys()) {
           QDir overDir(m_Organizer->overwritePath());
           if (sourceInfo.canonicalFilePath().compare(overDir.absoluteFilePath(dir),
                                                      Qt::CaseInsensitive) == 0) {
+            needsMove = false;
 
             QDirIterator dirIter(overDir.absoluteFilePath(dir),
                                  QDir::AllDirs | QDir::Files | QDir::NoDotAndDotDot);
@@ -1050,7 +1052,8 @@ bool ModList::dropLocalFiles(const ModListDropInfo& dropInfo, int row,
             }
           }
         }
-      } else {
+      }
+      if (needsMove) {
         QString sourceFile = sourceInfo.canonicalFilePath();
 
         QFileInfo targetInfo(modDir.absoluteFilePath(localUrl.relativePath));

--- a/src/modlistviewactions.cpp
+++ b/src/modlistviewactions.cpp
@@ -1308,8 +1308,9 @@ void ModListViewActions::moveOverwriteContentsTo(const QString& absolutePath) co
       auto entry = iter.nextFileInfo();
       if (entry.isDir() && m_core.managedGame()->getModMappings().keys().contains(
                                entry.fileName(), Qt::CaseInsensitive)) {
-        successful = shellCopy((QDir::toNativeSeparators(entry.absolutePath())),
-                  (QDir::toNativeSeparators(absolutePath)), false, m_parent);
+        successful =
+            shellCopy((QDir::toNativeSeparators(entry.absolutePath())),
+                      (QDir::toNativeSeparators(absolutePath)), false, m_parent);
         QDirIterator subDirIter(entry.absoluteFilePath(),
                                 QDir::AllDirs | QDir::Files | QDir::NoDotAndDotDot);
         while (subDirIter.hasNext()) {
@@ -1321,8 +1322,9 @@ void ModListViewActions::moveOverwriteContentsTo(const QString& absolutePath) co
           }
         }
       } else {
-        successful = shellMove((QDir::toNativeSeparators(iter.filePath())),
-                  (QDir::toNativeSeparators(absolutePath)), false, m_parent);
+        successful =
+            shellMove((QDir::toNativeSeparators(iter.filePath())),
+                      (QDir::toNativeSeparators(absolutePath)), false, m_parent);
       }
       if (!successful)
         break;
@@ -1427,8 +1429,8 @@ void ModListViewActions::clearOverwrite() const
             tr("About to recursively delete:\n") + overwriteDir.absolutePath(),
             QMessageBox::Ok | QMessageBox::Cancel) == QMessageBox::Ok) {
       QStringList delList;
-      for (auto f :
-           overwriteDir.entryInfoList(QDir::AllDirs | QDir::Files | QDir::NoDotAndDotDot)) {
+      for (auto f : overwriteDir.entryInfoList(QDir::AllDirs | QDir::Files |
+                                               QDir::NoDotAndDotDot)) {
         if (f.isDir() && m_core.managedGame()->getModMappings().keys().contains(
                              f.fileName(), Qt::CaseInsensitive)) {
           for (auto sf :

--- a/src/modlistviewactions.cpp
+++ b/src/modlistviewactions.cpp
@@ -599,10 +599,12 @@ void ModListViewActions::displayModInformation(ModInfo::Ptr modInfo,
       FilesOrigin& origin =
           m_core.directoryStructure()->getOriginByName(ToWString(modInfo->name()));
       origin.enable(false);
-
+      QString path       = modInfo->absolutePath();
+      QString modDataDir = m_core.managedGame()->modDataDirectory();
+      path               = modDataDir.isEmpty() ? path : path + "/" + modDataDir;
       m_core.directoryRefresher()->addModToStructure(
           m_core.directoryStructure(), modInfo->name(),
-          m_core.currentProfile()->getModPriority(modIndex), modInfo->absolutePath(),
+          m_core.currentProfile()->getModPriority(modIndex), path,
           modInfo->stealFiles(), modInfo->archives());
       DirectoryRefresher::cleanStructure(m_core.directoryStructure());
       m_core.directoryStructure()->getFileRegister()->sortOrigins();

--- a/src/organizercore.cpp
+++ b/src/organizercore.cpp
@@ -462,6 +462,16 @@ void OrganizerCore::createDefaultProfile()
   }
 }
 
+void OrganizerCore::createOverwriteDirectories()
+{
+  QString overwritePath = settings().paths().overwrite();
+  for (auto modDirectory : managedGame()->getModMappings().keys()) {
+    if (!modDirectory.isEmpty()) {
+      QDir(overwritePath).mkdir(modDirectory);
+    }
+  }
+}
+
 void OrganizerCore::prepareVFS()
 {
   m_USVFS.updateMapping(fileMapping(m_CurrentProfile->name(), QString()));
@@ -2034,12 +2044,7 @@ std::vector<Mapping> OrganizerCore::fileMapping(const QString& profileName,
 
   MappingType result;
 
-  QStringList dataPaths;
-  dataPaths.append(QDir::toNativeSeparators(game->dataDirectory().absolutePath()));
-
-  for (auto directory : game->secondaryDataDirectories()) {
-    dataPaths.append(directory.absolutePath());
-  }
+  auto dataMaps = game->getModMappings();
 
   bool overwriteActive = false;
 
@@ -2052,13 +2057,19 @@ std::vector<Mapping> OrganizerCore::fileMapping(const QString& profileName,
     ModInfo::Ptr modPtr   = ModInfo::getByIndex(modIndex);
 
     bool createTarget = customOverwrite == std::get<0>(mod);
+    QDir modDir       = QDir(std::get<1>(mod));
 
     overwriteActive |= createTarget;
 
     if (modPtr->isRegular()) {
-      for (auto dataPath : dataPaths) {
-        result.insert(result.end(), {QDir::toNativeSeparators(std::get<1>(mod)),
-                                     dataPath, true, createTarget});
+      for (auto dataMap : dataMaps.asKeyValueRange()) {
+        auto mapDir = QDir(modDir.absoluteFilePath(dataMap.first));
+        if (mapDir.exists()) {
+          for (auto dir : dataMap.second) {
+            result.insert(result.end(),
+                          {mapDir.absolutePath(), dir, true, createTarget});
+          }
+        }
       }
     }
   }
@@ -2080,10 +2091,15 @@ std::vector<Mapping> OrganizerCore::fileMapping(const QString& profileName,
     }
   }
 
-  for (auto dataPath : dataPaths) {
-    result.insert(result.end(),
-                  {QDir::toNativeSeparators(m_Settings.paths().overwrite()), dataPath,
-                   true, customOverwrite.isEmpty()});
+  QDir overwriteDir(m_Settings.paths().overwrite());
+  for (auto dataMap : dataMaps.asKeyValueRange()) {
+    auto overwriteSubpath = overwriteDir.absoluteFilePath(dataMap.first);
+    if (QDir(overwriteSubpath).exists()) {
+      for (auto dir : dataMap.second) {
+        result.insert(result.end(),
+                      {overwriteSubpath, dir, true, customOverwrite.isEmpty()});
+      }
+    }
   }
 
   for (MOBase::IPluginFileMapper* mapper :

--- a/src/organizercore.cpp
+++ b/src/organizercore.cpp
@@ -1406,8 +1406,11 @@ void OrganizerCore::updateModsInDirectoryStructure(
   std::vector<DirectoryRefresher::EntryInfo> entries;
 
   for (auto idx : modInfo.keys()) {
+    QString path       = modInfo[idx]->absolutePath();
+    QString modDataDir = managedGame()->modDataDirectory();
+    path               = modDataDir.isEmpty() ? path : path + "/" + modDataDir;
     entries.push_back({modInfo[idx]->name(),
-                       modInfo[idx]->absolutePath(),
+                       path,
                        modInfo[idx]->stealFiles(),
                        {},
                        m_CurrentProfile->getModPriority(idx)});

--- a/src/organizercore.cpp
+++ b/src/organizercore.cpp
@@ -1439,9 +1439,12 @@ void OrganizerCore::updateModsInDirectoryStructure(
 
   // finally also add files from bsas to the directory structure
   for (auto idx : modInfo.keys()) {
+    QString path       = modInfo[idx]->absolutePath();
+    QString modDataDir = managedGame()->modDataDirectory();
+    path               = modDataDir.isEmpty() ? path : path + "/" + modDataDir;
     m_DirectoryRefresher->addModBSAToStructure(
         m_DirectoryStructure, modInfo[idx]->name(),
-        m_CurrentProfile->getModPriority(idx), modInfo[idx]->absolutePath(),
+        m_CurrentProfile->getModPriority(idx), path,
         modInfo[idx]->archives());
   }
 }

--- a/src/organizercore.cpp
+++ b/src/organizercore.cpp
@@ -1444,8 +1444,7 @@ void OrganizerCore::updateModsInDirectoryStructure(
     path               = modDataDir.isEmpty() ? path : path + "/" + modDataDir;
     m_DirectoryRefresher->addModBSAToStructure(
         m_DirectoryStructure, modInfo[idx]->name(),
-        m_CurrentProfile->getModPriority(idx), path,
-        modInfo[idx]->archives());
+        m_CurrentProfile->getModPriority(idx), path, modInfo[idx]->archives());
   }
 }
 

--- a/src/organizercore.h
+++ b/src/organizercore.h
@@ -332,6 +332,7 @@ public:
   bool checkPathSymlinks();
   bool bootstrap();
   void createDefaultProfile();
+  void createOverwriteDirectories();
 
   MOBase::DelayedFileWriter& pluginsWriter() { return m_PluginListsWriter; }
 

--- a/src/overwriteinfodialog.cpp
+++ b/src/overwriteinfodialog.cpp
@@ -18,7 +18,6 @@ along with Mod Organizer.  If not, see <http://www.gnu.org/licenses/>.
 */
 
 #include "overwriteinfodialog.h"
-#include "organizercore.h"
 #include "report.h"
 #include "ui_overwriteinfodialog.h"
 #include "utility.h"
@@ -39,7 +38,7 @@ OverwriteInfoDialog::OverwriteInfoDialog(ModInfo::Ptr modInfo, OrganizerCore &or
 
   this->setWindowModality(Qt::NonModal);
 
-  m_FileSystemModel = new OverwriteFileSystemModel(this);
+  m_FileSystemModel = new OverwriteFileSystemModel(this, organizer);
   m_FileSystemModel->setReadOnly(false);
   setModInfo(modInfo);
   ui->filesView->setModel(m_FileSystemModel);

--- a/src/overwriteinfodialog.cpp
+++ b/src/overwriteinfodialog.cpp
@@ -28,7 +28,7 @@ along with Mod Organizer.  If not, see <http://www.gnu.org/licenses/>.
 
 using namespace MOBase;
 
-OverwriteInfoDialog::OverwriteInfoDialog(ModInfo::Ptr modInfo, OrganizerCore &organizer,
+OverwriteInfoDialog::OverwriteInfoDialog(ModInfo::Ptr modInfo, OrganizerCore& organizer,
                                          QWidget* parent)
     : QDialog(parent), m_Organizer(organizer), ui(new Ui::OverwriteInfoDialog),
       m_FileSystemModel(nullptr), m_DeleteAction(nullptr), m_RenameAction(nullptr),
@@ -144,7 +144,9 @@ void OverwriteInfoDialog::delete_activated()
         return;
       } else if (selection->selectedRows().count() == 1) {
         for (auto modDir : m_Organizer.managedGame()->getModMappings().keys()) {
-          if (root.absoluteFilePath(modDir).compare(m_FileSystemModel->filePath(selection->selectedRows().at(0)), Qt::CaseInsensitive) == 0) {
+          if (root.absoluteFilePath(modDir).compare(
+                  m_FileSystemModel->filePath(selection->selectedRows().at(0)),
+                  Qt::CaseInsensitive) == 0) {
             return;
           }
         }
@@ -167,9 +169,8 @@ void OverwriteInfoDialog::delete_activated()
 
       foreach (QModelIndex index, selection->selectedRows()) {
         for (auto modDir : m_Organizer.managedGame()->getModMappings().keys()) {
-          if (root.absoluteFilePath(modDir).compare(
-                  m_FileSystemModel->filePath(index),
-                  Qt::CaseInsensitive) == 0) {
+          if (root.absoluteFilePath(modDir).compare(m_FileSystemModel->filePath(index),
+                                                    Qt::CaseInsensitive) == 0) {
             return;
           }
         }
@@ -209,9 +210,8 @@ void OverwriteInfoDialog::deleteTriggered()
 
   foreach (QModelIndex index, m_FileSelection) {
     for (auto modDir : m_Organizer.managedGame()->getModMappings().keys()) {
-      if (root.absoluteFilePath(modDir).compare(
-              m_FileSystemModel->filePath(index),
-              Qt::CaseInsensitive) == 0) {
+      if (root.absoluteFilePath(modDir).compare(m_FileSystemModel->filePath(index),
+                                                Qt::CaseInsensitive) == 0) {
         return;
       }
     }

--- a/src/overwriteinfodialog.h
+++ b/src/overwriteinfodialog.h
@@ -79,7 +79,7 @@ class OverwriteInfoDialog : public QDialog
   Q_OBJECT
 
 public:
-  explicit OverwriteInfoDialog(ModInfo::Ptr modInfo, QWidget* parent = 0);
+  explicit OverwriteInfoDialog(ModInfo::Ptr modInfo, OrganizerCore &organizer, QWidget* parent = 0);
   ~OverwriteInfoDialog();
 
   ModInfo::Ptr modInfo() const { return m_ModInfo; }
@@ -122,6 +122,7 @@ private:
   QAction* m_NewFolderAction;
 
   ModInfo::Ptr m_ModInfo;
+  OrganizerCore &m_Organizer;
 };
 
 #endif  // OVERWRITEINFODIALOG_H

--- a/src/overwriteinfodialog.h
+++ b/src/overwriteinfodialog.h
@@ -36,7 +36,7 @@ class OverwriteFileSystemModel : public QFileSystemModel
   Q_OBJECT;
 
 public:
-  OverwriteFileSystemModel(QObject* parent, OrganizerCore &organizer)
+  OverwriteFileSystemModel(QObject* parent, OrganizerCore& organizer)
       : QFileSystemModel(parent), m_Organizer(organizer), m_RegularColumnCount(0)
   {}
 
@@ -73,7 +73,7 @@ public:
   }
 
   virtual bool dropMimeData(const QMimeData* data, Qt::DropAction action, int row,
-    int column, const QModelIndex& parent)
+                            int column, const QModelIndex& parent)
   {
     ModListDropInfo dropInfo(data, m_Organizer);
     if (dropInfo.isLocalFileDrop()) {
@@ -92,7 +92,7 @@ public:
 private:
   mutable int m_RegularColumnCount;
 
-  OrganizerCore &m_Organizer;
+  OrganizerCore& m_Organizer;
 };
 
 class OverwriteInfoDialog : public QDialog
@@ -100,7 +100,8 @@ class OverwriteInfoDialog : public QDialog
   Q_OBJECT
 
 public:
-  explicit OverwriteInfoDialog(ModInfo::Ptr modInfo, OrganizerCore &organizer, QWidget* parent = 0);
+  explicit OverwriteInfoDialog(ModInfo::Ptr modInfo, OrganizerCore& organizer,
+                               QWidget* parent = 0);
   ~OverwriteInfoDialog();
 
   ModInfo::Ptr modInfo() const { return m_ModInfo; }
@@ -143,7 +144,7 @@ private:
   QAction* m_NewFolderAction;
 
   ModInfo::Ptr m_ModInfo;
-  OrganizerCore &m_Organizer;
+  OrganizerCore& m_Organizer;
 };
 
 #endif  // OVERWRITEINFODIALOG_H

--- a/src/overwriteinfodialog.h
+++ b/src/overwriteinfodialog.h
@@ -21,6 +21,8 @@ along with Mod Organizer.  If not, see <http://www.gnu.org/licenses/>.
 #define OVERWRITEINFODIALOG_H
 
 #include "modinfo.h"
+#include "modlistdropinfo.h"
+#include "organizercore.h"
 #include <QDialog>
 #include <QFileSystemModel>
 
@@ -34,8 +36,8 @@ class OverwriteFileSystemModel : public QFileSystemModel
   Q_OBJECT;
 
 public:
-  OverwriteFileSystemModel(QObject* parent)
-      : QFileSystemModel(parent), m_RegularColumnCount(0)
+  OverwriteFileSystemModel(QObject* parent, OrganizerCore &organizer)
+      : QFileSystemModel(parent), m_Organizer(organizer), m_RegularColumnCount(0)
   {}
 
   virtual int columnCount(const QModelIndex& parent) const
@@ -70,8 +72,27 @@ public:
     }
   }
 
+  virtual bool dropMimeData(const QMimeData* data, Qt::DropAction action, int row,
+    int column, const QModelIndex& parent)
+  {
+    ModListDropInfo dropInfo(data, m_Organizer);
+    if (dropInfo.isLocalFileDrop()) {
+      for (auto entry : dropInfo.localUrls()) {
+        QFileInfo sourceInfo(entry.url.toLocalFile());
+        if (sourceInfo.isDir() &&
+            m_Organizer.managedGame()->getModMappings().keys().contains(
+                entry.relativePath, Qt::CaseInsensitive)) {
+          return false;
+        }
+      }
+    }
+    return QFileSystemModel::dropMimeData(data, action, row, column, parent);
+  }
+
 private:
   mutable int m_RegularColumnCount;
+
+  OrganizerCore &m_Organizer;
 };
 
 class OverwriteInfoDialog : public QDialog

--- a/src/pluginlist.cpp
+++ b/src/pluginlist.cpp
@@ -156,8 +156,8 @@ void PluginList::highlightPlugins(const std::vector<unsigned int>& modIndices,
       QStringList plugins;
       if (dir.exists()) {
         plugins = dir.entryList(QStringList() << "*.esp"
-                                                          << "*.esm"
-                                                          << "*.esl");
+                                              << "*.esm"
+                                              << "*.esl");
       }
       const MOShared::FilesOrigin& origin =
           directoryEntry.getOriginByName(selectedMod->internalName().toStdWString());

--- a/src/pluginlist.cpp
+++ b/src/pluginlist.cpp
@@ -147,10 +147,18 @@ void PluginList::highlightPlugins(const std::vector<unsigned int>& modIndices,
   for (auto& modIndex : modIndices) {
     ModInfo::Ptr selectedMod = ModInfo::getByIndex(modIndex);
     if (!selectedMod.isNull() && profile->modEnabled(modIndex)) {
-      QDir dir(selectedMod->absolutePath());
-      QStringList plugins = dir.entryList(QStringList() << "*.esp"
-                                                        << "*.esm"
-                                                        << "*.esl");
+      QString modDataPath = selectedMod->absolutePath();
+      modDataPath =
+          m_Organizer.managedGame()->modDataDirectory().isEmpty()
+              ? modDataPath
+              : modDataPath + "/" + m_Organizer.managedGame()->modDataDirectory();
+      QDir dir(modDataPath);
+      QStringList plugins;
+      if (dir.exists()) {
+        plugins = dir.entryList(QStringList() << "*.esp"
+                                                          << "*.esm"
+                                                          << "*.esl");
+      }
       const MOShared::FilesOrigin& origin =
           directoryEntry.getOriginByName(selectedMod->internalName().toStdWString());
       if (plugins.size() > 0) {

--- a/src/savestab.cpp
+++ b/src/savestab.cpp
@@ -3,6 +3,7 @@
 #include "organizercore.h"
 #include "ui_mainwindow.h"
 #include <iplugingame.h>
+#include <localsavegames.h>
 #include <isavegameinfowidget.h>
 
 using namespace MOBase;

--- a/src/savestab.cpp
+++ b/src/savestab.cpp
@@ -129,13 +129,14 @@ void SavesTab::refreshSavesIfOpen()
 
 QDir SavesTab::currentSavesDir() const
 {
+  // TODO: This code should probably be handled by the game plugins
   QDir savesDir;
   if (m_core.currentProfile()->localSavesEnabled()) {
     savesDir.setPath(m_core.currentProfile()->savePath());
   } else {
     auto iniFiles = m_core.managedGame()->iniFiles();
 
-    if (iniFiles.isEmpty()) {
+    if (iniFiles.isEmpty() || m_core.gameFeatures().gameFeature<LocalSavegames>() == nullptr) {
       return m_core.managedGame()->savesDirectory();
     }
 

--- a/src/savestab.cpp
+++ b/src/savestab.cpp
@@ -3,8 +3,8 @@
 #include "organizercore.h"
 #include "ui_mainwindow.h"
 #include <iplugingame.h>
-#include <localsavegames.h>
 #include <isavegameinfowidget.h>
+#include <localsavegames.h>
 
 using namespace MOBase;
 
@@ -136,7 +136,8 @@ QDir SavesTab::currentSavesDir() const
   } else {
     auto iniFiles = m_core.managedGame()->iniFiles();
 
-    if (iniFiles.isEmpty() || m_core.gameFeatures().gameFeature<LocalSavegames>() == nullptr) {
+    if (iniFiles.isEmpty() ||
+        m_core.gameFeatures().gameFeature<LocalSavegames>() == nullptr) {
       return m_core.managedGame()->savesDirectory();
     }
 

--- a/src/shared/directoryentry.cpp
+++ b/src/shared/directoryentry.cpp
@@ -24,9 +24,9 @@ along with Mod Organizer.  If not, see <http://www.gnu.org/licenses/>.
 #include "originconnection.h"
 #include "util.h"
 #include "windows_error.h"
+#include <filesystem>
 #include <log.h>
 #include <utility.h>
-#include <filesystem>
 
 namespace MOShared
 {
@@ -646,7 +646,6 @@ void DirectoryEntry::addFiles(env::DirectoryWalker& walker, FilesOrigin& origin,
           onFile((Context*)pcx, path, ft);
         });
   }
-
 }
 
 void DirectoryEntry::onDirectoryStart(Context* cx, std::wstring_view path)

--- a/src/shared/directoryentry.cpp
+++ b/src/shared/directoryentry.cpp
@@ -26,6 +26,7 @@ along with Mod Organizer.  If not, see <http://www.gnu.org/licenses/>.
 #include "windows_error.h"
 #include <log.h>
 #include <utility.h>
+#include <filesystem>
 
 namespace MOShared
 {
@@ -630,19 +631,22 @@ void DirectoryEntry::addFiles(env::DirectoryWalker& walker, FilesOrigin& origin,
   Context cx = {origin, stats};
   cx.current.push(this);
 
-  walker.forEachEntry(
-      path, &cx,
-      [](void* pcx, std::wstring_view path) {
-        onDirectoryStart((Context*)pcx, path);
-      },
+  if (std::filesystem::exists(path)) {
+    walker.forEachEntry(
+        path, &cx,
+        [](void* pcx, std::wstring_view path) {
+          onDirectoryStart((Context*)pcx, path);
+        },
 
-      [](void* pcx, std::wstring_view path) {
-        onDirectoryEnd((Context*)pcx, path);
-      },
+        [](void* pcx, std::wstring_view path) {
+          onDirectoryEnd((Context*)pcx, path);
+        },
 
-      [](void* pcx, std::wstring_view path, FILETIME ft, uint64_t) {
-        onFile((Context*)pcx, path, ft);
-      });
+        [](void* pcx, std::wstring_view path, FILETIME ft, uint64_t) {
+          onFile((Context*)pcx, path, ft);
+        });
+  }
+
 }
 
 void DirectoryEntry::onDirectoryStart(Context* cx, std::wstring_view path)


### PR DESCRIPTION
Note that the primary changes for this, other than the game plugin, involve adding a new game plugin function that allows defining custom VFS mappings in the mod directories.

This is a map of directory names to an array of locations that should be mapped by the VFS.

For example, Oblivion Remastered maps "Data" to the internal Data directory, "Paks" to the internal Paks\~mods directory, "Movies" to Movies, an "OBSE" files to the OBSE directory.

This does default to routing the root mod directory to the game data directory, as it functioned previously, and will add any 'secondary data directories' (see Starfield) to this default map.

Due to this, there are additional changes to how 'Overwrite' is managed. These directories will automatically be created in Overwrite and the logic has been updated to prevent deleting or removing these within MO2. (Files will be copied and then cleared from these directories if you send data to a new mod etc.)

The 'Data' tab file structure currently searches for a mod directory that maps to the set data directory for the game and will display files from that directory. Currently, other mod directory files do not display or evaluate conflicts.

That's a big 'TODO' but likely a lot of work...

https://github.com/ModOrganizer2/modorganizer-uibase/pull/168
https://github.com/ModOrganizer2/modorganizer-plugin_python/pull/140
https://github.com/ModOrganizer2/modorganizer-basic_games/pull/181