### PR TITLE
Avoid potential recursion in IconDelegate::paint

### DIFF
--- a/src/icondelegate.cpp
+++ b/src/icondelegate.cpp
@@ -77,11 +77,6 @@ void IconDelegate::paintIcons(QPainter* painter, const QStyleOptionViewItem& opt
 void IconDelegate::paint(QPainter* painter, const QStyleOptionViewItem& option,
                          const QModelIndex& index) const
 {
-  if (auto* w = qobject_cast<QAbstractItemView*>(parent())) {
-    w->itemDelegate()->paint(painter, option, index);
-  } else {
-    QStyledItemDelegate::paint(painter, option, index);
-  }
-
+  QStyledItemDelegate::paint(painter, option, index);
   paintIcons(painter, option, index, getIcons(index));
 }


### PR DESCRIPTION
The delegate previously forwarded painting to view->itemDelegate(), which may resolve back to the same delegate and risks recursion or reliance on undocumented behavior. This change calls QStyledItemDelegate::paint() directly, which is the documented and canonical approach for default item painting in Qt, ensuring correctness and predictable behavior.