### PR TITLE
Add executables list to plugin API

### DIFF
--- a/src/executableslist.cpp
+++ b/src/executableslist.cpp
@@ -364,6 +364,10 @@ void ExecutablesList::dump() const
       flags.push_back("hide");
     }
 
+    if (e.flags() & Executable::MinimizeToSystemTray) {
+      flags.push_back("minimizeToSystemTray");
+    }
+
     log::debug(" . executable '{}'\n"
                "    binary: {}\n"
                "    arguments: {}\n"

--- a/src/executableslist.h
+++ b/src/executableslist.h
@@ -28,6 +28,8 @@ along with Mod Organizer.  If not, see <http://www.gnu.org/licenses/>.
 #include <QFileInfo>
 #include <QMetaType>
 
+#include <uibase/iexecutable.h>
+
 namespace MOBase
 {
 class IPluginGame;
@@ -38,7 +40,7 @@ class Settings;
 /*!
  * @brief Information about an executable
  **/
-class Executable
+class Executable : public MOBase::IExecutable
 {
 public:
   enum Flag
@@ -58,11 +60,11 @@ public:
    */
   Executable(const MOBase::ExecutableInfo& info, Flags flags);
 
-  const QString& title() const;
-  const QFileInfo& binaryInfo() const;
-  const QString& arguments() const;
-  const QString& steamAppID() const;
-  const QString& workingDirectory() const;
+  const QString& title() const override;
+  const QFileInfo& binaryInfo() const override;
+  const QString& arguments() const override;
+  const QString& steamAppID() const override;
+  const QString& workingDirectory() const override;
   Flags flags() const;
 
   Executable& title(const QString& s);

--- a/src/executableslistproxy.cpp
+++ b/src/executableslistproxy.cpp
@@ -21,8 +21,8 @@ along with Mod Organizer.  If not, see <http://www.gnu.org/licenses/>.
 
 #include "executableslist.h"
 
-#include <memory>
-#include <vector>
+#include <generator>
+#include <stdexcept>
 
 #include <QFileInfo>
 #include <QString>
@@ -31,40 +31,33 @@ ExecutablesListProxy::ExecutablesListProxy(ExecutablesList* executablesList)
     : m_Proxied(executablesList)
 {}
 
-std::vector<std::shared_ptr<const MOBase::IExecutable>>
-ExecutablesListProxy::executables() const
+std::generator<const MOBase::IExecutable&> ExecutablesListProxy::executables() const
 {
-  std::vector<std::shared_ptr<const MOBase::IExecutable>> executables;
   for (const auto& exe : *m_Proxied) {
-    executables.emplace_back(std::make_shared<const Executable>(exe));
+    co_yield exe;
   }
-
-  return executables;
 }
 
-std::shared_ptr<const MOBase::IExecutable>
-ExecutablesListProxy::getByTitle(const QString& title) const
+const MOBase::IExecutable* ExecutablesListProxy::getByTitle(const QString& title) const
 {
   try {
-    const auto& exe = m_Proxied->get(title);
-    return std::make_shared<const Executable>(exe);
+    return &m_Proxied->get(title);
   } catch (const std::runtime_error&) {
     return nullptr;
   }
 }
 
-std::shared_ptr<const MOBase::IExecutable>
+const MOBase::IExecutable*
 ExecutablesListProxy::getByBinary(const QFileInfo& info) const
 {
   try {
-    const auto& exe = m_Proxied->getByBinary(info);
-    return std::make_shared<const Executable>(exe);
+    return &m_Proxied->getByBinary(info);
   } catch (const std::runtime_error&) {
     return nullptr;
   }
 }
 
-bool ExecutablesListProxy::titleExists(const QString& title) const
+bool ExecutablesListProxy::contains(const QString& title) const
 {
   return m_Proxied->titleExists(title);
 }

--- a/src/executableslistproxy.cpp
+++ b/src/executableslistproxy.cpp
@@ -1,0 +1,70 @@
+/*
+Copyright (C) 2012 Sebastian Herbord. All rights reserved.
+
+This file is part of Mod Organizer.
+
+Mod Organizer is free software: you can redistribute it and/or modify
+it under the terms of the GNU General Public License as published by
+the Free Software Foundation, either version 3 of the License, or
+(at your option) any later version.
+
+Mod Organizer is distributed in the hope that it will be useful,
+but WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+GNU General Public License for more details.
+
+You should have received a copy of the GNU General Public License
+along with Mod Organizer.  If not, see <http://www.gnu.org/licenses/>.
+*/
+
+#include "executableslistproxy.h"
+
+#include "executableslist.h"
+
+#include <memory>
+#include <vector>
+
+#include <QFileInfo>
+#include <QString>
+
+ExecutablesListProxy::ExecutablesListProxy(ExecutablesList* executablesList)
+    : m_Proxied(executablesList)
+{}
+
+std::vector<std::shared_ptr<const MOBase::IExecutable>>
+ExecutablesListProxy::executables() const
+{
+  std::vector<std::shared_ptr<const MOBase::IExecutable>> executables;
+  for (const auto& exe : *m_Proxied) {
+    executables.emplace_back(std::make_shared<const Executable>(exe));
+  }
+
+  return executables;
+}
+
+std::shared_ptr<const MOBase::IExecutable>
+ExecutablesListProxy::getByTitle(const QString& title) const
+{
+  try {
+    const auto& exe = m_Proxied->get(title);
+    return std::make_shared<const Executable>(exe);
+  } catch (const std::runtime_error&) {
+    return nullptr;
+  }
+}
+
+std::shared_ptr<const MOBase::IExecutable>
+ExecutablesListProxy::getByBinary(const QFileInfo& info) const
+{
+  try {
+    const auto& exe = m_Proxied->getByBinary(info);
+    return std::make_shared<const Executable>(exe);
+  } catch (const std::runtime_error&) {
+    return nullptr;
+  }
+}
+
+bool ExecutablesListProxy::titleExists(const QString& title) const
+{
+  return m_Proxied->titleExists(title);
+}

--- a/src/executableslistproxy.h
+++ b/src/executableslistproxy.h
@@ -22,8 +22,7 @@ along with Mod Organizer.  If not, see <http://www.gnu.org/licenses/>.
 
 #include "executableslist.h"
 
-#include <memory>
-#include <vector>
+#include <generator>
 
 #include <QFileInfo>
 #include <QString>
@@ -35,12 +34,10 @@ class ExecutablesListProxy : public MOBase::IExecutablesList
 {
 public:
   ExecutablesListProxy(ExecutablesList* executablesList);
-  std::vector<std::shared_ptr<const MOBase::IExecutable>> executables() const override;
-  std::shared_ptr<const MOBase::IExecutable>
-  getByTitle(const QString& title) const override;
-  std::shared_ptr<const MOBase::IExecutable>
-  getByBinary(const QFileInfo& info) const override;
-  bool titleExists(const QString& title) const override;
+  std::generator<const MOBase::IExecutable&> executables() const override;
+  const MOBase::IExecutable* getByTitle(const QString& title) const override;
+  const MOBase::IExecutable* getByBinary(const QFileInfo& info) const override;
+  bool contains(const QString& title) const override;
 
 private:
   ExecutablesList* m_Proxied;

--- a/src/executableslistproxy.h
+++ b/src/executableslistproxy.h
@@ -1,0 +1,49 @@
+/*
+Copyright (C) 2012 Sebastian Herbord. All rights reserved.
+
+This file is part of Mod Organizer.
+
+Mod Organizer is free software: you can redistribute it and/or modify
+it under the terms of the GNU General Public License as published by
+the Free Software Foundation, either version 3 of the License, or
+(at your option) any later version.
+
+Mod Organizer is distributed in the hope that it will be useful,
+but WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+GNU General Public License for more details.
+
+You should have received a copy of the GNU General Public License
+along with Mod Organizer.  If not, see <http://www.gnu.org/licenses/>.
+*/
+
+#ifndef EXECUTABLESLISTPROXY_H
+#define EXECUTABLESLISTPROXY_H
+
+#include "executableslist.h"
+
+#include <memory>
+#include <vector>
+
+#include <QFileInfo>
+#include <QString>
+
+#include <uibase/iexecutable.h>
+#include <uibase/iexecutableslist.h>
+
+class ExecutablesListProxy : public MOBase::IExecutablesList
+{
+public:
+  ExecutablesListProxy(ExecutablesList* executablesList);
+  std::vector<std::shared_ptr<const MOBase::IExecutable>> executables() const override;
+  std::shared_ptr<const MOBase::IExecutable>
+  getByTitle(const QString& title) const override;
+  std::shared_ptr<const MOBase::IExecutable>
+  getByBinary(const QFileInfo& info) const override;
+  bool titleExists(const QString& title) const override;
+
+private:
+  ExecutablesList* m_Proxied;
+};
+
+#endif  // EXECUTABLESLISTPROXY_H

--- a/src/organizerproxy.cpp
+++ b/src/organizerproxy.cpp
@@ -1,6 +1,7 @@
 #include "organizerproxy.h"
 
 #include "downloadmanagerproxy.h"
+#include "executableslistproxy.h"
 #include "gamefeaturesproxy.h"
 #include "glob_matching.h"
 #include "instancemanager.h"
@@ -28,6 +29,8 @@ OrganizerProxy::OrganizerProxy(OrganizerCore* organizer,
       m_DownloadManagerProxy(
           std::make_unique<DownloadManagerProxy>(this, organizer->downloadManager())),
       m_ModListProxy(std::make_unique<ModListProxy>(this, organizer->modList())),
+      m_ExecutablesListProxy(
+          std::make_unique<ExecutablesListProxy>(organizer->executablesList())),
       m_PluginListProxy(
           std::make_unique<PluginListProxy>(this, organizer->pluginList())),
       m_GameFeaturesProxy(
@@ -363,6 +366,11 @@ MOBase::IPluginList* OrganizerProxy::pluginList() const
 MOBase::IModList* OrganizerProxy::modList() const
 {
   return m_ModListProxy.get();
+}
+
+MOBase::IExecutablesList* OrganizerProxy::executablesList() const
+{
+  return m_ExecutablesListProxy.get();
 }
 
 MOBase::IGameFeatures* OrganizerProxy::gameFeatures() const

--- a/src/organizerproxy.h
+++ b/src/organizerproxy.h
@@ -11,6 +11,7 @@
 class GameFeaturesProxy;
 class PluginContainer;
 class DownloadManagerProxy;
+class ExecutablesListProxy;
 class ModListProxy;
 class PluginListProxy;
 
@@ -65,6 +66,7 @@ public:  // IOrganizer interface
   MOBase::IDownloadManager* downloadManager() const override;
   MOBase::IPluginList* pluginList() const override;
   MOBase::IModList* modList() const override;
+  MOBase::IExecutablesList* executablesList() const override;
   std::shared_ptr<MOBase::IProfile> profile() const override;
   QStringList profileNames() const override;
   std::shared_ptr<const MOBase::IProfile>
@@ -157,6 +159,7 @@ private:
   std::unique_ptr<DownloadManagerProxy> m_DownloadManagerProxy;
   std::unique_ptr<ModListProxy> m_ModListProxy;
   std::unique_ptr<PluginListProxy> m_PluginListProxy;
+  std::unique_ptr<ExecutablesListProxy> m_ExecutablesListProxy;
   std::unique_ptr<GameFeaturesProxy> m_GameFeaturesProxy;
 };
 


### PR DESCRIPTION
This adds the executables list to the plugin API as requested in #1631. Requires https://github.com/ModOrganizer2/modorganizer-uibase/pull/179