### PR TITLE
Fix an error when filters hide highlighted rows

### DIFF
--- a/src/pluginlist.cpp
+++ b/src/pluginlist.cpp
@@ -192,9 +192,6 @@ void PluginList::highlightMasters(const QModelIndexList& selectedPluginIndices)
       }
     }
   }
-
-  emit dataChanged(this->index(0, 0), this->index(static_cast<int>(m_ESPs.size()) - 1,
-                                                  this->columnCount() - 1));
 }
 
 void PluginList::refresh(const QString& profileName,

--- a/src/pluginlistview.cpp
+++ b/src/pluginlistview.cpp
@@ -286,6 +286,7 @@ void PluginListView::setup(OrganizerCore& core, MainWindow* mw, Ui::MainWindow* 
     }
     mwui->modList->setHighlightedMods(mods);
     m_core->pluginList()->highlightMasters(pluginIndices);
+    repaint();
     verticalScrollBar()->repaint();
   });
 


### PR DESCRIPTION
- Crash caused by dataChanged triggering selectionChanged in loop
- Repaint accomplishes what we need