### PR TITLE
Add author and uploader columns to mod list

### DIFF
--- a/src/downloadlistview.cpp
+++ b/src/downloadlistview.cpp
@@ -231,14 +231,18 @@ void DownloadListView::onCustomContextMenu(const QPoint& point)
         menu.addAction(tr("Install"), [=] {
           issueInstall(row);
         });
-        if (m_Manager->isInfoIncomplete(row))
+        if (m_Manager->isInfoIncomplete(row)) {
           menu.addAction(tr("Query Info"), [=] {
             issueQueryInfoMd5(row);
           });
-        else
+        } else {
           menu.addAction(tr("Visit on Nexus"), [=] {
             issueVisitOnNexus(row);
           });
+          menu.addAction(tr("Visit the uploader's profile"), [=] {
+            issueVisitUploaderProfile(row);
+          });
+        }
         menu.addAction(tr("Open File"), [=] {
           issueOpenFile(row);
         });
@@ -406,6 +410,11 @@ void DownloadListView::issueRestoreToViewAll()
 void DownloadListView::issueVisitOnNexus(int index)
 {
   emit visitOnNexus(index);
+}
+
+void DownloadListView::issueVisitUploaderProfile(int index)
+{
+  emit visitUploaderProfile(index);
 }
 
 void DownloadListView::issueOpenFile(int index)

--- a/src/downloadlistview.h
+++ b/src/downloadlistview.h
@@ -87,6 +87,7 @@ signals:
   void pauseDownload(int index);
   void resumeDownload(int index);
   void visitOnNexus(int index);
+  void visitUploaderProfile(int index);
   void openFile(int index);
   void openMetaFile(int index);
   void openInDownloadsFolder(int index);
@@ -105,6 +106,7 @@ private slots:
   void issueRestoreToView(int index);
   void issueRestoreToViewAll();
   void issueVisitOnNexus(int index);
+  void issueVisitUploaderProfile(int index);
   void issueOpenFile(int index);
   void issueOpenMetaFile(int index);
   void issueOpenInDownloadsFolder(int index);

--- a/src/downloadmanager.h
+++ b/src/downloadmanager.h
@@ -503,6 +503,8 @@ public slots:
 
   void visitOnNexus(int index);
 
+  void visitUploaderProfile(int index);
+
   void openFile(int index);
 
   void openMetaFile(int index);

--- a/src/downloadstab.cpp
+++ b/src/downloadstab.cpp
@@ -37,6 +37,8 @@ DownloadsTab::DownloadsTab(OrganizerCore& core, Ui::MainWindow* mwui)
           SLOT(queryInfoMd5(int)));
   connect(ui.list, SIGNAL(visitOnNexus(int)), m_core.downloadManager(),
           SLOT(visitOnNexus(int)));
