### PR TITLE
Add setting to show notifications when downloads complete or fail

### DIFF
--- a/src/downloadmanager.cpp
+++ b/src/downloadmanager.cpp
@@ -42,6 +42,7 @@ along with Mod Organizer.  If not, see <http://www.gnu.org/licenses/>.
 #include <QHttp2Configuration>
 #include <QInputDialog>
 #include <QMessageBox>
+#include <QSystemTrayIcon>
 #include <QTextDocument>
 #include <QTimer>
 
@@ -1403,7 +1404,11 @@ QString DownloadManager::getDisplayName(int index) const
   }
 
   DownloadInfo* info = m_ActiveDownloads.at(index);
+  return displayNameByInfo(info);
+}
 
+QString DownloadManager::displayNameByInfo(const DownloadInfo* info) const
+{
   QTextDocument doc;
   if (!info->m_FileInfo->name.isEmpty()) {
     doc.setHtml(info->m_FileInfo->name);
@@ -1817,6 +1822,11 @@ void DownloadManager::nxmDescriptionAvailable(QString, int, QVariant userData,
   info->m_FileInfo->modName = doc.toPlainText();
   if (info->m_FileInfo->fileID != 0) {
     setState(info, STATE_READY);
+    if (m_OrganizerCore->settings().interface().showDownloadNotifications()) {
+      m_OrganizerCore->showNotification(
+          tr("Download complete"),
+          tr("%1 is ready to be installed.").arg(displayNameByInfo(info)));
+    }
   } else {
     setState(info, STATE_FETCHINGFILEINFO);
   }
@@ -2392,6 +2402,12 @@ void DownloadManager::finishDownload(DownloadID id)
         emit showMessage(tr("Download failed: %1 (%2)")
                              .arg(reply->errorString())
                              .arg(reply->error()));
+        if (m_OrganizerCore->settings().interface().showDownloadNotifications()) {
+          m_OrganizerCore->showNotification(
+              tr("Download failed"),
+              tr("%1 failed to download.").arg(displayNameByInfo(info)),
+              QSystemTrayIcon::MessageIcon::Critical);
+        }
       }
       error = true;
       setState(info, STATE_ERROR);

--- a/src/downloadmanager.h
+++ b/src/downloadmanager.h
@@ -759,6 +759,8 @@ private:
 
   DownloadInfo* downloadInfoByID(DownloadID id);
 
+  QString displayNameByInfo(const DownloadInfo* info) const;
+
   void removePending(QString gameName, int modID, int fileID);
 
   /**

--- a/src/iuserinterface.h
+++ b/src/iuserinterface.h
@@ -4,6 +4,7 @@
 #include "modinfodialogfwd.h"
 #include <QMainWindow>
 #include <QMenu>
+#include <QSystemTrayIcon>
 #include <delayedfilewriter.h>
 #include <ipluginmodpage.h>
 #include <iplugintool.h>
@@ -27,6 +28,10 @@ public:
   virtual MOBase::DelayedFileWriterBase& archivesWriter() = 0;
 
   virtual QMainWindow* mainWindow() = 0;
+
+  virtual void showNotification(const QString& title, const QString& message,
+                                QSystemTrayIcon::MessageIcon icon =
+                                    QSystemTrayIcon::MessageIcon::Information) = 0;
 };
 
 #endif  // IUSERINTERFACE_H

--- a/src/mainwindow.cpp
+++ b/src/mainwindow.cpp
@@ -142,6 +142,7 @@ along with Mod Organizer.  If not, see <http://www.gnu.org/licenses/>.
 #include <QShortcut>
 #include <QSize>
 #include <QSizePolicy>
+#include <QSystemTrayIcon>
 #include <QTime>
 #include <QTimer>
 #include <QToolButton>
@@ -2264,6 +2265,12 @@ void MainWindow::storeSettings()
 QMainWindow* MainWindow::mainWindow()
 {
   return this;
+}
+
+void MainWindow::showNotification(const QString& title, const QString& message,
+                                  QSystemTrayIcon::MessageIcon icon)
+{
+  m_SystemTrayManager->showNotification(title, message, icon);
 }
 
 void MainWindow::on_tabWidget_currentChanged(int index)

--- a/src/mainwindow.h
+++ b/src/mainwindow.h
@@ -78,6 +78,7 @@ class DirectoryEntry;
 #include <QProcess>
 #include <QString>
 #include <QStringList>
+#include <QSystemTrayIcon>
 #include <QTime>
 #include <QTimer>
 #include <QVariant>
@@ -155,6 +156,10 @@ public:
   {
     return m_ArchiveListWriter;
   }
+
+  void showNotification(const QString& title, const QString& message,
+                        QSystemTrayIcon::MessageIcon icon =
+                            QSystemTrayIcon::MessageIcon::Information) override;
 
 public slots:
   void refresherProgress(const DirectoryRefreshProgress* p);

--- a/src/organizercore.cpp
+++ b/src/organizercore.cpp
@@ -46,6 +46,7 @@
 #include <QMessageBox>
 #include <QNetworkInterface>
 #include <QProcess>
+#include <QSystemTrayIcon>
 #include <QTimer>
 #include <QUrl>
 #include <QWidget>
@@ -537,6 +538,14 @@ std::wstring OrganizerCore::getGlobalCoreDumpPath()
   }
 
   return {};
+}
+
+void OrganizerCore::showNotification(const QString& message, const QString& title,
+                                     QSystemTrayIcon::MessageIcon icon)
+{
+  if (m_UserInterface) {
+    m_UserInterface->showNotification(message, title, icon);
+  }
 }
 
 void OrganizerCore::setCurrentProfile(const QString& profileName)

--- a/src/organizercore.h
+++ b/src/organizercore.h
@@ -8,6 +8,7 @@
 #include <QSettings>
 #include <QString>
 #include <QStringList>
+#include <QSystemTrayIcon>
 #include <QThread>
 #include <QVariant>
 
@@ -359,6 +360,10 @@ public:
   static env::CoreDumpTypes getGlobalCoreDumpType();
   static void setGlobalCoreDumpType(env::CoreDumpTypes type);
   static std::wstring getGlobalCoreDumpPath();
+
+  void showNotification(
+      const QString& title, const QString& message,
+      QSystemTrayIcon::MessageIcon icon = QSystemTrayIcon::MessageIcon::Information);
 
 public:
   MOBase::IModRepositoryBridge* createNexusBridge() const;

--- a/src/settings.cpp
+++ b/src/settings.cpp
@@ -2300,6 +2300,16 @@ void InterfaceSettings::setHideDownloadsAfterInstallation(bool b)
   set(m_Settings, "Settings", "autohide_downloads", b);
 }
 
+bool InterfaceSettings::showDownloadNotifications() const
+{
+  return get<bool>(m_Settings, "Settings", "download_notifications", false);
+}
+
+void InterfaceSettings::setShowDownloadNotifications(bool b)
+{
+  set(m_Settings, "Settings", "download_notifications", b);
+}
+
 bool InterfaceSettings::hideAPICounter() const
 {
   return get<bool>(m_Settings, "Settings", "hide_api_counter", false);

--- a/src/settings.h
+++ b/src/settings.h
@@ -653,6 +653,11 @@ public:
   bool hideDownloadsAfterInstallation() const;
   void setHideDownloadsAfterInstallation(bool b);
 
+  // whether to show notifications when downloads complete or fail
+  //
+  bool showDownloadNotifications() const;
+  void setShowDownloadNotifications(bool b);
+
   // whether the API counter should be hidden
   //
   bool hideAPICounter() const;

--- a/src/settingsdialog.ui
+++ b/src/settingsdialog.ui
@@ -166,6 +166,19 @@
                 </property>
                </widget>
               </item>
+              <item>
+               <widget class="QCheckBox" name="showDownloadNotificationsBox">
+                <property name="toolTip">
+                 <string>Show notifications when downloads complete or fail.</string>
+                </property>
+                <property name="whatsThis">
+                 <string>Show notifications when downloads complete or fail.</string>
+                </property>
+                <property name="text">
+                 <string>Show notifications for completed or failed downloads</string>
+                </property>
+               </widget>
+              </item>
               <item alignment="Qt::AlignmentFlag::AlignLeft">
                <widget class="QPushButton" name="associateModlButton">
                 <property name="maximumSize">
@@ -191,10 +204,10 @@
               <item>
                <widget class="QCheckBox" name="checkForUpdates">
                 <property name="toolTip">
-                 <string>Check for Mod Organizer updates on Github on startup.</string>
+                 <string>Check for Mod Organizer updates on GitHub on startup.</string>
                 </property>
                 <property name="whatsThis">
-                 <string>Check for Mod Organizer updates on Github on startup.</string>
+                 <string>Check for Mod Organizer updates on GitHub on startup.</string>
                 </property>
                 <property name="text">
                  <string>Check for updates</string>

--- a/src/settingsdialoggeneral.cpp
+++ b/src/settingsdialoggeneral.cpp
@@ -20,6 +20,8 @@ GeneralSettingsTab::GeneralSettingsTab(Settings& s, SettingsDialog& d)
   ui->showMetaBox->setChecked(settings().interface().metaDownloads());
   ui->hideDownloadInstallBox->setChecked(
       settings().interface().hideDownloadsAfterInstallation());
+  ui->showDownloadNotificationsBox->setChecked(
+      settings().interface().showDownloadNotifications());
 
   // connect MODL button
   QObject::connect(ui->associateModlButton, &QPushButton::clicked, [&] {
@@ -69,6 +71,8 @@ void GeneralSettingsTab::update()
   settings().interface().setMetaDownloads(ui->showMetaBox->isChecked());
   settings().interface().setHideDownloadsAfterInstallation(
       ui->hideDownloadInstallBox->isChecked());
+  settings().interface().setShowDownloadNotifications(
+      ui->showDownloadNotificationsBox->isChecked());
 
   // updates
   settings().setCheckForUpdates(ui->checkForUpdates->isChecked());

--- a/src/systemtraymanager.cpp
+++ b/src/systemtraymanager.cpp
@@ -66,9 +66,8 @@ void SystemTrayManager::restoreFromSystemTray()
   }
 }
 
-void SystemTrayManager::showNotification(
-    const QString& title, const QString& message,
-    QSystemTrayIcon::MessageIcon icon)
+void SystemTrayManager::showNotification(const QString& title, const QString& message,
+                                         QSystemTrayIcon::MessageIcon icon)
 {
   m_SystemTrayIcon->showMessage(title, message, icon);
 }

--- a/src/systemtraymanager.cpp
+++ b/src/systemtraymanager.cpp
@@ -24,6 +24,7 @@ along with Mod Organizer.  If not, see <http://www.gnu.org/licenses/>.
 #include <QIcon>
 #include <QMainWindow>
 #include <QMenu>
+#include <QString>
 #include <QSystemTrayIcon>
 
 SystemTrayManager::SystemTrayManager(QMainWindow* parent, QDockWidget* logDock)
@@ -42,11 +43,11 @@ SystemTrayManager::SystemTrayManager(QMainWindow* parent, QDockWidget* logDock)
   trayMenu->addAction(exitAction);
 
   m_SystemTrayIcon->setContextMenu(trayMenu);
+  m_SystemTrayIcon->show();
 }
 
 void SystemTrayManager::minimizeToSystemTray()
 {
-  m_SystemTrayIcon->show();
   m_Parent->hide();
 
   if (m_LogDock->isFloating() && m_LogDock->isVisible()) {
@@ -56,8 +57,6 @@ void SystemTrayManager::minimizeToSystemTray()
 
 void SystemTrayManager::restoreFromSystemTray()
 {
-  m_SystemTrayIcon->hide();
-
   m_Parent->showNormal();
   m_Parent->raise();
   m_Parent->activateWindow();
@@ -65,6 +64,13 @@ void SystemTrayManager::restoreFromSystemTray()
   if (m_LogDock->isFloating() && m_LogDock->isHidden()) {
     m_LogDock->show();
   }
+}
+
+void SystemTrayManager::showNotification(
+    const QString& title, const QString& message,
+    QSystemTrayIcon::MessageIcon icon)
+{
+  m_SystemTrayIcon->showMessage(title, message, icon);
 }
 
 void SystemTrayManager::on_systemTrayIcon_activated(

--- a/src/systemtraymanager.h
+++ b/src/systemtraymanager.h
@@ -21,8 +21,10 @@ along with Mod Organizer.  If not, see <http://www.gnu.org/licenses/>.
 #define SYSTEMTRAYMANAGER_H
 
 #include <QDockWidget>
+#include <QIcon>
 #include <QMainWindow>
 #include <QObject>
+#include <QString>
 #include <QSystemTrayIcon>
 
 class SystemTrayManager : public QObject
@@ -34,6 +36,10 @@ public:
 
   void minimizeToSystemTray();
   void restoreFromSystemTray();
+
+  void showNotification(
+      const QString& title, const QString& message,
+      QSystemTrayIcon::MessageIcon icon = QSystemTrayIcon::MessageIcon::Information);
 
 private:
   QMainWindow* m_Parent;


### PR DESCRIPTION
Closes #2045

Because showing notifications using `QSystemTrayIcon::showMessage` requires the tray icon to be visible, I changed the tray icon behavior to always show while Mod Organizer is running, instead of only while an executable with the "minimize to tray" option is running. I think it's okay to do it that way, since many other programs (especially game launchers like Steam, Epic, GOG, etc.) work like that as well.