### PR TITLE
Make command-line arguments -i "" launch the portable instance

### DIFF
--- a/src/commandline.cpp
+++ b/src/commandline.cpp
@@ -10,6 +10,8 @@
 #include <log.h>
 #include <report.h>
 
+#include <boost/optional/optional_io.hpp>
+
 namespace cl
 {
 
@@ -221,8 +223,12 @@ std::optional<int> CommandLine::runEarly()
 
 std::optional<int> CommandLine::runPostApplication(MOApplication& a)
 {
-  // handle -i with no arguments
-  if (m_vm.count("instance") && m_vm["instance"].as<std::string>() == "") {
+  const auto instanceArg = m_vm.find("instance");
+  if (instanceArg != m_vm.end() &&
+      !instanceArg->second.as<boost::optional<std::string>>().has_value()) {
+
+    // handle -i with no arguments (distinct from -i "", which will launch the
+    // portable instance if it exists, hence the use of boost::optional)
     env::Console c;
 
     if (auto i = InstanceManager::singleton().currentInstance()) {
@@ -314,7 +320,9 @@ void CommandLine::createOptions()
 
               ("logs", "duplicates the logs to stdout")
 
-                  ("instance,i", po::value<std::string>()->implicit_value(""),
+                  ("instance,i",
+                   po::value<boost::optional<std::string>>()->implicit_value(
+                       boost::none),
                    "use the given instance (defaults to last used)")
 
                       ("profile,p", po::value<std::string>(),
@@ -402,8 +410,14 @@ std::optional<QString> CommandLine::instance() const
 
   if (m_shortcut.isValid() && m_shortcut.hasInstance()) {
     return m_shortcut.instanceName();
-  } else if (m_vm.count("instance")) {
-    return QString::fromStdString(m_vm["instance"].as<std::string>());
+  } else {
+    const auto instanceArg = m_vm.find("instance");
+    if (instanceArg != m_vm.end()) {
+      const auto& instanceVal = instanceArg->second.as<boost::optional<std::string>>();
+      if (instanceVal.has_value()) {
+        return QString::fromStdString(instanceVal.value());
+      }
+    }
   }
 
   return {};

--- a/src/instancemanager.cpp
+++ b/src/instancemanager.cpp
@@ -566,6 +566,10 @@ std::shared_ptr<Instance> InstanceManager::currentInstance() const
       // no instance set
       return {};
     }
+  } else if (name.compare("portable", Qt::CaseInsensitive) == 0 &&
+             portableInstanceExists()) {
+    // use portable
+    return std::make_shared<Instance>(portablePath(), true, profile);
   }
 
   return std::make_shared<Instance>(instancePath(name), false, profile);

--- a/src/instancemanager.cpp
+++ b/src/instancemanager.cpp
@@ -566,10 +566,6 @@ std::shared_ptr<Instance> InstanceManager::currentInstance() const
       // no instance set
       return {};
     }
-  } else if (name.compare("portable", Qt::CaseInsensitive) == 0 &&
-             portableInstanceExists()) {
-    // use portable
-    return std::make_shared<Instance>(portablePath(), true, profile);
   }
 
   return std::make_shared<Instance>(instancePath(name), false, profile);


### PR DESCRIPTION
Closes #1633

The check for `-i` with no arguments doesn't distinguish between `-i ""` or just `-i`:
https://github.com/ModOrganizer2/modorganizer/blob/2043d9931cb9baf1eef23240ea6061fc40fee67d/src/commandline.cpp#L224-L225
~So if we want `-i ""` to also launch the portable instance, we need to find another way to distinguish between those cases. I don't think we really need that though.~

I changed it to use `boost::optional` so we can distinguish between those cases now. @Al12rs didn't like using `-i "Portable"`, since there could be a global instance named "Portable".