+  connect(ui.list, SIGNAL(visitUploaderProfile(int)), m_core.downloadManager(),
+          SLOT(visitUploaderProfile(int)));
   connect(ui.list, SIGNAL(openFile(int)), m_core.downloadManager(),
           SLOT(openFile(int)));
   connect(ui.list, SIGNAL(openMetaFile(int)), m_core.downloadManager(),

--- a/src/mainwindow.cpp
+++ b/src/mainwindow.cpp
@@ -3357,6 +3357,12 @@ void MainWindow::nxmModInfoAvailable(QString gameName, int modID, QVariant userD
 
     mod->setNexusCategory(result["category_id"].toInt());
 
+    mod->setAuthor(result["author"].toString());
+
+    mod->setUploader(result["uploaded_by"].toString());
+
+    mod->setUploaderUrl(result["uploaded_users_profile_url"].toString());
+
     if ((mod->endorsedState() != EndorsedState::ENDORSED_NEVER) &&
         (result.contains("endorsement"))) {
       QVariantMap endorsement   = result["endorsement"].toMap();

--- a/src/modinfo.h
+++ b/src/modinfo.h
@@ -352,6 +352,21 @@ public:  // IModInterface implementations / Re-declaration
   virtual QStringList categories() const override;
 
   /**
+   * @return the author of the mod.
+   */
+  virtual QString author() const = 0;
+
+  /**
+   * @return the name of the uploader of this mod.
+   */
+  virtual QString uploader() const = 0;
+
+  /**
+   * @return the URL of the uploader of this mod's profile.
+   */
+  virtual QString uploaderUrl() const = 0;
+
+  /**
    * @return the tracked state of this mod.
    */
   virtual MOBase::TrackedState trackedState() const override
@@ -485,6 +500,21 @@ public:  // Mutable operations:
    *     directory name wouldn't be valid).
    */
   virtual bool setName(const QString& name) = 0;
+
+  /**
+   * @brief Set the author of the mod.
+   */
+  virtual void setAuthor(const QString& author) = 0;
+
+  /**
+   * @brief Set the name of the uploader of this mod.
+   */
+  virtual void setUploader(const QString& uploader) = 0;
+
+  /**
+   * @brief Set the URL of the uploader of this mod's profile.
+   */
+  virtual void setUploaderUrl(const QString& uploaderUrl) = 0;
 
 public:  // Methods after this do not come from IModInterface:
   /**

--- a/src/modinfobackup.h
+++ b/src/modinfobackup.h
@@ -40,6 +40,12 @@ public:
   virtual QString getNexusDescription() const override { return QString(); }
   virtual void setNexusCategory(int) override {}
   virtual int getNexusCategory() const override { return 0; }
+  virtual QString author() const override { return QString(); }
+  virtual void setAuthor(const QString&) override {}
+  virtual QString uploader() const override { return QString(); }
+  virtual void setUploader(const QString&) override {}
+  virtual QString uploaderUrl() const override { return QString(); }
+  virtual void setUploaderUrl(const QString&) override {}
   virtual bool isBackup() const override { return true; }
 
   virtual void addInstalledFile(int, int) override {}

--- a/src/modinfoforeign.h
+++ b/src/modinfoforeign.h
@@ -67,6 +67,12 @@ public:
   virtual QDateTime getNexusLastModified() const override { return QDateTime(); }
   virtual void setNexusLastModified(QDateTime) override {}
   virtual QString getNexusDescription() const override { return QString(); }
+  virtual QString author() const override { return QString(); }
+  virtual void setAuthor(const QString&) override {}
+  virtual QString uploader() const override { return QString(); }
+  virtual void setUploader(const QString&) override {}
+  virtual QString uploaderUrl() const override { return QString(); }
+  virtual void setUploaderUrl(const QString&) override {}
   virtual QStringList archives(bool = false) override { return m_Archives; }
   virtual QStringList stealFiles() const override
   {

--- a/src/modinfooverwrite.h
+++ b/src/modinfooverwrite.h
@@ -70,6 +70,12 @@ public:
   virtual QString getNexusDescription() const override { return QString(); }
   virtual void setNexusCategory(int) override {}
   virtual int getNexusCategory() const override { return 0; }
+  virtual QString author() const override { return QString(); }
+  virtual void setAuthor(const QString&) override {}
+  virtual QString uploader() const override { return QString(); }
+  virtual void setUploader(const QString&) override {}
+  virtual QString uploaderUrl() const override { return QString(); }
+  virtual void setUploaderUrl(const QString&) override {}
   virtual QStringList archives(bool checkOnDisk = false) override;
   virtual void addInstalledFile(int, int) override {}
   virtual std::set<std::pair<int, int>> installedFiles() const override { return {}; }

--- a/src/modinforegular.cpp
+++ b/src/modinforegular.cpp
@@ -98,6 +98,9 @@ void ModInfoRegular::readMeta()
   m_NexusDescription = metaFile.value("nexusDescription", "").toString();
   m_NexusFileStatus  = metaFile.value("nexusFileStatus", "1").toInt();
   m_NexusCategory    = metaFile.value("nexusCategory", 0).toInt();
+  m_Author           = metaFile.value("author", "").toString();
+  m_Uploader         = metaFile.value("uploader", "").toString();
+  m_UploaderUrl      = metaFile.value("uploaderUrl", "").toString();
   m_Repository       = metaFile.value("repository", "Nexus").toString();
   m_Converted        = metaFile.value("converted", false).toBool();
   m_Validated        = metaFile.value("validated", false).toBool();
@@ -270,6 +273,9 @@ void ModInfoRegular::saveMeta()
       metaFile.setValue("lastNexusUpdate", m_LastNexusUpdate.toString(Qt::ISODate));
       metaFile.setValue("nexusLastModified", m_NexusLastModified.toString(Qt::ISODate));
       metaFile.setValue("nexusCategory", m_NexusCategory);
+      metaFile.setValue("author", m_Author);
+      metaFile.setValue("uploader", m_Uploader);
+      metaFile.setValue("uploaderUrl", m_UploaderUrl);
       metaFile.setValue("converted", m_Converted);
       metaFile.setValue("validated", m_Validated);
       metaFile.setValue("color", m_Color);
@@ -853,6 +859,45 @@ void ModInfoRegular::setNexusCategory(int category)
   m_NexusCategory   = category;
   m_MetaInfoChanged = true;
   saveMeta();
+}
+
+QString ModInfoRegular::author() const
+{
+  return m_Author;
+}
+
+void ModInfoRegular::setAuthor(const QString& author)
+{
+  m_Author          = author;
+  m_MetaInfoChanged = true;
+  saveMeta();
+  emit modDetailsUpdated(true);
+}
+
+QString ModInfoRegular::uploader() const
+{
+  return m_Uploader;
+}
+
+void ModInfoRegular::setUploader(const QString& uploader)
+{
+  m_Uploader        = uploader;
+  m_MetaInfoChanged = true;
+  saveMeta();
+  emit modDetailsUpdated(true);
+}
+
+QString ModInfoRegular::uploaderUrl() const
+{
+  return m_UploaderUrl;
+}
+
+void ModInfoRegular::setUploaderUrl(const QString& uploaderUrl)
+{
+  m_UploaderUrl     = uploaderUrl;
+  m_MetaInfoChanged = true;
+  saveMeta();
+  emit modDetailsUpdated(true);
 }
 
 void ModInfoRegular::setCustomURL(QString const& url)

--- a/src/modinforegular.h
+++ b/src/modinforegular.h
@@ -389,6 +389,36 @@ public:
    */
   virtual void setNexusCategory(int category) override;
 
+  /**
+   * @return the author of the mod.
+   */
+  virtual QString author() const override;
+
+  /**
+   * @brief Set the author of the mod.
+   */
+  virtual void setAuthor(const QString&) override;
+
+  /**
+   * @return the name of the uploader of this mod.
+   */
+  virtual QString uploader() const override;
+
+  /**
+   * @brief Set the name of the uploader of this mod.
+   */
+  virtual void setUploader(const QString&) override;
+
+  /**
+   * @return the URL of the uploader of this mod's profile.
+   */
+  virtual QString uploaderUrl() const override;
+
+  /**
+   * @brief Set the URL of the uploader of this mod's profile.
+   */
+  virtual void setUploaderUrl(const QString&) override;
+
   virtual QStringList archives(bool checkOnDisk = false) override;
 
   virtual void setColor(QColor color) override;
@@ -468,6 +498,9 @@ private:
   QDateTime m_LastNexusUpdate;
   QDateTime m_NexusLastModified;
   int m_NexusCategory;
+  QString m_Author;
+  QString m_Uploader;
+  QString m_UploaderUrl;
 
   QColor m_Color;
 

--- a/src/modinfoseparator.h
+++ b/src/modinfoseparator.h
@@ -49,6 +49,12 @@ public:
   virtual void setNexusCategory(int) override {}
   virtual QDateTime creationTime() const override { return QDateTime(); }
   virtual QString getNexusDescription() const override { return QString(); }
+  virtual QString author() const override { return QString(); }
+  virtual void setAuthor(const QString&) override {}
+  virtual QString uploader() const override { return QString(); }
+  virtual void setUploader(const QString&) override {}
+  virtual QString uploaderUrl() const override { return QString(); }
+  virtual void setUploaderUrl(const QString&) override {}
   virtual void addInstalledFile(int /*modId*/, int /*fileId*/) override {}
   virtual bool isSeparator() const override { return true; }
 

--- a/src/modlist.cpp
+++ b/src/modlist.cpp
@@ -250,6 +250,10 @@ QVariant ModList::data(const QModelIndex& modelIndex, int role) const
           return QVariant();
         }
       }
+    } else if (column == COL_AUTHOR) {
+      return modInfo->author();
+    } else if (column == COL_UPLOADER) {
+      return modInfo->uploader();
     } else if (column == COL_INSTALLTIME) {
       // display installation time for mods that can be updated
       if (modInfo->creationTime().isValid()) {
@@ -1317,6 +1321,10 @@ QString ModList::getColumnName(int column)
     return tr("Priority");
   case COL_CATEGORY:
     return tr("Category");
+  case COL_AUTHOR:
+    return tr("Author");
+  case COL_UPLOADER:
+    return tr("Uploader");
   case COL_GAME:
     return tr("Source Game");
   case COL_MODID:
@@ -1343,6 +1351,10 @@ QString ModList::getColumnToolTip(int column) const
               "overwrites files from mods with lower priority.");
   case COL_CATEGORY:
     return tr("Primary category of the mod.");
+  case COL_AUTHOR:
+    return tr("Author(s) of the mod.");
+  case COL_UPLOADER:
+    return tr("Uploader of the mod. This is not necessarily the same as the author.");
   case COL_GAME:
     return tr("The source game which was the origin of this mod.");
   case COL_MODID:

--- a/src/modlist.h
+++ b/src/modlist.h
@@ -85,6 +85,8 @@ public:
     COL_FLAGS,
     COL_CONTENT,
     COL_CATEGORY,
+    COL_AUTHOR,
+    COL_UPLOADER,
     COL_MODID,
     COL_GAME,
     COL_VERSION,

--- a/src/modlistcontextmenu.cpp
+++ b/src/modlistcontextmenu.cpp
@@ -443,6 +443,12 @@ void ModListContextMenu::addBackupActions(ModInfo::Ptr mod)
     });
   }
 
