### PR TITLE
Remove "Categories: " tooltips when there are no categories

### DIFF
--- a/src/modinforegular.cpp
+++ b/src/modinforegular.cpp
@@ -744,6 +744,10 @@ QString ModInfoRegular::getDescription() const
         .arg(name());
   } else {
     const std::set<int>& categories = getCategories();
+    if (categories.empty()) {
+      return QString();
+    }
+
     std::wostringstream categoryString;
     categoryString << ToWString(tr("Categories: <br>"));
     CategoryFactory& categoryFactory = CategoryFactory::instance();

--- a/src/modlist.cpp
+++ b/src/modlist.cpp
@@ -449,6 +449,10 @@ QVariant ModList::data(const QModelIndex& modelIndex, int role) const
       return text;
     } else if (column == COL_CATEGORY) {
       const std::set<int>& categories = modInfo->getCategories();
+      if (categories.empty()) {
+        return QString();
+      }
+
       std::wostringstream categoryString;
       categoryString << ToWString(tr("Categories: <br>"));
       CategoryFactory& categoryFactory = CategoryFactory::instance();


### PR DESCRIPTION
Hovering over a mod without categories inside the name or categories column would still show a tooltip with the text "Categories: " followed by an empty line. This PR fixes that, and should address #1929 for the most part (I'm not sure it would be worth adding a setting to disable the tooltips altogether).