+  if (!mod->uploaderUrl().isEmpty()) {
+    addAction(tr("Visit the uploader's profile"), [=]() {
+      m_actions.visitUploaderProfile(m_selected);
+    });
+  }
+
   const auto url = mod->parseCustomURL();
   if (url.isValid()) {
     addAction(tr("Visit on %1").arg(url.host()), [=]() {
@@ -609,6 +615,12 @@ void ModListContextMenu::addRegularActions(ModInfo::Ptr mod)
   if (mod->nexusId() > 0) {
     addAction(tr("Visit on Nexus"), [=]() {
       m_actions.visitOnNexus(m_selected);
+    });
+  }
+
+  if (!mod->uploaderUrl().isEmpty()) {
+    addAction(tr("Visit the uploader's profile"), [=]() {
+      m_actions.visitUploaderProfile(m_selected);
     });
   }
 

--- a/src/modlistview.cpp
+++ b/src/modlistview.cpp
@@ -817,6 +817,7 @@ void ModListView::setup(OrganizerCore& core, CategoryFactory& factory, MainWindo
     // hide these columns by default
     header()->setSectionHidden(ModList::COL_CONTENT, true);
     header()->setSectionHidden(ModList::COL_MODID, true);
+    header()->setSectionHidden(ModList::COL_UPLOADER, true);
     header()->setSectionHidden(ModList::COL_GAME, true);
     header()->setSectionHidden(ModList::COL_INSTALLTIME, true);
     header()->setSectionHidden(ModList::COL_NOTES, true);

--- a/src/modlistviewactions.cpp
+++ b/src/modlistviewactions.cpp
@@ -908,7 +908,7 @@ void ModListViewActions::markConverted(const QModelIndexList& indices) const
 void ModListViewActions::visitOnNexus(const QModelIndexList& indices) const
 {
   if (indices.size() > 10) {
-    if (!askOpenNexusLinksConfirmation(indices.size())) {
+    if (!askOpenLinksConfirmation(indices.size(), tr("Nexus Links"))) {
       return;
     }
   }
@@ -925,20 +925,10 @@ void ModListViewActions::visitOnNexus(const QModelIndexList& indices) const
   }
 }
 
-bool ModListViewActions::askOpenNexusLinksConfirmation(
-    const qlonglong numberOfLinks) const
-{
-  return QMessageBox::question(m_parent, tr("Opening Nexus Links"),
-                               tr("You are trying to open %1 links to Nexus Mods.  Are "
-                                  "you sure you want to do this?")
-                                   .arg(numberOfLinks),
-                               QMessageBox::Yes | QMessageBox::No) == QMessageBox::Yes;
-}
-
 void ModListViewActions::visitWebPage(const QModelIndexList& indices) const
 {
   if (indices.size() > 10) {
-    if (!askOpenWebPagesConfirmation(indices.size())) {
+    if (!askOpenLinksConfirmation(indices.size(), tr("Web Pages"))) {
       return;
     }
   }
@@ -956,7 +946,7 @@ void ModListViewActions::visitWebPage(const QModelIndexList& indices) const
 void ModListViewActions::visitNexusOrWebPage(const QModelIndexList& indices) const
 {
   if (indices.size() > 10) {
-    if (!askOpenWebPagesConfirmation(indices.size())) {
+    if (!askOpenLinksConfirmation(indices.size(), tr("Web Pages"))) {
       return;
     }
   }
@@ -985,7 +975,7 @@ void ModListViewActions::visitNexusOrWebPage(const QModelIndexList& indices) con
 void ModListViewActions::visitUploaderProfile(const QModelIndexList& indices) const
 {
   if (indices.size() > 10) {
-    if (!askOpenWebPagesConfirmation(indices.size())) {
+    if (!askOpenLinksConfirmation(indices.size(), tr("Uploader Profiles"))) {
       return;
     }
   }
@@ -1002,13 +992,14 @@ void ModListViewActions::visitUploaderProfile(const QModelIndexList& indices) co
   }
 }
 
-bool ModListViewActions::askOpenWebPagesConfirmation(
-    const qlonglong numberOfLinks) const
+bool ModListViewActions::askOpenLinksConfirmation(std::size_t numberOfLinks,
+                                                  const QString& nameOfLinks) const
 {
-  return QMessageBox::question(m_parent, tr("Opening Web Pages"),
-                               tr("You are trying to open %1 Web Pages.  Are you sure "
+  return QMessageBox::question(m_parent, tr("Opening %1").arg(nameOfLinks),
+                               tr("You are trying to open %1 %2. Are you sure "
                                   "you want to do this?")
-                                   .arg(numberOfLinks),
+                                   .arg(numberOfLinks)
+                                   .arg(nameOfLinks),
                                QMessageBox::Yes | QMessageBox::No) == QMessageBox::Yes;
 }
 

--- a/src/modlistviewactions.cpp
+++ b/src/modlistviewactions.cpp
@@ -378,8 +378,11 @@ void ModListViewActions::exportModListCSV() const
   QCheckBox* mod_Status = new QCheckBox(tr("Mod_Status"));
   mod_Status->setChecked(true);
   QCheckBox* primary_Category   = new QCheckBox(tr("Primary_Category"));
+  QCheckBox* mod_Author         = new QCheckBox(tr("Mod_Author"));
+  QCheckBox* mod_Uploader       = new QCheckBox(tr("Mod_Uploader"));
   QCheckBox* nexus_ID           = new QCheckBox(tr("Nexus_ID"));
   QCheckBox* mod_Nexus_URL      = new QCheckBox(tr("Mod_Nexus_URL"));
+  QCheckBox* mod_Uploader_URL   = new QCheckBox(tr("Mod_Uploader_URL"));
   QCheckBox* mod_Version        = new QCheckBox(tr("Mod_Version"));
   QCheckBox* install_Date       = new QCheckBox(tr("Install_Date"));
   QCheckBox* download_File_Name = new QCheckBox(tr("Download_File_Name"));
@@ -390,8 +393,11 @@ void ModListViewActions::exportModListCSV() const
   vbox1->addWidget(mod_Status);
   vbox1->addWidget(mod_Note);
   vbox1->addWidget(primary_Category);
+  vbox1->addWidget(mod_Author);
+  vbox1->addWidget(mod_Uploader);
   vbox1->addWidget(nexus_ID);
   vbox1->addWidget(mod_Nexus_URL);
+  vbox1->addWidget(mod_Uploader_URL);
   vbox1->addWidget(mod_Version);
   vbox1->addWidget(install_Date);
   vbox1->addWidget(download_File_Name);
@@ -435,12 +441,21 @@ void ModListViewActions::exportModListCSV() const
       if (primary_Category->isChecked())
         fields.push_back(
             std::make_pair(QString("#Primary_Category"), CSVBuilder::TYPE_STRING));
+      if (mod_Author->isChecked())
+        fields.push_back(
+            std::make_pair(QString("#Mod_Author"), CSVBuilder::TYPE_STRING));
+      if (mod_Uploader->isChecked())
+        fields.push_back(
+            std::make_pair(QString("#Mod_Uploader"), CSVBuilder::TYPE_STRING));
       if (nexus_ID->isChecked())
         fields.push_back(
             std::make_pair(QString("#Nexus_ID"), CSVBuilder::TYPE_INTEGER));
       if (mod_Nexus_URL->isChecked())
         fields.push_back(
             std::make_pair(QString("#Mod_Nexus_URL"), CSVBuilder::TYPE_STRING));
+      if (mod_Uploader_URL->isChecked())
+        fields.push_back(
+            std::make_pair(QString("#Mod_Uploader_URL"), CSVBuilder::TYPE_STRING));
       if (mod_Version->isChecked())
         fields.push_back(
             std::make_pair(QString("#Mod_Version"), CSVBuilder::TYPE_STRING));
@@ -485,6 +500,10 @@ void ModListViewActions::exportModListCSV() const
                 (m_categories.categoryExists(info->primaryCategory()))
                     ? m_categories.getCategoryNameByID(info->primaryCategory())
                     : "");
+          if (mod_Author->isChecked())
+            builder.setRowField("#Mod_Author", info->author());
+          if (mod_Uploader->isChecked())
+            builder.setRowField("#Mod_Uploader", info->uploader());
           if (nexus_ID->isChecked())
             builder.setRowField("#Nexus_ID", info->nexusId());
           if (mod_Nexus_URL->isChecked())
@@ -493,6 +512,8 @@ void ModListViewActions::exportModListCSV() const
                                     ? NexusInterface::instance().getModURL(
                                           info->nexusId(), info->gameName())
                                     : "");
+          if (mod_Uploader_URL->isChecked())
+            builder.setRowField("#Mod_Uploader_URL", info->uploaderUrl());
           if (mod_Version->isChecked())
             builder.setRowField("#Mod_Version", info->version().canonicalString());
           if (install_Date->isChecked())
@@ -887,11 +908,7 @@ void ModListViewActions::markConverted(const QModelIndexList& indices) const
 void ModListViewActions::visitOnNexus(const QModelIndexList& indices) const
 {
   if (indices.size() > 10) {
-    if (QMessageBox::question(m_parent, tr("Opening Nexus Links"),
-                              tr("You are trying to open %1 links to Nexus Mods.  Are "
-                                 "you sure you want to do this?")
-                                  .arg(indices.size()),
-                              QMessageBox::Yes | QMessageBox::No) != QMessageBox::Yes) {
+    if (!askOpenNexusLinksConfirmation(indices.size())) {
       return;
     }
   }
@@ -908,14 +925,20 @@ void ModListViewActions::visitOnNexus(const QModelIndexList& indices) const
   }
 }
 
+bool ModListViewActions::askOpenNexusLinksConfirmation(
+    const qlonglong numberOfLinks) const
+{
+  return QMessageBox::question(m_parent, tr("Opening Nexus Links"),
+                               tr("You are trying to open %1 links to Nexus Mods.  Are "
+                                  "you sure you want to do this?")
+                                   .arg(numberOfLinks),
+                               QMessageBox::Yes | QMessageBox::No) == QMessageBox::Yes;
+}
+
 void ModListViewActions::visitWebPage(const QModelIndexList& indices) const
 {
   if (indices.size() > 10) {
-    if (QMessageBox::question(m_parent, tr("Opening Web Pages"),
-                              tr("You are trying to open %1 Web Pages.  Are you sure "
-                                 "you want to do this?")
-                                  .arg(indices.size()),
-                              QMessageBox::Yes | QMessageBox::No) != QMessageBox::Yes) {
+    if (!askOpenWebPagesConfirmation(indices.size())) {
       return;
     }
   }
@@ -933,11 +956,7 @@ void ModListViewActions::visitWebPage(const QModelIndexList& indices) const
 void ModListViewActions::visitNexusOrWebPage(const QModelIndexList& indices) const
 {
   if (indices.size() > 10) {
-    if (QMessageBox::question(m_parent, tr("Opening Web Pages"),
-                              tr("You are trying to open %1 Web Pages.  Are you sure "
-                                 "you want to do this?")
-                                  .arg(indices.size()),
-                              QMessageBox::Yes | QMessageBox::No) != QMessageBox::Yes) {
+    if (!askOpenWebPagesConfirmation(indices.size())) {
       return;
     }
   }
@@ -961,6 +980,36 @@ void ModListViewActions::visitNexusOrWebPage(const QModelIndexList& indices) con
       log::error("mod '{}' has no valid link", info->name());
     }
   }
+}
+
+void ModListViewActions::visitUploaderProfile(const QModelIndexList& indices) const
+{
+  if (indices.size() > 10) {
+    if (!askOpenWebPagesConfirmation(indices.size())) {
+      return;
+    }
+  }
+
+  for (auto& idx : indices) {
+    ModInfo::Ptr info      = ModInfo::getByIndex(idx.data(ModList::IndexRole).toInt());
+    const auto uploaderUrl = info->uploaderUrl();
+
+    if (!uploaderUrl.isEmpty()) {
+      shell::Open(QUrl(uploaderUrl));
+    } else {
+      log::error("mod '{}' has no uploader url", info->name());
+    }
+  }
+}
+
+bool ModListViewActions::askOpenWebPagesConfirmation(
+    const qlonglong numberOfLinks) const
+{
+  return QMessageBox::question(m_parent, tr("Opening Web Pages"),
+                               tr("You are trying to open %1 Web Pages.  Are you sure "
+                                  "you want to do this?")
+                                   .arg(numberOfLinks),
+                               QMessageBox::Yes | QMessageBox::No) == QMessageBox::Yes;
 }
 
 void ModListViewActions::reinstallMod(const QModelIndex& index) const

--- a/src/modlistviewactions.h
+++ b/src/modlistviewactions.h
@@ -175,15 +175,11 @@ private:
   //
   void checkModsForUpdates(std::multimap<QString, int> const& IDs) const;
 
-  // ask the user for confirmation for opening many Nexus links at once.
+  // ask the user for confirmation for opening many links at once.
   // returns true if the user confirmed, false otherwise.
   //
-  bool askOpenNexusLinksConfirmation(const qlonglong numberOfLinks) const;
-
-  // ask the user for confirmation for opening many web pages at once.
-  // returns true if the user confirmed, false otherwise.
-  //
-  bool askOpenWebPagesConfirmation(const qlonglong numberOfLinks) const;
+  bool askOpenLinksConfirmation(std::size_t numberOfLinks,
+                                const QString& nameOfLinks) const;
 
 private:
   OrganizerCore& m_core;

--- a/src/modlistviewactions.h
+++ b/src/modlistviewactions.h
@@ -92,6 +92,7 @@ public:
   void visitOnNexus(const QModelIndexList& indices) const;
   void visitWebPage(const QModelIndexList& indices) const;
   void visitNexusOrWebPage(const QModelIndexList& indices) const;
+  void visitUploaderProfile(const QModelIndexList& indices) const;
   void reinstallMod(const QModelIndex& index) const;
   void createBackup(const QModelIndex& index) const;
   void restoreHiddenFiles(const QModelIndexList& indices) const;
@@ -173,6 +174,16 @@ private:
   // check the given mods from update, the map should map game names to nexus ID
   //
   void checkModsForUpdates(std::multimap<QString, int> const& IDs) const;
+
+  // ask the user for confirmation for opening many Nexus links at once.
+  // returns true if the user confirmed, false otherwise.
+  //
+  bool askOpenNexusLinksConfirmation(const qlonglong numberOfLinks) const;
+
+  // ask the user for confirmation for opening many web pages at once.
+  // returns true if the user confirmed, false otherwise.
+  //
+  bool askOpenWebPagesConfirmation(const qlonglong numberOfLinks) const;
 
 private:
   OrganizerCore& m_core;

--- a/src/nexusinterface.cpp
+++ b/src/nexusinterface.cpp
@@ -131,6 +131,9 @@ void NexusBridge::nxmFilesAvailable(QString gameName, int modID, QVariant userDa
       temp.categoryID      = fileInfo["category_id"].toInt();
       temp.fileID          = fileInfo["file_id"].toInt();
       temp.fileSize        = fileInfo["size"].toInt();
+      temp.author          = fileInfo["author"].toString();
+      temp.uploader        = fileInfo["uploaded_by"].toString();
+      temp.uploaderUrl     = fileInfo["uploaded_users_profile_url"].toString();
       fileInfoList.append(&temp);
     }
 
@@ -575,13 +578,16 @@ void NexusInterface::fakeFiles()
 
   QVariantList result;
   QVariantMap fileMap;
-  fileMap["uri"]         = "fakeURI";
-  fileMap["name"]        = "fakeName";
-  fileMap["description"] = "fakeDescription";
-  fileMap["version"]     = "1.0.0";
-  fileMap["category_id"] = "1";
-  fileMap["id"]          = "1";
-  fileMap["size"]        = "512";
+  fileMap["uri"]                        = "fakeURI";
+  fileMap["name"]                       = "fakeName";
+  fileMap["description"]                = "fakeDescription";
+  fileMap["version"]                    = "1.0.0";
+  fileMap["category_id"]                = "1";
+  fileMap["id"]                         = "1";
+  fileMap["size"]                       = "512";
+  fileMap["author"]                     = "fakeAuthor";
+  fileMap["uploaded_by"]                = "fakeUploader";
+  fileMap["uploaded_users_profile_url"] = "https://fakeuploader.com";
   result.append(fileMap);
 
   emit nxmFilesAvailable("fakeGame", 1234, "fake", result, id++);


### PR DESCRIPTION
Requires https://github.com/ModOrganizer2/modorganizer-uibase/pull/174
Resolves #1550 and #2065 

This adds author and uploader columns to the mod list and the ability to visit the uploader's profile through the context menu on both the mod and download lists. The required data will automatically be fetched when downloading new mods from Nexus, or querying metadata. These columns, as well as the profile URLs, can also be exported to CSV.