### PR TITLE
Fix DownloadManager and a few code improvements

### DIFF
--- a/src/activatemodsdialog.cpp
+++ b/src/activatemodsdialog.cpp
@@ -48,7 +48,7 @@ ActivateModsDialog::ActivateModsDialog(SaveGameInfo::MissingAssets const& missin
   for (SaveGameInfo::MissingAssets::const_iterator espIter = missingAssets.begin();
        espIter != missingAssets.end(); ++espIter, ++row) {
     modsTable->setCellWidget(row, 0, new QLabel(espIter.key()));
-    if (espIter->size() == 0) {
+    if (espIter->isEmpty()) {
       modsTable->setCellWidget(row, 1, new QLabel(tr("not found")));
     } else {
       QComboBox* combo = new QComboBox();

--- a/src/archivefiletree.cpp
+++ b/src/archivefiletree.cpp
@@ -65,7 +65,7 @@ public
     :  // Public for make_shared (but not accessible by other since not exposed in .h):
   ArchiveFileTreeImpl(std::shared_ptr<const IFileTree> parent, QString name, int index,
                       std::vector<File> files)
-      : FileTreeEntry(parent, name), ArchiveFileEntry(parent, name, index), IFileTree(),
+      : FileTreeEntry(parent, name), IFileTree(), ArchiveFileEntry(parent, name, index),
         m_Files(std::move(files))
   {}
 

--- a/src/archivefiletree.h
+++ b/src/archivefiletree.h
@@ -17,8 +17,8 @@ You should have received a copy of the GNU General Public License
 along with Mod Organizer.  If not, see <http://www.gnu.org/licenses/>.
 */
 
-#ifndef ARCHIVEFILENETRY_H
-#define ARCHIVEFILENTRY_H
+#ifndef ARCHIVEFILETREE_H
+#define ARCHIVEFILETREE_H
 
 #include <archive/archive.h>
 #include <uibase/ifiletree.h>

--- a/src/categories.cpp
+++ b/src/categories.cpp
@@ -253,8 +253,7 @@ int CategoryFactory::addCategory(const QString& name,
 void CategoryFactory::addCategory(int id, const QString& name, int parentID)
 {
   int index = static_cast<int>(m_Categories.size());
-  m_Categories.emplace_back(
-      index, id, name, parentID, std::vector<NexusCategory>());
+  m_Categories.emplace_back(index, id, name, parentID, std::vector<NexusCategory>());
   m_IDMap[id] = index;
 }
 

--- a/src/categories.cpp
+++ b/src/categories.cpp
@@ -76,7 +76,7 @@ void CategoryFactory::loadCategories()
             if (!ok) {
               log::error(tr("invalid category id {0}"), iter->constData());
             }
-            nexusCats.push_back(NexusCategory("Unknown", temp));
+            nexusCats.emplace_back("Unknown", temp);
           }
         }
         bool cell0Ok = true;
@@ -224,8 +224,8 @@ void CategoryFactory::saveCategories()
   emit categoriesSaved();
 }
 
-unsigned int
-CategoryFactory::countCategories(std::function<bool(const Category& category)> filter)
+template <std::predicate<const CategoryFactory::Category&> Filter>
+unsigned int CategoryFactory::countCategories(Filter filter)
 {
   unsigned int result = 0;
   for (const Category& cat : m_Categories) {
@@ -241,7 +241,7 @@ int CategoryFactory::addCategory(const QString& name,
                                  int parentID)
 {
   int id = 1;
-  while (m_IDMap.find(id) != m_IDMap.end()) {
+  while (m_IDMap.contains(id)) {
     ++id;
   }
   addCategory(id, name, nexusCats, parentID);
@@ -253,8 +253,8 @@ int CategoryFactory::addCategory(const QString& name,
 void CategoryFactory::addCategory(int id, const QString& name, int parentID)
 {
   int index = static_cast<int>(m_Categories.size());
-  m_Categories.push_back(
-      Category(index, id, name, parentID, std::vector<NexusCategory>()));
+  m_Categories.emplace_back(
+      index, id, name, parentID, std::vector<NexusCategory>());
   m_IDMap[id] = index;
 }
 
@@ -267,7 +267,7 @@ void CategoryFactory::addCategory(int id, const QString& name,
     m_NexusMap.at(nexusCat.ID()).setCategoryID(id);
   }
   int index = static_cast<int>(m_Categories.size());
-  m_Categories.push_back(Category(index, id, name, parentID, nexusCats));
+  m_Categories.emplace_back(index, id, name, parentID, nexusCats);
   m_IDMap[id] = index;
 }
 
@@ -275,7 +275,7 @@ void CategoryFactory::setNexusCategories(
     const std::vector<CategoryFactory::NexusCategory>& nexusCats)
 {
   for (const auto& nexusCat : nexusCats) {
-    m_NexusMap.emplace(nexusCat.ID(), nexusCat);
+    m_NexusMap.try_emplace(nexusCat.ID(), nexusCat);
   }
 
   saveCategories();
@@ -360,7 +360,7 @@ int CategoryFactory::getParentID(unsigned int index) const
 
 bool CategoryFactory::categoryExists(int id) const
 {
-  return m_IDMap.find(id) != m_IDMap.end();
+  return m_IDMap.contains(id);
 }
 
 bool CategoryFactory::isDescendantOf(int id, int parentID) const
@@ -508,7 +508,7 @@ unsigned int CategoryFactory::resolveNexusID(int nexusID) const
 {
   auto result = m_NexusMap.find(nexusID);
   if (result != m_NexusMap.end()) {
-    if (m_IDMap.count(result->second.categoryID())) {
+    if (m_IDMap.contains(result->second.categoryID())) {
       log::debug(tr("nexus category id {0} maps to internal {1}"), nexusID,
                  m_IDMap.at(result->second.categoryID()));
       return m_IDMap.at(result->second.categoryID());

--- a/src/categories.h
+++ b/src/categories.h
@@ -151,8 +151,7 @@ public:
    * @param filter the filter to test
    * @return number of matching categories
    */
-  //unsigned int countCategories(const std::function<bool(const Category& category)> &filter);
-  template <std::predicate < const CategoryFactory::Category& > Filter >
+  template <std::predicate<const CategoryFactory::Category&> Filter>
   unsigned int countCategories(Filter filter);
 
   /**

--- a/src/categories.h
+++ b/src/categories.h
@@ -151,7 +151,9 @@ public:
    * @param filter the filter to test
    * @return number of matching categories
    */
-  unsigned int countCategories(std::function<bool(const Category& category)> filter);
+  //unsigned int countCategories(const std::function<bool(const Category& category)> &filter);
+  template <std::predicate < const CategoryFactory::Category& > Filter >
+  unsigned int countCategories(Filter filter);
 
   /**
    * @brief get the id of the parent category

--- a/src/categoriesdialog.cpp
+++ b/src/categoriesdialog.cpp
@@ -158,8 +158,8 @@ void CategoriesDialog::commitChanges()
       nexusData = ui->categoriesTable->item(index, 3)->data(Qt::UserRole).toList();
     std::vector<CategoryFactory::NexusCategory> nexusCats;
     for (const auto& nexusCat : nexusData) {
-      nexusCats.emplace_back(
-          nexusCat.toList()[0].toString(), nexusCat.toList()[1].toInt());
+      nexusCats.emplace_back(nexusCat.toList()[0].toString(),
+                             nexusCat.toList()[1].toInt());
     }
 
     categories.addCategory(ui->categoriesTable->item(index, 0)->text().toInt(),

--- a/src/categoriesdialog.cpp
+++ b/src/categoriesdialog.cpp
@@ -40,7 +40,7 @@ public:
     if (intRes == Acceptable) {
       bool ok = false;
       int id  = input.toInt(&ok);
-      if (m_UsedIDs.find(id) != m_UsedIDs.end()) {
+      if (m_UsedIDs.contains(id)) {
         return QValidator::Intermediate;
       }
     }
@@ -61,7 +61,7 @@ public:
     if (intRes == Acceptable) {
       bool ok = false;
       int id  = input.toInt(&ok);
-      if ((id == 0) || (m_UsedIDs.find(id) != m_UsedIDs.end())) {
+      if ((id == 0) || (m_UsedIDs.contains(id))) {
         return QValidator::Acceptable;
       } else {
         return QValidator::Intermediate;
@@ -157,9 +157,9 @@ void CategoriesDialog::commitChanges()
     if (ui->categoriesTable->item(index, 3) != nullptr)
       nexusData = ui->categoriesTable->item(index, 3)->data(Qt::UserRole).toList();
     std::vector<CategoryFactory::NexusCategory> nexusCats;
-    for (auto nexusCat : nexusData) {
-      nexusCats.push_back(CategoryFactory::NexusCategory(
-          nexusCat.toList()[0].toString(), nexusCat.toList()[1].toInt()));
+    for (const auto& nexusCat : nexusData) {
+      nexusCats.emplace_back(
+          nexusCat.toList()[0].toString(), nexusCat.toList()[1].toInt());
     }
 
     categories.addCategory(ui->categoriesTable->item(index, 0)->text().toInt(),
@@ -171,9 +171,9 @@ void CategoriesDialog::commitChanges()
 
   std::vector<CategoryFactory::NexusCategory> nexusCats;
   for (int i = 0; i < ui->nexusCategoryList->count(); ++i) {
-    nexusCats.push_back(CategoryFactory::NexusCategory(
+    nexusCats.emplace_back(
         ui->nexusCategoryList->item(i)->data(Qt::DisplayRole).toString(),
-        ui->nexusCategoryList->item(i)->data(Qt::UserRole).toInt()));
+        ui->nexusCategoryList->item(i)->data(Qt::UserRole).toInt());
   }
 
   categories.setNexusCategories(nexusCats);
@@ -250,7 +250,7 @@ void CategoriesDialog::fillTable()
       newData.append(nexusCat.second.ID());
       itemData.insert(itemData.length(), newData);
       QStringList names;
-      for (auto cat : itemData) {
+      for (const auto& cat : itemData) {
         names.append(cat.toList()[0].toString());
       }
       item->setData(Qt::UserRole, itemData);

--- a/src/categoriestable.cpp
+++ b/src/categoriestable.cpp
@@ -46,13 +46,13 @@ bool CategoriesTable::dropMimeData(int row, int column, const QMimeData* data,
       if (item->column() != 3)
         continue;
       QVariantList newData;
-      for (auto nexData : item->data(Qt::UserRole).toList()) {
+      for (const auto& nexData : item->data(Qt::UserRole).toList()) {
         if (nexData.toList()[1].toInt() != roleDataMap.value(Qt::UserRole)) {
           newData.insert(newData.length(), nexData);
         }
       }
       QStringList names;
-      for (auto nexData : newData) {
+      for (const auto& nexData : newData) {
         names.append(nexData.toList()[0].toString());
       }
       item->setData(Qt::DisplayRole, names.join(", "));
@@ -66,7 +66,7 @@ bool CategoriesTable::dropMimeData(int row, int column, const QMimeData* data,
     newData.append(roleDataMap.value(Qt::UserRole).toInt());
     itemData.insert(itemData.length(), newData);
     QStringList names;
-    for (auto cat : itemData) {
+    for (const auto& cat : itemData) {
       names.append(cat.toList()[0].toString());
     }
     nexusItem->setData(Qt::UserRole, itemData);

--- a/src/colortable.cpp
+++ b/src/colortable.cpp
@@ -187,7 +187,7 @@ ColorTable::ColorTable(QWidget* parent) : QTableWidget(parent), m_settings(nullp
   setItemDelegateForColumn(2, new FakeModConflictIconDelegate(this));
   setItemDelegateForColumn(3, new FakeModFlagIconDelegate(this));
 
-  connect(this, &QTableWidget::cellActivated, [&] {
+  connect(this, &QTableWidget::cellActivated, [this] {
     onColorActivated();
   });
 }
@@ -264,7 +264,7 @@ void ColorTable::resetColors()
 {
   bool changed = false;
 
-  forEachColorItem(this, [&](auto* item) {
+  forEachColorItem(this, [&changed](auto* item) {
     if (item->reset()) {
       changed = true;
     }

--- a/src/commandline.cpp
+++ b/src/commandline.cpp
@@ -591,7 +591,7 @@ std::optional<int> CrashDumpCommand::runEarly()
   env::Console console;
 
   const auto& typeString = vm()["type"].as<std::string>();
-  const auto type       = env::coreDumpTypeFromString(typeString);
+  const auto type        = env::coreDumpTypeFromString(typeString);
 
   // dump
   const auto b = env::coredumpOther(type);

--- a/src/commandline.cpp
+++ b/src/commandline.cpp
@@ -360,7 +360,7 @@ std::string CommandLine::usage(const Command* c) const
         continue;
       }
 
-      v.push_back({c->name(), c->description()});
+      v.emplace_back(c->name(), c->description());
     }
 
     oss << table(v, 2, 4) << "\n"
@@ -590,7 +590,7 @@ std::optional<int> CrashDumpCommand::runEarly()
 {
   env::Console console;
 
-  const auto typeString = vm()["type"].as<std::string>();
+  const auto& typeString = vm()["type"].as<std::string>();
   const auto type       = env::coreDumpTypeFromString(typeString);
 
   // dump
@@ -671,9 +671,9 @@ LaunchCommand::UntouchedCommandLineArguments(int parseArgCount,
     if (*cmd == ' ') {
       if (arg)
         if (cmd - 1 > arg && *arg == '"' && *(cmd - 1) == '"')
-          parsedArgs.push_back(std::wstring(arg + 1, cmd - 1));
+          parsedArgs.emplace_back(arg + 1, cmd - 1);
         else
-          parsedArgs.push_back(std::wstring(arg, cmd));
+          parsedArgs.emplace_back(arg, cmd);
       arg = cmd + 1;
       --parseArgCount;
     }

--- a/src/createinstancedialog.cpp
+++ b/src/createinstancedialog.cpp
@@ -133,23 +133,23 @@ CreateInstanceDialog::CreateInstanceDialog(const PluginContainer& pc, Settings* 
 
   addShortcutAction(QKeySequence::Find, Actions::Find);
 
-  addShortcut(Qt::ALT + Qt::Key_Left, [&] {
+  addShortcut(Qt::ALT + Qt::Key_Left, [this] {
     back();
   });
-  addShortcut(Qt::ALT + Qt::Key_Right, [&] {
+  addShortcut(Qt::ALT + Qt::Key_Right, [this] {
     next(false);
   });
-  addShortcut(Qt::CTRL + Qt::Key_Return, [&] {
+  addShortcut(Qt::CTRL + Qt::Key_Return, [this] {
     next();
   });
 
-  connect(ui->next, &QPushButton::clicked, [&] {
+  connect(ui->next, &QPushButton::clicked, [this] {
     next();
   });
-  connect(ui->back, &QPushButton::clicked, [&] {
+  connect(ui->back, &QPushButton::clicked, [this] {
     back();
   });
-  connect(ui->cancel, &QPushButton::clicked, [&] {
+  connect(ui->cancel, &QPushButton::clicked, [this] {
     reject();
   });
 }

--- a/src/createinstancedialogpages.cpp
+++ b/src/createinstancedialogpages.cpp
@@ -836,8 +836,8 @@ void VariantsPage::fillList()
 }
 
 NamePage::NamePage(CreateInstanceDialog& dlg)
-    : Page(dlg), m_label(ui->instanceNameLabel), m_exists(ui->instanceNameExists), m_invalid(ui->instanceNameInvalid),
-      m_modified(false), m_okay(false)
+    : Page(dlg), m_label(ui->instanceNameLabel), m_exists(ui->instanceNameExists),
+      m_invalid(ui->instanceNameInvalid), m_modified(false), m_okay(false)
 {
   QObject::connect(ui->instanceName, &QLineEdit::textEdited, [this] {
     onChanged();

--- a/src/createinstancedialogpages.cpp
+++ b/src/createinstancedialogpages.cpp
@@ -152,7 +152,7 @@ CreateInstanceDialog::ProfileSettings Page::profileSettings() const
 IntroPage::IntroPage(CreateInstanceDialog& dlg)
     : Page(dlg), m_skip(GlobalSettings::hideCreateInstanceIntro())
 {
-  QObject::connect(ui->hideIntro, &QCheckBox::toggled, [&] {
+  QObject::connect(ui->hideIntro, &QCheckBox::toggled, [this] {
     GlobalSettings::setHideCreateInstanceIntro(ui->hideIntro->isChecked());
   });
 }
@@ -181,11 +181,11 @@ TypePage::TypePage(CreateInstanceDialog& dlg)
     ui->portableExistsLabel->setVisible(false);
   }
 
-  QObject::connect(ui->createGlobal, &QAbstractButton::clicked, [&] {
+  QObject::connect(ui->createGlobal, &QAbstractButton::clicked, [this] {
     global();
   });
 
-  QObject::connect(ui->createPortable, &QAbstractButton::clicked, [&] {
+  QObject::connect(ui->createPortable, &QAbstractButton::clicked, [this] {
     portable();
   });
 }
@@ -241,10 +241,10 @@ GamePage::GamePage(CreateInstanceDialog& dlg) : Page(dlg), m_selection(nullptr)
 
   m_filter.setEdit(ui->gamesFilter);
 
-  QObject::connect(&m_filter, &FilterWidget::changed, [&] {
+  QObject::connect(&m_filter, &FilterWidget::changed, [this] {
     fillList();
   });
-  QObject::connect(ui->showAllGames, &QCheckBox::clicked, [&] {
+  QObject::connect(ui->showAllGames, &QCheckBox::clicked, [this] {
     fillList();
   });
 }
@@ -550,7 +550,7 @@ QCommandLinkButton* GamePage::createCustomButton()
   b->setText(QObject::tr("Browse..."));
   b->setDescription(QObject::tr("The folder must contain a valid game installation"));
 
-  QObject::connect(b, &QAbstractButton::clicked, [&] {
+  QObject::connect(b, &QAbstractButton::clicked, [this] {
     selectCustom();
   });
 
@@ -839,11 +839,11 @@ NamePage::NamePage(CreateInstanceDialog& dlg)
     : Page(dlg), m_label(ui->instanceNameLabel), m_exists(ui->instanceNameExists), m_invalid(ui->instanceNameInvalid),
       m_modified(false), m_okay(false)
 {
-  QObject::connect(ui->instanceName, &QLineEdit::textEdited, [&] {
+  QObject::connect(ui->instanceName, &QLineEdit::textEdited, [this] {
     onChanged();
   });
 
-  QObject::connect(ui->instanceName, &QLineEdit::returnPressed, [&] {
+  QObject::connect(ui->instanceName, &QLineEdit::returnPressed, [this] {
     next();
   });
 }
@@ -964,10 +964,10 @@ PathsPage::PathsPage(CreateInstanceDialog& dlg)
       m_advancedInvalid(ui->advancedDirInvalid), m_okay(false)
 {
   auto setEdit = [&](QLineEdit* e) {
-    QObject::connect(e, &QLineEdit::textEdited, [&] {
+    QObject::connect(e, &QLineEdit::textEdited, [this] {
       onChanged();
     });
-    QObject::connect(e, &QLineEdit::returnPressed, [&] {
+    QObject::connect(e, &QLineEdit::returnPressed, [this] {
       next();
     });
   };
@@ -992,7 +992,7 @@ PathsPage::PathsPage(CreateInstanceDialog& dlg)
   setBrowse(ui->browseProfiles, ui->profiles);
   setBrowse(ui->browseOverwrite, ui->overwrite);
 
-  QObject::connect(ui->advancedPathOptions, &QCheckBox::clicked, [&] {
+  QObject::connect(ui->advancedPathOptions, &QCheckBox::clicked, [this] {
     onAdvanced();
   });
 

--- a/src/createinstancedialogpages.cpp
+++ b/src/createinstancedialogpages.cpp
@@ -361,7 +361,7 @@ void GamePage::selectCustom()
   }
 
   // try to find a plugin that likes this directory
-  for (auto& g : m_games) {
+  for (const auto& g : m_games) {
     if (g->game->looksValid(path)) {
       // found one
       g->dir       = path;
@@ -388,7 +388,7 @@ void GamePage::warnUnrecognized(const QString& path)
 {
   // put the list of supported games in the details textbox
   QString supportedGames;
-  for (auto* game : sortedGamePlugins()) {
+  for (const auto* game : sortedGamePlugins()) {
     supportedGames += game->displayGameName() + "\n";
   }
 
@@ -433,9 +433,9 @@ void GamePage::createGames()
   }
 }
 
-GamePage::Game* GamePage::findGame(IPluginGame* game)
+GamePage::Game* GamePage::findGame(const IPluginGame* game)
 {
-  for (auto& g : m_games) {
+  for (const auto& g : m_games) {
     if (g->game == game) {
       return g.get();
     }
@@ -537,7 +537,7 @@ void GamePage::clearButtons()
 
   ui->games->setUpdatesEnabled(true);
 
-  for (auto& g : m_games) {
+  for (const auto& g : m_games) {
     // all buttons have been deleted
     g->button = nullptr;
   }
@@ -565,7 +565,7 @@ void GamePage::fillList()
 
   Game* firstButton = nullptr;
 
-  for (auto& g : m_games) {
+  for (const auto& g : m_games) {
     if (!showAll && !g->installed) {
       // not installed
       continue;
@@ -622,7 +622,7 @@ GamePage::Game* GamePage::checkInstallation(const QString& path, Game* g)
 
   if (otherGame) {
     // an alternative was found, ask the user about it
-    auto* confirmedGame = confirmOtherGame(path, g->game, otherGame);
+    const auto* confirmedGame = confirmOtherGame(path, g->game, otherGame);
 
     if (!confirmedGame) {
       // cancelled
@@ -751,7 +751,7 @@ bool VariantsPage::ready() const
 
 bool VariantsPage::doSkip() const
 {
-  auto* g = m_dlg.rawCreationInfo().game;
+  const auto* g = m_dlg.rawCreationInfo().game;
   if (!g) {
     // shouldn't happen
     return true;
@@ -811,14 +811,14 @@ void VariantsPage::fillList()
   ui->editions->clear();
   m_buttons.clear();
 
-  auto* g = m_dlg.rawCreationInfo().game;
+  const auto* g = m_dlg.rawCreationInfo().game;
   if (!g) {
     // shouldn't happen
     return;
   }
 
   // for each variant, create a checkable button and add it
-  for (auto& v : g->gameVariants()) {
+  for (const auto& v : g->gameVariants()) {
     auto* b = new QCommandLinkButton(v);
     b->setCheckable(true);
 
@@ -836,8 +836,8 @@ void VariantsPage::fillList()
 }
 
 NamePage::NamePage(CreateInstanceDialog& dlg)
-    : Page(dlg), m_modified(false), m_okay(false), m_label(ui->instanceNameLabel),
-      m_exists(ui->instanceNameExists), m_invalid(ui->instanceNameInvalid)
+    : Page(dlg), m_label(ui->instanceNameLabel), m_exists(ui->instanceNameExists), m_invalid(ui->instanceNameInvalid),
+      m_modified(false), m_okay(false)
 {
   QObject::connect(ui->instanceName, &QLineEdit::textEdited, [&] {
     onChanged();
@@ -862,7 +862,7 @@ bool NamePage::doSkip() const
 
 void NamePage::doActivated(bool)
 {
-  auto* g = m_dlg.rawCreationInfo().game;
+  const auto* g = m_dlg.rawCreationInfo().game;
   if (!g) {
     // shouldn't happen, next should be disabled
     return;
@@ -950,7 +950,7 @@ bool ProfilePage::ready() const
 
 CreateInstanceDialog::ProfileSettings ProfilePage::profileSettings() const
 {
-  CreateInstanceDialog::ProfileSettings profileSettings;
+  CreateInstanceDialog::ProfileSettings profileSettings{};
   profileSettings.localInis           = ui->profileInisCheckbox->isChecked();
   profileSettings.localSaves          = ui->profileSavesCheckbox->isChecked();
   profileSettings.archiveInvalidation = ui->archiveInvalidationCheckbox->isChecked();
@@ -1143,7 +1143,7 @@ void PathsPage::setIfEmpty(QLineEdit* e, const QString& path, bool force)
 bool PathsPage::checkPath(QString path, PlaceholderLabel& existsLabel,
                           PlaceholderLabel& invalidLabel)
 {
-  auto& m = InstanceManager::singleton();
+  const auto& m = InstanceManager::singleton();
 
   bool exists  = false;
   bool invalid = false;

--- a/src/createinstancedialogpages.h
+++ b/src/createinstancedialogpages.h
@@ -282,7 +282,7 @@ private:
 
   // finds the game struct associated with the given game
   //
-  Game* findGame(MOBase::IPluginGame* game);
+  Game* findGame(const MOBase::IPluginGame* game);
 
   // creates the ui for the given game button
   //

--- a/src/csvbuilder.cpp
+++ b/src/csvbuilder.cpp
@@ -10,7 +10,7 @@ CSVBuilder::CSVBuilder(QIODevice* target)
   m_QuoteMode[TYPE_STRING]  = QUOTE_ONDEMAND;
 }
 
-CSVBuilder::~CSVBuilder() {}
+CSVBuilder::~CSVBuilder() = default;
 
 void CSVBuilder::setFieldSeparator(char sep)
 {

--- a/src/datatab.cpp
+++ b/src/datatab.cpp
@@ -38,23 +38,23 @@ DataTab::DataTab(OrganizerCore& core, PluginContainer& pc, QWidget* parent,
     m->setDynamicSortFilter(false);
   }
 
-  connect(&m_filter, &FilterWidget::aboutToChange, [&] {
+  connect(&m_filter, &FilterWidget::aboutToChange, [this] {
     ensureFullyLoaded();
   });
 
-  connect(ui.refresh, &QPushButton::clicked, [&] {
+  connect(ui.refresh, &QPushButton::clicked, [this] {
     onRefresh();
   });
 
-  connect(ui.conflicts, &QCheckBox::toggled, [&] {
+  connect(ui.conflicts, &QCheckBox::toggled, [this] {
     onConflicts();
   });
 
-  connect(ui.archives, &QCheckBox::toggled, [&] {
+  connect(ui.archives, &QCheckBox::toggled, [this] {
     onArchives();
   });
 
-  connect(ui.hiddenFiles, &QCheckBox::toggled, [&] {
+  connect(ui.hiddenFiles, &QCheckBox::toggled, [this] {
     onHiddenFiles();
   });
 

--- a/src/directoryrefresher.cpp
+++ b/src/directoryrefresher.cpp
@@ -184,8 +184,8 @@ void DirectoryRefresher::setMods(
     QString path       = std::get<1>(*mod);
     QString modDataDir = m_Core.managedGame()->modDataDirectory();
     path               = modDataDir.isEmpty() ? path : path + "/" + modDataDir;
-    m_Mods.push_back(
-        EntryInfo(name, path, info->stealFiles(), info->archives(), std::get<2>(*mod)));
+    m_Mods.emplace_back(
+        name, path, info->stealFiles(), info->archives(), std::get<2>(*mod));
   }
 
   m_EnabledArchives = managedArchives;
@@ -480,7 +480,7 @@ void DirectoryRefresher::refresh()
       m_Root->addFromOrigin(L"data", dataDirectory, 0, dummy);
     }
 
-    for (auto directory : game->secondaryDataDirectories().toStdMap()) {
+    for (const auto& directory : game->secondaryDataDirectories().toStdMap()) {
       DirectoryStats dummy;
       m_Root->addFromOrigin(
           directory.first.toStdWString(),

--- a/src/directoryrefresher.cpp
+++ b/src/directoryrefresher.cpp
@@ -352,7 +352,7 @@ struct ModThread
   void run()
   {
     std::unique_lock lock(mutex);
-    cv.wait(lock, [&] {
+    cv.wait(lock, [this] {
       return ready;
     });
 

--- a/src/directoryrefresher.cpp
+++ b/src/directoryrefresher.cpp
@@ -184,8 +184,8 @@ void DirectoryRefresher::setMods(
     QString path       = std::get<1>(*mod);
     QString modDataDir = m_Core.managedGame()->modDataDirectory();
     path               = modDataDir.isEmpty() ? path : path + "/" + modDataDir;
-    m_Mods.emplace_back(
-        name, path, info->stealFiles(), info->archives(), std::get<2>(*mod));
+    m_Mods.emplace_back(name, path, info->stealFiles(), info->archives(),
+                        std::get<2>(*mod));
   }
 
   m_EnabledArchives = managedArchives;

--- a/src/downloadlist.h
+++ b/src/downloadlist.h
@@ -88,7 +88,8 @@ public slots:
   /**
    * @brief used to inform the model that data has changed
    *
-   * @param row the row that changed. This can be negative to update the whole view
+   * @param row the row that changed. This can be negative to update the whole view,
+   *            but you have to call aboutToUpdate() before that case, and only then.
    **/
   void update(int row);
 

--- a/src/downloadlistview.cpp
+++ b/src/downloadlistview.cpp
@@ -139,7 +139,7 @@ DownloadListView::DownloadListView(QWidget* parent) : QTreeView(parent)
           SLOT(onCustomContextMenu(QPoint)));
 }
 
-DownloadListView::~DownloadListView() {}
+DownloadListView::~DownloadListView() = default;
 
 void DownloadListView::setManager(DownloadManager* manager)
 {
@@ -228,64 +228,64 @@ void DownloadListView::onCustomContextMenu(const QPoint& point)
       hidden = m_Manager->isHidden(row);
 
       if (state >= DownloadManager::STATE_READY) {
-        menu.addAction(tr("Install"), [=] {
+        menu.addAction(tr("Install"), [this, row] {
           issueInstall(row);
         });
         if (m_Manager->isInfoIncomplete(row)) {
-          menu.addAction(tr("Query Info"), [=] {
+          menu.addAction(tr("Query Info"), [this, row] {
             issueQueryInfoMd5(row);
           });
         } else {
-          menu.addAction(tr("Visit on Nexus"), [=] {
+          menu.addAction(tr("Visit on Nexus"), [this, row] {
             issueVisitOnNexus(row);
           });
-          menu.addAction(tr("Visit the uploader's profile"), [=] {
+          menu.addAction(tr("Visit the uploader's profile"), [this, row] {
             issueVisitUploaderProfile(row);
           });
         }
-        menu.addAction(tr("Open File"), [=] {
+        menu.addAction(tr("Open File"), [this, row] {
           issueOpenFile(row);
         });
-        menu.addAction(tr("Open Meta File"), [=] {
+        menu.addAction(tr("Open Meta File"), [this, row] {
           issueOpenMetaFile(row);
         });
-        menu.addAction(tr("Reveal in Explorer"), [=] {
+        menu.addAction(tr("Reveal in Explorer"), [this, row] {
           issueOpenInDownloadsFolder(row);
         });
 
         menu.addSeparator();
 
-        menu.addAction(tr("Delete..."), [=] {
+        menu.addAction(tr("Delete..."), [this, row] {
           issueDelete(row);
         });
         if (hidden)
-          menu.addAction(tr("Un-Hide"), [=] {
+          menu.addAction(tr("Un-Hide"), [this, row] {
             issueRestoreToView(row);
           });
         else
-          menu.addAction(tr("Hide"), [=] {
+          menu.addAction(tr("Hide"), [this, row] {
             issueRemoveFromView(row);
           });
       } else if (state == DownloadManager::STATE_DOWNLOADING) {
-        menu.addAction(tr("Cancel"), [=] {
+        menu.addAction(tr("Cancel"), [this, row] {
           issueCancel(row);
         });
-        menu.addAction(tr("Pause"), [=] {
+        menu.addAction(tr("Pause"), [this, row] {
           issuePause(row);
         });
-        menu.addAction(tr("Reveal in Explorer"), [=] {
+        menu.addAction(tr("Reveal in Explorer"), [this, row] {
           issueOpenInDownloadsFolder(row);
         });
       } else if ((state == DownloadManager::STATE_PAUSED) ||
                  (state == DownloadManager::STATE_ERROR) ||
                  (state == DownloadManager::STATE_PAUSING)) {
-        menu.addAction(tr("Delete..."), [=] {
+        menu.addAction(tr("Delete..."), [this, row] {
           issueDelete(row);
         });
-        menu.addAction(tr("Resume"), [=] {
+        menu.addAction(tr("Resume"), [this, row] {
           issueResume(row);
         });
-        menu.addAction(tr("Reveal in Explorer"), [=] {
+        menu.addAction(tr("Reveal in Explorer"), [this, row] {
           issueOpenInDownloadsFolder(row);
         });
       }
@@ -297,29 +297,29 @@ void DownloadListView::onCustomContextMenu(const QPoint& point)
     // display download-specific actions
   }
 
-  menu.addAction(tr("Delete Installed Downloads..."), [=] {
+  menu.addAction(tr("Delete Installed Downloads..."), [this] {
     issueDeleteCompleted();
   });
-  menu.addAction(tr("Delete Uninstalled Downloads..."), [=] {
+  menu.addAction(tr("Delete Uninstalled Downloads..."), [this] {
     issueDeleteUninstalled();
   });
-  menu.addAction(tr("Delete All Downloads..."), [=] {
+  menu.addAction(tr("Delete All Downloads..."), [this] {
     issueDeleteAll();
   });
 
   menu.addSeparator();
   if (!hidden) {
-    menu.addAction(tr("Hide Installed..."), [=] {
+    menu.addAction(tr("Hide Installed..."), [this] {
       issueRemoveFromViewCompleted();
     });
-    menu.addAction(tr("Hide Uninstalled..."), [=] {
+    menu.addAction(tr("Hide Uninstalled..."), [this] {
       issueRemoveFromViewUninstalled();
     });
-    menu.addAction(tr("Hide All..."), [=] {
+    menu.addAction(tr("Hide All..."), [this] {
       issueRemoveFromViewAll();
     });
   } else {
-    menu.addAction(tr("Un-Hide All..."), [=] {
+    menu.addAction(tr("Un-Hide All..."), [this] {
       issueRestoreToViewAll();
     });
   }

--- a/src/downloadmanager.cpp
+++ b/src/downloadmanager.cpp
@@ -338,7 +338,7 @@ void DownloadManager::refreshList()
     // avoid triggering other refreshes
     ScopedDisableDirWatcher scopedDirWatcher(this);
 
-    //int downloadsBefore = m_ActiveDownloads.size(); //unused
+    // int downloadsBefore = m_ActiveDownloads.size(); //unused
 
     // remove finished downloads
     for (QVector<DownloadInfo*>::iterator iter = m_ActiveDownloads.begin();
@@ -604,7 +604,7 @@ void DownloadManager::startDownload(QNetworkReply* reply, DownloadInfo* newDownl
   }
 
   newDownload->m_StartTime.start();
-  //createMetaFile(newDownload); //only create meta file on finished download
+  // createMetaFile(newDownload); //only create meta file on finished download
 
   if (!newDownload->m_Output.open(mode)) {
     reportError(tr("failed to download %1: could not open output file: %2")
@@ -626,7 +626,7 @@ void DownloadManager::startDownload(QNetworkReply* reply, DownloadInfo* newDownl
     removePending(newDownload->m_FileInfo->gameName, newDownload->m_FileInfo->modID,
                   newDownload->m_FileInfo->fileID);
 
-    //emit aboutToUpdate();
+    // emit aboutToUpdate();
     m_ActiveDownloads.append(newDownload);
 
     emit update(indexByInfo(newDownload));
@@ -717,7 +717,7 @@ void DownloadManager::addNXMDownload(const QString& url)
     if (std::get<0>(tuple).compare(foundGame->gameShortName(), Qt::CaseInsensitive) ==
             0 &&
         std::get<1>(tuple) == nxmInfo.modId() &&
-            std::get<2>(tuple) == nxmInfo.fileId()) {
+        std::get<2>(tuple) == nxmInfo.fileId()) {
       const auto infoStr =
           tr("There is already a download queued for this file.\n\nMod %1\nFile %2")
               .arg(nxmInfo.modId())
@@ -736,48 +736,48 @@ void DownloadManager::addNXMDownload(const QString& url)
     if (download->m_FileInfo->modID == nxmInfo.modId() &&
         download->m_FileInfo->fileID == nxmInfo.fileId() &&
         (download->m_State == STATE_DOWNLOADING || download->m_State == STATE_PAUSED ||
-          download->m_State == STATE_STARTED)) {
-        QString debugStr(
-            "download requested is already started (mod %1: %2, file %3: %4)");
-        QString infoStr(tr("There is already a download started for this file.\n\nMod "
-                           "%1:\t%2\nFile %3:\t%4"));
+         download->m_State == STATE_STARTED)) {
+      QString debugStr(
+          "download requested is already started (mod %1: %2, file %3: %4)");
+      QString infoStr(tr("There is already a download started for this file.\n\nMod "
+                         "%1:\t%2\nFile %3:\t%4"));
 
-        // %1
-        debugStr = debugStr.arg(download->m_FileInfo->modID);
-        infoStr  = infoStr.arg(download->m_FileInfo->modID);
+      // %1
+      debugStr = debugStr.arg(download->m_FileInfo->modID);
+      infoStr  = infoStr.arg(download->m_FileInfo->modID);
 
-        // %2
-        if (!download->m_FileInfo->name.isEmpty()) {
-          debugStr = debugStr.arg(download->m_FileInfo->name);
-          infoStr  = infoStr.arg(download->m_FileInfo->name);
-        } else if (!download->m_FileInfo->modName.isEmpty()) {
-          debugStr = debugStr.arg(download->m_FileInfo->modName);
-          infoStr  = infoStr.arg(download->m_FileInfo->modName);
-        } else {
-          debugStr = debugStr.arg(QStringLiteral("<blank>"));
-          infoStr  = infoStr.arg(QStringLiteral("<blank>"));
-        }
+      // %2
+      if (!download->m_FileInfo->name.isEmpty()) {
+        debugStr = debugStr.arg(download->m_FileInfo->name);
+        infoStr  = infoStr.arg(download->m_FileInfo->name);
+      } else if (!download->m_FileInfo->modName.isEmpty()) {
+        debugStr = debugStr.arg(download->m_FileInfo->modName);
+        infoStr  = infoStr.arg(download->m_FileInfo->modName);
+      } else {
+        debugStr = debugStr.arg(QStringLiteral("<blank>"));
+        infoStr  = infoStr.arg(QStringLiteral("<blank>"));
+      }
 
-        // %3
-        debugStr = debugStr.arg(download->m_FileInfo->fileID);
-        infoStr  = infoStr.arg(download->m_FileInfo->fileID);
+      // %3
+      debugStr = debugStr.arg(download->m_FileInfo->fileID);
+      infoStr  = infoStr.arg(download->m_FileInfo->fileID);
 
-        // %4
-        if (!download->m_FileInfo->fileName.isEmpty()) {
-          debugStr = debugStr.arg(download->m_FileInfo->fileName);
-          infoStr  = infoStr.arg(download->m_FileInfo->fileName);
-        } else if (!download->m_FileName.isEmpty()) {
-          debugStr = debugStr.arg(download->m_FileName);
-          infoStr  = infoStr.arg(download->m_FileName);
-        } else {
-          debugStr = debugStr.arg(QStringLiteral("<blank>"));
-          infoStr  = infoStr.arg(QStringLiteral("<blank>"));
-        }
+      // %4
+      if (!download->m_FileInfo->fileName.isEmpty()) {
+        debugStr = debugStr.arg(download->m_FileInfo->fileName);
+        infoStr  = infoStr.arg(download->m_FileInfo->fileName);
+      } else if (!download->m_FileName.isEmpty()) {
+        debugStr = debugStr.arg(download->m_FileName);
+        infoStr  = infoStr.arg(download->m_FileName);
+      } else {
+        debugStr = debugStr.arg(QStringLiteral("<blank>"));
+        infoStr  = infoStr.arg(QStringLiteral("<blank>"));
+      }
 
-        log::debug("{}", debugStr);
-        QMessageBox::information(m_ParentWidget, tr("Already Started"), infoStr,
-                                 QMessageBox::Ok);
-        return;
+      log::debug("{}", debugStr);
+      QMessageBox::information(m_ParentWidget, tr("Already Started"), infoStr,
+                               QMessageBox::Ok);
+      return;
     }
   }
 
@@ -810,7 +810,7 @@ void DownloadManager::removeFile(int index, bool deleteFile)
   }
 
   const DownloadInfo* download = m_ActiveDownloads.at(index);
-  QString filePath       = m_OutputDirectory + "/" + download->m_FileName;
+  QString filePath             = m_OutputDirectory + "/" + download->m_FileName;
   if ((download->m_State == STATE_STARTED) ||
       (download->m_State == STATE_DOWNLOADING)) {
     // shouldn't have been possible
@@ -1054,10 +1054,9 @@ void DownloadManager::resumeDownloadInt(int index)
 
 DownloadManager::DownloadInfo* DownloadManager::downloadInfoByID(unsigned int id)
 {
-  auto iter = std::ranges::find_if(m_ActiveDownloads,
-                           [id](const DownloadInfo* info) {
-                             return info->m_DownloadID == id;
-                           });
+  auto iter = std::ranges::find_if(m_ActiveDownloads, [id](const DownloadInfo* info) {
+    return info->m_DownloadID == id;
+  });
   /* if (iter != m_ActiveDownloads.end()) {
     return *iter;
   } else {
@@ -1462,7 +1461,7 @@ QString DownloadManager::getDisplayGameName(int index) const
   if ((index < 0) || (index >= m_ActiveDownloads.size())) {
     throw MyException(tr("mod id: invalid download index %1").arg(index));
   }
-  QString gameName        = m_ActiveDownloads.at(index)->m_FileInfo->gameName;
+  QString gameName              = m_ActiveDownloads.at(index)->m_FileInfo->gameName;
   const IPluginGame* gamePlugin = m_OrganizerCore->getGame(gameName);
   if (gamePlugin) {
     gameName = gamePlugin->gameName();
@@ -1686,7 +1685,7 @@ void DownloadManager::downloadProgress(qint64 bytesReceived, qint64 bytesTotal)
   try {
     DownloadInfo* info = findDownload(this->sender(), &index);
     if (info != nullptr) {
-      //info->m_HasData = true;
+      // info->m_HasData = true;
       if (info->m_State == STATE_CANCELING) {
         setState(info, STATE_CANCELED);
       } else if (info->m_State == STATE_PAUSING) {
@@ -1769,7 +1768,7 @@ void DownloadManager::createMetaFile(DownloadInfo* info)
   // slightly hackish...
   for (int i = 0; i < m_ActiveDownloads.size(); ++i) {
     if (m_ActiveDownloads[i] == info) {
-      //emit aboutToUpdate();
+      // emit aboutToUpdate();
       emit update(i);
     }
   }
@@ -1974,7 +1973,7 @@ static int evaluateFileInfoMap(const QVariantMap& map,
 // sort function to sort by best download server
 //
 static bool ServerByPreference(const ServerList::container& preferredServers,
-                        const QVariant& LHS, const QVariant& RHS)
+                               const QVariant& LHS, const QVariant& RHS)
 {
   const auto a = evaluateFileInfoMap(LHS.toMap(), preferredServers);
   const auto b = evaluateFileInfoMap(RHS.toMap(), preferredServers);
@@ -1999,15 +1998,15 @@ int DownloadManager::startDownloadURLs(const QStringList& urls)
 {
   ModRepositoryFileInfo info;
   addDownload(urls, "", -1, -1, &info);
-  //return m_ActiveDownloads.size() - 1;
-  
+  // return m_ActiveDownloads.size() - 1;
+
   return generateRandomDownloadID();
 }
 
 int DownloadManager::startDownloadNexusFile(const QString& gameName, int modID,
                                             int fileID)
 {
-  //int newID = m_ActiveDownloads.size();
+  // int newID = m_ActiveDownloads.size();
 
   addNXMDownload(
       QString("nxm://%1/mods/%2/files/%3").arg(gameName).arg(modID).arg(fileID));
@@ -2341,12 +2340,12 @@ void DownloadManager::downloadFinished(int index)
                "There may be an issue with the Nexus servers."));
       emit update(-1);
     } else if (info->isPausedState() || info->m_State == STATE_PAUSING) {
-      //emit aboutToUpdate();
+      // emit aboutToUpdate();
       info->m_Output.close();
       createMetaFile(info);
       emit update(index);
     } else {
-      //emit aboutToUpdate();
+      // emit aboutToUpdate();
       QString url = info->m_Urls[info->m_CurrentUrl];
       if (info->m_FileInfo->userData.contains("downloadMap")) {
         foreach (const QVariant& server,

--- a/src/downloadmanager.cpp
+++ b/src/downloadmanager.cpp
@@ -657,15 +657,8 @@ void DownloadManager::startDownload(QNetworkReply* reply, DownloadInfo* newDownl
       }
     }
   }
-  // always connect finished - avoid missing the finished signal in certain flows
+  // always connect finished to avoid missing the finished signal in certain flows
   connect(newDownload->m_Reply, SIGNAL(finished()), this, SLOT(downloadFinished()));
-
-  // If the reply already has data in its buffer (signals may have been emitted
-  // before we connected), process it immediately to avoid getting stuck.
-  if (newDownload->m_Reply->bytesAvailable() > 0) {
-    // newDownload->m_HasData = true;
-    writeData(newDownload);
-  }
 
   QCoreApplication::processEvents();
 
@@ -2295,9 +2288,7 @@ void DownloadManager::downloadFinished(int index)
   if (info != nullptr) {
     QNetworkReply* reply = info->m_Reply;
     if (reply->isFinished()) {
-      if (reply->isOpen() && reply->bytesAvailable() > 0) {
-        writeData(info);
-      }
+      writeData(info);
       info->m_Output.close();
       TaskProgressManager::instance().forgetMe(info->m_TaskProgressId);
     } else {
@@ -2335,9 +2326,7 @@ void DownloadManager::downloadFinished(int index)
     if (info->m_State == STATE_CANCELING) {
       setState(info, STATE_CANCELED);
     } else if (info->m_State == STATE_PAUSING) {
-      if (reply->isOpen() && reply->bytesAvailable() > 0) {
-        writeData(info);
-      }
+      writeData(info);
       setState(info, STATE_PAUSED);
     }
 
@@ -2477,7 +2466,8 @@ void DownloadManager::checkDownloadTimeout()
 
 void DownloadManager::writeData(DownloadInfo* info)
 {
-  if (info != nullptr && info->m_Reply != nullptr && info->m_Reply->isOpen()) {
+  if (info != nullptr && info->m_Reply != nullptr && info->m_Reply->isOpen() &&
+      info->m_Reply->bytesAvailable() > 0) {
     QByteArray data = info->m_Reply->readAll();
     if (data.isEmpty()) {
       return;

--- a/src/downloadmanager.cpp
+++ b/src/downloadmanager.cpp
@@ -30,10 +30,8 @@ along with Mod Organizer.  If not, see <http://www.gnu.org/licenses/>.
 #include "selectiondialog.h"
 #include "shared/util.h"
 #include "utility.h"
-#include <nxmurl.h>
 #include <report.h>
 #include <taskprogressmanager.h>
-#include <utility.h>
 
 #include <QCoreApplication>
 #include <QDesktopServices>
@@ -84,8 +82,6 @@ DownloadManager::DownloadInfo::createFromMeta(const QString& filePath, bool show
                                               const QString outputDirectory,
                                               std::optional<uint64_t> fileSize)
 {
-  DownloadInfo* info = new DownloadInfo;
-
   QString metaFileName = filePath + ".meta";
   QFileInfo metaFileInfo(metaFileName);
   if (QDir::fromNativeSeparators(metaFileInfo.path())
@@ -93,6 +89,9 @@ DownloadManager::DownloadInfo::createFromMeta(const QString& filePath, bool show
       0)
     return nullptr;
   QSettings metaFile(metaFileName, QSettings::IniFormat);
+
+  DownloadInfo* info = new DownloadInfo;
+
   if (!showHidden && metaFile.value("removed", false).toBool()) {
     return nullptr;
   } else {
@@ -225,8 +224,8 @@ QString DownloadManager::DownloadInfo::currentURL()
 }
 
 DownloadManager::DownloadManager(NexusInterface* nexusInterface, QObject* parent)
-    : m_NexusInterface(nexusInterface), m_DirWatcher(), m_ShowHidden(false),
-      m_ParentWidget(nullptr)
+    : m_NexusInterface(nexusInterface), m_ParentWidget(nullptr), m_DirWatcher(),
+      m_ShowHidden(false)
 {
   m_OrganizerCore = dynamic_cast<OrganizerCore*>(parent);
   connect(&m_DirWatcher, SIGNAL(directoryChanged(QString)), this,
@@ -339,7 +338,7 @@ void DownloadManager::refreshList()
     // avoid triggering other refreshes
     ScopedDisableDirWatcher scopedDirWatcher(this);
 
-    int downloadsBefore = m_ActiveDownloads.size();
+    //int downloadsBefore = m_ActiveDownloads.size(); //unused
 
     // remove finished downloads
     for (QVector<DownloadInfo*>::iterator iter = m_ActiveDownloads.begin();
@@ -508,6 +507,8 @@ bool DownloadManager::addDownload(const QStringList& URLs, QString gameName, int
   QNetworkRequest request(preferredUrl);
   request.setHeader(QNetworkRequest::UserAgentHeader,
                     m_NexusInterface->getAccessManager()->userAgent());
+  request.setAttribute(QNetworkRequest::RedirectPolicyAttribute,
+                       QNetworkRequest::NoLessSafeRedirectPolicy);
   request.setAttribute(QNetworkRequest::CacheSaveControlAttribute, false);
   request.setAttribute(QNetworkRequest::CacheLoadControlAttribute,
                        QNetworkRequest::AlwaysNetwork);
@@ -567,8 +568,8 @@ void DownloadManager::removePending(QString gameName, int modID, int fileID)
   QString gameShortName = gameName;
   QStringList games(m_ManagedGame->validShortNames());
   games += m_ManagedGame->gameShortName();
-  for (auto game : games) {
-    MOBase::IPluginGame* gamePlugin = m_OrganizerCore->getGame(game);
+  for (const auto& game : games) {
+    const MOBase::IPluginGame* gamePlugin = m_OrganizerCore->getGame(game);
     if (gamePlugin != nullptr &&
         gamePlugin->gameNexusName().compare(gameName, Qt::CaseInsensitive) == 0) {
       gameShortName = gamePlugin->gameShortName();
@@ -576,7 +577,7 @@ void DownloadManager::removePending(QString gameName, int modID, int fileID)
     }
   }
   emit aboutToUpdate();
-  for (auto iter : m_PendingDownloads) {
+  for (auto& iter : m_PendingDownloads) {
     if (gameShortName.compare(std::get<0>(iter), Qt::CaseInsensitive) == 0 &&
         (std::get<1>(iter) == modID) && (std::get<2>(iter) == fileID)) {
       m_PendingDownloads.removeAt(m_PendingDownloads.indexOf(iter));
@@ -603,7 +604,7 @@ void DownloadManager::startDownload(QNetworkReply* reply, DownloadInfo* newDownl
   }
 
   newDownload->m_StartTime.start();
-  createMetaFile(newDownload);
+  //createMetaFile(newDownload); //only create meta file on finished download
 
   if (!newDownload->m_Output.open(mode)) {
     reportError(tr("failed to download %1: could not open output file: %2")
@@ -625,10 +626,10 @@ void DownloadManager::startDownload(QNetworkReply* reply, DownloadInfo* newDownl
     removePending(newDownload->m_FileInfo->gameName, newDownload->m_FileInfo->modID,
                   newDownload->m_FileInfo->fileID);
 
-    emit aboutToUpdate();
+    //emit aboutToUpdate();
     m_ActiveDownloads.append(newDownload);
 
-    emit update(-1);
+    emit update(indexByInfo(newDownload));
     emit downloadAdded();
 
     if (QFile::exists(m_OutputDirectory + "/" + newDownload->m_FileName)) {
@@ -654,22 +655,29 @@ void DownloadManager::startDownload(QNetworkReply* reply, DownloadInfo* newDownl
         else
           setState(newDownload, STATE_DOWNLOADING);
       }
-    } else
-      connect(newDownload->m_Reply, SIGNAL(finished()), this, SLOT(downloadFinished()));
-
-    QCoreApplication::processEvents();
-
-    if (newDownload->m_State != STATE_DOWNLOADING &&
-        newDownload->m_State != STATE_READY &&
-        newDownload->m_State != STATE_FETCHINGMODINFO && reply->isFinished()) {
-      int index = indexByInfo(newDownload);
-      if (index >= 0) {
-        downloadFinished(index);
-      }
-      return;
     }
-  } else
-    connect(newDownload->m_Reply, SIGNAL(finished()), this, SLOT(downloadFinished()));
+  }
+  // always connect finished - avoid missing the finished signal in certain flows
+  connect(newDownload->m_Reply, SIGNAL(finished()), this, SLOT(downloadFinished()));
+
+  // If the reply already has data in its buffer (signals may have been emitted
+  // before we connected), process it immediately to avoid getting stuck.
+  if (newDownload->m_Reply->bytesAvailable() > 0) {
+    // newDownload->m_HasData = true;
+    writeData(newDownload);
+  }
+
+  QCoreApplication::processEvents();
+
+  if (newDownload->m_State != STATE_DOWNLOADING &&
+      newDownload->m_State != STATE_READY &&
+      newDownload->m_State != STATE_FETCHINGMODINFO && reply->isFinished()) {
+    int index = indexByInfo(newDownload);
+    if (index >= 0) {
+      downloadFinished(index);
+    }
+    return;
+  }
 }
 
 void DownloadManager::addNXMDownload(const QString& url)
@@ -680,7 +688,7 @@ void DownloadManager::addNXMDownload(const QString& url)
   MOBase::IPluginGame* foundGame = nullptr;
   validGames.append(m_ManagedGame->gameShortName());
   validGames.append(m_ManagedGame->validShortNames());
-  for (auto game : validGames) {
+  for (const auto& game : validGames) {
     MOBase::IPluginGame* gamePlugin = m_OrganizerCore->getGame(game);
 
     // some game plugins give names in validShortNames() that may refer to other
@@ -712,9 +720,9 @@ void DownloadManager::addNXMDownload(const QString& url)
     return;
   }
 
-  for (auto tuple : m_PendingDownloads) {
+  for (const auto& tuple : m_PendingDownloads) {
     if (std::get<0>(tuple).compare(foundGame->gameShortName(), Qt::CaseInsensitive) ==
-            0,
+            0 &&
         std::get<1>(tuple) == nxmInfo.modId() &&
             std::get<2>(tuple) == nxmInfo.fileId()) {
       const auto infoStr =
@@ -731,11 +739,11 @@ void DownloadManager::addNXMDownload(const QString& url)
     }
   }
 
-  for (DownloadInfo* download : m_ActiveDownloads) {
+  for (const DownloadInfo* download : m_ActiveDownloads) {
     if (download->m_FileInfo->modID == nxmInfo.modId() &&
-        download->m_FileInfo->fileID == nxmInfo.fileId()) {
-      if (download->m_State == STATE_DOWNLOADING || download->m_State == STATE_PAUSED ||
-          download->m_State == STATE_STARTED) {
+        download->m_FileInfo->fileID == nxmInfo.fileId() &&
+        (download->m_State == STATE_DOWNLOADING || download->m_State == STATE_PAUSED ||
+          download->m_State == STATE_STARTED)) {
         QString debugStr(
             "download requested is already started (mod %1: %2, file %3: %4)");
         QString infoStr(tr("There is already a download started for this file.\n\nMod "
@@ -777,7 +785,6 @@ void DownloadManager::addNXMDownload(const QString& url)
         QMessageBox::information(m_ParentWidget, tr("Already Started"), infoStr,
                                  QMessageBox::Ok);
         return;
-      }
     }
   }
 
@@ -809,7 +816,7 @@ void DownloadManager::removeFile(int index, bool deleteFile)
     throw MyException(tr("remove: invalid download index %1").arg(index));
   }
 
-  DownloadInfo* download = m_ActiveDownloads.at(index);
+  const DownloadInfo* download = m_ActiveDownloads.at(index);
   QString filePath       = m_OutputDirectory + "/" + download->m_FileName;
   if ((download->m_State == STATE_STARTED) ||
       (download->m_State == STATE_DOWNLOADING)) {
@@ -844,7 +851,7 @@ class LessThanWrapper
 {
 public:
   LessThanWrapper(DownloadManager* manager) : m_Manager(manager) {}
-  bool operator()(int LHS, int RHS)
+  bool operator()(int LHS, int RHS) const
   {
     return m_Manager->getFileName(LHS).compare(m_Manager->getFileName(RHS),
                                                Qt::CaseInsensitive) < 0;
@@ -1023,7 +1030,7 @@ void DownloadManager::resumeDownloadInt(int index)
       }
     }
     if ((info->m_Urls.size() == 0) ||
-        ((info->m_Urls.size() == 1) && (info->m_Urls[0].size() == 0))) {
+        ((info->m_Urls.size() == 1) && (info->m_Urls[0].isEmpty()))) {
       emit showMessage(
           tr("No known download urls. Sorry, this download can't be resumed."));
       return;
@@ -1054,15 +1061,16 @@ void DownloadManager::resumeDownloadInt(int index)
 
 DownloadManager::DownloadInfo* DownloadManager::downloadInfoByID(unsigned int id)
 {
-  auto iter = std::find_if(m_ActiveDownloads.begin(), m_ActiveDownloads.end(),
-                           [id](DownloadInfo* info) {
+  auto iter = std::ranges::find_if(m_ActiveDownloads,
+                           [id](const DownloadInfo* info) {
                              return info->m_DownloadID == id;
                            });
-  if (iter != m_ActiveDownloads.end()) {
+  /* if (iter != m_ActiveDownloads.end()) {
     return *iter;
   } else {
     return nullptr;
-  }
+  }*/
+  return iter != nullptr ? *iter : nullptr;
 }
 
 void DownloadManager::queryInfo(int index)
@@ -1116,7 +1124,7 @@ void DownloadManager::queryInfo(int index)
     if (choices.size() == 1) {
       info->m_FileInfo->gameName = choices[0].first;
     } else {
-      for (auto choice : choices) {
+      for (const auto& choice : choices) {
         selection.addChoice(choice.first, choice.second, choice.first);
       }
       if (selection.exec() == QDialog::Accepted) {
@@ -1199,7 +1207,7 @@ void DownloadManager::visitOnNexus(int index)
     reportError(tr("VisitNexus: invalid download index %1").arg(index));
     return;
   }
-  DownloadInfo* info = m_ActiveDownloads[index];
+  const DownloadInfo* info = m_ActiveDownloads[index];
 
   if (info->m_FileInfo->repository != "Nexus") {
     log::warn("Visiting mod page is currently only possible with Nexus");
@@ -1226,7 +1234,7 @@ void DownloadManager::visitUploaderProfile(int index)
     reportError(tr("VisitUploaderProfile: invalid download index %1").arg(index));
     return;
   }
-  DownloadInfo* info = m_ActiveDownloads[index];
+  const DownloadInfo* info = m_ActiveDownloads[index];
 
   if (info->m_State < DownloadManager::STATE_READY) {
     // UI shouldn't allow this
@@ -1364,7 +1372,7 @@ QString DownloadManager::getDisplayName(int index) const
     throw MyException(tr("display name: invalid download index %1").arg(index));
   }
 
-  DownloadInfo* info = m_ActiveDownloads.at(index);
+  const DownloadInfo* info = m_ActiveDownloads.at(index);
 
   QTextDocument doc;
   if (!info->m_FileInfo->name.isEmpty()) {
@@ -1462,7 +1470,7 @@ QString DownloadManager::getDisplayGameName(int index) const
     throw MyException(tr("mod id: invalid download index %1").arg(index));
   }
   QString gameName        = m_ActiveDownloads.at(index)->m_FileInfo->gameName;
-  IPluginGame* gamePlugin = m_OrganizerCore->getGame(gameName);
+  const IPluginGame* gamePlugin = m_OrganizerCore->getGame(gameName);
   if (gamePlugin) {
     gameName = gamePlugin->gameName();
   }
@@ -1503,7 +1511,7 @@ void DownloadManager::markInstalled(int index)
   // Avoid triggering refreshes from DirWatcher
   ScopedDisableDirWatcher scopedDirWatcher(this);
 
-  DownloadInfo* info = m_ActiveDownloads.at(index);
+  const DownloadInfo* info = m_ActiveDownloads.at(index);
   QSettings metaFile(info->m_Output.fileName() + ".meta", QSettings::IniFormat);
   metaFile.setValue("installed", true);
   metaFile.setValue("uninstalled", false);
@@ -1544,7 +1552,7 @@ void DownloadManager::markUninstalled(int index)
   // Avoid triggering refreshes from DirWatcher
   ScopedDisableDirWatcher scopedDirWatcher(this);
 
-  DownloadInfo* info = m_ActiveDownloads.at(index);
+  const DownloadInfo* info = m_ActiveDownloads.at(index);
   QSettings metaFile(info->m_Output.fileName() + ".meta", QSettings::IniFormat);
   metaFile.setValue("uninstalled", true);
 
@@ -1597,6 +1605,13 @@ QString DownloadManager::getFileNameFromNetworkReply(QNetworkReply* reply)
       return MOBase::sanitizeFileName(QString::fromUtf8(result.str(1).c_str()));
     }
   }
+  // fallback to url path
+  if (reply->url().isValid()) {
+    auto filename = QFileInfo(reply->url().path()).fileName();
+    std::regex exp("^.+\\..+$");
+    if (std::regex_search(filename.toStdString(), exp))
+      return MOBase::sanitizeFileName(filename);
+  }
 
   return QString();
 }
@@ -1614,7 +1629,8 @@ void DownloadManager::setState(DownloadManager::DownloadInfo* info,
   info->m_State = state;
   switch (state) {
   case STATE_PAUSED: {
-    info->m_Reply->abort();
+    if ((info->m_Reply != nullptr) && (info->m_Reply->isRunning()))
+      info->m_Reply->abort();
     info->m_Output.close();
     m_DownloadPaused(row);
   } break;
@@ -1677,7 +1693,7 @@ void DownloadManager::downloadProgress(qint64 bytesReceived, qint64 bytesTotal)
   try {
     DownloadInfo* info = findDownload(this->sender(), &index);
     if (info != nullptr) {
-      info->m_HasData = true;
+      //info->m_HasData = true;
       if (info->m_State == STATE_CANCELING) {
         setState(info, STATE_CANCELED);
       } else if (info->m_State == STATE_PAUSING) {
@@ -1760,6 +1776,7 @@ void DownloadManager::createMetaFile(DownloadInfo* info)
   // slightly hackish...
   for (int i = 0; i < m_ActiveDownloads.size(); ++i) {
     if (m_ActiveDownloads[i] == info) {
+      //emit aboutToUpdate();
       emit update(i);
     }
   }
@@ -1922,8 +1939,8 @@ void DownloadManager::nxmFileInfoAvailable(QString gameName, int modID, int file
 
   QStringList games(m_ManagedGame->validShortNames());
   games += m_ManagedGame->gameShortName();
-  for (auto game : games) {
-    MOBase::IPluginGame* gamePlugin = m_OrganizerCore->getGame(game);
+  for (const auto& game : games) {
+    const MOBase::IPluginGame* gamePlugin = m_OrganizerCore->getGame(game);
     if (gamePlugin != nullptr &&
         gamePlugin->gameNexusName().compare(gameName, Qt::CaseInsensitive) == 0) {
       info->gameName = gamePlugin->gameShortName();
@@ -1963,7 +1980,7 @@ static int evaluateFileInfoMap(const QVariantMap& map,
 
 // sort function to sort by best download server
 //
-bool ServerByPreference(const ServerList::container& preferredServers,
+static bool ServerByPreference(const ServerList::container& preferredServers,
                         const QVariant& LHS, const QVariant& RHS)
 {
   const auto a = evaluateFileInfoMap(LHS.toMap(), preferredServers);
@@ -1971,23 +1988,41 @@ bool ServerByPreference(const ServerList::container& preferredServers,
   return (a > b);
 }
 
+int DownloadManager::generateRandomDownloadID()
+{
+  QRandomGenerator* generator = QRandomGenerator::global();
+  auto currentDownloadSet     = std::set<int>();
+  for (const auto& download : m_ActiveDownloads) {
+    currentDownloadSet.insert(download->m_DownloadID);
+  }
+  int newID;
+  do {
+    newID = generator->generate();
+  } while (currentDownloadSet.contains(newID));
+  return newID;
+}
+
 int DownloadManager::startDownloadURLs(const QStringList& urls)
 {
   ModRepositoryFileInfo info;
   addDownload(urls, "", -1, -1, &info);
-  return m_ActiveDownloads.size() - 1;
+  //return m_ActiveDownloads.size() - 1;
+  
+  return generateRandomDownloadID();
 }
 
 int DownloadManager::startDownloadNexusFile(const QString& gameName, int modID,
                                             int fileID)
 {
-  int newID = m_ActiveDownloads.size();
+  //int newID = m_ActiveDownloads.size();
+
   addNXMDownload(
       QString("nxm://%1/mods/%2/files/%3").arg(gameName).arg(modID).arg(fileID));
-  return newID;
+
+  return generateRandomDownloadID();
 }
 
-QString DownloadManager::downloadPath(int id)
+QString DownloadManager::downloadPath(int id) const
 {
   return getFilePath(id);
 }
@@ -2159,8 +2194,8 @@ void DownloadManager::nxmFileInfoFromMd5Available(QString gameName, QVariant use
   QString gameShortName = gameName;
   QStringList games(m_ManagedGame->validShortNames());
   games += m_ManagedGame->gameShortName();
-  for (auto game : games) {
-    MOBase::IPluginGame* gamePlugin = m_OrganizerCore->getGame(game);
+  for (const auto& game : games) {
+    const MOBase::IPluginGame* gamePlugin = m_OrganizerCore->getGame(game);
     if (gamePlugin != nullptr &&
         gamePlugin->gameNexusName().compare(gameName, Qt::CaseInsensitive) == 0) {
       gameShortName = gamePlugin->gameShortName();
@@ -2235,6 +2270,16 @@ void DownloadManager::nxmRequestFailed(QString gameName, int modID, int fileID,
   emit showMessage(tr("Failed to request file info from nexus: %1").arg(errorString));
 }
 
+void DownloadManager::downloadFinished(const DownloadInfo* info)
+{
+  int index = indexByInfo(info);
+  if (index >= 0) {
+    downloadFinished(index);
+  } else {
+    emit showMessage("download finished: invalid download info");
+  }
+}
+
 void DownloadManager::downloadFinished(int index)
 {
   DownloadInfo* info;
@@ -2243,19 +2288,22 @@ void DownloadManager::downloadFinished(int index)
   else {
     info = findDownload(this->sender(), &index);
     if (info == nullptr && index == 0) {
-      info = m_ActiveDownloads[index];
+      info = m_ActiveDownloads[m_ActiveDownloads.size() - 1];
     }
   }
 
   if (info != nullptr) {
     QNetworkReply* reply = info->m_Reply;
-    QByteArray data;
-    if (reply->isOpen() && info->m_HasData) {
-      data = reply->readAll();
-      info->m_Output.write(data);
+    if (reply->isFinished()) {
+      if (reply->isOpen() && reply->bytesAvailable() > 0) {
+        writeData(info);
+      }
+      info->m_Output.close();
+      TaskProgressManager::instance().forgetMe(info->m_TaskProgressId);
+    } else {
+      emit showMessage(
+          tr("Download finished event received but download is not finished?"));
     }
-    info->m_Output.close();
-    TaskProgressManager::instance().forgetMe(info->m_TaskProgressId);
 
     bool error = false;
     if ((info->m_State != STATE_CANCELING) && (info->m_State != STATE_PAUSING)) {
@@ -2287,8 +2335,8 @@ void DownloadManager::downloadFinished(int index)
     if (info->m_State == STATE_CANCELING) {
       setState(info, STATE_CANCELED);
     } else if (info->m_State == STATE_PAUSING) {
-      if (info->m_Output.isOpen() && info->m_HasData) {
-        info->m_Output.write(info->m_Reply->readAll());
+      if (reply->isOpen() && reply->bytesAvailable() > 0) {
+        writeData(info);
       }
       setState(info, STATE_PAUSED);
     }
@@ -2304,12 +2352,12 @@ void DownloadManager::downloadFinished(int index)
                "There may be an issue with the Nexus servers."));
       emit update(-1);
     } else if (info->isPausedState() || info->m_State == STATE_PAUSING) {
-      emit aboutToUpdate();
+      //emit aboutToUpdate();
       info->m_Output.close();
       createMetaFile(info);
       emit update(index);
     } else {
-      emit aboutToUpdate();
+      //emit aboutToUpdate();
       QString url = info->m_Urls[info->m_CurrentUrl];
       if (info->m_FileInfo->userData.contains("downloadMap")) {
         foreach (const QVariant& server,
@@ -2370,7 +2418,7 @@ void DownloadManager::downloadFinished(int index)
 void DownloadManager::downloadError(QNetworkReply::NetworkError error)
 {
   if (error != QNetworkReply::OperationCanceledError) {
-    QNetworkReply* reply = qobject_cast<QNetworkReply*>(sender());
+    const QNetworkReply* reply = qobject_cast<QNetworkReply*>(sender());
     log::warn("{} ({})",
               reply != nullptr ? reply->errorString() : "Download error occured",
               error);
@@ -2429,20 +2477,25 @@ void DownloadManager::checkDownloadTimeout()
 
 void DownloadManager::writeData(DownloadInfo* info)
 {
-  if (info != nullptr) {
-    qint64 ret = info->m_Output.write(info->m_Reply->readAll());
-    if (ret < info->m_Reply->size()) {
+  if (info != nullptr && info->m_Reply != nullptr && info->m_Reply->isOpen()) {
+    QByteArray data = info->m_Reply->readAll();
+    if (data.isEmpty()) {
+      return;
+    }
+    qint64 ret = info->m_Output.write(data);
+    if (ret < data.size()) {
       QString fileName =
           info->m_FileName;  // m_FileName may be destroyed after setState
       setState(info, DownloadState::STATE_CANCELED);
 
-      log::error("Unable to write download \"{}\" to drive (return {})",
-                 info->m_FileName, ret);
+      log::error("Unable to write download \"{}\" to drive (wrote {} of {})",
+                 info->m_FileName, ret, data.size());
 
-      reportError(tr("Unable to write download to drive (return %1).\n"
-                     "Check the drive's available storage.\n\n"
-                     "Canceling download \"%2\"...")
+      reportError(tr("Unable to write download to drive (wrote %1).\n"
+                     "Check the drive's available storage (need %2).\n\n"
+                     "Canceling download \"%3\"...")
                       .arg(ret)
+                      .arg(data.size())
                       .arg(fileName));
     }
   }

--- a/src/downloadmanager.h
+++ b/src/downloadmanager.h
@@ -94,7 +94,7 @@ private:
     QElapsedTimer m_StartTime;
     qint64 m_PreResumeSize;
     std::pair<int, QString> m_Progress;
-    //bool m_HasData;
+    // bool m_HasData;
     DownloadState m_State;
     int m_CurrentUrl;
     QStringList m_Urls;
@@ -143,7 +143,7 @@ private:
 
   private:
     DownloadInfo()
-        : m_TotalSize(0), m_ReQueried(false), m_Hidden(false), //m_HasData(false),
+        : m_TotalSize(0), m_ReQueried(false), m_Hidden(false),  // m_HasData(false),
           m_AskIfNotFound(true), m_DownloadTimeLast(0), m_DownloadLast(0),
           m_DownloadAcc(tag::rolling_window::window_size = 200),
           m_DownloadTimeAcc(tag::rolling_window::window_size = 200)

--- a/src/downloadmanager.h
+++ b/src/downloadmanager.h
@@ -94,7 +94,7 @@ private:
     QElapsedTimer m_StartTime;
     qint64 m_PreResumeSize;
     std::pair<int, QString> m_Progress;
-    bool m_HasData;
+    //bool m_HasData;
     DownloadState m_State;
     int m_CurrentUrl;
     QStringList m_Urls;
@@ -132,7 +132,7 @@ private:
      **/
     void setName(QString newName, bool renameFile);
 
-    unsigned int downloadID() { return m_DownloadID; }
+    unsigned int downloadID() const { return m_DownloadID; }
 
     bool isPausedState();
 
@@ -143,7 +143,7 @@ private:
 
   private:
     DownloadInfo()
-        : m_TotalSize(0), m_ReQueried(false), m_Hidden(false), m_HasData(false),
+        : m_TotalSize(0), m_ReQueried(false), m_Hidden(false), //m_HasData(false),
           m_AskIfNotFound(true), m_DownloadTimeLast(0), m_DownloadLast(0),
           m_DownloadAcc(tag::rolling_window::window_size = 200),
           m_DownloadTimeAcc(tag::rolling_window::window_size = 200)
@@ -408,10 +408,11 @@ public:
    */
   void queryDownloadListInfo();
 
-public:  // IDownloadManager interface:
+public:
+  // IDownloadManager interface:
   int startDownloadURLs(const QStringList& urls);
   int startDownloadNexusFile(const QString& gameName, int modID, int fileID);
-  QString downloadPath(int id);
+  QString downloadPath(int id) const;
 
   boost::signals2::connection
   onDownloadComplete(const std::function<void(int)>& callback);
@@ -535,6 +536,7 @@ private slots:
 
   void downloadProgress(qint64 bytesReceived, qint64 bytesTotal);
   void downloadReadyRead();
+  void downloadFinished(const DownloadInfo* info);
   void downloadFinished(int index = 0);
   void downloadError(QNetworkReply::NetworkError error);
   void metaDataChanged();
@@ -543,6 +545,7 @@ private slots:
 
 private:
   void createMetaFile(DownloadInfo* info);
+  int generateRandomDownloadID();
   DownloadManager::DownloadInfo* getDownloadInfo(QString fileName);
 
 public:

--- a/src/downloadstab.cpp
+++ b/src/downloadstab.cpp
@@ -24,10 +24,10 @@ DownloadsTab::DownloadsTab(OrganizerCore& core, Ui::MainWindow* mwui)
     return sourceModel->lessThanPredicate(left, right);
   });
 
-  connect(ui.refresh, &QPushButton::clicked, [&] {
+  connect(ui.refresh, &QPushButton::clicked, [this] {
     refresh();
   });
-  connect(ui.queryInfos, &QPushButton::clicked, [&] {
+  connect(ui.queryInfos, &QPushButton::clicked, [this] {
     queryInfos();
   });
   connect(ui.list, SIGNAL(installDownload(int)), &m_core, SLOT(installDownload(int)));
@@ -53,7 +53,7 @@ DownloadsTab::DownloadsTab(OrganizerCore& core, Ui::MainWindow* mwui)
           SLOT(cancelDownload(int)));
   connect(ui.list, SIGNAL(pauseDownload(int)), m_core.downloadManager(),
           SLOT(pauseDownload(int)));
-  connect(ui.list, &DownloadListView::resumeDownload, [&](int i) {
+  connect(ui.list, &DownloadListView::resumeDownload, [this](int i) {
     resumeDownload(i);
   });
 }

--- a/src/editexecutablesdialog.cpp
+++ b/src/editexecutablesdialog.cpp
@@ -88,43 +88,43 @@ EditExecutablesDialog::EditExecutablesDialog(OrganizerCore& oc, int sel,
   }
 
   auto* m = new QMenu;
-  m->addAction(tr("Add from file..."), [&] {
+  m->addAction(tr("Add from file..."), [this] {
     addFromFile();
   });
-  m->addAction(tr("Add empty"), [&] {
+  m->addAction(tr("Add empty"), [this] {
     addEmpty();
   });
-  m->addAction(tr("Clone selected"), [&] {
+  m->addAction(tr("Clone selected"), [this] {
     clone();
   });
   ui->add->setMenu(m);
 
   // some widgets need to do more than just save() and have their own handler
-  connect(ui->binary, &QLineEdit::textChanged, [&] {
+  connect(ui->binary, &QLineEdit::textChanged, [this] {
     save();
   });
-  connect(ui->workingDirectory, &QLineEdit::textChanged, [&] {
+  connect(ui->workingDirectory, &QLineEdit::textChanged, [this] {
     save();
   });
-  connect(ui->arguments, &QLineEdit::textChanged, [&] {
+  connect(ui->arguments, &QLineEdit::textChanged, [this] {
     save();
   });
-  connect(ui->steamAppID, &QLineEdit::textChanged, [&] {
+  connect(ui->steamAppID, &QLineEdit::textChanged, [this] {
     save();
   });
-  connect(ui->mods, &QComboBox::currentTextChanged, [&] {
+  connect(ui->mods, &QComboBox::currentTextChanged, [this] {
     save();
   });
-  connect(ui->useApplicationIcon, &QCheckBox::toggled, [&] {
+  connect(ui->useApplicationIcon, &QCheckBox::toggled, [this] {
     save();
   });
-  connect(ui->minimizeToSystemTray, &QCheckBox::toggled, [&] {
+  connect(ui->minimizeToSystemTray, &QCheckBox::toggled, [this] {
     save();
   });
-  connect(ui->hide, &QCheckBox::toggled, [&] {
+  connect(ui->hide, &QCheckBox::toggled, [this] {
     save();
   });
-  connect(ui->list->model(), &QAbstractItemModel::rowsMoved, [&] {
+  connect(ui->list->model(), &QAbstractItemModel::rowsMoved, [this] {
     saveOrder();
   });
 }

--- a/src/editexecutablesdialog.cpp
+++ b/src/editexecutablesdialog.cpp
@@ -309,7 +309,7 @@ Executable* EditExecutablesDialog::selectedExe()
     return nullptr;
   }
 
-  return &*itor;
+  return std::to_address(itor);
 }
 
 void EditExecutablesDialog::fillList()

--- a/src/env.cpp
+++ b/src/env.cpp
@@ -128,7 +128,7 @@ void ModuleNotification::fire(QString path, std::size_t fileSize)
   }
 }
 
-Environment::Environment() {}
+Environment::Environment() = default;
 
 // anchor
 Environment::~Environment() = default;
@@ -1087,7 +1087,7 @@ std::wstring safeVersion()
   }
 }
 
-HandlePtr tempFile(const std::wstring dir)
+HandlePtr tempFile(const std::wstring& dir)
 {
   // maximum tries of incrementing the counter
   const int MaxTries = 100;
@@ -1223,7 +1223,7 @@ bool createMiniDump(const wchar_t* dir, HANDLE process, CoreDumpTypes type)
 
   const auto ret =
       MiniDumpWriteDump(process, pid, file.get(), flags, nullptr, nullptr, nullptr);
-
+  
   if (!ret) {
     const auto e = GetLastError();
 

--- a/src/env.cpp
+++ b/src/env.cpp
@@ -886,7 +886,7 @@ bool isKeyEmpty(HKEY key)
     return false;
   }
 
-  auto r = forEachSubKey(key, [&](const wchar_t* name) {
+  auto r = forEachSubKey(key, [&key](const wchar_t* name) {
     // a subkey exists, recursively check if it's empty
     auto subkey = openRegistryKey(key, name);
 
@@ -1223,7 +1223,7 @@ bool createMiniDump(const wchar_t* dir, HANDLE process, CoreDumpTypes type)
 
   const auto ret =
       MiniDumpWriteDump(process, pid, file.get(), flags, nullptr, nullptr, nullptr);
-  
+
   if (!ret) {
     const auto e = GetLastError();
 

--- a/src/envfs.cpp
+++ b/src/envfs.cpp
@@ -173,7 +173,7 @@ public:
     MOShared::SetThisThreadName("HandleCloserThread");
 
     std::unique_lock lock(m_mutex);
-    m_cv.wait(lock, [&] {
+    m_cv.wait(lock, [this] {
       return m_ready;
     });
 

--- a/src/envfs.cpp
+++ b/src/envfs.cpp
@@ -379,7 +379,7 @@ Directory getFilesAndDirs(const std::wstring& path)
       [](void* pcx, std::wstring_view path) {
         Context* cx = (Context*)pcx;
 
-        cx->current.top()->dirs.push_back(Directory(path));
+        cx->current.top()->dirs.emplace_back(path);
         cx->current.push(&cx->current.top()->dirs.back());
       },
 
@@ -391,7 +391,7 @@ Directory getFilesAndDirs(const std::wstring& path)
       [](void* pcx, std::wstring_view path, FILETIME ft, uint64_t s) {
         Context* cx = (Context*)pcx;
 
-        cx->current.top()->files.push_back(File(path, ft, s));
+        cx->current.top()->files.emplace_back(path, ft, s);
       });
 
   return root;
@@ -426,14 +426,14 @@ void getFilesAndDirsWithFindImpl(const std::wstring& path, Directory& d)
         if ((wcscmp(findData.cFileName, L".") != 0) &&
             (wcscmp(findData.cFileName, L"..") != 0)) {
           const std::wstring newPath = path + L"\\" + findData.cFileName;
-          d.dirs.push_back(Directory(findData.cFileName));
+          d.dirs.emplace_back(findData.cFileName);
           getFilesAndDirsWithFindImpl(newPath, d.dirs.back());
         }
       } else {
         const auto size =
             (findData.nFileSizeHigh * (MAXDWORD + 1)) + findData.nFileSizeLow;
 
-        d.files.push_back(File(findData.cFileName, findData.ftLastWriteTime, size));
+        d.files.emplace_back(findData.cFileName, findData.ftLastWriteTime, size);
       }
 
       result = ::FindNextFileW(searchHandle, &findData);

--- a/src/envmodule.cpp
+++ b/src/envmodule.cpp
@@ -518,7 +518,7 @@ std::vector<Process> getRunningProcesses()
 {
   std::vector<Process> v;
 
-  forEachRunningProcess([&](auto&& entry) {
+  forEachRunningProcess([&v](auto&& entry) {
     v.push_back(Process(entry.th32ProcessID, entry.th32ParentProcessID,
                         QString::fromStdWString(entry.szExeFile)));
 
@@ -640,7 +640,7 @@ Process getProcessTreeFromJob(HANDLE h)
 
   std::vector<Process> ps;
 
-  forEachRunningProcess([&](auto&& entry) {
+  forEachRunningProcess([&ids, &ps](auto&& entry) {
     for (auto&& id : ids) {
       if (entry.th32ProcessID == id) {
         ps.push_back(Process(entry.th32ProcessID, entry.th32ParentProcessID,
@@ -771,7 +771,7 @@ DWORD getProcessParentID(DWORD pid)
 {
   DWORD ppid = 0;
 
-  forEachRunningProcess([&](auto&& entry) {
+  forEachRunningProcess([&pid, &ppid](auto&& entry) {
     if (entry.th32ProcessID == pid) {
       ppid = entry.th32ParentProcessID;
       return false;

--- a/src/envmodule.cpp
+++ b/src/envmodule.cpp
@@ -450,7 +450,7 @@ std::vector<Module> getLoadedModules()
   for (;;) {
     const auto path = QString::fromWCharArray(me.szExePath);
     if (!path.isEmpty()) {
-      v.push_back(Module(path, me.modBaseSize));
+      v.emplace_back(path, me.modBaseSize);
     }
 
     // next module

--- a/src/envsecurity.cpp
+++ b/src/envsecurity.cpp
@@ -306,7 +306,7 @@ std::vector<SecurityProduct> getSecurityProductsFromWMI()
   // that to avoid duplicating entries
   std::map<QUuid, SecurityProduct> map;
 
-  auto f = [&](auto* o) {
+  auto f = [&map](auto* o) {
     if (auto p = handleProduct(o)) {
       map.emplace(p->guid(), std::move(*p));
     }

--- a/src/envshell.cpp
+++ b/src/envshell.cpp
@@ -496,7 +496,7 @@ void ShellMenuCollection::addDetails(QString s)
 
 void ShellMenuCollection::add(QString name, ShellMenu m)
 {
-  m_menus.push_back({name, std::move(m)});
+  m_menus.emplace_back(name, std::move(m));
 }
 
 void ShellMenuCollection::exec(const QPoint& pos)

--- a/src/envshell.cpp
+++ b/src/envshell.cpp
@@ -180,7 +180,7 @@ void ShellMenu::exec(const QPoint& pos)
     const auto hwnd = getHWND(m_mw);
 
     auto filter = std::make_unique<WndProcFilter>(
-        [&](HWND h, UINT m, WPARAM wp, LPARAM lp, LRESULT* out) {
+        [this](HWND h, UINT m, WPARAM wp, LPARAM lp, LRESULT* out) {
           return wndProc(h, m, wp, lp, out);
         });
 
@@ -552,7 +552,7 @@ void ShellMenuCollection::exec(const QPoint& pos)
   auto hwnd = getHWND(m_mw);
 
   auto filter = std::make_unique<WndProcFilter>(
-      [&](HWND h, UINT m, WPARAM wp, LPARAM lp, LRESULT* out) {
+      [this](HWND h, UINT m, WPARAM wp, LPARAM lp, LRESULT* out) {
         return wndProc(h, m, wp, lp, out);
       });
 

--- a/src/executableslist.cpp
+++ b/src/executableslist.cpp
@@ -145,7 +145,7 @@ ExecutablesList::getPluginExecutables(MOBase::IPluginGame const* game) const
       continue;
     }
 
-    v.push_back({info, Executable::UseApplicationIcon});
+    v.emplace_back(info, Executable::UseApplicationIcon);
   }
 
   const QFileInfo eppBin(QCoreApplication::applicationDirPath() +

--- a/src/filetree.cpp
+++ b/src/filetree.cpp
@@ -125,19 +125,19 @@ FileTree::FileTree(OrganizerCore& core, PluginContainer& pc, QTreeView* tree)
 
   MOBase::setCustomizableColumns(m_tree);
 
-  connect(m_tree, &QTreeView::customContextMenuRequested, [&](auto pos) {
+  connect(m_tree, &QTreeView::customContextMenuRequested, [this](auto pos) {
     onContextMenu(pos);
   });
 
-  connect(m_tree, &QTreeView::expanded, [&](auto&& index) {
+  connect(m_tree, &QTreeView::expanded, [this](auto&& index) {
     onExpandedChanged(index, true);
   });
 
-  connect(m_tree, &QTreeView::collapsed, [&](auto&& index) {
+  connect(m_tree, &QTreeView::collapsed, [this](auto&& index) {
     onExpandedChanged(index, false);
   });
 
-  connect(m_tree, &QTreeView::activated, [&](auto&& index) {
+  connect(m_tree, &QTreeView::activated, [this](auto&& index) {
     onItemActivated(index);
   });
 }
@@ -649,7 +649,7 @@ void FileTree::addFileMenus(QMenu& menu, const FileEntry& file, int originID)
   const QFileInfo target(QString::fromStdWString(file.getFullPath()));
 
   MenuItem(tr("&Add as Executable"))
-      .callback([&] {
+      .callback([this] {
         addAsExecutable();
       })
       .hint(tr("Add this file to the executables list"))
@@ -658,7 +658,7 @@ void FileTree::addFileMenus(QMenu& menu, const FileEntry& file, int originID)
       .addTo(menu);
 
   MenuItem(tr("Reveal in E&xplorer"))
-      .callback([&] {
+      .callback([this] {
         exploreOrigin();
       })
       .hint(tr("Opens the file in Explorer"))
@@ -667,7 +667,7 @@ void FileTree::addFileMenus(QMenu& menu, const FileEntry& file, int originID)
       .addTo(menu);
 
   MenuItem(tr("Open &Mod Info"))
-      .callback([&] {
+      .callback([this] {
         openModInfo();
       })
       .hint(tr("Opens the Mod Info Window"))
@@ -677,7 +677,7 @@ void FileTree::addFileMenus(QMenu& menu, const FileEntry& file, int originID)
 
   if (isHidden(file)) {
     MenuItem(tr("&Un-Hide"))
-        .callback([&] {
+        .callback([this] {
           unhide();
         })
         .hint(tr("Un-hides the file"))
@@ -686,7 +686,7 @@ void FileTree::addFileMenus(QMenu& menu, const FileEntry& file, int originID)
         .addTo(menu);
   } else {
     MenuItem(tr("&Hide"))
-        .callback([&] {
+        .callback([this] {
           hide();
         })
         .hint(tr("Hides the file"))
@@ -706,7 +706,7 @@ void FileTree::addOpenMenus(QMenu& menu, const MOShared::FileEntry& file)
 
   if (getFileExecutionType(target) == FileExecutionTypes::Executable) {
     openMenu.caption(tr("&Execute"))
-        .callback([&] {
+        .callback([this] {
           open();
         })
         .hint(tr("Launches this program"))
@@ -714,7 +714,7 @@ void FileTree::addOpenMenus(QMenu& menu, const MOShared::FileEntry& file)
         .enabled(!file.isFromArchive());
 
     openHookedMenu.caption(tr("Execute with &VFS"))
-        .callback([&] {
+        .callback([this] {
           openHooked();
         })
         .hint(tr("Launches this program hooked to the VFS"))
@@ -722,7 +722,7 @@ void FileTree::addOpenMenus(QMenu& menu, const MOShared::FileEntry& file)
         .enabled(!file.isFromArchive());
   } else {
     openMenu.caption(tr("&Open"))
-        .callback([&] {
+        .callback([this] {
           open();
         })
         .hint(tr("Opens this file with its default handler"))
@@ -730,7 +730,7 @@ void FileTree::addOpenMenus(QMenu& menu, const MOShared::FileEntry& file)
         .enabled(!file.isFromArchive());
 
     openHookedMenu.caption(tr("Open with &VFS"))
-        .callback([&] {
+        .callback([this] {
           openHooked();
         })
         .hint(tr("Opens this file with its default handler hooked to the VFS"))
@@ -740,7 +740,7 @@ void FileTree::addOpenMenus(QMenu& menu, const MOShared::FileEntry& file)
 
   MenuItem previewMenu(tr("&Preview"));
   previewMenu
-      .callback([&] {
+      .callback([this] {
         preview();
       })
       .hint(tr("Previews this file within Mod Organizer"))
@@ -780,27 +780,27 @@ void FileTree::addCommonMenus(QMenu& menu)
   menu.addSeparator();
 
   MenuItem(tr("&Save Tree to Text File..."))
-      .callback([&] {
+      .callback([this] {
         dumpToFile();
       })
       .hint(tr("Writes the list of files to a text file"))
       .addTo(menu);
 
   MenuItem(tr("&Refresh"))
-      .callback([&] {
+      .callback([this] {
         refresh();
       })
       .hint(tr("Refreshes the list"))
       .addTo(menu);
 
   MenuItem(tr("Ex&pand All"))
-      .callback([&] {
+      .callback([this] {
         expandAll();
       })
       .addTo(menu);
 
   MenuItem(tr("&Collapse All"))
-      .callback([&] {
+      .callback([this] {
         collapseAll();
       })
       .addTo(menu);

--- a/src/filetree.cpp
+++ b/src/filetree.cpp
@@ -41,7 +41,7 @@ bool canUnhideFile(const FileEntry& file);
 class MenuItem
 {
 public:
-  MenuItem(QString s = {}) : m_action(new QAction(std::move(s))) {}
+  MenuItem(QString s = {}) : m_action(new QAction(s)) {}
 
   MenuItem& caption(const QString& s)
   {
@@ -319,7 +319,7 @@ void FileTree::exploreOrigin(FileTreeItem* item)
     return;
   }
 
-  const auto path = item->realPath();
+  const auto& path = item->realPath();
 
   log::debug("opening in explorer: {}", path);
   shell::Explore(path);
@@ -538,7 +538,7 @@ bool FileTree::showShellMenu(QPoint pos)
 
     auto itor = menus.find(item->originID());
     if (itor == menus.end()) {
-      itor = menus.emplace(item->originID(), mw).first;
+      itor = menus.try_emplace(item->originID(), mw).first;
     }
 
     if (!QFile::exists(item->realPath())) {
@@ -560,7 +560,7 @@ bool FileTree::showShellMenu(QPoint pos)
         continue;
       }
 
-      const auto alts = file->getAlternatives();
+      const auto& alts = file->getAlternatives();
       if (alts.empty()) {
         log::warn("file '{}' has no alternative origins but is marked as conflicted",
                   item->dataRelativeFilePath());
@@ -569,7 +569,7 @@ bool FileTree::showShellMenu(QPoint pos)
       for (auto&& alt : alts) {
         auto itor = menus.find(alt.originID());
         if (itor == menus.end()) {
-          itor = menus.emplace(alt.originID(), mw).first;
+          itor = menus.try_emplace(alt.originID(), mw).first;
         }
 
         const auto fullPath = file->getFullPath(alt.originID());

--- a/src/filetreemodel.cpp
+++ b/src/filetreemodel.cpp
@@ -189,13 +189,13 @@ FileTreeModel::FileTreeModel(OrganizerCore& core, QObject* parent)
   m_root->setExpanded(true);
   m_sortTimer.setSingleShot(true);
 
-  connect(&m_removeTimer, &QTimer::timeout, [&] {
+  connect(&m_removeTimer, &QTimer::timeout, [this] {
     removeItems();
   });
-  connect(&m_sortTimer, &QTimer::timeout, [&] {
+  connect(&m_sortTimer, &QTimer::timeout, [this] {
     sortItems();
   });
-  connect(&m_iconPendingTimer, &QTimer::timeout, [&] {
+  connect(&m_iconPendingTimer, &QTimer::timeout, [this] {
     updatePendingIcons();
   });
 }
@@ -816,7 +816,7 @@ bool FileTreeModel::addNewFiles(FileTreeItem& parentItem,
   bool added = false;
 
   // for each directory on the filesystem
-  parentEntry.forEachFileIndex([&](auto&& fileIndex) {
+  parentEntry.forEachFileIndex([this, &seen, &range, &toAdd, &parentEntry, &parentPath, &parentItem, &added](auto&& fileIndex) {
     if (seen.contains(fileIndex)) {
       // already seen in the parent item
 
@@ -1034,7 +1034,7 @@ bool FileTreeModel::shouldShowFolder(const DirectoryEntry& dir,
   bool foundFile = false;
 
   // check all files in this directory, return early if a file should be shown
-  dir.forEachFile([&](auto&& f) {
+  dir.forEachFile([this, &foundFile](auto&& f) {
     if (shouldShowFile(f)) {
       foundFile = true;
 

--- a/src/filetreemodel.cpp
+++ b/src/filetreemodel.cpp
@@ -816,7 +816,8 @@ bool FileTreeModel::addNewFiles(FileTreeItem& parentItem,
   bool added = false;
 
   // for each directory on the filesystem
-  parentEntry.forEachFileIndex([this, &seen, &range, &toAdd, &parentEntry, &parentPath, &parentItem, &added](auto&& fileIndex) {
+  parentEntry.forEachFileIndex([this, &seen, &range, &toAdd, &parentEntry, &parentPath,
+                                &parentItem, &added](auto&& fileIndex) {
     if (seen.contains(fileIndex)) {
       // already seen in the parent item
 

--- a/src/filterlist.cpp
+++ b/src/filterlist.cpp
@@ -214,8 +214,8 @@ FilterList::FilterList(Ui::MainWindow* ui, OrganizerCore& core,
 
   connect(ui->filtersSeparators, qOverload<int>(&QComboBox::currentIndexChanged),
           [this] {
-    onOptionsChanged();
-  });
+            onOptionsChanged();
+          });
 
   ui->filters->header()->setMinimumSectionSize(0);
   ui->filters->header()->resizeSection(0, 23);

--- a/src/filterlist.cpp
+++ b/src/filterlist.cpp
@@ -192,27 +192,28 @@ FilterList::FilterList(Ui::MainWindow* ui, OrganizerCore& core,
                        CategoryFactory& factory)
     : ui(ui), m_core(core), m_factory(factory)
 {
-  auto* eventFilter = new CriteriaItemFilter(ui->filters, [&](auto* item, int dir) {
+  auto* eventFilter = new CriteriaItemFilter(ui->filters, [this](auto* item, int dir) {
     return cycleItem(item, dir);
   });
 
   ui->filters->installEventFilter(eventFilter);
   ui->filters->viewport()->installEventFilter(eventFilter);
 
-  connect(ui->filtersClear, &QPushButton::clicked, [&] {
+  connect(ui->filtersClear, &QPushButton::clicked, [this] {
     clearSelection();
   });
-  connect(ui->filtersEdit, &QPushButton::clicked, [&] {
+  connect(ui->filtersEdit, &QPushButton::clicked, [this] {
     editCategories();
   });
-  connect(ui->filtersAnd, &QCheckBox::toggled, [&] {
+  connect(ui->filtersAnd, &QCheckBox::toggled, [this] {
     onOptionsChanged();
   });
-  connect(ui->filtersOr, &QCheckBox::toggled, [&] {
+  connect(ui->filtersOr, &QCheckBox::toggled, [this] {
     onOptionsChanged();
   });
 
-  connect(ui->filtersSeparators, qOverload<int>(&QComboBox::currentIndexChanged), [&] {
+  connect(ui->filtersSeparators, qOverload<int>(&QComboBox::currentIndexChanged),
+          [this] {
     onOptionsChanged();
   });
 

--- a/src/forcedloaddialog.cpp
+++ b/src/forcedloaddialog.cpp
@@ -61,7 +61,7 @@ void ForcedLoadDialog::on_addRowButton_clicked()
 
 void ForcedLoadDialog::on_deleteRowButton_clicked()
 {
-  for (auto rowIndex : ui->tableWidget->selectionModel()->selectedRows()) {
+  for (const auto& rowIndex : ui->tableWidget->selectionModel()->selectedRows()) {
     int row     = rowIndex.row();
     auto widget = (ForcedLoadDialogWidget*)ui->tableWidget->cellWidget(row, 0);
     if (!widget->getForced()) {

--- a/src/game_features.cpp
+++ b/src/game_features.cpp
@@ -161,8 +161,8 @@ GameFeatures::GameFeatures(OrganizerCore* core, PluginContainer* plugins)
             // remove features from the current plugin
             for (auto& [_, features] : m_allFeatures) {
               std::erase_if(features, [plugin](const auto& feature) {
-                                              return feature.plugin() == plugin;
-                                            });
+                return feature.plugin() == plugin;
+              });
             }
 
             // update current features
@@ -315,8 +315,8 @@ int GameFeatures::unregisterGameFeatures(MOBase::IPlugin* plugin,
   const auto initialSize = features.size();
 
   std::erase_if(features, [plugin](const auto& feature) {
-                                  return feature.plugin() == plugin;
-                                });
+    return feature.plugin() == plugin;
+  });
 
   const int removed = features.size() - initialSize;
 

--- a/src/game_features.cpp
+++ b/src/game_features.cpp
@@ -160,11 +160,9 @@ GameFeatures::GameFeatures(OrganizerCore* core, PluginContainer* plugins)
           [this, updateFeatures](MOBase::IPlugin* plugin) {
             // remove features from the current plugin
             for (auto& [_, features] : m_allFeatures) {
-              features.erase(std::remove_if(features.begin(), features.end(),
-                                            [plugin](const auto& feature) {
+              std::erase_if(features, [plugin](const auto& feature) {
                                               return feature.plugin() == plugin;
-                                            }),
-                             features.end());
+                                            });
             }
 
             // update current features
@@ -172,7 +170,7 @@ GameFeatures::GameFeatures(OrganizerCore* core, PluginContainer* plugins)
           });
 }
 
-GameFeatures::~GameFeatures() {}
+GameFeatures::~GameFeatures() = default;
 
 GameFeatures::CombinedModDataChecker& GameFeatures::modDataChecker() const
 {
@@ -185,7 +183,7 @@ GameFeatures::CombinedModDataContent& GameFeatures::modDataContent() const
 
 void GameFeatures::updateCurrentFeatures(std::type_index const& index)
 {
-  auto& features = m_allFeatures[index];
+  const auto& features = m_allFeatures[index];
 
   m_currentFeatures[index].clear();
 
@@ -246,7 +244,7 @@ void GameFeatures::updateCurrentFeatures()
   // plugin is disabled or unregistered)
   //
 
-  for (auto& [info, _] : m_allFeatures) {
+  for (const auto& [info, _] : m_allFeatures) {
     updateCurrentFeatures(info);
   }
 }
@@ -316,11 +314,9 @@ int GameFeatures::unregisterGameFeatures(MOBase::IPlugin* plugin,
 
   const auto initialSize = features.size();
 
-  features.erase(std::remove_if(features.begin(), features.end(),
-                                [plugin](const auto& feature) {
+  std::erase_if(features, [plugin](const auto& feature) {
                                   return feature.plugin() == plugin;
-                                }),
-                 features.end());
+                                });
 
   const int removed = features.size() - initialSize;
 

--- a/src/icondelegate.cpp
+++ b/src/icondelegate.cpp
@@ -47,7 +47,7 @@ void IconDelegate::paintIcons(QPainter* painter, const QStyleOptionViewItem& opt
   int x = 4;
   painter->save();
 
-  int iconWidth = icons.size() > 0 ? ((option.rect.width() / icons.size()) - 4) : 16;
+  int iconWidth = !icons.isEmpty() ? ((option.rect.width() / icons.size()) - 4) : 16;
   iconWidth     = std::min(16, iconWidth);
 
   const int margin = (option.rect.height() - iconWidth) / 2;

--- a/src/iconfetcher.cpp
+++ b/src/iconfetcher.cpp
@@ -111,7 +111,7 @@ void IconFetcher::checkCache(Cache& cache)
 
   std::map<QString, QPixmap> map;
   for (auto&& ext : queue) {
-    map.emplace(std::move(ext), getPixmapIcon(QFileInfo(ext)));
+    map.try_emplace(ext, getPixmapIcon(QFileInfo(ext)));
   }
 
   {

--- a/src/iconfetcher.cpp
+++ b/src/iconfetcher.cpp
@@ -5,7 +5,7 @@
 void IconFetcher::Waiter::wait()
 {
   std::unique_lock lock(m_wakeUpMutex);
-  m_wakeUp.wait(lock, [&] {
+  m_wakeUp.wait(lock, [this] {
     return m_queueAvailable;
   });
   m_queueAvailable = false;
@@ -26,7 +26,7 @@ IconFetcher::IconFetcher() : m_iconSize(GetSystemMetrics(SM_CXSMICON)), m_stop(f
   m_quickCache.file      = getPixmapIcon(QFileIconProvider::File);
   m_quickCache.directory = getPixmapIcon(QFileIconProvider::Folder);
 
-  m_thread = MOShared::startSafeThread([&] {
+  m_thread = MOShared::startSafeThread([this] {
     threadFun();
   });
 }

--- a/src/installationmanager.cpp
+++ b/src/installationmanager.cpp
@@ -143,7 +143,7 @@ bool InstallationManager::extractFiles(QString extractPath, QString title,
   QFuture<bool> future;
 
   if (silent) {
-    future = QtConcurrent::run([&]() -> bool {
+    future = QtConcurrent::run([this, &extractPath, &errorCallback]() -> bool {
       return m_ArchiveHandler->extract(extractPath.toStdWString(), nullptr, nullptr,
                                        errorCallback);
     });
@@ -214,7 +214,7 @@ bool InstallationManager::extractFiles(QString extractPath, QString title,
     QFutureWatcher<bool> futureWatcher;
     connect(&futureWatcher, &QFutureWatcher<bool>::finished, &loop, &QEventLoop::wakeUp,
             Qt::QueuedConnection);
-    futureWatcher.setFuture(QtConcurrent::run([&]() -> bool {
+    futureWatcher.setFuture(QtConcurrent::run([this, &extractPath, &progressCallback, &showFilenames, &fileChangeCallback, &errorCallback]() -> bool {
       return m_ArchiveHandler->extract(extractPath.toStdWString(), progressCallback,
                                        showFilenames ? fileChangeCallback : nullptr,
                                        errorCallback);
@@ -753,8 +753,8 @@ InstallationResult InstallationManager::install(const QString& fileName,
 
   auto installers = m_PluginContainer->plugins<IPluginInstaller>();
 
-  std::sort(installers.begin(), installers.end(),
-            [](IPluginInstaller* lhs, IPluginInstaller* rhs) {
+  std::ranges::sort(installers,
+            [](const IPluginInstaller* lhs, const IPluginInstaller* rhs) {
               return lhs->priority() > rhs->priority();
             });
 

--- a/src/installationmanager.cpp
+++ b/src/installationmanager.cpp
@@ -109,7 +109,7 @@ InstallationManager::InstallationManager() : m_ParentWidget(nullptr), m_IsRunnin
           &InstallationManager::queryPassword, Qt::BlockingQueuedConnection);
 }
 
-InstallationManager::~InstallationManager() {}
+InstallationManager::~InstallationManager() = default;
 
 void InstallationManager::setParentWidget(QWidget* widget)
 {
@@ -279,7 +279,7 @@ QStringList InstallationManager::extractFiles(
   // Retrieve the file path:
   QStringList result;
 
-  for (auto& entry : files) {
+  for (const auto& entry : files) {
     auto path = entry->path();
     result.append(QDir::tempPath().append("/").append(path));
     m_TempFilesToDelete.insert(path);
@@ -820,7 +820,7 @@ InstallationResult InstallationManager::install(const QString& fileName,
              ((filesTree == nullptr) &&
               installerCustom->isArchiveSupported(fileName)))) {
           std::set<QString> installerExt = installerCustom->supportedExtensions();
-          if (installerExt.find(fileInfo.suffix()) != installerExt.end()) {
+          if (installerExt.contains(fileInfo.suffix())) {
             installResult.m_result =
                 installerCustom->install(modName, gameName, fileName, version, modID);
             unsigned int idx = ModInfo::getIndex(modName);

--- a/src/installationmanager.cpp
+++ b/src/installationmanager.cpp
@@ -214,11 +214,13 @@ bool InstallationManager::extractFiles(QString extractPath, QString title,
     QFutureWatcher<bool> futureWatcher;
     connect(&futureWatcher, &QFutureWatcher<bool>::finished, &loop, &QEventLoop::wakeUp,
             Qt::QueuedConnection);
-    futureWatcher.setFuture(QtConcurrent::run([this, &extractPath, &progressCallback, &showFilenames, &fileChangeCallback, &errorCallback]() -> bool {
-      return m_ArchiveHandler->extract(extractPath.toStdWString(), progressCallback,
-                                       showFilenames ? fileChangeCallback : nullptr,
-                                       errorCallback);
-    }));
+    futureWatcher.setFuture(
+        QtConcurrent::run([this, &extractPath, &progressCallback, &showFilenames,
+                           &fileChangeCallback, &errorCallback]() -> bool {
+          return m_ArchiveHandler->extract(extractPath.toStdWString(), progressCallback,
+                                           showFilenames ? fileChangeCallback : nullptr,
+                                           errorCallback);
+        }));
 
     installationProgress->setModal(true);
     installationProgress->show();
@@ -754,9 +756,9 @@ InstallationResult InstallationManager::install(const QString& fileName,
   auto installers = m_PluginContainer->plugins<IPluginInstaller>();
 
   std::ranges::sort(installers,
-            [](const IPluginInstaller* lhs, const IPluginInstaller* rhs) {
-              return lhs->priority() > rhs->priority();
-            });
+                    [](const IPluginInstaller* lhs, const IPluginInstaller* rhs) {
+                      return lhs->priority() > rhs->priority();
+                    });
 
   InstallationResult installResult(IPluginInstaller::RESULT_NOTATTEMPTED);
 

--- a/src/instancemanager.cpp
+++ b/src/instancemanager.cpp
@@ -127,7 +127,7 @@ bool Instance::isPortable() const
 
 bool Instance::isActive() const
 {
-  auto& m = InstanceManager::singleton();
+  const auto& m = InstanceManager::singleton();
 
   if (auto i = m.currentInstance()) {
     if (m_portable) {
@@ -427,7 +427,7 @@ std::vector<Instance::Object> Instance::objectsForDeletion() const
   // don't delete that
   if (!isPortable()) {
     if (QDir(loc).exists()) {
-      roots.push_back({loc, true});
+      roots.emplace_back(loc, true);
     }
   }
 
@@ -435,7 +435,7 @@ std::vector<Instance::Object> Instance::objectsForDeletion() const
   // if it's the same
   if (canonicalDir(base) != canonicalDir(loc)) {
     if (QDir(base).exists()) {
-      roots.push_back({base, false});
+      roots.emplace_back(base, false);
     }
   }
 
@@ -474,14 +474,14 @@ std::vector<Instance::Object> Instance::objectsForDeletion() const
       // not in roots, this is a path that was changed by the user; make
       // sure it exists
       if (QDir(f.path).exists()) {
-        cleanDirs.push_back({prettyDir(f.path), f.mandatoryDelete});
+        cleanDirs.emplace_back(prettyDir(f.path), f.mandatoryDelete);
       }
     }
   }
 
   // prepending the roots
   for (auto itor = roots.rbegin(); itor != roots.rend(); ++itor) {
-    cleanDirs.insert(cleanDirs.begin(), {prettyDir(itor->path), itor->mandatoryDelete});
+    cleanDirs.emplace(cleanDirs.begin(), prettyDir(itor->path), itor->mandatoryDelete);
   }
 
   // this will contain the individual files that are not inside the roots;
@@ -503,7 +503,7 @@ std::vector<Instance::Object> Instance::objectsForDeletion() const
       // not in roots, this is a path that was changed by the user; make
       // sure it exists
       if (QFileInfo(f.path).exists()) {
-        cleanFiles.push_back({prettyFile(f.path), f.mandatoryDelete});
+        cleanFiles.emplace_back(prettyFile(f.path), f.mandatoryDelete);
       }
     }
   }
@@ -743,7 +743,7 @@ bool InstanceManager::instanceExists(const QString& instanceName) const
 
 std::shared_ptr<Instance> selectInstance()
 {
-  auto& m = InstanceManager::singleton();
+  const auto& m = InstanceManager::singleton();
 
   // since there is no instance currently active, load plugins with a null
   // OrganizerCore; see PluginContainer::initPlugin()

--- a/src/instancemanagerdialog.cpp
+++ b/src/instancemanagerdialog.cpp
@@ -103,7 +103,7 @@ QString getInstanceName(QWidget* parent, const QString& title, const QString& mo
   ly->addStretch();
   ly->addWidget(bb);
 
-  auto check = [&] {
+  auto check = [&text, &error, &oldName, &bb, &m] {
     bool okay = false;
 
     if (text->text().isEmpty()) {
@@ -124,13 +124,13 @@ QString getInstanceName(QWidget* parent, const QString& title, const QString& mo
     bb->button(QDialogButtonBox::Ok)->setEnabled(okay);
   };
 
-  QObject::connect(text, &QLineEdit::textChanged, [&] {
+  QObject::connect(text, &QLineEdit::textChanged, [&check] {
     check();
   });
-  QObject::connect(bb, &QDialogButtonBox::accepted, [&] {
+  QObject::connect(bb, &QDialogButtonBox::accepted, [&dlg] {
     dlg.accept();
   });
-  QObject::connect(bb, &QDialogButtonBox::rejected, [&] {
+  QObject::connect(bb, &QDialogButtonBox::rejected, [&dlg] {
     dlg.reject();
   });
 
@@ -167,47 +167,47 @@ InstanceManagerDialog::InstanceManagerDialog(PluginContainer& pc, QWidget* paren
   updateList();
   selectActiveInstance();
 
-  connect(ui->createNew, &QPushButton::clicked, [&] {
+  connect(ui->createNew, &QPushButton::clicked, [this] {
     createNew();
   });
 
-  connect(ui->list->selectionModel(), &QItemSelectionModel::selectionChanged, [&] {
+  connect(ui->list->selectionModel(), &QItemSelectionModel::selectionChanged, [this] {
     onSelection();
   });
-  connect(ui->list, &QListView::activated, [&] {
+  connect(ui->list, &QListView::activated, [this] {
     openSelectedInstance();
   });
 
-  connect(ui->rename, &QPushButton::clicked, [&] {
+  connect(ui->rename, &QPushButton::clicked, [this] {
     rename();
   });
-  connect(ui->exploreLocation, &QPushButton::clicked, [&] {
+  connect(ui->exploreLocation, &QPushButton::clicked, [this] {
     exploreLocation();
   });
-  connect(ui->exploreBaseDirectory, &QPushButton::clicked, [&] {
+  connect(ui->exploreBaseDirectory, &QPushButton::clicked, [this] {
     exploreBaseDirectory();
   });
-  connect(ui->exploreGame, &QPushButton::clicked, [&] {
+  connect(ui->exploreGame, &QPushButton::clicked, [this] {
     exploreGame();
   });
 
-  connect(ui->convertToGlobal, &QPushButton::clicked, [&] {
+  connect(ui->convertToGlobal, &QPushButton::clicked, [this] {
     convertToGlobal();
   });
-  connect(ui->convertToPortable, &QPushButton::clicked, [&] {
+  connect(ui->convertToPortable, &QPushButton::clicked, [this] {
     convertToPortable();
   });
-  connect(ui->openINI, &QPushButton::clicked, [&] {
+  connect(ui->openINI, &QPushButton::clicked, [this] {
     openINI();
   });
-  connect(ui->deleteInstance, &QPushButton::clicked, [&] {
+  connect(ui->deleteInstance, &QPushButton::clicked, [this] {
     deleteInstance();
   });
 
-  connect(ui->switchToInstance, &QPushButton::clicked, [&] {
+  connect(ui->switchToInstance, &QPushButton::clicked, [this] {
     openSelectedInstance();
   });
-  connect(ui->close, &QPushButton::clicked, [&] {
+  connect(ui->close, &QPushButton::clicked, [this] {
     close();
   });
 }

--- a/src/listdialog.cpp
+++ b/src/listdialog.cpp
@@ -57,7 +57,7 @@ QString ListDialog::getChoice() const
 void ListDialog::on_filterEdit_textChanged(QString filter)
 {
   QStringList newChoices;
-  for (auto choice : m_Choices) {
+  for (const auto& choice : m_Choices) {
     if (choice.contains(filter, Qt::CaseInsensitive)) {
       newChoices << choice;
     }

--- a/src/loglist.cpp
+++ b/src/loglist.cpp
@@ -31,7 +31,7 @@ static std::unique_ptr<env::Console> m_console;
 static bool m_stdout = false;
 static std::mutex m_stdoutMutex;
 
-LogModel::LogModel() {}
+LogModel::LogModel() = default;
 
 void LogModel::create()
 {
@@ -43,12 +43,12 @@ LogModel& LogModel::instance()
   return *g_instance;
 }
 
-void LogModel::add(MOBase::log::Entry e)
+void LogModel::add(const MOBase::log::Entry& e)
 {
   QMetaObject::invokeMethod(
       this,
       [this, e] {
-        onEntryAdded(std::move(e));
+        onEntryAdded(e);
       },
       Qt::QueuedConnection);
 }

--- a/src/loglist.cpp
+++ b/src/loglist.cpp
@@ -186,19 +186,19 @@ LogList::LogList(QWidget* parent)
   setAutoScroll(true);
   scrollToBottom();
 
-  connect(this, &QWidget::customContextMenuRequested, [&](auto&& pos) {
+  connect(this, &QWidget::customContextMenuRequested, [this](auto&& pos) {
     onContextMenu(pos);
   });
 
-  connect(model(), &LogModel::rowsInserted, this, [&] {
+  connect(model(), &LogModel::rowsInserted, this, [this] {
     onNewEntry();
   });
-  connect(model(), &LogModel::dataChanged, this, [&] {
+  connect(model(), &LogModel::dataChanged, this, [this] {
     onNewEntry();
   });
 
   m_timer.setSingleShot(true);
-  connect(&m_timer, &QTimer::timeout, [&] {
+  connect(&m_timer, &QTimer::timeout, [this] {
     scrollToBottom();
   });
 
@@ -247,17 +247,17 @@ QMenu* LogList::createMenu(QWidget* parent)
 {
   auto* menu = new QMenu(parent);
 
-  menu->addAction(tr("Copy"), [&] {
+  menu->addAction(tr("Copy"), [this] {
     m_copyFilter.copySelection();
   });
-  menu->addAction(tr("&Copy all"), [&] {
+  menu->addAction(tr("&Copy all"), [this] {
     copyToClipboard();
   });
   menu->addSeparator();
-  menu->addAction(tr("C&lear all"), [&] {
+  menu->addAction(tr("C&lear all"), [this] {
     clear();
   });
-  menu->addAction(tr("&Open logs folder"), [&] {
+  menu->addAction(tr("&Open logs folder"), [this] {
     openLogsFolder();
   });
 

--- a/src/loglist.h
+++ b/src/loglist.h
@@ -36,7 +36,7 @@ public:
   static void create();
   static LogModel& instance();
 
-  void add(MOBase::log::Entry e);
+  void add(const MOBase::log::Entry& e);
   void clear();
 
   const std::deque<MOBase::log::Entry>& entries() const;

--- a/src/loot.cpp
+++ b/src/loot.cpp
@@ -448,7 +448,7 @@ bool Loot::start(QWidget* parent, bool didUpdateMasterList)
 
   // starting thread
   log::debug("starting loot thread");
-  m_thread.reset(QThread::create([&] {
+  m_thread.reset(QThread::create([this] {
     lootThread();
   }));
   m_thread->start();

--- a/src/lootdialog.cpp
+++ b/src/lootdialog.cpp
@@ -62,28 +62,28 @@ LootDialog::LootDialog(QWidget* parent, OrganizerCore& core, Loot& loot)
 
   QObject::connect(
       &m_loot, &Loot::output, this,
-      [&](auto&& s) {
+      [this](auto&& s) {
         addOutput(s);
       },
       Qt::QueuedConnection);
 
   QObject::connect(
       &m_loot, &Loot::progress, this,
-      [&](auto&& p) {
+      [this](auto&& p) {
         setProgress(p);
       },
       Qt::QueuedConnection);
 
   QObject::connect(
       &m_loot, &Loot::log, this,
-      [&](auto&& lv, auto&& s) {
+      [this](auto&& lv, auto&& s) {
         log(lv, s);
       },
       Qt::QueuedConnection);
 
   QObject::connect(
       &m_loot, &Loot::finished, this,
-      [&] {
+      [this] {
         onFinished();
       },
       Qt::QueuedConnection);
@@ -210,7 +210,7 @@ void LootDialog::createUI()
 
   m_expander.set(ui->details, ui->detailsPanel);
   ui->openJsonReport->setEnabled(false);
-  connect(ui->openJsonReport, &QPushButton::clicked, [&] {
+  connect(ui->openJsonReport, &QPushButton::clicked, [this] {
     openReport();
   });
 

--- a/src/mainwindow.cpp
+++ b/src/mainwindow.cpp
@@ -1166,7 +1166,7 @@ bool MainWindow::addProfile()
   QString name = QInputDialog::getText(this, tr("Name"),
                                        tr("Please enter a name for the new profile"),
                                        QLineEdit::Normal, QString(), &okClicked);
-  if (okClicked && (name.size() > 0)) {
+  if (okClicked && (!name.isEmpty())) {
     try {
       profileBox->addItem(name);
       profileBox->setCurrentIndex(profileBox->count() - 1);
@@ -1533,11 +1533,9 @@ void MainWindow::updateToolMenu()
             });
 
   // Remove disabled plugins:
-  toolPlugins.erase(std::remove_if(std::begin(toolPlugins), std::end(toolPlugins),
-                                   [&](auto* tool) {
+  std::erase_if(toolPlugins, [this](auto* tool) {
                                      return !m_PluginContainer.isEnabled(tool);
-                                   }),
-                    toolPlugins.end());
+                                   });
 
   // Group the plugins into submenus
   QMap<QString, QList<QPair<QString, IPluginTool*>>> submenuMap;
@@ -1550,10 +1548,10 @@ void MainWindow::updateToolMenu()
   }
 
   // Start registering plugins
-  for (auto submenuKey : submenuMap.keys()) {
+  for (const auto& submenuKey : submenuMap.keys()) {
     if (submenuMap[submenuKey].length() > 1) {
       QMenu* submenu = new QMenu(submenuKey, this);
-      for (auto info : submenuMap[submenuKey]) {
+      for (const auto& info : submenuMap[submenuKey]) {
         registerPluginTool(info.second, info.first, submenu);
       }
       ui->actionTool->menu()->addMenu(submenu);
@@ -1636,12 +1634,9 @@ void MainWindow::updateModPageMenu()
             });
 
   // Remove disabled plugins
-  modPagePlugins.erase(std::remove_if(std::begin(modPagePlugins),
-                                      std::end(modPagePlugins),
-                                      [&](auto* tool) {
+  std::erase_if(modPagePlugins, [&](auto* tool) {
                                         return !m_PluginContainer.isEnabled(tool);
-                                      }),
-                       modPagePlugins.end());
+                                      });
 
   for (auto* modPagePlugin : modPagePlugins) {
     registerModPage(modPagePlugin);
@@ -1655,7 +1650,7 @@ void MainWindow::updateModPageMenu()
     registeredSources << gameShortName;
 
   // Add the primary sources
-  for (auto gameName : m_OrganizerCore.managedGame()->primarySources()) {
+  for (const auto& gameName : m_OrganizerCore.managedGame()->primarySources()) {
     if (!registeredSources.contains(gameName) && registerNexusPage(gameName))
       registeredSources << gameName;
   }
@@ -1667,14 +1662,14 @@ void MainWindow::updateModPageMenu()
   // Add the secondary games (sorted)
   QStringList secondaryGames = m_OrganizerCore.managedGame()->validShortNames();
   secondaryGames.sort(Qt::CaseInsensitive);
-  for (auto gameName : secondaryGames) {
+  for (const auto& gameName : secondaryGames) {
     if (!registeredSources.contains(gameName) && registerNexusPage(gameName))
       registeredSources << gameName;
   }
 
   // No mod page plugin and the menu was visible
   bool keepOriginalAction =
-      modPagePlugins.size() == 0 && registeredSources.length() <= 1;
+      modPagePlugins.empty() && registeredSources.length() <= 1;
   if (keepOriginalAction) {
     ui->toolBar->insertAction(ui->actionAdd_Profile, ui->actionNexus);
   } else {
@@ -1786,11 +1781,7 @@ void MainWindow::on_profileBox_currentIndexChanged(int index)
     }
 
     // note that setCurrentText() is recursive, it will re-execute this function
-    if (newSelection) {
-      ui->profileBox->setCurrentText(*newSelection);
-    } else {
-      ui->profileBox->setCurrentText(previousName);
-    }
+    ui->profileBox->setCurrentText(newSelection.value_or(previousName));
 
     // nothing else to do because setCurrentText() is recursive and will
     // have re-executed on_profileBox_currentIndexChanged() again, doing all
@@ -1955,7 +1946,7 @@ void MainWindow::updateBSAList(const QStringList& defaultArchives,
   };
 
   for (FileEntryPtr current : files) {
-    QFileInfo fileInfo(ToQString(current->getName().c_str()));
+    QFileInfo fileInfo(ToQString(current->getName()));
 
     if (fileInfo.suffix().toLower() == "bsa" || fileInfo.suffix().toLower() == "ba2") {
       int index = activeArchives.indexOf(fileInfo.fileName());
@@ -2025,7 +2016,7 @@ void MainWindow::updateBSAList(const QStringList& defaultArchives,
     QList<QTreeWidgetItem*> items =
         ui->bsaList->findItems(modName, Qt::MatchFixedString);
     QTreeWidgetItem* subItem = nullptr;
-    if (items.length() > 0) {
+    if (!items.isEmpty()) {
       subItem = items.at(0);
     } else {
       subItem = new QTreeWidgetItem(QStringList(modName));
@@ -2146,7 +2137,7 @@ void MainWindow::readSettings()
   }
 
   s.geometry().restoreState(this);
-  s.geometry().restoreDocks(this);
+  //s.geometry().restoreDocks(this);
   s.geometry().restoreToolbars(this);
   s.geometry().restoreState(ui->splitter);
   s.geometry().restoreState(ui->categoriesSplitter);
@@ -2231,7 +2222,7 @@ void MainWindow::storeSettings()
 
   s.geometry().saveState(this);
   s.geometry().saveGeometry(this);
-  s.geometry().saveDocks(this);
+  //s.geometry().saveDocks(this);
 
   s.geometry().saveVisibility(ui->menuBar);
   s.geometry().saveVisibility(ui->statusBar);
@@ -2868,9 +2859,9 @@ void MainWindow::refreshNexusCategories(CategoriesDialog* dialog)
 
 void MainWindow::categoriesSaved()
 {
-  for (auto modName : m_OrganizerCore.modList()->allMods()) {
+  for (const auto& modName : m_OrganizerCore.modList()->allMods()) {
     auto mod = ModInfo::getByName(modName);
-    for (auto category : mod->getCategories()) {
+    for (const auto& category : mod->getCategories()) {
       if (!m_CategoryFactory.categoryExists(category))
         mod->setCategory(category, false);
     }
@@ -3086,15 +3077,17 @@ void MainWindow::nxmEndorsementsAvailable(QVariant userData, QVariant resultData
   QStringList games = m_OrganizerCore.managedGame()->validShortNames();
   games += m_OrganizerCore.managedGame()->gameShortName();
   bool searchedMO2NexusGame = false;
-  for (auto endorsementData : data) {
+  for (const auto& endorsementData : data) {
     QVariantMap endorsement      = endorsementData.toMap();
     std::pair<int, QString> data = std::make_pair<int, QString>(
         endorsement["mod_id"].toInt(), endorsement["status"].toString());
     sorted.insert(std::pair<QString, std::pair<int, QString>>(
         endorsement["domain_name"].toString(), data));
   }
-  for (auto game : games) {
-    IPluginGame* gamePlugin = m_OrganizerCore.getGame(game);
+  for (const auto& game : games) {
+    const IPluginGame* gamePlugin = m_OrganizerCore.getGame(game);
+    if (gamePlugin == nullptr)
+      continue;
     if (gamePlugin != nullptr &&
         gamePlugin->gameShortName().compare("SkyrimSE", Qt::CaseInsensitive) == 0)
       searchedMO2NexusGame = true;
@@ -3103,7 +3096,7 @@ void MainWindow::nxmEndorsementsAvailable(QVariant userData, QVariant resultData
       std::vector<ModInfo::Ptr> modsList =
           ModInfo::getByModID(result->first, result->second.first);
 
-      for (auto mod : modsList) {
+      for (const auto& mod : modsList) {
         if (mod->endorsedState() != EndorsedState::ENDORSED_NEVER) {
           if (result->second.second == "Endorsed")
             mod->setIsEndorsed(true);
@@ -3147,7 +3140,7 @@ void MainWindow::nxmUpdateInfoAvailable(QString gameName, QVariant userData,
                                         QVariant resultData, int)
 {
   QString gameNameReal;
-  for (IPluginGame* game : m_PluginContainer.plugins<IPluginGame>()) {
+  for (const IPluginGame* game : m_PluginContainer.plugins<IPluginGame>()) {
     if (game->gameNexusName() == gameName) {
       gameNameReal = game->gameShortName();
       break;
@@ -3203,7 +3196,7 @@ void MainWindow::nxmUpdatesAvailable(QString gameName, int modID, QVariant userD
   QList fileUpdates      = resultInfo["file_updates"].toList();
   QString gameNameReal;
 
-  for (IPluginGame* game : m_PluginContainer.plugins<IPluginGame>()) {
+  for (const IPluginGame* game : m_PluginContainer.plugins<IPluginGame>()) {
     if (game->gameNexusName() == gameName) {
       gameNameReal = game->gameShortName();
       break;
@@ -3214,7 +3207,7 @@ void MainWindow::nxmUpdatesAvailable(QString gameName, int modID, QVariant userD
 
   bool requiresInfo = false;
 
-  for (auto mod : modsList) {
+  for (const auto& mod : modsList) {
     QString validNewVersion;
     int newModStatus      = -1;
     QString installedFile = QFileInfo(mod->installationFile()).fileName();
@@ -3223,7 +3216,7 @@ void MainWindow::nxmUpdatesAvailable(QString gameName, int modID, QVariant userD
       QVariantMap foundFileData;
 
       // update the file status
-      for (auto& file : files) {
+      for (const auto& file : files) {
         QVariantMap fileData = file.toMap();
 
         if (fileData["file_name"].toString().compare(installedFile,
@@ -3254,7 +3247,7 @@ void MainWindow::nxmUpdatesAvailable(QString gameName, int modID, QVariant userD
 
       // find installed file ID from the updates list since old filenames are not
       // guaranteed to be unique
-      for (auto& updateEntry : fileUpdates) {
+      for (const auto& updateEntry : fileUpdates) {
         const QVariantMap& updateData = updateEntry.toMap();
 
         if (installedFile.compare(updateData["old_file_name"].toString(),
@@ -3274,14 +3267,14 @@ void MainWindow::nxmUpdatesAvailable(QString gameName, int modID, QVariant userD
         while (lookForMoreUpdates) {
           lookForMoreUpdates = false;
 
-          for (auto& updateEntry : fileUpdates) {
+          for (const auto& updateEntry : fileUpdates) {
             const QVariantMap& updateData = updateEntry.toMap();
 
             if (currentUpdateId == updateData["old_file_id"].toInt()) {
               currentUpdateId = updateData["new_file_id"].toInt();
 
               // check if the new file is still active
-              for (auto& file : files) {
+              for (const auto& file : files) {
                 const QVariantMap& fileData = file.toMap();
 
                 if (currentUpdateId == fileData["file_id"].toInt()) {
@@ -3346,7 +3339,7 @@ void MainWindow::nxmModInfoAvailable(QString gameName, int modID, QVariant userD
   QString gameNameReal;
   bool foundUpdate = false;
 
-  for (IPluginGame* game : m_PluginContainer.plugins<IPluginGame>()) {
+  for (const IPluginGame* game : m_PluginContainer.plugins<IPluginGame>()) {
     if (game->gameNexusName() == gameName) {
       gameNameReal = game->gameShortName();
       break;
@@ -3355,7 +3348,7 @@ void MainWindow::nxmModInfoAvailable(QString gameName, int modID, QVariant userD
 
   std::vector<ModInfo::Ptr> modsList = ModInfo::getByModID(gameNameReal, modID);
 
-  for (auto mod : modsList) {
+  for (const auto& mod : modsList) {
     QDateTime now          = QDateTime::currentDateTimeUtc();
     QDateTime updateTarget = mod->getExpires();
 
@@ -3465,7 +3458,7 @@ void MainWindow::nxmTrackedModsAvailable(QVariant userData, QVariant resultData,
 
     bool found       = false;
     auto resultsList = resultData.toList();
-    for (auto item : resultsList) {
+    for (const auto& item : resultsList) {
       auto results = item.toMap();
       if ((gameNames[results["domain_name"].toString()].compare(
                modInfo->gameName(), Qt::CaseInsensitive) == 0) &&
@@ -3522,11 +3515,10 @@ void MainWindow::nxmGameInfoAvailable(QString gameName, QVariant, QVariant resul
   QVariantList categories     = result["categories"].toList();
   CategoryFactory& catFactory = CategoryFactory::instance();
   catFactory.reset();
-  for (auto category : categories) {
+  for (const auto& category : categories) {
     auto catMap = category.toMap();
     std::vector<CategoryFactory::NexusCategory> nexusCat;
-    nexusCat.push_back(CategoryFactory::NexusCategory(catMap["name"].toString(),
-                                                      catMap["category_id"].toInt()));
+    nexusCat.emplace_back(catMap["name"].toString(), catMap["category_id"].toInt());
     catFactory.addCategory(catMap["name"].toString(), nexusCat, 0);
   }
 }
@@ -3542,7 +3534,7 @@ void MainWindow::nxmRequestFailed(QString gameName, int modID, int, QVariant, in
     // update last checked timestamp on orphaned mods as well to avoid repeating
     // requests
     QString gameNameReal;
-    for (IPluginGame* game : m_PluginContainer.plugins<IPluginGame>()) {
+    for (const IPluginGame* game : m_PluginContainer.plugins<IPluginGame>()) {
       if (game->gameNexusName() == gameName) {
         gameNameReal = game->gameShortName();
         break;
@@ -3605,7 +3597,7 @@ BSA::EErrorCode MainWindow::extractBSA(BSA::Archive& archive, BSA::Folder::Ptr f
 }
 
 bool MainWindow::extractProgress(QProgressDialog& progress, int percentage,
-                                 std::string fileName)
+                                 const std::string& fileName)
 {
   progress.setLabelText(fileName.c_str());
   progress.setValue(percentage);
@@ -3639,7 +3631,7 @@ void MainWindow::extractBSATriggered(QTreeWidgetItem* item)
       archives = QStringList({item->text(0)});
     }
 
-    for (auto archiveName : archives) {
+    for (const auto& archiveName : archives) {
       BSA::Archive archive;
       QString archivePath = QString("%1\\%2").arg(origin).arg(archiveName);
       BSA::EErrorCode result =
@@ -3920,7 +3912,7 @@ void MainWindow::dragEnterEvent(QDragEnterEvent* event)
         if (url.isLocalFile()) {
           QString local = url.toLocalFile();
           bool fok      = false;
-          for (auto ext : extensions) {
+          for (const auto& ext : extensions) {
             if (local.endsWith(ext, Qt::CaseInsensitive)) {
               fok = true;
               break;

--- a/src/mainwindow.cpp
+++ b/src/mainwindow.cpp
@@ -316,16 +316,16 @@ MainWindow::MainWindow(Settings& settings, OrganizerCore& organizerCore,
   m_DataTab.reset(new DataTab(m_OrganizerCore, m_PluginContainer, this, ui));
   m_DataTab->restoreState(settings);
 
-  connect(m_DataTab.get(), &DataTab::executablesChanged, [&] {
+  connect(m_DataTab.get(), &DataTab::executablesChanged, [this] {
     refreshExecutablesList();
   });
 
-  connect(m_DataTab.get(), &DataTab::originModified, [&](int id) {
+  connect(m_DataTab.get(), &DataTab::originModified, [this](int id) {
     originModified(id);
   });
 
   connect(m_DataTab.get(), &DataTab::displayModInformation,
-          [&](auto&& m, auto&& i, auto&& tab) {
+          [this](auto&& m, auto&& i, auto&& tab) {
             displayModInformation(m, i, tab);
           });
 
@@ -421,13 +421,13 @@ MainWindow::MainWindow(Settings& settings, OrganizerCore& organizerCore,
           SIGNAL(tabChanged(int)));
   connect(ui->toolBar, SIGNAL(customContextMenuRequested(QPoint)), this,
           SLOT(toolBar_customContextMenuRequested(QPoint)));
-  connect(ui->menuToolbars, &QMenu::aboutToShow, [&] {
+  connect(ui->menuToolbars, &QMenu::aboutToShow, [this] {
     updateToolbarMenu();
   });
-  connect(ui->menuView, &QMenu::aboutToShow, [&] {
+  connect(ui->menuView, &QMenu::aboutToShow, [this] {
     updateViewMenu();
   });
-  connect(ui->actionTool->menu(), &QMenu::aboutToShow, [&] {
+  connect(ui->actionTool->menu(), &QMenu::aboutToShow, [this] {
     updateToolMenu();
   });
   connect(&m_PluginContainer, &PluginContainer::pluginEnabled, this,
@@ -552,7 +552,7 @@ void MainWindow::setupModList()
   connect(&ui->modList->actions(), &ModListViewActions::modInfoDisplayed, this,
           &MainWindow::modInfoDisplayed);
 
-  connect(m_OrganizerCore.modList(), &ModList::modPrioritiesChanged, [&]() {
+  connect(m_OrganizerCore.modList(), &ModList::modPrioritiesChanged, [this]() {
     m_ArchiveListWriter.write();
   });
 }
@@ -1534,8 +1534,8 @@ void MainWindow::updateToolMenu()
 
   // Remove disabled plugins:
   std::erase_if(toolPlugins, [this](auto* tool) {
-                                     return !m_PluginContainer.isEnabled(tool);
-                                   });
+    return !m_PluginContainer.isEnabled(tool);
+  });
 
   // Group the plugins into submenus
   QMap<QString, QList<QPair<QString, IPluginTool*>>> submenuMap;
@@ -1634,9 +1634,9 @@ void MainWindow::updateModPageMenu()
             });
 
   // Remove disabled plugins
-  std::erase_if(modPagePlugins, [&](auto* tool) {
-                                        return !m_PluginContainer.isEnabled(tool);
-                                      });
+  std::erase_if(modPagePlugins, [this](auto* tool) {
+    return !m_PluginContainer.isEnabled(tool);
+  });
 
   for (auto* modPagePlugin : modPagePlugins) {
     registerModPage(modPagePlugin);
@@ -1668,8 +1668,7 @@ void MainWindow::updateModPageMenu()
   }
 
   // No mod page plugin and the menu was visible
-  bool keepOriginalAction =
-      modPagePlugins.empty() && registeredSources.length() <= 1;
+  bool keepOriginalAction = modPagePlugins.empty() && registeredSources.length() <= 1;
   if (keepOriginalAction) {
     ui->toolBar->insertAction(ui->actionAdd_Profile, ui->actionNexus);
   } else {
@@ -2137,7 +2136,7 @@ void MainWindow::readSettings()
   }
 
   s.geometry().restoreState(this);
-  //s.geometry().restoreDocks(this);
+  // s.geometry().restoreDocks(this);
   s.geometry().restoreToolbars(this);
   s.geometry().restoreState(ui->splitter);
   s.geometry().restoreState(ui->categoriesSplitter);
@@ -2222,7 +2221,7 @@ void MainWindow::storeSettings()
 
   s.geometry().saveState(this);
   s.geometry().saveGeometry(this);
-  //s.geometry().saveDocks(this);
+  // s.geometry().saveDocks(this);
 
   s.geometry().saveVisibility(ui->menuBar);
   s.geometry().saveVisibility(ui->statusBar);
@@ -3661,7 +3660,7 @@ void MainWindow::extractBSATriggered(QTreeWidgetItem* item)
 void MainWindow::on_bsaList_customContextMenuRequested(const QPoint& pos)
 {
   QMenu menu;
-  menu.addAction(tr("Extract..."), [=, item = ui->bsaList->itemAt(pos)]() {
+  menu.addAction(tr("Extract..."), [this, item = ui->bsaList->itemAt(pos)]() {
     extractBSATriggered(item);
   });
 

--- a/src/mainwindow.h
+++ b/src/mainwindow.h
@@ -223,7 +223,7 @@ private:
   void fixCategories();
 
   bool extractProgress(QProgressDialog& extractProgress, int percentage,
-                       std::string fileName);
+                       const std::string& fileName);
 
   // Performs checks, sets the m_NumberOfProblems and signals checkForProblemsDone().
   void checkForProblemsImpl();

--- a/src/moapplication.cpp
+++ b/src/moapplication.cpp
@@ -150,7 +150,7 @@ MOApplication::MOApplication(int& argc, char** argv) : QApplication(argc, argv)
 
   qputenv("QML_DISABLE_DISK_CACHE", "true");
 
-  connect(&m_styleWatcher, &QFileSystemWatcher::fileChanged, [&](auto&& file) {
+  connect(&m_styleWatcher, &QFileSystemWatcher::fileChanged, [this](auto&& file) {
     log::debug("style file '{}' changed, reloading", file);
     updateStyle(file);
   });

--- a/src/modinfo.cpp
+++ b/src/modinfo.cpp
@@ -143,7 +143,7 @@ std::vector<ModInfo::Ptr> ModInfo::getByModID(QString game, int modID)
   QMutexLocker locker(&s_Mutex);
 
   std::vector<unsigned int> match;
-  for (auto iter : s_ModsByModID) {
+  for (const auto& iter : s_ModsByModID) {
     if (iter.first.second == modID) {
       if (iter.first.first.compare(game, Qt::CaseInsensitive) == 0) {
         match.insert(match.end(), iter.second.begin(), iter.second.end());
@@ -195,7 +195,7 @@ bool ModInfo::removeMod(unsigned int index)
       std::pair<QString, int>(modInfo->gameName(), modInfo->nexusId()));
   if (iter != s_ModsByModID.end()) {
     std::vector<unsigned int> indices = iter->second;
-    indices.erase(std::remove(indices.begin(), indices.end(), index), indices.end());
+    std::erase(indices, index);
     s_ModsByModID[std::pair<QString, int>(modInfo->gameName(), modInfo->nexusId())] =
         indices;
   }
@@ -294,7 +294,7 @@ void ModInfo::updateIndices()
   }
 }
 
-ModInfo::ModInfo(OrganizerCore& core) : m_PrimaryCategory(-1), m_Core(core) {}
+ModInfo::ModInfo(OrganizerCore& core) : m_Core(core), m_PrimaryCategory(-1) {}
 
 bool ModInfo::checkAllForUpdate(PluginContainer* pluginContainer, QObject* receiver)
 {
@@ -358,26 +358,26 @@ bool ModInfo::checkAllForUpdate(PluginContainer* pluginContainer, QObject* recei
                          "in order to parse the remaining mods."));
     }
 
-    for (auto game : organizedGames)
+    for (const auto& game : organizedGames)
       NexusInterface::instance().requestUpdates(game.second, receiver, QVariant(),
                                                 game.first, QString());
   } else if (earliest < QDateTime::currentDateTimeUtc().addMonths(-1)) {
-    for (auto gameName : games)
+    for (const auto& gameName : games)
       NexusInterface::instance().requestUpdateInfo(gameName,
                                                    NexusInterface::UpdatePeriod::MONTH,
                                                    receiver, QVariant(true), QString());
   } else if (earliest < QDateTime::currentDateTimeUtc().addDays(-7)) {
-    for (auto gameName : games)
+    for (const auto& gameName : games)
       NexusInterface::instance().requestUpdateInfo(
           gameName, NexusInterface::UpdatePeriod::MONTH, receiver, QVariant(false),
           QString());
   } else if (earliest < QDateTime::currentDateTimeUtc().addDays(-1)) {
-    for (auto gameName : games)
+    for (const auto& gameName : games)
       NexusInterface::instance().requestUpdateInfo(
           gameName, NexusInterface::UpdatePeriod::WEEK, receiver, QVariant(false),
           QString());
   } else {
-    for (auto gameName : games)
+    for (const auto& gameName : games)
       NexusInterface::instance().requestUpdateInfo(
           gameName, NexusInterface::UpdatePeriod::DAY, receiver, QVariant(false),
           QString());
@@ -426,22 +426,22 @@ std::set<QSharedPointer<ModInfo>> ModInfo::filteredMods(QString gameName,
     std::set<QSharedPointer<ModInfo>> diff;
     std::set_difference(updates.begin(), updates.end(), finalMods.begin(),
                         finalMods.end(), std::inserter(diff, diff.end()));
-    for (auto skipped : diff) {
+    for (const auto& skipped : diff) {
       skipped->setLastNexusUpdate(QDateTime::currentDateTimeUtc());
     }
   }
   return finalMods;
 }
 
-void ModInfo::manualUpdateCheck(QObject* receiver, std::multimap<QString, int> IDs)
+void ModInfo::manualUpdateCheck(QObject* receiver, const std::multimap<QString, int>& IDs)
 {
   std::vector<QSharedPointer<ModInfo>> mods;
   std::set<std::pair<QString, int>> organizedGames;
 
-  for (auto ID : IDs) {
-    for (auto matchedMod : getByModID(ID.first, ID.second)) {
+  for (const auto& ID : IDs) {
+    for (const auto& matchedMod : getByModID(ID.first, ID.second)) {
       bool alreadyMatched = false;
-      for (auto mod : mods) {
+      for (const auto& mod : mods) {
         if (mod == matchedMod) {
           alreadyMatched = true;
           break;
@@ -451,12 +451,10 @@ void ModInfo::manualUpdateCheck(QObject* receiver, std::multimap<QString, int> I
         mods.push_back(matchedMod);
     }
   }
-  mods.erase(std::remove_if(mods.begin(), mods.end(),
-                            [](ModInfo::Ptr mod) -> bool {
+  std::erase_if(mods, [](ModInfo::Ptr mod) -> bool {
                               return mod->nexusId() <= 0;
-                            }),
-             mods.end());
-  for (auto mod : mods) {
+                            });
+  for (const auto& mod : mods) {
     mod->setLastNexusUpdate(QDateTime());
   }
 
@@ -465,15 +463,15 @@ void ModInfo::manualUpdateCheck(QObject* receiver, std::multimap<QString, int> I
               return a->getLastNexusUpdate() < b->getLastNexusUpdate();
             });
 
-  if (mods.size()) {
+  if (!mods.empty()) {
     log::info("Checking updates for {} mods...", mods.size());
 
-    for (auto mod : mods) {
+    for (const auto& mod : mods) {
       organizedGames.insert(
           std::make_pair<QString, int>(mod->gameName().toLower(), mod->nexusId()));
     }
 
-    for (auto game : organizedGames) {
+    for (const auto& game : organizedGames) {
       NexusInterface::instance().requestUpdates(game.second, receiver, QVariant(),
                                                 game.first, QString());
     }
@@ -527,13 +525,12 @@ QStringList ModInfo::categories() const
   return result;
 }
 
-bool ModInfo::hasFlag(ModInfo::EFlag flag) const
+bool ModInfo::hasFlag(const ModInfo::EFlag& flag) const
 {
-  std::vector<EFlag> flags = getFlags();
-  return std::find(flags.begin(), flags.end(), flag) != flags.end();
+  return std::ranges::contains(getFlags(), flag);
 }
 
-bool ModInfo::hasAnyOfTheseFlags(std::vector<ModInfo::EFlag> flags) const
+bool ModInfo::hasAnyOfTheseFlags(const std::vector<ModInfo::EFlag>& flags) const
 {
   std::vector<EFlag> modFlags = getFlags();
   for (auto modFlag : modFlags) {

--- a/src/modinfo.cpp
+++ b/src/modinfo.cpp
@@ -303,7 +303,7 @@ bool ModInfo::checkAllForUpdate(PluginContainer* pluginContainer, QObject* recei
   QDateTime earliest = QDateTime::currentDateTimeUtc();
   QDateTime latest   = QDateTime::fromMSecsSinceEpoch(0);
   std::set<QString> games;
-  for (auto mod : s_Collection) {
+  for (const auto& mod : s_Collection) {
     if (mod->canBeUpdated()) {
       if (mod->getLastNexusUpdate() < earliest)
         earliest = mod->getLastNexusUpdate();
@@ -336,11 +336,10 @@ bool ModInfo::checkAllForUpdate(PluginContainer* pluginContainer, QObject* recei
 
   if (latest < QDateTime::currentDateTimeUtc().addMonths(-1)) {
     std::set<std::pair<QString, int>> organizedGames;
-    for (auto mod : s_Collection) {
+    for (const auto& mod : s_Collection) {
       if (mod->canBeUpdated() &&
           mod->getLastNexusUpdate() < QDateTime::currentDateTimeUtc().addMonths(-1)) {
-        organizedGames.insert(
-            std::make_pair<QString, int>(mod->gameName().toLower(), mod->nexusId()));
+        organizedGames.emplace(mod->gameName().toLower(), mod->nexusId());
       }
     }
 
@@ -392,7 +391,7 @@ std::set<QSharedPointer<ModInfo>> ModInfo::filteredMods(QString gameName,
                                                         bool markUpdated)
 {
   std::set<QSharedPointer<ModInfo>> finalMods;
-  for (QVariant result : updateData) {
+  for (const QVariant& result : updateData) {
     QVariantMap update = result.toMap();
     std::copy_if(s_Collection.begin(), s_Collection.end(),
                  std::inserter(finalMods, finalMods.end()),
@@ -433,7 +432,8 @@ std::set<QSharedPointer<ModInfo>> ModInfo::filteredMods(QString gameName,
   return finalMods;
 }
 
-void ModInfo::manualUpdateCheck(QObject* receiver, const std::multimap<QString, int>& IDs)
+void ModInfo::manualUpdateCheck(QObject* receiver,
+                                const std::multimap<QString, int>& IDs)
 {
   std::vector<QSharedPointer<ModInfo>> mods;
   std::set<std::pair<QString, int>> organizedGames;
@@ -452,8 +452,8 @@ void ModInfo::manualUpdateCheck(QObject* receiver, const std::multimap<QString, 
     }
   }
   std::erase_if(mods, [](ModInfo::Ptr mod) -> bool {
-                              return mod->nexusId() <= 0;
-                            });
+    return mod->nexusId() <= 0;
+  });
   for (const auto& mod : mods) {
     mod->setLastNexusUpdate(QDateTime());
   }
@@ -517,7 +517,7 @@ QStringList ModInfo::categories() const
 {
   QStringList result;
 
-  CategoryFactory& catFac = CategoryFactory::instance();
+  const CategoryFactory& catFac = CategoryFactory::instance();
   for (int id : m_Categories) {
     result.append(catFac.getCategoryName(catFac.getCategoryIndex(id)));
   }

--- a/src/modinfo.h
+++ b/src/modinfo.h
@@ -207,7 +207,8 @@ public:  // Static functions:
    * @brief Run a limited batch of mod update checks for "newest version" information.
    *
    */
-  static void manualUpdateCheck(QObject* receiver, const std::multimap<QString, int>& IDs);
+  static void manualUpdateCheck(QObject* receiver,
+                                const std::multimap<QString, int>& IDs);
 
   /**
    * @brief Query nexus information for every mod and update the "newest version"

--- a/src/modinfo.h
+++ b/src/modinfo.h
@@ -207,7 +207,7 @@ public:  // Static functions:
    * @brief Run a limited batch of mod update checks for "newest version" information.
    *
    */
-  static void manualUpdateCheck(QObject* receiver, std::multimap<QString, int> IDs);
+  static void manualUpdateCheck(QObject* receiver, const std::multimap<QString, int>& IDs);
 
   /**
    * @brief Query nexus information for every mod and update the "newest version"
@@ -704,7 +704,7 @@ public:  // Methods after this do not come from IModInterface:
    *
    * @return true if the flag is set, false otherwise.
    */
-  bool hasFlag(EFlag flag) const;
+  bool hasFlag(const EFlag& flag) const;
 
   /**
    * @brief Check if any of the provided flags are set for this mod.
@@ -713,7 +713,7 @@ public:  // Methods after this do not come from IModInterface:
    *
    * @return true if any of the flags are set, false otherwise.
    */
-  bool hasAnyOfTheseFlags(std::vector<ModInfo::EFlag> flags) const;
+  bool hasAnyOfTheseFlags(const std::vector<ModInfo::EFlag>& flags) const;
 
   /**
    * @brief Check if this mod contains the specified content.

--- a/src/modinfodialog.cpp
+++ b/src/modinfodialog.cpp
@@ -175,19 +175,19 @@ ModInfoDialog::ModInfoDialog(OrganizerCore& core, PluginContainer& plugin,
 
   {
     auto* sc = new QShortcut(QKeySequence::Delete, this);
-    connect(sc, &QShortcut::activated, [&] {
+    connect(sc, &QShortcut::activated, [this] {
       onDeleteShortcut();
     });
   }
   {
     auto* sc = new QShortcut(QKeySequence::MoveToNextPage, this);
-    connect(sc, &QShortcut::activated, [&] {
+    connect(sc, &QShortcut::activated, [this] {
       onNextMod();
     });
   }
   {
     auto* sc = new QShortcut(QKeySequence::MoveToPreviousPage, this);
-    connect(sc, &QShortcut::activated, [&] {
+    connect(sc, &QShortcut::activated, [this] {
       onPreviousMod();
     });
   }
@@ -195,19 +195,19 @@ ModInfoDialog::ModInfoDialog(OrganizerCore& core, PluginContainer& plugin,
   setMod(mod);
   createTabs();
 
-  connect(ui->tabWidget, &QTabWidget::currentChanged, [&] {
+  connect(ui->tabWidget, &QTabWidget::currentChanged, [this] {
     onTabSelectionChanged();
   });
-  connect(ui->tabWidget->tabBar(), &QTabBar::tabMoved, [&] {
+  connect(ui->tabWidget->tabBar(), &QTabBar::tabMoved, [this] {
     onTabMoved();
   });
-  connect(ui->close, &QPushButton::clicked, [&] {
+  connect(ui->close, &QPushButton::clicked, [this] {
     onCloseButton();
   });
-  connect(ui->previousMod, &QPushButton::clicked, [&] {
+  connect(ui->previousMod, &QPushButton::clicked, [this] {
     onPreviousMod();
   });
-  connect(ui->nextMod, &QPushButton::clicked, [&] {
+  connect(ui->nextMod, &QPushButton::clicked, [this] {
     onNextMod();
   });
 }
@@ -256,17 +256,17 @@ void ModInfoDialog::createTabs()
       onOriginModified(originID);
     });
 
-    connect(tabInfo.tab.get(), &ModInfoDialogTab::modOpen, [&](const QString& name) {
+    connect(tabInfo.tab.get(), &ModInfoDialogTab::modOpen, [this](const QString& name) {
       setMod(name);
       update();
     });
 
-    connect(tabInfo.tab.get(), &ModInfoDialogTab::hasDataChanged, [&] {
+    connect(tabInfo.tab.get(), &ModInfoDialogTab::hasDataChanged, [this] {
       setTabsColors();
     });
 
     connect(tabInfo.tab.get(), &ModInfoDialogTab::wantsFocus,
-            [&, id = tabInfo.tab->tabID()] {
+            [this, id = tabInfo.tab->tabID()] {
               switchToTab(id);
             });
   }

--- a/src/modinfodialogcategories.cpp
+++ b/src/modinfodialogcategories.cpp
@@ -6,13 +6,13 @@
 CategoriesTab::CategoriesTab(ModInfoDialogTabContext cx)
     : ModInfoDialogTab(std::move(cx))
 {
-  connect(ui->categories, &QTreeWidget::itemChanged, [&](auto* item, int col) {
+  connect(ui->categories, &QTreeWidget::itemChanged, [this](auto* item, int col) {
     onCategoryChanged(item, col);
   });
 
   connect(ui->primaryCategories,
           static_cast<void (QComboBox::*)(int)>(&QComboBox::currentIndexChanged),
-          [&](int index) {
+          [this](int index) {
             onPrimaryChanged(index);
           });
 }

--- a/src/modinfodialogcategories.cpp
+++ b/src/modinfodialogcategories.cpp
@@ -61,7 +61,7 @@ void CategoriesTab::add(const CategoryFactory& factory,
     newItem->setFlags(newItem->flags() | Qt::ItemIsUserCheckable);
 
     newItem->setCheckState(0,
-                           enabledCategories.find(categoryID) != enabledCategories.end()
+                           enabledCategories.contains(categoryID)
                                ? Qt::Checked
                                : Qt::Unchecked);
 

--- a/src/modinfodialogcategories.cpp
+++ b/src/modinfodialogcategories.cpp
@@ -60,10 +60,8 @@ void CategoriesTab::add(const CategoryFactory& factory,
 
     newItem->setFlags(newItem->flags() | Qt::ItemIsUserCheckable);
 
-    newItem->setCheckState(0,
-                           enabledCategories.contains(categoryID)
-                               ? Qt::Checked
-                               : Qt::Unchecked);
+    newItem->setCheckState(0, enabledCategories.contains(categoryID) ? Qt::Checked
+                                                                     : Qt::Unchecked);
 
     newItem->setData(0, Qt::UserRole, categoryID);
 

--- a/src/modinfodialogconflicts.cpp
+++ b/src/modinfodialogconflicts.cpp
@@ -19,7 +19,7 @@ const std::size_t max_small_selection = 50;
 
 std::size_t smallSelectionSize(const QTreeView* tree)
 {
-  const std::size_t too_many = std::numeric_limits<std::size_t>::max();
+  constexpr std::size_t too_many = std::numeric_limits<std::size_t>::max();
 
   std::size_t n   = 0;
   const auto* sel = tree->selectionModel();
@@ -205,7 +205,7 @@ void ConflictsTab::activateItems(QTreeView* tree)
   // the menu item is only shown for a single selection, but handle all of them
   // in case this changes
   forEachInSelection(tree, [&](const ConflictItem* item) {
-    const auto path = item->fileName();
+    const auto& path = item->fileName();
 
     if (tryPreview && canPreviewFile(plugin(), item->isArchive(), path)) {
       previewItem(item);

--- a/src/modinfodialogconflicts.cpp
+++ b/src/modinfodialogconflicts.cpp
@@ -68,11 +68,11 @@ ConflictsTab::ConflictsTab(ModInfoDialogTabContext cx)
     : ModInfoDialogTab(cx),  // don't move, cx is used again
       m_general(this, cx.ui, cx.core), m_advanced(this, cx.ui, cx.core)
 {
-  connect(&m_general, &GeneralConflictsTab::modOpen, [&](const QString& name) {
+  connect(&m_general, &GeneralConflictsTab::modOpen, [this](const QString& name) {
     emitModOpen(name);
   });
 
-  connect(&m_advanced, &AdvancedConflictsTab::modOpen, [&](const QString& name) {
+  connect(&m_advanced, &AdvancedConflictsTab::modOpen, [this](const QString& name) {
     emitModOpen(name);
   });
 }
@@ -151,7 +151,7 @@ void ConflictsTab::hideItems(QTreeView* tree)
     return;
   }
 
-  forEachInSelection(tree, [&](const ConflictItem* item) {
+  forEachInSelection(tree, [&stop, &renamer, &changed](const ConflictItem* item) {
     if (stop) {
       return false;
     }
@@ -204,7 +204,7 @@ void ConflictsTab::activateItems(QTreeView* tree)
 
   // the menu item is only shown for a single selection, but handle all of them
   // in case this changes
-  forEachInSelection(tree, [&](const ConflictItem* item) {
+  forEachInSelection(tree, [this, &tryPreview](const ConflictItem* item) {
     const auto& path = item->fileName();
 
     if (tryPreview && canPreviewFile(plugin(), item->isArchive(), path)) {
@@ -221,7 +221,7 @@ void ConflictsTab::openItems(QTreeView* tree, bool hooked)
 {
   // the menu item is only shown for a single selection, but handle all of them
   // in case this changes
-  forEachInSelection(tree, [&](const ConflictItem* item) {
+  forEachInSelection(tree, [this, &hooked](const ConflictItem* item) {
     openItem(item, hooked);
     return true;
   });
@@ -241,7 +241,7 @@ void ConflictsTab::previewItems(QTreeView* tree)
 {
   // the menu item is only shown for a single selection, but handle all of them
   // in case this changes
-  forEachInSelection(tree, [&](const ConflictItem* item) {
+  forEachInSelection(tree, [this](const ConflictItem* item) {
     previewItem(item);
     return true;
   });
@@ -256,7 +256,7 @@ void ConflictsTab::exploreItems(QTreeView* tree)
 {
   // the menu item is only shown for a single selection, but handle all of them
   // in case this changes
-  forEachInSelection(tree, [&](const ConflictItem* item) {
+  forEachInSelection(tree, [](const ConflictItem* item) {
     shell::Explore(item->fileName());
     return true;
   });
@@ -270,14 +270,14 @@ void ConflictsTab::showContextMenu(const QPoint& pos, QTreeView* tree)
 
   // open
   if (actions.open) {
-    connect(actions.open, &QAction::triggered, [&] {
+    connect(actions.open, &QAction::triggered, [this, &tree] {
       openItems(tree, false);
     });
   }
 
   // preview
   if (actions.preview) {
-    connect(actions.preview, &QAction::triggered, [&] {
+    connect(actions.preview, &QAction::triggered, [this, &tree] {
       previewItems(tree);
     });
   }
@@ -303,7 +303,7 @@ void ConflictsTab::showContextMenu(const QPoint& pos, QTreeView* tree)
 
   // run hooked
   if (actions.runHooked) {
-    connect(actions.runHooked, &QAction::triggered, [&] {
+    connect(actions.runHooked, &QAction::triggered, [this, &tree] {
       openItems(tree, true);
     });
 
@@ -315,7 +315,7 @@ void ConflictsTab::showContextMenu(const QPoint& pos, QTreeView* tree)
     menu.addMenu(actions.gotoMenu);
 
     for (auto* a : actions.gotoActions) {
-      connect(a, &QAction::triggered, [&, name = a->text()] {
+      connect(a, &QAction::triggered, [this, name = a->text()] {
         emitModOpen(name);
       });
 
@@ -325,7 +325,7 @@ void ConflictsTab::showContextMenu(const QPoint& pos, QTreeView* tree)
 
   // explore
   if (actions.explore) {
-    connect(actions.explore, &QAction::triggered, [&] {
+    connect(actions.explore, &QAction::triggered, [this, &tree] {
       exploreItems(tree);
     });
 
@@ -336,7 +336,7 @@ void ConflictsTab::showContextMenu(const QPoint& pos, QTreeView* tree)
 
   // hide
   if (actions.hide) {
-    connect(actions.hide, &QAction::triggered, [&] {
+    connect(actions.hide, &QAction::triggered, [this, &tree] {
       hideItems(tree);
     });
 
@@ -420,7 +420,7 @@ ConflictsTab::Actions ConflictsTab::createMenuActions(QTreeView* tree)
       // show the menu items is worth it
       enableHide = false;
 
-      forEachInSelection(tree, [&](const ConflictItem* item) {
+      forEachInSelection(tree, [&enableHide, &enableGoto](const ConflictItem* item) {
         if (item->canHide()) {
           enableHide = true;
         }
@@ -531,30 +531,30 @@ GeneralConflictsTab::GeneralConflictsTab(ConflictsTab* tab, Ui::ModInfoDialog* p
   m_filterNoConflicts.setList(ui->noConflictTree);
   m_filterNoConflicts.setUseSourceSort(true);
 
-  QObject::connect(ui->overwriteTree, &QTreeView::doubleClicked, [&](auto&&) {
+  QObject::connect(ui->overwriteTree, &QTreeView::doubleClicked, [this](auto&&) {
     m_tab->activateItems(ui->overwriteTree);
   });
 
-  QObject::connect(ui->overwrittenTree, &QTreeView::doubleClicked, [&](auto&& item) {
+  QObject::connect(ui->overwrittenTree, &QTreeView::doubleClicked, [this](auto&& item) {
     m_tab->activateItems(ui->overwrittenTree);
   });
 
-  QObject::connect(ui->noConflictTree, &QTreeView::doubleClicked, [&](auto&& item) {
+  QObject::connect(ui->noConflictTree, &QTreeView::doubleClicked, [this](auto&& item) {
     m_tab->activateItems(ui->noConflictTree);
   });
 
   QObject::connect(ui->overwriteTree, &QTreeView::customContextMenuRequested,
-                   [&](const QPoint& p) {
+                   [this](const QPoint& p) {
                      m_tab->showContextMenu(p, ui->overwriteTree);
                    });
 
   QObject::connect(ui->overwrittenTree, &QTreeView::customContextMenuRequested,
-                   [&](const QPoint& p) {
+                   [this](const QPoint& p) {
                      m_tab->showContextMenu(p, ui->overwrittenTree);
                    });
 
   QObject::connect(ui->noConflictTree, &QTreeView::customContextMenuRequested,
-                   [&](const QPoint& p) {
+                   [this](const QPoint& p) {
                      m_tab->showContextMenu(p, ui->noConflictTree);
                    });
 }
@@ -898,24 +898,24 @@ AdvancedConflictsTab::AdvancedConflictsTab(ConflictsTab* tab, Ui::ModInfoDialog*
 
   // don't elide the overwritten by column so that the nearest are visible
 
-  QObject::connect(ui->conflictsAdvancedShowNoConflict, &QCheckBox::clicked, [&] {
+  QObject::connect(ui->conflictsAdvancedShowNoConflict, &QCheckBox::clicked, [this] {
     update();
   });
 
-  QObject::connect(ui->conflictsAdvancedShowAll, &QRadioButton::clicked, [&] {
+  QObject::connect(ui->conflictsAdvancedShowAll, &QRadioButton::clicked, [this] {
     update();
   });
 
-  QObject::connect(ui->conflictsAdvancedShowNearest, &QRadioButton::clicked, [&] {
+  QObject::connect(ui->conflictsAdvancedShowNearest, &QRadioButton::clicked, [this] {
     update();
   });
 
-  QObject::connect(ui->conflictsAdvancedList, &QTreeView::activated, [&] {
+  QObject::connect(ui->conflictsAdvancedList, &QTreeView::activated, [this] {
     m_tab->activateItems(ui->conflictsAdvancedList);
   });
 
   QObject::connect(ui->conflictsAdvancedList, &QTreeView::customContextMenuRequested,
-                   [&](const QPoint& p) {
+                   [this](const QPoint& p) {
                      m_tab->showContextMenu(p, ui->conflictsAdvancedList);
                    });
 }

--- a/src/modinfodialogesps.cpp
+++ b/src/modinfodialogesps.cpp
@@ -202,11 +202,11 @@ ESPsTab::ESPsTab(ModInfoDialogTabContext cx)
   ui->inactiveESPList->setModel(m_inactiveModel);
   ui->activeESPList->setModel(m_activeModel);
 
-  QObject::connect(ui->activateESP, &QToolButton::clicked, [&] {
+  QObject::connect(ui->activateESP, &QToolButton::clicked, [this] {
     onActivate();
   });
 
-  QObject::connect(ui->deactivateESP, &QToolButton::clicked, [&] {
+  QObject::connect(ui->deactivateESP, &QToolButton::clicked, [this] {
     onDeactivate();
   });
 }

--- a/src/modinfodialogfiletree.cpp
+++ b/src/modinfodialogfiletree.cpp
@@ -32,39 +32,40 @@ FileTreeTab::FileTreeTab(ModInfoDialogTabContext cx)
   m_actions.hide      = new QAction(tr("&Hide"), ui->filetree);
   m_actions.unhide    = new QAction(tr("&Unhide"), ui->filetree);
 
-  connect(m_actions.newFolder, &QAction::triggered, [&] {
+  connect(m_actions.newFolder, &QAction::triggered, [this] {
     onCreateDirectory();
   });
-  connect(m_actions.open, &QAction::triggered, [&] {
+  connect(m_actions.open, &QAction::triggered, [this] {
     onOpen();
   });
-  connect(m_actions.runHooked, &QAction::triggered, [&] {
+  connect(m_actions.runHooked, &QAction::triggered, [this] {
     onRunHooked();
   });
-  connect(m_actions.preview, &QAction::triggered, [&] {
+  connect(m_actions.preview, &QAction::triggered, [this] {
     onPreview();
   });
-  connect(m_actions.explore, &QAction::triggered, [&] {
+  connect(m_actions.explore, &QAction::triggered, [this] {
     onExplore();
   });
-  connect(m_actions.rename, &QAction::triggered, [&] {
+  connect(m_actions.rename, &QAction::triggered, [this] {
     onRename();
   });
-  connect(m_actions.del, &QAction::triggered, [&] {
+  connect(m_actions.del, &QAction::triggered, [this] {
     onDelete();
   });
-  connect(m_actions.hide, &QAction::triggered, [&] {
+  connect(m_actions.hide, &QAction::triggered, [this] {
     onHide();
   });
-  connect(m_actions.unhide, &QAction::triggered, [&] {
+  connect(m_actions.unhide, &QAction::triggered, [this] {
     onUnhide();
   });
 
-  connect(ui->openInExplorer, &QToolButton::clicked, [&] {
+  connect(ui->openInExplorer, &QToolButton::clicked, [this] {
     onOpenInExplorer();
   });
 
-  connect(ui->filetree, &QTreeView::customContextMenuRequested, [&](const QPoint& pos) {
+  connect(ui->filetree, &QTreeView::customContextMenuRequested,
+          [this](const QPoint& pos) {
     onContextMenu(pos);
   });
 
@@ -72,7 +73,7 @@ FileTreeTab::FileTreeTab(ModInfoDialogTabContext cx)
   ui->filetree->setEditTriggers(ui->filetree->editTriggers() &
                                 (~QAbstractItemView::DoubleClicked));
 
-  connect(ui->filetree, &QTreeView::activated, [&](auto&&) {
+  connect(ui->filetree, &QTreeView::activated, [this](auto&&) {
     onActivated();
   });
 }
@@ -434,7 +435,7 @@ void FileTreeTab::onContextMenu(const QPoint& pos)
     enableDelete    = true;
 
     // only enable open action if a file is selected
-    bool hasFiles = false;
+    //bool hasFiles = false;
 
     const QString fileName = m_fs->fileName(selection[0]);
 

--- a/src/modinfodialogfiletree.cpp
+++ b/src/modinfodialogfiletree.cpp
@@ -66,8 +66,8 @@ FileTreeTab::FileTreeTab(ModInfoDialogTabContext cx)
 
   connect(ui->filetree, &QTreeView::customContextMenuRequested,
           [this](const QPoint& pos) {
-    onContextMenu(pos);
-  });
+            onContextMenu(pos);
+          });
 
   // disable renaming on double click, open the file instead
   ui->filetree->setEditTriggers(ui->filetree->editTriggers() &
@@ -435,7 +435,7 @@ void FileTreeTab::onContextMenu(const QPoint& pos)
     enableDelete    = true;
 
     // only enable open action if a file is selected
-    //bool hasFiles = false;
+    // bool hasFiles = false;
 
     const QString fileName = m_fs->fileName(selection[0]);
 

--- a/src/modinfodialogimages.cpp
+++ b/src/modinfodialogimages.cpp
@@ -780,7 +780,7 @@ void ScalableImage::paintEvent(QPaintEvent* e)
 }
 
 Metrics::Metrics()
-    : margins(3), border(1), padding(0), spacing(5), textSpacing(2), textHeight(0)
+    : margins(3), border(1), padding(0), textSpacing(2), textHeight(0), spacing(5)
 {}
 
 Geometry::Geometry(QSize widgetSize, Metrics metrics)

--- a/src/modinfodialogimages.cpp
+++ b/src/modinfodialogimages.cpp
@@ -52,24 +52,24 @@ ImagesTab::ImagesTab(ModInfoDialogTabContext cx)
   ui->imagesThumbnails->setTab(this);
 
   ui->imagesScrollerVBar->setTab(this);
-  connect(ui->imagesScrollerVBar, &QScrollBar::valueChanged, [&] {
+  connect(ui->imagesScrollerVBar, &QScrollBar::valueChanged, [this] {
     onScrolled();
   });
 
   ui->imagesShowDDS->setEnabled(m_ddsAvailable);
 
   m_filter.setEdit(ui->imagesFilter);
-  connect(&m_filter, &FilterWidget::changed, [&] {
+  connect(&m_filter, &FilterWidget::changed, [this] {
     onFilterChanged();
   });
 
-  connect(ui->imagesExplore, &QAbstractButton::clicked, [&] {
+  connect(ui->imagesExplore, &QAbstractButton::clicked, [this] {
     onExplore();
   });
-  connect(ui->imagesShowDDS, &QCheckBox::toggled, [&] {
+  connect(ui->imagesShowDDS, &QCheckBox::toggled, [this] {
     onShowDDS();
   });
-  connect(ui->previewPluginButton, &QAbstractButton::clicked, [&] {
+  connect(ui->previewPluginButton, &QAbstractButton::clicked, [this] {
     onPreviewButton();
   });
 
@@ -196,7 +196,7 @@ void ImagesTab::switchToFiltered()
   for (File& f : m_files.allFiles()) {
     if (hasTextFilter) {
       // check filter widget
-      const auto m = m_filter.matches([&](const QRegularExpression& regex) {
+      const auto m = m_filter.matches([&f](const QRegularExpression& regex) {
         return regex.match(f.filename()).hasMatch();
       });
 

--- a/src/modinfodialognexus.cpp
+++ b/src/modinfodialognexus.cpp
@@ -22,40 +22,41 @@ NexusTab::NexusTab(ModInfoDialogTabContext cx)
   ui->endorse->setVisible(core().settings().nexus().endorsementIntegration());
   ui->track->setVisible(core().settings().nexus().trackedIntegration());
 
-  connect(ui->modID, &QLineEdit::editingFinished, [&] {
+  connect(ui->modID, &QLineEdit::editingFinished, [this] {
     onModIDChanged();
   });
   connect(ui->sourceGame,
-          static_cast<void (QComboBox::*)(int)>(&QComboBox::currentIndexChanged), [&] {
+          static_cast<void (QComboBox::*)(int)>(&QComboBox::currentIndexChanged),
+          [this] {
             onSourceGameChanged();
           });
-  connect(ui->version, &QLineEdit::editingFinished, [&] {
+  connect(ui->version, &QLineEdit::editingFinished, [this] {
     onVersionChanged();
   });
-  connect(ui->category, &QLineEdit::editingFinished, [&] {
+  connect(ui->category, &QLineEdit::editingFinished, [this] {
     onCategoryChanged();
   });
 
-  connect(ui->refresh, &QPushButton::clicked, [&] {
+  connect(ui->refresh, &QPushButton::clicked, [this] {
     onRefreshBrowser();
   });
-  connect(ui->visitNexus, &QPushButton::clicked, [&] {
+  connect(ui->visitNexus, &QPushButton::clicked, [this] {
     onVisitNexus();
   });
-  connect(ui->endorse, &QPushButton::clicked, [&] {
+  connect(ui->endorse, &QPushButton::clicked, [this] {
     onEndorse();
   });
-  connect(ui->track, &QPushButton::clicked, [&] {
+  connect(ui->track, &QPushButton::clicked, [this] {
     onTrack();
   });
 
-  connect(ui->hasCustomURL, &QCheckBox::toggled, [&] {
+  connect(ui->hasCustomURL, &QCheckBox::toggled, [this] {
     onCustomURLToggled();
   });
-  connect(ui->customURL, &QLineEdit::editingFinished, [&] {
+  connect(ui->customURL, &QLineEdit::editingFinished, [this] {
     onCustomURLChanged();
   });
-  connect(ui->visitCustomURL, &QPushButton::clicked, [&] {
+  connect(ui->visitCustomURL, &QPushButton::clicked, [this] {
     onVisitCustomURL();
   });
 }
@@ -117,7 +118,7 @@ void NexusTab::update()
   auto* page = new NexusTabWebpage(ui->browser);
   ui->browser->setPage(page);
 
-  connect(page, &NexusTabWebpage::linkClicked, [&](const QUrl& url) {
+  connect(page, &NexusTabWebpage::linkClicked, [](const QUrl& url) {
     shell::Open(url);
   });
 
@@ -138,7 +139,7 @@ void NexusTab::setMod(ModInfoPtr mod, MOShared::FilesOrigin* origin)
 
   ModInfoDialogTab::setMod(mod, origin);
 
-  m_modConnection = connect(mod.data(), &ModInfo::modDetailsUpdated, [&] {
+  m_modConnection = connect(mod.data(), &ModInfo::modDetailsUpdated, [this] {
     onModChanged();
   });
 }

--- a/src/modinfodialogtab.cpp
+++ b/src/modinfodialogtab.cpp
@@ -5,7 +5,7 @@
 #include "ui_modinfodialog.h"
 
 ModInfoDialogTab::ModInfoDialogTab(ModInfoDialogTabContext cx)
-    : ui(cx.ui), m_core(cx.core), m_plugin(cx.plugin), m_parent(cx.parent),
+    : ui(cx.ui), m_parent(cx.parent), m_core(cx.core), m_plugin(cx.plugin),
       m_origin(cx.origin), m_tabID(cx.id), m_hasData(false), m_firstActivation(true)
 {}
 

--- a/src/modinfodialogtab.cpp
+++ b/src/modinfodialogtab.cpp
@@ -149,16 +149,16 @@ void ModInfoDialogTab::setFocus()
 
 NotesTab::NotesTab(ModInfoDialogTabContext cx) : ModInfoDialogTab(std::move(cx))
 {
-  connect(ui->comments, &QLineEdit::editingFinished, [&] {
+  connect(ui->comments, &QLineEdit::editingFinished, [this] {
     onComments();
   });
-  connect(ui->notes, &HTMLEditor::editingFinished, [&] {
+  connect(ui->notes, &HTMLEditor::editingFinished, [this] {
     onNotes();
   });
-  connect(ui->setColorButton, &QPushButton::clicked, [&] {
+  connect(ui->setColorButton, &QPushButton::clicked, [this] {
     onSetColor();
   });
-  connect(ui->resetColorButton, &QPushButton::clicked, [&] {
+  connect(ui->resetColorButton, &QPushButton::clicked, [this] {
     onResetColor();
   });
 }

--- a/src/modinfodialogtextfiles.cpp
+++ b/src/modinfodialogtextfiles.cpp
@@ -111,7 +111,7 @@ GenericFilesTab::GenericFilesTab(ModInfoDialogTabContext cx, QListView* list,
   m_filter.setList(m_list);
 
   QObject::connect(m_list->selectionModel(), &QItemSelectionModel::currentRowChanged,
-                   [&](auto current, auto previous) {
+                   [this](auto current, auto previous) {
                      onSelection(current, previous);
                    });
 }

--- a/src/modinfooverwrite.cpp
+++ b/src/modinfooverwrite.cpp
@@ -64,9 +64,7 @@ int ModInfoOverwrite::getHighlight() const
 {
   int highlight =
       (isValid() ? HIGHLIGHT_IMPORTANT : HIGHLIGHT_INVALID) | HIGHLIGHT_CENTER;
-  auto flags = getFlags();
-  if (std::find(flags.begin(), flags.end(), ModInfo::FLAG_PLUGIN_SELECTED) !=
-      flags.end())
+  if (std::ranges::contains(getFlags(), ModInfo::FLAG_PLUGIN_SELECTED))
     highlight |= HIGHLIGHT_PLUGIN;
   return highlight;
 }

--- a/src/modinforegular.cpp
+++ b/src/modinforegular.cpp
@@ -31,8 +31,8 @@ static bool ByName(const ModInfo::Ptr& LHS, const ModInfo::Ptr& RHS)
 ModInfoRegular::ModInfoRegular(const QDir& path, OrganizerCore& core)
     : ModInfoWithConflictInfo(core), m_Name(path.dirName()),
       m_Path(path.absolutePath()), m_Repository(),
-      m_GameName(core.managedGame()->gameShortName()), m_IsAlternate(false),
-      m_Converted(false), m_Validated(false), m_MetaInfoChanged(false),
+      m_GameName(core.managedGame()->gameShortName()), m_MetaInfoChanged(false),
+      m_IsAlternate(false), m_Converted(false), m_Validated(false),
       m_EndorsedState(EndorsedState::ENDORSED_UNKNOWN),
       m_TrackedState(TrackedState::TRACKED_UNKNOWN),
       m_NexusBridge(&core.pluginContainer())
@@ -234,9 +234,9 @@ void ModInfoRegular::readMeta()
 
   // Plugin settings:
   metaFile.beginGroup("Plugins");
-  for (auto pluginName : metaFile.childGroups()) {
+  for (const auto& pluginName : metaFile.childGroups()) {
     metaFile.beginGroup(pluginName);
-    for (auto settingKey : metaFile.childKeys()) {
+    for (const auto& settingKey : metaFile.childKeys()) {
       m_PluginSettings[pluginName][settingKey] = metaFile.value(settingKey);
     }
     metaFile.endGroup();
@@ -458,7 +458,7 @@ void ModInfoRegular::setCategory(int categoryID, bool active)
       m_Categories.erase(iter);
     }
     if (categoryID == m_PrimaryCategory) {
-      if (m_Categories.size() == 0) {
+      if (m_Categories.empty()) {
         m_PrimaryCategory = -1;
       } else {
         m_PrimaryCategory = *(m_Categories.begin());
@@ -700,7 +700,7 @@ std::vector<ModInfo::EFlag> ModInfoRegular::getFlags() const
   if (!isValid() && !m_Validated) {
     result.push_back(ModInfo::FLAG_INVALID);
   }
-  if (m_Notes.length() != 0) {
+  if (!m_Notes.isEmpty()) {
     result.push_back(ModInfo::FLAG_NOTES);
   }
   if (m_PluginSelected) {
@@ -729,9 +729,7 @@ int ModInfoRegular::getHighlight() const
 {
   if (!isValid() && !m_Validated)
     return HIGHLIGHT_INVALID;
-  auto flags = getFlags();
-  if (std::find(flags.begin(), flags.end(), ModInfo::FLAG_PLUGIN_SELECTED) !=
-      flags.end())
+  if (std::ranges::contains(getFlags(), ModInfo::FLAG_PLUGIN_SELECTED))
     return HIGHLIGHT_PLUGIN;
   return HIGHLIGHT_NONE;
 }

--- a/src/modlist.cpp
+++ b/src/modlist.cpp
@@ -987,7 +987,7 @@ void ModList::notifyModStateChanged(QList<unsigned int> modIndices) const
   for (auto modIndex : modIndices) {
     indices.append(index(modIndex, 0));
     ModInfo::Ptr modInfo = ModInfo::getByIndex(modIndex);
-    mods.emplace(modInfo->name(), state(modIndex));
+    mods.try_emplace(modInfo->name(), modIndex);
   }
 
   emit modStatesChanged(indices);
@@ -1035,12 +1035,12 @@ bool ModList::dropLocalFiles(const ModListDropInfo& dropInfo, int row,
   QStringList targetList;
   QList<QPair<QString, QString>> relativePathList;
 
-  for (auto localUrl : dropInfo.localUrls()) {
+  for (const auto& localUrl : dropInfo.localUrls()) {
     QFileInfo sourceInfo(localUrl.url.toLocalFile());
     if (localUrl.originName.compare("overwrite", Qt::CaseInsensitive) == 0) {
       bool needsMove = true;
       if (sourceInfo.isDir()) {
-        for (auto dir : m_Organizer->managedGame()->getModMappings().keys()) {
+        for (const auto& dir : m_Organizer->managedGame()->getModMappings().keys()) {
           QDir overDir(m_Organizer->overwritePath());
           if (sourceInfo.canonicalFilePath().compare(overDir.absoluteFilePath(dir),
                                                      Qt::CaseInsensitive) == 0) {
@@ -1089,7 +1089,7 @@ bool ModList::dropLocalFiles(const ModListDropInfo& dropInfo, int row,
     }
   }
 
-  for (auto iter : relativePathList) {
+  for (const auto& iter : relativePathList) {
     emit fileMoved(iter.first, iter.second, modInfo->name());
   }
 
@@ -1448,7 +1448,7 @@ bool ModList::toggleState(const QModelIndexList& indices)
 
   QList<unsigned int> modsToEnable;
   QList<unsigned int> modsToDisable;
-  for (auto index : indices) {
+  for (const auto& index : indices) {
     auto idx = index.data(IndexRole).toInt();
     if (m_Profile->modEnabled(idx)) {
       modsToDisable.append(idx);

--- a/src/modlistbypriorityproxy.cpp
+++ b/src/modlistbypriorityproxy.cpp
@@ -75,7 +75,7 @@ void ModListByPriorityProxy::buildTree()
   TreeItem* overwrite;
   std::vector<TreeItem*> backups;
 
-  auto fn = [&](const auto& p) {
+  auto fn = [this, &root, &overwrite, &backups](const auto& p) {
     auto& [priority, index] = p;
     ModInfo::Ptr modInfo    = ModInfo::getByIndex(index);
     TreeItem* item          = m_IndexToItem[index].get();

--- a/src/modlistbypriorityproxy.cpp
+++ b/src/modlistbypriorityproxy.cpp
@@ -12,7 +12,7 @@ ModListByPriorityProxy::ModListByPriorityProxy(Profile* profile, OrganizerCore& 
     : QAbstractProxyModel(parent), m_core(core), m_profile(profile)
 {}
 
-ModListByPriorityProxy::~ModListByPriorityProxy() {}
+ModListByPriorityProxy::~ModListByPriorityProxy() = default;
 
 void ModListByPriorityProxy::setSourceModel(QAbstractItemModel* model)
 {

--- a/src/modlistsortproxy.cpp
+++ b/src/modlistsortproxy.cpp
@@ -88,7 +88,7 @@ unsigned long ModListSortProxy::conflictFlagsId(
 {
   unsigned long result = 0;
   for (ModInfo::EConflictFlag flag : flags) {
-    if ((flag != ModInfo::FLAG_OVERWRITE_CONFLICT)) {
+    if (flag != ModInfo::FLAG_OVERWRITE_CONFLICT) {
       result += 1 << (int)flag;
     }
   }
@@ -499,7 +499,7 @@ bool ModListSortProxy::filterMatchesMod(ModInfo::Ptr info, bool enabled) const
 
         // Search by categories
         if (!foundKeyword && m_EnabledColumns[ModList::COL_CATEGORY]) {
-          for (auto category : info->categories()) {
+          for (const auto& category : info->categories()) {
             if (category.contains(currentKeyword, Qt::CaseInsensitive)) {
               foundKeyword = true;
               break;

--- a/src/modlistview.cpp
+++ b/src/modlistview.cpp
@@ -404,7 +404,7 @@ void ModListView::setSelected(const QModelIndex& current,
                               const QModelIndexList& selected)
 {
   setCurrentIndex(indexModelToView(current));
-  for (auto idx : selected) {
+  for (const auto& idx : selected) {
     selectionModel()->select(indexModelToView(idx),
                              QItemSelectionModel::Select | QItemSelectionModel::Rows);
   }
@@ -425,7 +425,7 @@ void ModListView::scrollToAndSelect(const QModelIndexList& indexes,
   scrollTo(current.isValid() ? current : indexes.first());
   setCurrentIndex(current.isValid() ? current : indexes.first());
   QItemSelection selection;
-  for (auto& idx : indexes) {
+  for (const auto& idx : indexes) {
     selection.select(idx, idx);
   }
   selectionModel()->select(selection,
@@ -449,7 +449,7 @@ void ModListView::refreshExpandedItems()
 void ModListView::onModPrioritiesChanged(const QModelIndexList& indices)
 {
   // expand separator whose priority has changed and parents
-  for (auto index : indices) {
+  for (const auto& index : indices) {
     auto idx = indexModelToView(index);
     if (hasCollapsibleSeparators() && model()->hasChildren(idx)) {
       setExpanded(idx, true);

--- a/src/modlistviewactions.cpp
+++ b/src/modlistviewactions.cpp
@@ -429,42 +429,31 @@ void ModListViewActions::exportModListCSV() const
       builder.setEscapeMode(CSVBuilder::TYPE_STRING, CSVBuilder::QUOTE_ALWAYS);
       std::vector<std::pair<QString, CSVBuilder::EFieldType>> fields;
       if (mod_Priority->isChecked())
-        fields.emplace_back(
-            QString("#Mod_Priority"), CSVBuilder::TYPE_STRING);
+        fields.emplace_back(QString("#Mod_Priority"), CSVBuilder::TYPE_STRING);
       if (mod_Status->isChecked())
-        fields.emplace_back(
-            QString("#Mod_Status"), CSVBuilder::TYPE_STRING);
+        fields.emplace_back(QString("#Mod_Status"), CSVBuilder::TYPE_STRING);
       if (mod_Name->isChecked())
         fields.emplace_back(QString("#Mod_Name"), CSVBuilder::TYPE_STRING);
       if (mod_Note->isChecked())
         fields.emplace_back(QString("#Note"), CSVBuilder::TYPE_STRING);
       if (primary_Category->isChecked())
-        fields.emplace_back(
-            QString("#Primary_Category"), CSVBuilder::TYPE_STRING);
+        fields.emplace_back(QString("#Primary_Category"), CSVBuilder::TYPE_STRING);
       if (mod_Author->isChecked())
-        fields.emplace_back(
-            QString("#Mod_Author"), CSVBuilder::TYPE_STRING);
+        fields.emplace_back(QString("#Mod_Author"), CSVBuilder::TYPE_STRING);
       if (mod_Uploader->isChecked())
-        fields.emplace_back(
-            QString("#Mod_Uploader"), CSVBuilder::TYPE_STRING);
+        fields.emplace_back(QString("#Mod_Uploader"), CSVBuilder::TYPE_STRING);
       if (nexus_ID->isChecked())
-        fields.emplace_back(
-            QString("#Nexus_ID"), CSVBuilder::TYPE_INTEGER);
+        fields.emplace_back(QString("#Nexus_ID"), CSVBuilder::TYPE_INTEGER);
       if (mod_Nexus_URL->isChecked())
-        fields.emplace_back(
-            QString("#Mod_Nexus_URL"), CSVBuilder::TYPE_STRING);
+        fields.emplace_back(QString("#Mod_Nexus_URL"), CSVBuilder::TYPE_STRING);
       if (mod_Uploader_URL->isChecked())
-        fields.emplace_back(
-            QString("#Mod_Uploader_URL"), CSVBuilder::TYPE_STRING);
+        fields.emplace_back(QString("#Mod_Uploader_URL"), CSVBuilder::TYPE_STRING);
       if (mod_Version->isChecked())
-        fields.emplace_back(
-            QString("#Mod_Version"), CSVBuilder::TYPE_STRING);
+        fields.emplace_back(QString("#Mod_Version"), CSVBuilder::TYPE_STRING);
       if (install_Date->isChecked())
-        fields.emplace_back(
-            QString("#Install_Date"), CSVBuilder::TYPE_STRING);
+        fields.emplace_back(QString("#Install_Date"), CSVBuilder::TYPE_STRING);
       if (download_File_Name->isChecked())
-        fields.emplace_back(
-            QString("#Download_File_Name"), CSVBuilder::TYPE_STRING);
+        fields.emplace_back(QString("#Download_File_Name"), CSVBuilder::TYPE_STRING);
 
       builder.setFields(fields);
 

--- a/src/modlistviewactions.cpp
+++ b/src/modlistviewactions.cpp
@@ -429,42 +429,42 @@ void ModListViewActions::exportModListCSV() const
       builder.setEscapeMode(CSVBuilder::TYPE_STRING, CSVBuilder::QUOTE_ALWAYS);
       std::vector<std::pair<QString, CSVBuilder::EFieldType>> fields;
       if (mod_Priority->isChecked())
-        fields.push_back(
-            std::make_pair(QString("#Mod_Priority"), CSVBuilder::TYPE_STRING));
+        fields.emplace_back(
+            QString("#Mod_Priority"), CSVBuilder::TYPE_STRING);
       if (mod_Status->isChecked())
-        fields.push_back(
-            std::make_pair(QString("#Mod_Status"), CSVBuilder::TYPE_STRING));
+        fields.emplace_back(
+            QString("#Mod_Status"), CSVBuilder::TYPE_STRING);
       if (mod_Name->isChecked())
-        fields.push_back(std::make_pair(QString("#Mod_Name"), CSVBuilder::TYPE_STRING));
+        fields.emplace_back(QString("#Mod_Name"), CSVBuilder::TYPE_STRING);
       if (mod_Note->isChecked())
-        fields.push_back(std::make_pair(QString("#Note"), CSVBuilder::TYPE_STRING));
+        fields.emplace_back(QString("#Note"), CSVBuilder::TYPE_STRING);
       if (primary_Category->isChecked())
-        fields.push_back(
-            std::make_pair(QString("#Primary_Category"), CSVBuilder::TYPE_STRING));
+        fields.emplace_back(
+            QString("#Primary_Category"), CSVBuilder::TYPE_STRING);
       if (mod_Author->isChecked())
-        fields.push_back(
-            std::make_pair(QString("#Mod_Author"), CSVBuilder::TYPE_STRING));
+        fields.emplace_back(
+            QString("#Mod_Author"), CSVBuilder::TYPE_STRING);
       if (mod_Uploader->isChecked())
-        fields.push_back(
-            std::make_pair(QString("#Mod_Uploader"), CSVBuilder::TYPE_STRING));
+        fields.emplace_back(
+            QString("#Mod_Uploader"), CSVBuilder::TYPE_STRING);
       if (nexus_ID->isChecked())
-        fields.push_back(
-            std::make_pair(QString("#Nexus_ID"), CSVBuilder::TYPE_INTEGER));
+        fields.emplace_back(
+            QString("#Nexus_ID"), CSVBuilder::TYPE_INTEGER);
       if (mod_Nexus_URL->isChecked())
-        fields.push_back(
-            std::make_pair(QString("#Mod_Nexus_URL"), CSVBuilder::TYPE_STRING));
+        fields.emplace_back(
+            QString("#Mod_Nexus_URL"), CSVBuilder::TYPE_STRING);
       if (mod_Uploader_URL->isChecked())
-        fields.push_back(
-            std::make_pair(QString("#Mod_Uploader_URL"), CSVBuilder::TYPE_STRING));
+        fields.emplace_back(
+            QString("#Mod_Uploader_URL"), CSVBuilder::TYPE_STRING);
       if (mod_Version->isChecked())
-        fields.push_back(
-            std::make_pair(QString("#Mod_Version"), CSVBuilder::TYPE_STRING));
+        fields.emplace_back(
+            QString("#Mod_Version"), CSVBuilder::TYPE_STRING);
       if (install_Date->isChecked())
-        fields.push_back(
-            std::make_pair(QString("#Install_Date"), CSVBuilder::TYPE_STRING));
+        fields.emplace_back(
+            QString("#Install_Date"), CSVBuilder::TYPE_STRING);
       if (download_File_Name->isChecked())
-        fields.push_back(
-            std::make_pair(QString("#Download_File_Name"), CSVBuilder::TYPE_STRING));
+        fields.emplace_back(
+            QString("#Download_File_Name"), CSVBuilder::TYPE_STRING);
 
       builder.setFields(fields);
 

--- a/src/nexusinterface.cpp
+++ b/src/nexusinterface.cpp
@@ -360,7 +360,7 @@ void NexusInterface::interpretNexusFileName(const QString& fileName, QString& mo
     SelectionDialog selection(tr("Please pick the mod ID for \"%1\"").arg(fileName));
     int index   = 0;
     auto splits = fileName.split(QRegularExpression("[^0-9]"), Qt::KeepEmptyParts);
-    for (auto substr : splits) {
+    for (const auto& substr : splits) {
       bool ok   = false;
       int value = substr.toInt(&ok);
       if (ok) {
@@ -435,13 +435,13 @@ std::vector<std::pair<QString, QString>>
 NexusInterface::getGameChoices(const MOBase::IPluginGame* game)
 {
   std::vector<std::pair<QString, QString>> choices;
-  choices.push_back(
-      std::pair<QString, QString>(game->gameShortName(), game->gameName()));
-  for (QString gameName : game->validShortNames()) {
+  choices.emplace_back(
+      game->gameShortName(), game->gameName());
+  for (const auto& gameName : game->validShortNames()) {
     for (auto gamePlugin : m_PluginContainer->plugins<IPluginGame>()) {
       if (gamePlugin->gameShortName().compare(gameName, Qt::CaseInsensitive) == 0) {
-        choices.push_back(std::pair<QString, QString>(gamePlugin->gameShortName(),
-                                                      gamePlugin->gameName()));
+        choices.emplace_back(gamePlugin->gameShortName(),
+                                                      gamePlugin->gameName());
         break;
       }
     }
@@ -617,7 +617,7 @@ int NexusInterface::requestFileInfo(QString gameName, int modID, int fileID,
                                     QObject* receiver, QVariant userData,
                                     const QString& subModule)
 {
-  IPluginGame* gamePlugin = getGame(gameName);
+  const IPluginGame* gamePlugin = getGame(gameName);
   if (gamePlugin == nullptr) {
     log::error("requestFileInfo can't find plugin for {}", gameName);
     return -1;
@@ -923,7 +923,7 @@ void NexusInterface::nextRequest()
                 .arg(info.m_FileID);
     } break;
     case NXMRequestInfo::TYPE_DOWNLOADURL: {
-      ModRepositoryFileInfo* fileInfo = qobject_cast<ModRepositoryFileInfo*>(
+      const ModRepositoryFileInfo* fileInfo = qobject_cast<ModRepositoryFileInfo*>(
           qvariant_cast<QObject*>(info.m_UserData));
       if (m_User.type() == APIUserAccountTypes::Premium) {
         url = QString("%1/games/%2/mods/%3/files/%4/download_link")
@@ -986,6 +986,8 @@ void NexusInterface::nextRequest()
     url = info.m_URL;
   }
   QNetworkRequest request(url);
+  request.setAttribute(QNetworkRequest::RedirectPolicyAttribute,
+                       QNetworkRequest::NoLessSafeRedirectPolicy);
   request.setAttribute(QNetworkRequest::CacheSaveControlAttribute, false);
   request.setAttribute(QNetworkRequest::CacheLoadControlAttribute,
                        QNetworkRequest::AlwaysNetwork);
@@ -1069,19 +1071,22 @@ void NexusInterface::requestFinished(std::list<NXMRequestInfo>::iterator iter)
                           iter->m_UserData, iter->m_ID, statusCode, errorMsg);
   } else {
     int statusCode = reply->attribute(QNetworkRequest::HttpStatusCodeAttribute).toInt();
-    if (statusCode == 301) {
+    if (statusCode >= 301 && statusCode <= 308) {
       // redirect request, return request to queue
       iter->m_URL =
           reply->attribute(QNetworkRequest::RedirectionTargetAttribute).toString();
       iter->m_Reroute = true;
       m_RequestQueue.enqueue(*iter);
       // nextRequest();
+      log::debug("redirected download of " + reply->url().toString() + " to " +
+                 iter->m_URL + " with status code " +
+                 reply->attribute(QNetworkRequest::HttpStatusCodeAttribute).toString());
       return;
     }
     QByteArray data = reply->readAll();
     if (data.isNull() || data.isEmpty() || (strcmp(data.constData(), "null") == 0)) {
       QString nexusError(reply->rawHeader("NexusErrorInfo"));
-      if (nexusError.length() == 0) {
+      if (nexusError.isEmpty()) {
         nexusError = tr("empty response");
       }
       log::debug("nexus error: {}", nexusError);
@@ -1170,7 +1175,7 @@ void NexusInterface::requestFinished(std::list<NXMRequestInfo>::iterator iter)
 
 void NexusInterface::requestFinished()
 {
-  QNetworkReply* reply = static_cast<QNetworkReply*>(sender());
+  const QNetworkReply* reply = static_cast<QNetworkReply*>(sender());
   for (std::list<NXMRequestInfo>::iterator iter = m_ActiveRequest.begin();
        iter != m_ActiveRequest.end(); ++iter) {
     if (iter->m_Reply == reply) {
@@ -1187,7 +1192,7 @@ void NexusInterface::requestFinished()
 
 void NexusInterface::requestError(QNetworkReply::NetworkError)
 {
-  QNetworkReply* reply = qobject_cast<QNetworkReply*>(sender());
+  const QNetworkReply* reply = qobject_cast<QNetworkReply*>(sender());
   if (reply == nullptr) {
     log::warn("invalid sender type");
     return;
@@ -1199,7 +1204,7 @@ void NexusInterface::requestError(QNetworkReply::NetworkError)
 
 void NexusInterface::requestTimeout()
 {
-  QTimer* timer = qobject_cast<QTimer*>(sender());
+  const QTimer* timer = qobject_cast<QTimer*>(sender());
   if (timer == nullptr) {
     log::warn("invalid sender type");
     return;

--- a/src/nexusinterface.cpp
+++ b/src/nexusinterface.cpp
@@ -435,13 +435,11 @@ std::vector<std::pair<QString, QString>>
 NexusInterface::getGameChoices(const MOBase::IPluginGame* game)
 {
   std::vector<std::pair<QString, QString>> choices;
-  choices.emplace_back(
-      game->gameShortName(), game->gameName());
+  choices.emplace_back(game->gameShortName(), game->gameName());
   for (const auto& gameName : game->validShortNames()) {
     for (auto gamePlugin : m_PluginContainer->plugins<IPluginGame>()) {
       if (gamePlugin->gameShortName().compare(gameName, Qt::CaseInsensitive) == 0) {
-        choices.emplace_back(gamePlugin->gameShortName(),
-                                                      gamePlugin->gameName());
+        choices.emplace_back(gamePlugin->gameShortName(), gamePlugin->gameName());
         break;
       }
     }

--- a/src/nxmaccessmanager.cpp
+++ b/src/nxmaccessmanager.cpp
@@ -480,8 +480,8 @@ void ValidationAttempt::onFinished()
     return;
   }
 
-  const auto doc       = QJsonDocument::fromJson(m_reply->readAll());
-  //const auto& httpError = m_reply->errorString();
+  const auto doc = QJsonDocument::fromJson(m_reply->readAll());
+  // const auto& httpError = m_reply->errorString();
 
   const QJsonObject data = doc.object();
 

--- a/src/nxmaccessmanager.cpp
+++ b/src/nxmaccessmanager.cpp
@@ -53,10 +53,10 @@ ValidationProgressDialog::ValidationProgressDialog(Settings* s, NexusKeyValidato
   ui.reset(new Ui::ValidationProgressDialog);
   ui->setupUi(this);
 
-  connect(ui->hide, &QPushButton::clicked, [&] {
+  connect(ui->hide, &QPushButton::clicked, [this] {
     onHide();
   });
-  connect(ui->cancel, &QPushButton::clicked, [&] {
+  connect(ui->cancel, &QPushButton::clicked, [this] {
     onCancel();
   });
 }
@@ -79,7 +79,7 @@ void ValidationProgressDialog::start()
 {
   if (!m_updateTimer) {
     m_updateTimer = new QTimer(this);
-    connect(m_updateTimer, &QTimer::timeout, [&] {
+    connect(m_updateTimer, &QTimer::timeout, [this] {
       onTimer();
     });
     m_updateTimer->setInterval(100ms);
@@ -364,7 +364,7 @@ ValidationAttempt::ValidationAttempt(std::chrono::seconds timeout)
   m_timeout.setSingleShot(true);
   m_timeout.setInterval(timeout);
 
-  QObject::connect(&m_timeout, &QTimer::timeout, [&] {
+  QObject::connect(&m_timeout, &QTimer::timeout, [this] {
     onTimeout();
   });
 }
@@ -402,11 +402,11 @@ bool ValidationAttempt::sendRequest(NXMAccessManager& m, const QString& key)
     return false;
   }
 
-  QObject::connect(m_reply, &QNetworkReply::finished, [&] {
+  QObject::connect(m_reply, &QNetworkReply::finished, [this] {
     onFinished();
   });
 
-  QObject::connect(m_reply, &QNetworkReply::sslErrors, [&](auto&& errors) {
+  QObject::connect(m_reply, &QNetworkReply::sslErrors, [this](auto&& errors) {
     onSslErrors(errors);
   });
 
@@ -699,10 +699,10 @@ bool NexusKeyValidator::nextTry()
 {
   for (auto&& a : m_attempts) {
     if (!a->done()) {
-      a->success = [&](auto&& user) {
+      a->success = [this, &a](auto&& user) {
         onAttemptSuccess(*a, user);
       };
-      a->failure = [&] {
+      a->failure = [this, &a] {
         onAttemptFailure(*a);
       };
 
@@ -766,11 +766,11 @@ NXMAccessManager::NXMAccessManager(QObject* parent, Settings* s,
     : QNetworkAccessManager(parent), m_Settings(s), m_MOVersion(moVersion),
       m_validator(s, *this), m_validationState(NotChecked)
 {
-  m_validator.finished = [&](auto&& r, auto&& m, auto&& u) {
+  m_validator.finished = [this](auto&& r, auto&& m, auto&& u) {
     onValidatorFinished(r, m, u);
   };
 
-  m_validator.attemptFinished = [&](auto&& a) {
+  m_validator.attemptFinished = [this](auto&& a) {
     onValidatorAttemptFinished(a);
   };
 

--- a/src/nxmaccessmanager.cpp
+++ b/src/nxmaccessmanager.cpp
@@ -158,29 +158,29 @@ NexusSSOLogin::NexusSSOLogin() : m_keyReceived(false), m_active(false)
   m_timeout.setInterval(10s);
   m_timeout.setSingleShot(true);
 
-  QObject::connect(&m_socket, &QWebSocket::connected, [&] {
+  QObject::connect(&m_socket, &QWebSocket::connected, [this] {
     onConnected();
   });
 
   QObject::connect(&m_socket,
-                   qOverload<QAbstractSocket::SocketError>(&QWebSocket::error),
-                   [&](auto&& e) {
+                   qOverload<QAbstractSocket::SocketError>(&QWebSocket::errorOccurred),
+                   [this](auto&& e) {
                      onError(e);
                    });
 
-  QObject::connect(&m_socket, &QWebSocket::sslErrors, [&](auto&& errors) {
+  QObject::connect(&m_socket, &QWebSocket::sslErrors, [this](const auto& errors) {
     onSslErrors(errors);
   });
 
-  QObject::connect(&m_socket, &QWebSocket::textMessageReceived, [&](auto&& s) {
+  QObject::connect(&m_socket, &QWebSocket::textMessageReceived, [this](const auto& s) {
     onMessage(s);
   });
 
-  QObject::connect(&m_socket, &QWebSocket::disconnected, [&] {
+  QObject::connect(&m_socket, &QWebSocket::disconnected, [this] {
     onDisconnected();
   });
 
-  QObject::connect(&m_timeout, &QTimer::timeout, [&] {
+  QObject::connect(&m_timeout, &QTimer::timeout, [this] {
     onTimeout();
   });
 }
@@ -481,8 +481,7 @@ void ValidationAttempt::onFinished()
   }
 
   const auto doc       = QJsonDocument::fromJson(m_reply->readAll());
-  const auto headers   = m_reply->rawHeaderPairs();
-  const auto httpError = m_reply->errorString();
+  //const auto& httpError = m_reply->errorString();
 
   const QJsonObject data = doc.object();
 
@@ -529,6 +528,8 @@ void ValidationAttempt::onFinished()
     setFailure(HardError, QObject::tr("API key is empty"));
     return;
   }
+
+  const auto& headers = m_reply->rawHeaderPairs();
 
   const auto user =
       APIUserAccount()
@@ -663,13 +664,9 @@ void NexusKeyValidator::cancel()
 
 bool NexusKeyValidator::isActive() const
 {
-  for (auto&& a : m_attempts) {
-    if (!a->done()) {
-      return true;
-    }
-  }
-
-  return false;
+  return std::ranges::any_of(m_attempts, [](auto&& a) {
+    return !a->done();
+  });
 }
 
 const ValidationAttempt* NexusKeyValidator::lastAttempt() const

--- a/src/organizer_en.ts
+++ b/src/organizer_en.ts
@@ -1197,17 +1197,17 @@ API requests will be consumed, and Mod Organizer may stutter.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="downloadmanager.cpp" line="714"/>
+        <location filename="downloadmanager.cpp" line="707"/>
         <source>Wrong Game</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="downloadmanager.cpp" line="715"/>
+        <location filename="downloadmanager.cpp" line="708"/>
         <source>The download link is for a mod for &quot;%1&quot; but this instance of MO has been set up for &quot;%2&quot;.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="downloadmanager.cpp" line="729"/>
+        <location filename="downloadmanager.cpp" line="722"/>
         <source>There is already a download queued for this file.
 
 Mod %1
@@ -1215,12 +1215,12 @@ File %2</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="downloadmanager.cpp" line="736"/>
+        <location filename="downloadmanager.cpp" line="729"/>
         <source>Already Queued</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="downloadmanager.cpp" line="749"/>
+        <location filename="downloadmanager.cpp" line="742"/>
         <source>There is already a download started for this file.
 
 Mod %1:	%2
@@ -1228,302 +1228,302 @@ File %3:	%4</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="downloadmanager.cpp" line="785"/>
+        <location filename="downloadmanager.cpp" line="778"/>
         <source>Already Started</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="downloadmanager.cpp" line="816"/>
-        <location filename="downloadmanager.cpp" line="946"/>
+        <location filename="downloadmanager.cpp" line="809"/>
+        <location filename="downloadmanager.cpp" line="939"/>
         <source>remove: invalid download index %1</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="downloadmanager.cpp" line="834"/>
+        <location filename="downloadmanager.cpp" line="827"/>
         <source>failed to delete %1</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="downloadmanager.cpp" line="840"/>
+        <location filename="downloadmanager.cpp" line="833"/>
         <source>failed to delete meta file for %1</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="downloadmanager.cpp" line="899"/>
+        <location filename="downloadmanager.cpp" line="892"/>
         <source>restore: invalid download index: %1</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="downloadmanager.cpp" line="965"/>
+        <location filename="downloadmanager.cpp" line="958"/>
         <source>cancel: invalid download index %1</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="downloadmanager.cpp" line="977"/>
+        <location filename="downloadmanager.cpp" line="970"/>
         <source>pause: invalid download index %1</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="downloadmanager.cpp" line="999"/>
+        <location filename="downloadmanager.cpp" line="992"/>
         <source>resume: invalid download index %1</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="downloadmanager.cpp" line="1010"/>
+        <location filename="downloadmanager.cpp" line="1003"/>
         <source>resume (int): invalid download index %1</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="downloadmanager.cpp" line="1035"/>
+        <location filename="downloadmanager.cpp" line="1028"/>
         <source>No known download urls. Sorry, this download can&apos;t be resumed.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="downloadmanager.cpp" line="1079"/>
-        <location filename="downloadmanager.cpp" line="1144"/>
+        <location filename="downloadmanager.cpp" line="1072"/>
+        <location filename="downloadmanager.cpp" line="1137"/>
         <source>query: invalid download index %1</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="downloadmanager.cpp" line="1101"/>
+        <location filename="downloadmanager.cpp" line="1094"/>
         <source>Please enter the Nexus mod ID</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="downloadmanager.cpp" line="1102"/>
+        <location filename="downloadmanager.cpp" line="1095"/>
         <source>Mod ID:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="downloadmanager.cpp" line="1120"/>
+        <location filename="downloadmanager.cpp" line="1113"/>
         <source>Please select the source game code for %1</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="downloadmanager.cpp" line="1178"/>
+        <location filename="downloadmanager.cpp" line="1171"/>
         <source>Hashing download file &apos;%1&apos;</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="downloadmanager.cpp" line="1179"/>
+        <location filename="downloadmanager.cpp" line="1172"/>
         <source>Cancel</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="downloadmanager.cpp" line="1207"/>
+        <location filename="downloadmanager.cpp" line="1200"/>
         <source>VisitNexus: invalid download index %1</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="downloadmanager.cpp" line="1227"/>
+        <location filename="downloadmanager.cpp" line="1220"/>
         <source>Nexus ID for this Mod is unknown</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="downloadmanager.cpp" line="1234"/>
+        <location filename="downloadmanager.cpp" line="1227"/>
         <source>VisitUploaderProfile: invalid download index %1</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="downloadmanager.cpp" line="1248"/>
+        <location filename="downloadmanager.cpp" line="1241"/>
         <source>Uploader for this Mod is unknown</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="downloadmanager.cpp" line="1255"/>
+        <location filename="downloadmanager.cpp" line="1248"/>
         <source>OpenFile: invalid download index %1</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="downloadmanager.cpp" line="1299"/>
+        <location filename="downloadmanager.cpp" line="1292"/>
         <source>OpenFileInDownloadsFolder: invalid download index %1</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="downloadmanager.cpp" line="1332"/>
+        <location filename="downloadmanager.cpp" line="1325"/>
         <source>get pending: invalid download index %1</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="downloadmanager.cpp" line="1341"/>
+        <location filename="downloadmanager.cpp" line="1334"/>
         <source>get path: invalid download index %1</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="downloadmanager.cpp" line="1351"/>
+        <location filename="downloadmanager.cpp" line="1344"/>
         <source>Main</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="downloadmanager.cpp" line="1353"/>
+        <location filename="downloadmanager.cpp" line="1346"/>
         <source>Update</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="downloadmanager.cpp" line="1355"/>
+        <location filename="downloadmanager.cpp" line="1348"/>
         <source>Optional</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="downloadmanager.cpp" line="1357"/>
+        <location filename="downloadmanager.cpp" line="1350"/>
         <source>Old</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="downloadmanager.cpp" line="1359"/>
+        <location filename="downloadmanager.cpp" line="1352"/>
         <source>Miscellaneous</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="downloadmanager.cpp" line="1361"/>
+        <location filename="downloadmanager.cpp" line="1354"/>
         <source>Deleted</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="downloadmanager.cpp" line="1363"/>
+        <location filename="downloadmanager.cpp" line="1356"/>
         <source>Archived</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="downloadmanager.cpp" line="1365"/>
+        <location filename="downloadmanager.cpp" line="1358"/>
         <source>Unknown</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="downloadmanager.cpp" line="1372"/>
+        <location filename="downloadmanager.cpp" line="1365"/>
         <source>display name: invalid download index %1</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="downloadmanager.cpp" line="1393"/>
+        <location filename="downloadmanager.cpp" line="1386"/>
         <source>file name: invalid download index %1</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="downloadmanager.cpp" line="1402"/>
+        <location filename="downloadmanager.cpp" line="1395"/>
         <source>file time: invalid download index %1</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="downloadmanager.cpp" line="1421"/>
+        <location filename="downloadmanager.cpp" line="1414"/>
         <source>file size: invalid download index %1</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="downloadmanager.cpp" line="1430"/>
+        <location filename="downloadmanager.cpp" line="1423"/>
         <source>progress: invalid download index %1</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="downloadmanager.cpp" line="1439"/>
+        <location filename="downloadmanager.cpp" line="1432"/>
         <source>state: invalid download index %1</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="downloadmanager.cpp" line="1448"/>
+        <location filename="downloadmanager.cpp" line="1441"/>
         <source>infocomplete: invalid download index %1</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="downloadmanager.cpp" line="1462"/>
-        <location filename="downloadmanager.cpp" line="1470"/>
-        <location filename="downloadmanager.cpp" line="1483"/>
+        <location filename="downloadmanager.cpp" line="1455"/>
+        <location filename="downloadmanager.cpp" line="1463"/>
+        <location filename="downloadmanager.cpp" line="1476"/>
         <source>mod id: invalid download index %1</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="downloadmanager.cpp" line="1491"/>
+        <location filename="downloadmanager.cpp" line="1484"/>
         <source>ishidden: invalid download index %1</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="downloadmanager.cpp" line="1499"/>
+        <location filename="downloadmanager.cpp" line="1492"/>
         <source>file info: invalid download index %1</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="downloadmanager.cpp" line="1508"/>
+        <location filename="downloadmanager.cpp" line="1501"/>
         <source>mark installed: invalid download index %1</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="downloadmanager.cpp" line="1549"/>
+        <location filename="downloadmanager.cpp" line="1542"/>
         <source>mark uninstalled: invalid download index %1</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="downloadmanager.cpp" line="1722"/>
+        <location filename="downloadmanager.cpp" line="1715"/>
         <source>%1% - %2 - ~%3</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="downloadmanager.cpp" line="1733"/>
+        <location filename="downloadmanager.cpp" line="1726"/>
         <source>Memory allocation error (in processing progress event).</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="downloadmanager.cpp" line="1742"/>
+        <location filename="downloadmanager.cpp" line="1735"/>
         <source>Memory allocation error (in processing downloaded data).</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="downloadmanager.cpp" line="1873"/>
+        <location filename="downloadmanager.cpp" line="1866"/>
         <source>Information updated</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="downloadmanager.cpp" line="1875"/>
-        <location filename="downloadmanager.cpp" line="1898"/>
+        <location filename="downloadmanager.cpp" line="1868"/>
+        <location filename="downloadmanager.cpp" line="1891"/>
         <source>No matching file found on Nexus! Maybe this file is no longer available or it was renamed?</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="downloadmanager.cpp" line="1878"/>
+        <location filename="downloadmanager.cpp" line="1871"/>
         <source>No file on Nexus matches the selected file by name. Please manually choose the correct one.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="downloadmanager.cpp" line="2092"/>
+        <location filename="downloadmanager.cpp" line="2085"/>
         <source>No download server available. Please try again later.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="downloadmanager.cpp" line="2270"/>
+        <location filename="downloadmanager.cpp" line="2263"/>
         <source>Failed to request file info from nexus: %1</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="downloadmanager.cpp" line="2305"/>
+        <location filename="downloadmanager.cpp" line="2296"/>
         <source>Download finished event received but download is not finished?</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="downloadmanager.cpp" line="2315"/>
+        <location filename="downloadmanager.cpp" line="2306"/>
         <source>Warning: Content type is: %1</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="downloadmanager.cpp" line="2322"/>
+        <location filename="downloadmanager.cpp" line="2313"/>
         <source>Download header content length: %1 downloaded file size: %2</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="downloadmanager.cpp" line="2326"/>
+        <location filename="downloadmanager.cpp" line="2317"/>
         <source>Download failed: %1 (%2)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="downloadmanager.cpp" line="2351"/>
+        <location filename="downloadmanager.cpp" line="2340"/>
         <source>We were unable to download the file due to errors after four retries. There may be an issue with the Nexus servers.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="downloadmanager.cpp" line="2442"/>
+        <location filename="downloadmanager.cpp" line="2431"/>
         <source>failed to re-open %1</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="downloadmanager.cpp" line="2494"/>
+        <location filename="downloadmanager.cpp" line="2484"/>
         <source>Unable to write download to drive (wrote %1).
 Check the drive&apos;s available storage (need %2).
 
@@ -2112,7 +2112,7 @@ Right now the only case I know of where this needs to be overwritten is for the 
     </message>
     <message>
         <location filename="modinfodialogfiletree.cpp" line="27"/>
-        <location filename="modinfodialogfiletree.cpp" line="502"/>
+        <location filename="modinfodialogfiletree.cpp" line="503"/>
         <source>Open with &amp;VFS</source>
         <translation type="unfinished"></translation>
     </message>
@@ -2147,48 +2147,48 @@ Right now the only case I know of where this needs to be overwritten is for the 
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="modinfodialogfiletree.cpp" line="146"/>
-        <location filename="modinfodialogfiletree.cpp" line="152"/>
+        <location filename="modinfodialogfiletree.cpp" line="147"/>
+        <location filename="modinfodialogfiletree.cpp" line="153"/>
         <source>New Folder</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="modinfodialogfiletree.cpp" line="158"/>
+        <location filename="modinfodialogfiletree.cpp" line="159"/>
         <source>Failed to create &quot;%1&quot;</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="modinfodialogfiletree.cpp" line="267"/>
+        <location filename="modinfodialogfiletree.cpp" line="268"/>
         <source>Are you sure you want to delete &quot;%1&quot;?</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="modinfodialogfiletree.cpp" line="269"/>
+        <location filename="modinfodialogfiletree.cpp" line="270"/>
         <source>Are you sure you want to delete the selected files?</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="modinfodialogfiletree.cpp" line="272"/>
+        <location filename="modinfodialogfiletree.cpp" line="273"/>
         <source>Confirm</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="modinfodialogfiletree.cpp" line="308"/>
+        <location filename="modinfodialogfiletree.cpp" line="309"/>
         <source>Failed to delete %1</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="modinfodialogfiletree.cpp" line="498"/>
+        <location filename="modinfodialogfiletree.cpp" line="499"/>
         <source>&amp;Execute</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="modinfodialogfiletree.cpp" line="499"/>
+        <location filename="modinfodialogfiletree.cpp" line="500"/>
         <source>Execute with &amp;VFS</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="modinfodialogfiletree.cpp" line="501"/>
+        <location filename="modinfodialogfiletree.cpp" line="502"/>
         <source>&amp;Open</source>
         <translation type="unfinished"></translation>
     </message>
@@ -2196,22 +2196,22 @@ Right now the only case I know of where this needs to be overwritten is for the 
 <context>
     <name>FilterList</name>
     <message>
-        <location filename="filterlist.cpp" line="224"/>
+        <location filename="filterlist.cpp" line="225"/>
         <source>Filter separators</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="filterlist.cpp" line="226"/>
+        <location filename="filterlist.cpp" line="227"/>
         <source>Show separators</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="filterlist.cpp" line="228"/>
+        <location filename="filterlist.cpp" line="229"/>
         <source>Hide separators</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="filterlist.cpp" line="269"/>
+        <location filename="filterlist.cpp" line="270"/>
         <source>Contains %1</source>
         <translation type="unfinished"></translation>
     </message>
@@ -3060,7 +3060,7 @@ This is likely due to a corrupted or incompatible download or unrecognized archi
     <message>
         <location filename="mainwindow.ui" line="812"/>
         <location filename="mainwindow.ui" line="815"/>
-        <location filename="mainwindow.cpp" line="3065"/>
+        <location filename="mainwindow.cpp" line="3064"/>
         <source>Sort the plugins using LOOT.</source>
         <translation type="unfinished"></translation>
     </message>
@@ -3464,7 +3464,7 @@ This is likely due to a corrupted or incompatible download or unrecognized archi
     <message>
         <location filename="mainwindow.ui" line="1871"/>
         <location filename="mainwindow.ui" line="1874"/>
-        <location filename="mainwindow.cpp" line="2987"/>
+        <location filename="mainwindow.cpp" line="2986"/>
         <source>Endorse Mod Organizer</source>
         <translation type="unfinished"></translation>
     </message>
@@ -3761,286 +3761,286 @@ As a final option, you can disable Nexus category mapping altogether, which can 
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="mainwindow.cpp" line="1877"/>
+        <location filename="mainwindow.cpp" line="1876"/>
         <source>&lt;Edit...&gt;</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="mainwindow.cpp" line="1888"/>
+        <location filename="mainwindow.cpp" line="1887"/>
         <source>(no executables)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="mainwindow.cpp" line="2060"/>
+        <location filename="mainwindow.cpp" line="2059"/>
         <source>This bsa is enabled in the ini file so it may be required!</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="mainwindow.cpp" line="2111"/>
+        <location filename="mainwindow.cpp" line="2110"/>
         <source>Activating Network Proxy</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="mainwindow.cpp" line="2208"/>
+        <location filename="mainwindow.cpp" line="2207"/>
         <source>Notice: Your current MO version (%1) is lower than the previously used one (%2). The GUI may not downgrade gracefully, so you may experience oddities. However, there should be no serious issues.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="mainwindow.cpp" line="2494"/>
+        <location filename="mainwindow.cpp" line="2493"/>
         <source>failed to change origin name: %1</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="mainwindow.cpp" line="2524"/>
+        <location filename="mainwindow.cpp" line="2523"/>
         <source>failed to move &quot;%1&quot; from mod &quot;%2&quot; to &quot;%3&quot;: %4</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="mainwindow.cpp" line="2651"/>
+        <location filename="mainwindow.cpp" line="2650"/>
         <source>Open Game folder</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="mainwindow.cpp" line="2652"/>
+        <location filename="mainwindow.cpp" line="2651"/>
         <source>Open MyGames folder</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="mainwindow.cpp" line="2653"/>
+        <location filename="mainwindow.cpp" line="2652"/>
         <source>Open INIs folder</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="mainwindow.cpp" line="2658"/>
+        <location filename="mainwindow.cpp" line="2657"/>
         <source>Open Instance folder</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="mainwindow.cpp" line="2659"/>
+        <location filename="mainwindow.cpp" line="2658"/>
         <source>Open Mods folder</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="mainwindow.cpp" line="2660"/>
+        <location filename="mainwindow.cpp" line="2659"/>
         <source>Open Profile folder</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="mainwindow.cpp" line="2661"/>
+        <location filename="mainwindow.cpp" line="2660"/>
         <source>Open Downloads folder</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="mainwindow.cpp" line="2667"/>
+        <location filename="mainwindow.cpp" line="2666"/>
         <source>Open MO2 Install folder</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="mainwindow.cpp" line="2668"/>
+        <location filename="mainwindow.cpp" line="2667"/>
         <source>Open MO2 Plugins folder</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="mainwindow.cpp" line="2669"/>
+        <location filename="mainwindow.cpp" line="2668"/>
         <source>Open MO2 Stylesheets folder</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="mainwindow.cpp" line="2671"/>
+        <location filename="mainwindow.cpp" line="2670"/>
         <source>Open MO2 Logs folder</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="mainwindow.cpp" line="2751"/>
+        <location filename="mainwindow.cpp" line="2750"/>
         <source>Restart Mod Organizer</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="mainwindow.cpp" line="2753"/>
+        <location filename="mainwindow.cpp" line="2752"/>
         <source>Mod Organizer must restart to finish configuration changes</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="mainwindow.cpp" line="2755"/>
+        <location filename="mainwindow.cpp" line="2754"/>
         <source>Restart</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="mainwindow.cpp" line="2757"/>
+        <location filename="mainwindow.cpp" line="2756"/>
         <source>Continue</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="mainwindow.cpp" line="2757"/>
+        <location filename="mainwindow.cpp" line="2756"/>
         <source>Some things might be weird.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="mainwindow.cpp" line="2786"/>
+        <location filename="mainwindow.cpp" line="2785"/>
         <source>Can&apos;t change download directory while downloads are in progress!</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="mainwindow.cpp" line="2950"/>
+        <location filename="mainwindow.cpp" line="2949"/>
         <source>Update available</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="mainwindow.cpp" line="2988"/>
+        <location filename="mainwindow.cpp" line="2987"/>
         <source>Do you want to endorse Mod Organizer on %1 now?</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="mainwindow.cpp" line="3006"/>
+        <location filename="mainwindow.cpp" line="3005"/>
         <source>Abstain from Endorsing Mod Organizer</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="mainwindow.cpp" line="3007"/>
+        <location filename="mainwindow.cpp" line="3006"/>
         <source>Are you sure you want to abstain from endorsing Mod Organizer 2?
 You will have to visit the mod page on the %1 Nexus site to change your mind.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="mainwindow.cpp" line="3034"/>
+        <location filename="mainwindow.cpp" line="3033"/>
         <source>Thank you for endorsing MO2! :)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="mainwindow.cpp" line="3039"/>
+        <location filename="mainwindow.cpp" line="3038"/>
         <source>Please reconsider endorsing MO2 on Nexus!</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="mainwindow.cpp" line="3068"/>
+        <location filename="mainwindow.cpp" line="3067"/>
         <source>There is no supported sort mechanism for this game. You will probably have to use a third-party tool.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="mainwindow.cpp" line="3169"/>
+        <location filename="mainwindow.cpp" line="3168"/>
         <source>None of your %1 mods appear to have had recent file updates.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="mainwindow.cpp" line="3182"/>
+        <location filename="mainwindow.cpp" line="3181"/>
         <source>All of your mods have been checked recently. We restrict update checks to help preserve your available API requests.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="mainwindow.cpp" line="3418"/>
+        <location filename="mainwindow.cpp" line="3417"/>
         <source>Thank you!</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="mainwindow.cpp" line="3419"/>
+        <location filename="mainwindow.cpp" line="3418"/>
         <source>Thank you for your endorsement!</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="mainwindow.cpp" line="3532"/>
+        <location filename="mainwindow.cpp" line="3531"/>
         <source>Mod ID %1 no longer seems to be available on Nexus.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="mainwindow.cpp" line="3550"/>
+        <location filename="mainwindow.cpp" line="3549"/>
         <source>Error %1: Request to Nexus failed: %2</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="mainwindow.cpp" line="3567"/>
-        <location filename="mainwindow.cpp" line="3640"/>
+        <location filename="mainwindow.cpp" line="3566"/>
+        <location filename="mainwindow.cpp" line="3639"/>
         <source>failed to read %1: %2</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="mainwindow.cpp" line="3580"/>
+        <location filename="mainwindow.cpp" line="3579"/>
         <source>Error</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="mainwindow.cpp" line="3581"/>
+        <location filename="mainwindow.cpp" line="3580"/>
         <source>failed to extract %1 (errorcode %2)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="mainwindow.cpp" line="3615"/>
+        <location filename="mainwindow.cpp" line="3614"/>
         <source>Extract BSA</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="mainwindow.cpp" line="3654"/>
+        <location filename="mainwindow.cpp" line="3653"/>
         <source>This archive contains invalid hashes. Some files may be broken.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="mainwindow.cpp" line="3664"/>
+        <location filename="mainwindow.cpp" line="3663"/>
         <source>Extract...</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="mainwindow.cpp" line="3733"/>
+        <location filename="mainwindow.cpp" line="3732"/>
         <source>Remove &apos;%1&apos; from the toolbar</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="mainwindow.cpp" line="3789"/>
+        <location filename="mainwindow.cpp" line="3788"/>
         <source>Backup of load order created</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="mainwindow.cpp" line="3800"/>
+        <location filename="mainwindow.cpp" line="3799"/>
         <source>Choose backup to restore</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="mainwindow.cpp" line="3817"/>
+        <location filename="mainwindow.cpp" line="3816"/>
         <source>This file might be left over following a crash or power loss event. Check its contents before restoring.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="mainwindow.cpp" line="3826"/>
+        <location filename="mainwindow.cpp" line="3825"/>
         <source>No Backups</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="mainwindow.cpp" line="3827"/>
+        <location filename="mainwindow.cpp" line="3826"/>
         <source>There are no backups to restore</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="mainwindow.cpp" line="3850"/>
+        <location filename="mainwindow.cpp" line="3874"/>
+        <source>Restore failed</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="mainwindow.cpp" line="3851"/>
         <location filename="mainwindow.cpp" line="3875"/>
-        <source>Restore failed</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="mainwindow.cpp" line="3852"/>
-        <location filename="mainwindow.cpp" line="3876"/>
         <source>Failed to restore the backup. Errorcode: %1</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="mainwindow.cpp" line="3864"/>
+        <location filename="mainwindow.cpp" line="3863"/>
         <source>Backup of mod list created</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="mainwindow.cpp" line="3944"/>
+        <location filename="mainwindow.cpp" line="3943"/>
         <source>A file with the same name has already been downloaded. What would you like to do?</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="mainwindow.cpp" line="3946"/>
+        <location filename="mainwindow.cpp" line="3945"/>
         <source>Overwrite</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="mainwindow.cpp" line="3947"/>
+        <location filename="mainwindow.cpp" line="3946"/>
         <source>Rename new file</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="mainwindow.cpp" line="3948"/>
+        <location filename="mainwindow.cpp" line="3947"/>
         <source>Ignore file</source>
         <translation type="unfinished"></translation>
     </message>
@@ -4077,12 +4077,12 @@ You will have to visit the mod page on the %1 Nexus site to change your mind.</s
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="modinfo.cpp" line="349"/>
+        <location filename="modinfo.cpp" line="348"/>
         <source>All of your mods have been checked recently. We restrict update checks to help preserve your available API requests.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="modinfo.cpp" line="353"/>
+        <location filename="modinfo.cpp" line="352"/>
         <source>You have mods that haven&apos;t been checked within the last month using the new API. These mods must be checked before we can use the bulk update API. This will consume significantly more API requests than usual. You will need to rerun the update check once complete in order to parse the remaining mods.</source>
         <translation type="unfinished"></translation>
     </message>
@@ -5705,27 +5705,27 @@ Please enter a name:</source>
 <context>
     <name>NexusTab</name>
     <message>
-        <location filename="modinfodialognexus.cpp" line="156"/>
+        <location filename="modinfodialognexus.cpp" line="157"/>
         <source>Current Version: %1</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="modinfodialognexus.cpp" line="159"/>
+        <location filename="modinfodialognexus.cpp" line="160"/>
         <source>No update available</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="modinfodialognexus.cpp" line="191"/>
+        <location filename="modinfodialognexus.cpp" line="192"/>
         <source>Tracked</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="modinfodialognexus.cpp" line="194"/>
+        <location filename="modinfodialognexus.cpp" line="195"/>
         <source>Untracked</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="modinfodialognexus.cpp" line="307"/>
+        <location filename="modinfodialognexus.cpp" line="308"/>
         <source>
       &lt;div style=&quot;text-align: center;&quot;&gt;
       &lt;p&gt;This mod does not have a valid Nexus ID. You can add a custom web
@@ -7539,13 +7539,13 @@ Destination:<byte value="xd"/>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="mainwindow.cpp" line="1819"/>
-        <location filename="mainwindow.cpp" line="2919"/>
+        <location filename="mainwindow.cpp" line="1818"/>
+        <location filename="mainwindow.cpp" line="2918"/>
         <source>&lt;Manage...&gt;</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="mainwindow.cpp" line="1831"/>
+        <location filename="mainwindow.cpp" line="1830"/>
         <source>failed to parse profile %1: %2</source>
         <translation type="unfinished"></translation>
     </message>

--- a/src/organizer_en.ts
+++ b/src/organizer_en.ts
@@ -1008,145 +1008,150 @@ p, li { white-space: pre-wrap; }
     </message>
     <message>
         <location filename="downloadlistview.cpp" line="242"/>
+        <source>Visit the uploader&apos;s profile</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="downloadlistview.cpp" line="246"/>
         <source>Open File</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="downloadlistview.cpp" line="245"/>
+        <location filename="downloadlistview.cpp" line="249"/>
         <source>Open Meta File</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="downloadlistview.cpp" line="248"/>
-        <location filename="downloadlistview.cpp" line="272"/>
-        <location filename="downloadlistview.cpp" line="284"/>
+        <location filename="downloadlistview.cpp" line="252"/>
+        <location filename="downloadlistview.cpp" line="276"/>
+        <location filename="downloadlistview.cpp" line="288"/>
         <source>Reveal in Explorer</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="downloadlistview.cpp" line="254"/>
-        <location filename="downloadlistview.cpp" line="278"/>
+        <location filename="downloadlistview.cpp" line="258"/>
+        <location filename="downloadlistview.cpp" line="282"/>
         <source>Delete...</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="downloadlistview.cpp" line="258"/>
+        <location filename="downloadlistview.cpp" line="262"/>
         <source>Un-Hide</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="downloadlistview.cpp" line="262"/>
+        <location filename="downloadlistview.cpp" line="266"/>
         <source>Hide</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="downloadlistview.cpp" line="266"/>
-        <location filename="downloadlistview.cpp" line="380"/>
+        <location filename="downloadlistview.cpp" line="270"/>
+        <location filename="downloadlistview.cpp" line="384"/>
         <source>Cancel</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="downloadlistview.cpp" line="269"/>
+        <location filename="downloadlistview.cpp" line="273"/>
         <source>Pause</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="downloadlistview.cpp" line="281"/>
+        <location filename="downloadlistview.cpp" line="285"/>
         <source>Resume</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="downloadlistview.cpp" line="296"/>
+        <location filename="downloadlistview.cpp" line="300"/>
         <source>Delete Installed Downloads...</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="downloadlistview.cpp" line="299"/>
+        <location filename="downloadlistview.cpp" line="303"/>
         <source>Delete Uninstalled Downloads...</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="downloadlistview.cpp" line="302"/>
+        <location filename="downloadlistview.cpp" line="306"/>
         <source>Delete All Downloads...</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="downloadlistview.cpp" line="308"/>
+        <location filename="downloadlistview.cpp" line="312"/>
         <source>Hide Installed...</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="downloadlistview.cpp" line="311"/>
+        <location filename="downloadlistview.cpp" line="315"/>
         <source>Hide Uninstalled...</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="downloadlistview.cpp" line="314"/>
+        <location filename="downloadlistview.cpp" line="318"/>
         <source>Hide All...</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="downloadlistview.cpp" line="318"/>
+        <location filename="downloadlistview.cpp" line="322"/>
         <source>Un-Hide All...</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="downloadlistview.cpp" line="375"/>
+        <location filename="downloadlistview.cpp" line="379"/>
         <source>Delete download</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="downloadlistview.cpp" line="379"/>
+        <location filename="downloadlistview.cpp" line="383"/>
         <source>Move to the Recycle Bin</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="downloadlistview.cpp" line="444"/>
-        <location filename="downloadlistview.cpp" line="455"/>
-        <location filename="downloadlistview.cpp" line="466"/>
+        <location filename="downloadlistview.cpp" line="453"/>
+        <location filename="downloadlistview.cpp" line="464"/>
+        <location filename="downloadlistview.cpp" line="475"/>
         <source>Delete Files?</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="downloadlistview.cpp" line="445"/>
+        <location filename="downloadlistview.cpp" line="454"/>
         <source>This will remove all finished downloads from this list and from disk.
 
 Are you absolutely sure you want to proceed?</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="downloadlistview.cpp" line="456"/>
+        <location filename="downloadlistview.cpp" line="465"/>
         <source>This will remove all installed downloads from this list and from disk.
 
 Are you absolutely sure you want to proceed?</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="downloadlistview.cpp" line="467"/>
+        <location filename="downloadlistview.cpp" line="476"/>
         <source>This will remove all uninstalled downloads from this list and from disk.
 
 Are you absolutely sure you want to proceed?</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="downloadlistview.cpp" line="476"/>
-        <location filename="downloadlistview.cpp" line="486"/>
-        <location filename="downloadlistview.cpp" line="496"/>
+        <location filename="downloadlistview.cpp" line="485"/>
+        <location filename="downloadlistview.cpp" line="495"/>
+        <location filename="downloadlistview.cpp" line="505"/>
         <source>Hide Files?</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="downloadlistview.cpp" line="477"/>
+        <location filename="downloadlistview.cpp" line="486"/>
         <source>This will remove all finished downloads from this list (but NOT from disk).</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="downloadlistview.cpp" line="487"/>
+        <location filename="downloadlistview.cpp" line="496"/>
         <source>This will remove all installed downloads from this list (but NOT from disk).</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="downloadlistview.cpp" line="497"/>
+        <location filename="downloadlistview.cpp" line="506"/>
         <source>This will remove all uninstalled downloads from this list (but NOT from disk).</source>
         <translation type="unfinished"></translation>
     </message>
@@ -1154,22 +1159,22 @@ Are you absolutely sure you want to proceed?</source>
 <context>
     <name>DownloadManager</name>
     <message>
-        <location filename="downloadmanager.cpp" line="198"/>
+        <location filename="downloadmanager.cpp" line="200"/>
         <source>failed to rename &quot;%1&quot; to &quot;%2&quot;</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="downloadmanager.cpp" line="440"/>
+        <location filename="downloadmanager.cpp" line="442"/>
         <source>Memory allocation error (in refreshing directory).</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="downloadmanager.cpp" line="455"/>
+        <location filename="downloadmanager.cpp" line="457"/>
         <source>Query Metadata</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="downloadmanager.cpp" line="456"/>
+        <location filename="downloadmanager.cpp" line="458"/>
         <source>There are %1 downloads with incomplete metadata.
 
 Do you want to fetch all incomplete metadata?
@@ -1177,32 +1182,32 @@ API requests will be consumed, and Mod Organizer may stutter.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="downloadmanager.cpp" line="606"/>
+        <location filename="downloadmanager.cpp" line="610"/>
         <source>failed to download %1: could not open output file: %2</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="downloadmanager.cpp" line="635"/>
+        <location filename="downloadmanager.cpp" line="639"/>
         <source>Download again?</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="downloadmanager.cpp" line="636"/>
+        <location filename="downloadmanager.cpp" line="640"/>
         <source>A file with the same name &quot;%1&quot; has already been downloaded. Do you want to download it again? The new file will receive a different name.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="downloadmanager.cpp" line="703"/>
+        <location filename="downloadmanager.cpp" line="714"/>
         <source>Wrong Game</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="downloadmanager.cpp" line="704"/>
+        <location filename="downloadmanager.cpp" line="715"/>
         <source>The download link is for a mod for &quot;%1&quot; but this instance of MO has been set up for &quot;%2&quot;.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="downloadmanager.cpp" line="718"/>
+        <location filename="downloadmanager.cpp" line="729"/>
         <source>There is already a download queued for this file.
 
 Mod %1
@@ -1210,12 +1215,12 @@ File %2</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="downloadmanager.cpp" line="725"/>
+        <location filename="downloadmanager.cpp" line="736"/>
         <source>Already Queued</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="downloadmanager.cpp" line="738"/>
+        <location filename="downloadmanager.cpp" line="749"/>
         <source>There is already a download started for this file.
 
 Mod %1:	%2
@@ -1223,303 +1228,318 @@ File %3:	%4</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="downloadmanager.cpp" line="774"/>
+        <location filename="downloadmanager.cpp" line="785"/>
         <source>Already Started</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="downloadmanager.cpp" line="806"/>
-        <location filename="downloadmanager.cpp" line="936"/>
+        <location filename="downloadmanager.cpp" line="816"/>
+        <location filename="downloadmanager.cpp" line="946"/>
         <source>remove: invalid download index %1</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="downloadmanager.cpp" line="824"/>
+        <location filename="downloadmanager.cpp" line="834"/>
         <source>failed to delete %1</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="downloadmanager.cpp" line="830"/>
+        <location filename="downloadmanager.cpp" line="840"/>
         <source>failed to delete meta file for %1</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="downloadmanager.cpp" line="889"/>
+        <location filename="downloadmanager.cpp" line="899"/>
         <source>restore: invalid download index: %1</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="downloadmanager.cpp" line="955"/>
+        <location filename="downloadmanager.cpp" line="965"/>
         <source>cancel: invalid download index %1</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="downloadmanager.cpp" line="967"/>
+        <location filename="downloadmanager.cpp" line="977"/>
         <source>pause: invalid download index %1</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="downloadmanager.cpp" line="989"/>
+        <location filename="downloadmanager.cpp" line="999"/>
         <source>resume: invalid download index %1</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="downloadmanager.cpp" line="1000"/>
+        <location filename="downloadmanager.cpp" line="1010"/>
         <source>resume (int): invalid download index %1</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="downloadmanager.cpp" line="1025"/>
+        <location filename="downloadmanager.cpp" line="1035"/>
         <source>No known download urls. Sorry, this download can&apos;t be resumed.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="downloadmanager.cpp" line="1068"/>
-        <location filename="downloadmanager.cpp" line="1133"/>
+        <location filename="downloadmanager.cpp" line="1079"/>
+        <location filename="downloadmanager.cpp" line="1144"/>
         <source>query: invalid download index %1</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="downloadmanager.cpp" line="1090"/>
+        <location filename="downloadmanager.cpp" line="1101"/>
         <source>Please enter the Nexus mod ID</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="downloadmanager.cpp" line="1091"/>
+        <location filename="downloadmanager.cpp" line="1102"/>
         <source>Mod ID:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="downloadmanager.cpp" line="1109"/>
+        <location filename="downloadmanager.cpp" line="1120"/>
         <source>Please select the source game code for %1</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="downloadmanager.cpp" line="1167"/>
+        <location filename="downloadmanager.cpp" line="1178"/>
         <source>Hashing download file &apos;%1&apos;</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="downloadmanager.cpp" line="1168"/>
+        <location filename="downloadmanager.cpp" line="1179"/>
         <source>Cancel</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="downloadmanager.cpp" line="1196"/>
+        <location filename="downloadmanager.cpp" line="1207"/>
         <source>VisitNexus: invalid download index %1</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="downloadmanager.cpp" line="1216"/>
+        <location filename="downloadmanager.cpp" line="1227"/>
         <source>Nexus ID for this Mod is unknown</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="downloadmanager.cpp" line="1223"/>
+        <location filename="downloadmanager.cpp" line="1234"/>
+        <source>VisitUploaderProfile: invalid download index %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="downloadmanager.cpp" line="1248"/>
+        <source>Uploader for this Mod is unknown</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="downloadmanager.cpp" line="1255"/>
         <source>OpenFile: invalid download index %1</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="downloadmanager.cpp" line="1267"/>
+        <location filename="downloadmanager.cpp" line="1299"/>
         <source>OpenFileInDownloadsFolder: invalid download index %1</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="downloadmanager.cpp" line="1300"/>
+        <location filename="downloadmanager.cpp" line="1332"/>
         <source>get pending: invalid download index %1</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="downloadmanager.cpp" line="1309"/>
+        <location filename="downloadmanager.cpp" line="1341"/>
         <source>get path: invalid download index %1</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="downloadmanager.cpp" line="1319"/>
+        <location filename="downloadmanager.cpp" line="1351"/>
         <source>Main</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="downloadmanager.cpp" line="1321"/>
+        <location filename="downloadmanager.cpp" line="1353"/>
         <source>Update</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="downloadmanager.cpp" line="1323"/>
+        <location filename="downloadmanager.cpp" line="1355"/>
         <source>Optional</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="downloadmanager.cpp" line="1325"/>
+        <location filename="downloadmanager.cpp" line="1357"/>
         <source>Old</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="downloadmanager.cpp" line="1327"/>
+        <location filename="downloadmanager.cpp" line="1359"/>
         <source>Miscellaneous</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="downloadmanager.cpp" line="1329"/>
+        <location filename="downloadmanager.cpp" line="1361"/>
         <source>Deleted</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="downloadmanager.cpp" line="1331"/>
+        <location filename="downloadmanager.cpp" line="1363"/>
         <source>Archived</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="downloadmanager.cpp" line="1333"/>
+        <location filename="downloadmanager.cpp" line="1365"/>
         <source>Unknown</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="downloadmanager.cpp" line="1340"/>
+        <location filename="downloadmanager.cpp" line="1372"/>
         <source>display name: invalid download index %1</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="downloadmanager.cpp" line="1361"/>
+        <location filename="downloadmanager.cpp" line="1393"/>
         <source>file name: invalid download index %1</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="downloadmanager.cpp" line="1370"/>
+        <location filename="downloadmanager.cpp" line="1402"/>
         <source>file time: invalid download index %1</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="downloadmanager.cpp" line="1389"/>
+        <location filename="downloadmanager.cpp" line="1421"/>
         <source>file size: invalid download index %1</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="downloadmanager.cpp" line="1398"/>
+        <location filename="downloadmanager.cpp" line="1430"/>
         <source>progress: invalid download index %1</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="downloadmanager.cpp" line="1407"/>
+        <location filename="downloadmanager.cpp" line="1439"/>
         <source>state: invalid download index %1</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="downloadmanager.cpp" line="1416"/>
+        <location filename="downloadmanager.cpp" line="1448"/>
         <source>infocomplete: invalid download index %1</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="downloadmanager.cpp" line="1430"/>
-        <location filename="downloadmanager.cpp" line="1438"/>
-        <location filename="downloadmanager.cpp" line="1451"/>
+        <location filename="downloadmanager.cpp" line="1462"/>
+        <location filename="downloadmanager.cpp" line="1470"/>
+        <location filename="downloadmanager.cpp" line="1483"/>
         <source>mod id: invalid download index %1</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="downloadmanager.cpp" line="1459"/>
+        <location filename="downloadmanager.cpp" line="1491"/>
         <source>ishidden: invalid download index %1</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="downloadmanager.cpp" line="1467"/>
+        <location filename="downloadmanager.cpp" line="1499"/>
         <source>file info: invalid download index %1</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="downloadmanager.cpp" line="1476"/>
+        <location filename="downloadmanager.cpp" line="1508"/>
         <source>mark installed: invalid download index %1</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="downloadmanager.cpp" line="1517"/>
+        <location filename="downloadmanager.cpp" line="1549"/>
         <source>mark uninstalled: invalid download index %1</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="downloadmanager.cpp" line="1682"/>
+        <location filename="downloadmanager.cpp" line="1722"/>
         <source>%1% - %2 - ~%3</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="downloadmanager.cpp" line="1693"/>
+        <location filename="downloadmanager.cpp" line="1733"/>
         <source>Memory allocation error (in processing progress event).</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="downloadmanager.cpp" line="1702"/>
+        <location filename="downloadmanager.cpp" line="1742"/>
         <source>Memory allocation error (in processing downloaded data).</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="downloadmanager.cpp" line="1823"/>
+        <location filename="downloadmanager.cpp" line="1873"/>
         <source>Information updated</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="downloadmanager.cpp" line="1825"/>
-        <location filename="downloadmanager.cpp" line="1848"/>
+        <location filename="downloadmanager.cpp" line="1875"/>
+        <location filename="downloadmanager.cpp" line="1898"/>
         <source>No matching file found on Nexus! Maybe this file is no longer available or it was renamed?</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="downloadmanager.cpp" line="1828"/>
+        <location filename="downloadmanager.cpp" line="1878"/>
         <source>No file on Nexus matches the selected file by name. Please manually choose the correct one.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="downloadmanager.cpp" line="2024"/>
+        <location filename="downloadmanager.cpp" line="2092"/>
         <source>No download server available. Please try again later.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="downloadmanager.cpp" line="2199"/>
+        <location filename="downloadmanager.cpp" line="2270"/>
         <source>Failed to request file info from nexus: %1</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="downloadmanager.cpp" line="2231"/>
+        <location filename="downloadmanager.cpp" line="2305"/>
+        <source>Download finished event received but download is not finished?</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="downloadmanager.cpp" line="2315"/>
         <source>Warning: Content type is: %1</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="downloadmanager.cpp" line="2238"/>
+        <location filename="downloadmanager.cpp" line="2322"/>
         <source>Download header content length: %1 downloaded file size: %2</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="downloadmanager.cpp" line="2242"/>
+        <location filename="downloadmanager.cpp" line="2326"/>
         <source>Download failed: %1 (%2)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="downloadmanager.cpp" line="2267"/>
+        <location filename="downloadmanager.cpp" line="2351"/>
         <source>We were unable to download the file due to errors after four retries. There may be an issue with the Nexus servers.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="downloadmanager.cpp" line="2358"/>
+        <location filename="downloadmanager.cpp" line="2442"/>
         <source>failed to re-open %1</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="downloadmanager.cpp" line="2406"/>
-        <source>Unable to write download to drive (return %1).
-Check the drive&apos;s available storage.
+        <location filename="downloadmanager.cpp" line="2494"/>
+        <source>Unable to write download to drive (wrote %1).
+Check the drive&apos;s available storage (need %2).
 
-Canceling download &quot;%2&quot;...</source>
+Canceling download &quot;%3&quot;...</source>
         <translation type="unfinished"></translation>
     </message>
 </context>
 <context>
     <name>DownloadsTab</name>
     <message>
-        <location filename="downloadstab.cpp" line="90"/>
+        <location filename="downloadstab.cpp" line="92"/>
         <source>Query Metadata</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="downloadstab.cpp" line="91"/>
+        <location filename="downloadstab.cpp" line="93"/>
         <source>Cannot query metadata while offline mode is enabled. Do you want to disable offline mode?</source>
         <translation type="unfinished"></translation>
     </message>
@@ -1722,16 +1742,27 @@ Right now the only case I know of where this needs to be overwritten is for the 
     <message>
         <location filename="editexecutablesdialog.ui" line="444"/>
         <location filename="editexecutablesdialog.ui" line="447"/>
-        <source>This executable will not appear in the list, on the toolbar or in the menu. It will still be visible in this dialog.</source>
+        <source>Mod Organizer will minimize to the system tray while this executable is running. It will reappear after it finishes.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="editexecutablesdialog.ui" line="450"/>
-        <source>Hide in user interface</source>
+        <source>Minimize to system tray while running</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="editexecutablesdialog.ui" line="457"/>
+        <location filename="editexecutablesdialog.ui" line="460"/>
+        <source>This executable will not appear in the list, on the toolbar or in the menu. It will still be visible in this dialog.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="editexecutablesdialog.ui" line="463"/>
+        <source>Hide in user interface</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="editexecutablesdialog.ui" line="470"/>
         <source>(*) Profile specific</source>
         <translation type="unfinished"></translation>
     </message>
@@ -1751,68 +1782,68 @@ Right now the only case I know of where this needs to be overwritten is for the 
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="editexecutablesdialog.cpp" line="211"/>
+        <location filename="editexecutablesdialog.cpp" line="214"/>
         <source>Empty output mod</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="editexecutablesdialog.cpp" line="212"/>
+        <location filename="editexecutablesdialog.cpp" line="215"/>
         <source>The output mod for %2 is empty.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="editexecutablesdialog.cpp" line="216"/>
+        <location filename="editexecutablesdialog.cpp" line="219"/>
         <source>Output mod not found</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="editexecutablesdialog.cpp" line="217"/>
+        <location filename="editexecutablesdialog.cpp" line="220"/>
         <source>The output mod &apos;%1&apos; for %2 does not exist.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="editexecutablesdialog.cpp" line="563"/>
+        <location filename="editexecutablesdialog.cpp" line="576"/>
         <source>Reset plugin executables</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="editexecutablesdialog.cpp" line="566"/>
+        <location filename="editexecutablesdialog.cpp" line="579"/>
         <source>This will restore all the executables provided by the game plugin. If there are existing executables with the same names, they will be automatically renamed and left unchanged.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="editexecutablesdialog.cpp" line="753"/>
-        <location filename="editexecutablesdialog.cpp" line="795"/>
+        <location filename="editexecutablesdialog.cpp" line="766"/>
+        <location filename="editexecutablesdialog.cpp" line="808"/>
         <source>New Executable</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="editexecutablesdialog.cpp" line="808"/>
+        <location filename="editexecutablesdialog.cpp" line="821"/>
         <source>Select a directory</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="editexecutablesdialog.cpp" line="855"/>
+        <location filename="editexecutablesdialog.cpp" line="868"/>
         <source>Executables (*.exe *.bat *.jar)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="editexecutablesdialog.cpp" line="855"/>
+        <location filename="editexecutablesdialog.cpp" line="868"/>
         <source>All Files (*.*)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="editexecutablesdialog.cpp" line="858"/>
+        <location filename="editexecutablesdialog.cpp" line="871"/>
         <source>Select an executable</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="editexecutablesdialog.cpp" line="873"/>
+        <location filename="editexecutablesdialog.cpp" line="886"/>
         <source>Java required</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="editexecutablesdialog.cpp" line="874"/>
+        <location filename="editexecutablesdialog.cpp" line="887"/>
         <source>MO requires Java to run this application. If you already have it installed, select javaw.exe from that installation as the binary.</source>
         <translation type="unfinished"></translation>
     </message>
@@ -2522,96 +2553,96 @@ This is likely due to a corrupted or incompatible download or unrecognized archi
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="instancemanagerdialog.cpp" line="399"/>
+        <location filename="instancemanagerdialog.cpp" line="394"/>
         <source>Switching instances</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="instancemanagerdialog.cpp" line="400"/>
+        <location filename="instancemanagerdialog.cpp" line="395"/>
         <source>Mod Organizer must restart to manage the instance &apos;%1&apos;.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="instancemanagerdialog.cpp" line="402"/>
+        <location filename="instancemanagerdialog.cpp" line="397"/>
         <source>This confirmation can be disabled in the settings.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="instancemanagerdialog.cpp" line="404"/>
+        <location filename="instancemanagerdialog.cpp" line="399"/>
         <source>Restart Mod Organizer</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="instancemanagerdialog.cpp" line="405"/>
-        <location filename="instancemanagerdialog.cpp" line="522"/>
+        <location filename="instancemanagerdialog.cpp" line="400"/>
+        <location filename="instancemanagerdialog.cpp" line="517"/>
         <source>Cancel</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="instancemanagerdialog.cpp" line="422"/>
-        <location filename="instancemanagerdialog.cpp" line="428"/>
+        <location filename="instancemanagerdialog.cpp" line="417"/>
+        <location filename="instancemanagerdialog.cpp" line="423"/>
         <source>Rename instance</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="instancemanagerdialog.cpp" line="423"/>
+        <location filename="instancemanagerdialog.cpp" line="418"/>
         <source>The active instance cannot be renamed.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="instancemanagerdialog.cpp" line="429"/>
+        <location filename="instancemanagerdialog.cpp" line="424"/>
         <source>Instance name</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="instancemanagerdialog.cpp" line="445"/>
+        <location filename="instancemanagerdialog.cpp" line="440"/>
         <source>Error</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="instancemanagerdialog.cpp" line="446"/>
+        <location filename="instancemanagerdialog.cpp" line="441"/>
         <source>Failed to rename &quot;%1&quot; to &quot;%2&quot;: %3</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="instancemanagerdialog.cpp" line="501"/>
-        <location filename="instancemanagerdialog.cpp" line="516"/>
-        <location filename="instancemanagerdialog.cpp" line="568"/>
+        <location filename="instancemanagerdialog.cpp" line="496"/>
+        <location filename="instancemanagerdialog.cpp" line="511"/>
+        <location filename="instancemanagerdialog.cpp" line="563"/>
         <source>Deleting instance</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="instancemanagerdialog.cpp" line="502"/>
+        <location filename="instancemanagerdialog.cpp" line="497"/>
         <source>The active instance cannot be deleted.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="instancemanagerdialog.cpp" line="517"/>
+        <location filename="instancemanagerdialog.cpp" line="512"/>
         <source>These files and folders will be deleted</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="instancemanagerdialog.cpp" line="518"/>
+        <location filename="instancemanagerdialog.cpp" line="513"/>
         <source>All checked items will be deleted.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="instancemanagerdialog.cpp" line="520"/>
+        <location filename="instancemanagerdialog.cpp" line="515"/>
         <source>Move to the recycle bin</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="instancemanagerdialog.cpp" line="521"/>
+        <location filename="instancemanagerdialog.cpp" line="516"/>
         <source>Delete permanently</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="instancemanagerdialog.cpp" line="568"/>
+        <location filename="instancemanagerdialog.cpp" line="563"/>
         <source>Nothing to delete.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="instancemanagerdialog.cpp" line="700"/>
+        <location filename="instancemanagerdialog.cpp" line="695"/>
         <source>A portable instance already exists.</source>
         <translation type="unfinished"></translation>
     </message>
@@ -3029,7 +3060,7 @@ This is likely due to a corrupted or incompatible download or unrecognized archi
     <message>
         <location filename="mainwindow.ui" line="812"/>
         <location filename="mainwindow.ui" line="815"/>
-        <location filename="mainwindow.cpp" line="3055"/>
+        <location filename="mainwindow.cpp" line="3065"/>
         <source>Sort the plugins using LOOT.</source>
         <translation type="unfinished"></translation>
     </message>
@@ -3175,7 +3206,7 @@ This is likely due to a corrupted or incompatible download or unrecognized archi
     </message>
     <message>
         <location filename="mainwindow.ui" line="1284"/>
-        <location filename="mainwindow.cpp" line="1156"/>
+        <location filename="mainwindow.cpp" line="1166"/>
         <source>Name</source>
         <translation type="unfinished"></translation>
     </message>
@@ -3433,7 +3464,7 @@ This is likely due to a corrupted or incompatible download or unrecognized archi
     <message>
         <location filename="mainwindow.ui" line="1871"/>
         <location filename="mainwindow.ui" line="1874"/>
-        <location filename="mainwindow.cpp" line="2977"/>
+        <location filename="mainwindow.cpp" line="2987"/>
         <source>Endorse Mod Organizer</source>
         <translation type="unfinished"></translation>
     </message>
@@ -3517,169 +3548,169 @@ This is likely due to a corrupted or incompatible download or unrecognized archi
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="mainwindow.cpp" line="352"/>
+        <location filename="mainwindow.cpp" line="356"/>
         <source>Toolbar and Menu</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="mainwindow.cpp" line="354"/>
+        <location filename="mainwindow.cpp" line="358"/>
         <source>Desktop</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="mainwindow.cpp" line="356"/>
+        <location filename="mainwindow.cpp" line="360"/>
         <source>Start Menu</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="mainwindow.cpp" line="632"/>
+        <location filename="mainwindow.cpp" line="642"/>
         <source>Crash on exit</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="mainwindow.cpp" line="633"/>
+        <location filename="mainwindow.cpp" line="643"/>
         <source>MO crashed while exiting.  Some settings may not be saved.
 
 Error: %1</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="mainwindow.cpp" line="935"/>
+        <location filename="mainwindow.cpp" line="945"/>
         <source>There are notifications to read</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="mainwindow.cpp" line="955"/>
+        <location filename="mainwindow.cpp" line="965"/>
         <source>There are no notifications</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="mainwindow.cpp" line="1057"/>
+        <location filename="mainwindow.cpp" line="1067"/>
         <source>Endorse</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="mainwindow.cpp" line="1061"/>
+        <location filename="mainwindow.cpp" line="1071"/>
         <source>Won&apos;t Endorse</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="mainwindow.cpp" line="1070"/>
+        <location filename="mainwindow.cpp" line="1080"/>
         <source>First Steps</source>
         <extracomment>Translation strings for tutorial names</extracomment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="mainwindow.cpp" line="1071"/>
+        <location filename="mainwindow.cpp" line="1081"/>
         <source>Conflict Resolution</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="mainwindow.cpp" line="1072"/>
+        <location filename="mainwindow.cpp" line="1082"/>
         <source>Overview</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="mainwindow.cpp" line="1083"/>
+        <location filename="mainwindow.cpp" line="1093"/>
         <source>Help on UI</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="mainwindow.cpp" line="1087"/>
+        <location filename="mainwindow.cpp" line="1097"/>
         <source>Documentation</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="mainwindow.cpp" line="1092"/>
-        <location filename="mainwindow.cpp" line="1260"/>
+        <location filename="mainwindow.cpp" line="1102"/>
+        <location filename="mainwindow.cpp" line="1270"/>
         <source>Game Support Wiki</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="mainwindow.cpp" line="1097"/>
+        <location filename="mainwindow.cpp" line="1107"/>
         <source>Chat on Discord</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="mainwindow.cpp" line="1101"/>
+        <location filename="mainwindow.cpp" line="1111"/>
         <source>Report Issue</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="mainwindow.cpp" line="1105"/>
+        <location filename="mainwindow.cpp" line="1115"/>
         <source>Tutorials</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="mainwindow.cpp" line="1147"/>
+        <location filename="mainwindow.cpp" line="1157"/>
         <source>About</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="mainwindow.cpp" line="1148"/>
+        <location filename="mainwindow.cpp" line="1158"/>
         <source>About Qt</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="mainwindow.cpp" line="1157"/>
+        <location filename="mainwindow.cpp" line="1167"/>
         <source>Please enter a name for the new profile</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="mainwindow.cpp" line="1165"/>
+        <location filename="mainwindow.cpp" line="1175"/>
         <source>failed to create profile: %1</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="mainwindow.cpp" line="1202"/>
+        <location filename="mainwindow.cpp" line="1212"/>
         <source>Show tutorial?</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="mainwindow.cpp" line="1203"/>
+        <location filename="mainwindow.cpp" line="1213"/>
         <source>You are starting Mod Organizer for the first time. Do you want to show a tutorial of its basic features? If you choose no you can always start the tutorial from the &quot;Help&quot; menu.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="mainwindow.cpp" line="1208"/>
+        <location filename="mainwindow.cpp" line="1218"/>
         <source>Never ask to show tutorials</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="mainwindow.cpp" line="1261"/>
+        <location filename="mainwindow.cpp" line="1271"/>
         <source>Do you know how to mod this game? Do you need to learn? There&apos;s a game support wiki available! Click OK to open the wiki. In the future, you can access this link from the &quot;Help&quot; menu.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="mainwindow.cpp" line="1270"/>
+        <location filename="mainwindow.cpp" line="1280"/>
         <source>Category Setup</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="mainwindow.cpp" line="1272"/>
+        <location filename="mainwindow.cpp" line="1282"/>
         <source>Please choose how to handle the default category setup.
 
 If you&apos;ve already connected to Nexus, you can automatically import Nexus categories for this game (if applicable). Otherwise, use the old Mod Organizer default category structure, or leave the categories blank (for manual setup).</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="mainwindow.cpp" line="1277"/>
-        <location filename="mainwindow.cpp" line="1315"/>
+        <location filename="mainwindow.cpp" line="1287"/>
+        <location filename="mainwindow.cpp" line="1325"/>
         <source>&amp;Import Nexus Categories</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="mainwindow.cpp" line="1278"/>
+        <location filename="mainwindow.cpp" line="1288"/>
         <source>Use &amp;Old Category Defaults</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="mainwindow.cpp" line="1279"/>
+        <location filename="mainwindow.cpp" line="1289"/>
         <source>Do &amp;Nothing</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="mainwindow.cpp" line="1303"/>
+        <location filename="mainwindow.cpp" line="1313"/>
         <source>This is your first time running version 2.5 or higher with an old MO2 instance. The category system now relies on an updated system to map Nexus categories.
 
 In order to assign Nexus categories automatically, you will need to import the Nexus categories for the currently managed game and map them to your preferred category structure.
@@ -3690,326 +3721,326 @@ As a final option, you can disable Nexus category mapping altogether, which can 
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="mainwindow.cpp" line="1316"/>
+        <location filename="mainwindow.cpp" line="1326"/>
         <source>&amp;Open Categories Dialog</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="mainwindow.cpp" line="1317"/>
+        <location filename="mainwindow.cpp" line="1327"/>
         <source>&amp;Disable Nexus Mappings</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="mainwindow.cpp" line="1318"/>
+        <location filename="mainwindow.cpp" line="1328"/>
         <source>&amp;Close</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="mainwindow.cpp" line="1319"/>
+        <location filename="mainwindow.cpp" line="1329"/>
         <source>&amp;Don&apos;t show this again</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="mainwindow.cpp" line="1442"/>
+        <location filename="mainwindow.cpp" line="1452"/>
         <source>Downloads in progress</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="mainwindow.cpp" line="1443"/>
+        <location filename="mainwindow.cpp" line="1453"/>
         <source>There are still downloads in progress, do you really want to quit?</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="mainwindow.cpp" line="1502"/>
+        <location filename="mainwindow.cpp" line="1512"/>
         <source>Plugin &quot;%1&quot; failed: %2</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="mainwindow.cpp" line="1504"/>
+        <location filename="mainwindow.cpp" line="1514"/>
         <source>Plugin &quot;%1&quot; failed</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="mainwindow.cpp" line="1872"/>
+        <location filename="mainwindow.cpp" line="1877"/>
         <source>&lt;Edit...&gt;</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="mainwindow.cpp" line="1883"/>
+        <location filename="mainwindow.cpp" line="1888"/>
         <source>(no executables)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="mainwindow.cpp" line="2054"/>
+        <location filename="mainwindow.cpp" line="2060"/>
         <source>This bsa is enabled in the ini file so it may be required!</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="mainwindow.cpp" line="2105"/>
+        <location filename="mainwindow.cpp" line="2111"/>
         <source>Activating Network Proxy</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="mainwindow.cpp" line="2202"/>
+        <location filename="mainwindow.cpp" line="2208"/>
         <source>Notice: Your current MO version (%1) is lower than the previously used one (%2). The GUI may not downgrade gracefully, so you may experience oddities. However, there should be no serious issues.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="mainwindow.cpp" line="2484"/>
+        <location filename="mainwindow.cpp" line="2494"/>
         <source>failed to change origin name: %1</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="mainwindow.cpp" line="2514"/>
+        <location filename="mainwindow.cpp" line="2524"/>
         <source>failed to move &quot;%1&quot; from mod &quot;%2&quot; to &quot;%3&quot;: %4</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="mainwindow.cpp" line="2641"/>
+        <location filename="mainwindow.cpp" line="2651"/>
         <source>Open Game folder</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="mainwindow.cpp" line="2642"/>
+        <location filename="mainwindow.cpp" line="2652"/>
         <source>Open MyGames folder</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="mainwindow.cpp" line="2643"/>
+        <location filename="mainwindow.cpp" line="2653"/>
         <source>Open INIs folder</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="mainwindow.cpp" line="2648"/>
+        <location filename="mainwindow.cpp" line="2658"/>
         <source>Open Instance folder</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="mainwindow.cpp" line="2649"/>
+        <location filename="mainwindow.cpp" line="2659"/>
         <source>Open Mods folder</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="mainwindow.cpp" line="2650"/>
+        <location filename="mainwindow.cpp" line="2660"/>
         <source>Open Profile folder</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="mainwindow.cpp" line="2651"/>
+        <location filename="mainwindow.cpp" line="2661"/>
         <source>Open Downloads folder</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="mainwindow.cpp" line="2657"/>
+        <location filename="mainwindow.cpp" line="2667"/>
         <source>Open MO2 Install folder</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="mainwindow.cpp" line="2658"/>
+        <location filename="mainwindow.cpp" line="2668"/>
         <source>Open MO2 Plugins folder</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="mainwindow.cpp" line="2659"/>
+        <location filename="mainwindow.cpp" line="2669"/>
         <source>Open MO2 Stylesheets folder</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="mainwindow.cpp" line="2661"/>
+        <location filename="mainwindow.cpp" line="2671"/>
         <source>Open MO2 Logs folder</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="mainwindow.cpp" line="2741"/>
+        <location filename="mainwindow.cpp" line="2751"/>
         <source>Restart Mod Organizer</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="mainwindow.cpp" line="2743"/>
+        <location filename="mainwindow.cpp" line="2753"/>
         <source>Mod Organizer must restart to finish configuration changes</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="mainwindow.cpp" line="2745"/>
+        <location filename="mainwindow.cpp" line="2755"/>
         <source>Restart</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="mainwindow.cpp" line="2747"/>
+        <location filename="mainwindow.cpp" line="2757"/>
         <source>Continue</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="mainwindow.cpp" line="2747"/>
+        <location filename="mainwindow.cpp" line="2757"/>
         <source>Some things might be weird.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="mainwindow.cpp" line="2776"/>
+        <location filename="mainwindow.cpp" line="2786"/>
         <source>Can&apos;t change download directory while downloads are in progress!</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="mainwindow.cpp" line="2940"/>
+        <location filename="mainwindow.cpp" line="2950"/>
         <source>Update available</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="mainwindow.cpp" line="2978"/>
+        <location filename="mainwindow.cpp" line="2988"/>
         <source>Do you want to endorse Mod Organizer on %1 now?</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="mainwindow.cpp" line="2996"/>
+        <location filename="mainwindow.cpp" line="3006"/>
         <source>Abstain from Endorsing Mod Organizer</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="mainwindow.cpp" line="2997"/>
+        <location filename="mainwindow.cpp" line="3007"/>
         <source>Are you sure you want to abstain from endorsing Mod Organizer 2?
 You will have to visit the mod page on the %1 Nexus site to change your mind.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="mainwindow.cpp" line="3024"/>
+        <location filename="mainwindow.cpp" line="3034"/>
         <source>Thank you for endorsing MO2! :)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="mainwindow.cpp" line="3029"/>
+        <location filename="mainwindow.cpp" line="3039"/>
         <source>Please reconsider endorsing MO2 on Nexus!</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="mainwindow.cpp" line="3058"/>
+        <location filename="mainwindow.cpp" line="3068"/>
         <source>There is no supported sort mechanism for this game. You will probably have to use a third-party tool.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="mainwindow.cpp" line="3157"/>
+        <location filename="mainwindow.cpp" line="3169"/>
         <source>None of your %1 mods appear to have had recent file updates.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="mainwindow.cpp" line="3170"/>
+        <location filename="mainwindow.cpp" line="3182"/>
         <source>All of your mods have been checked recently. We restrict update checks to help preserve your available API requests.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="mainwindow.cpp" line="3400"/>
+        <location filename="mainwindow.cpp" line="3418"/>
         <source>Thank you!</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="mainwindow.cpp" line="3401"/>
+        <location filename="mainwindow.cpp" line="3419"/>
         <source>Thank you for your endorsement!</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="mainwindow.cpp" line="3515"/>
+        <location filename="mainwindow.cpp" line="3532"/>
         <source>Mod ID %1 no longer seems to be available on Nexus.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="mainwindow.cpp" line="3533"/>
+        <location filename="mainwindow.cpp" line="3550"/>
         <source>Error %1: Request to Nexus failed: %2</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="mainwindow.cpp" line="3550"/>
-        <location filename="mainwindow.cpp" line="3623"/>
+        <location filename="mainwindow.cpp" line="3567"/>
+        <location filename="mainwindow.cpp" line="3640"/>
         <source>failed to read %1: %2</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="mainwindow.cpp" line="3563"/>
+        <location filename="mainwindow.cpp" line="3580"/>
         <source>Error</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="mainwindow.cpp" line="3564"/>
+        <location filename="mainwindow.cpp" line="3581"/>
         <source>failed to extract %1 (errorcode %2)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="mainwindow.cpp" line="3598"/>
+        <location filename="mainwindow.cpp" line="3615"/>
         <source>Extract BSA</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="mainwindow.cpp" line="3637"/>
+        <location filename="mainwindow.cpp" line="3654"/>
         <source>This archive contains invalid hashes. Some files may be broken.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="mainwindow.cpp" line="3647"/>
+        <location filename="mainwindow.cpp" line="3664"/>
         <source>Extract...</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="mainwindow.cpp" line="3716"/>
+        <location filename="mainwindow.cpp" line="3733"/>
         <source>Remove &apos;%1&apos; from the toolbar</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="mainwindow.cpp" line="3772"/>
+        <location filename="mainwindow.cpp" line="3789"/>
         <source>Backup of load order created</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="mainwindow.cpp" line="3783"/>
+        <location filename="mainwindow.cpp" line="3800"/>
         <source>Choose backup to restore</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="mainwindow.cpp" line="3800"/>
+        <location filename="mainwindow.cpp" line="3817"/>
         <source>This file might be left over following a crash or power loss event. Check its contents before restoring.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="mainwindow.cpp" line="3809"/>
+        <location filename="mainwindow.cpp" line="3826"/>
         <source>No Backups</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="mainwindow.cpp" line="3810"/>
+        <location filename="mainwindow.cpp" line="3827"/>
         <source>There are no backups to restore</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="mainwindow.cpp" line="3834"/>
-        <location filename="mainwindow.cpp" line="3858"/>
+        <location filename="mainwindow.cpp" line="3851"/>
+        <location filename="mainwindow.cpp" line="3875"/>
         <source>Restore failed</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="mainwindow.cpp" line="3835"/>
-        <location filename="mainwindow.cpp" line="3859"/>
+        <location filename="mainwindow.cpp" line="3852"/>
+        <location filename="mainwindow.cpp" line="3876"/>
         <source>Failed to restore the backup. Errorcode: %1</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="mainwindow.cpp" line="3847"/>
+        <location filename="mainwindow.cpp" line="3864"/>
         <source>Backup of mod list created</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="mainwindow.cpp" line="3927"/>
+        <location filename="mainwindow.cpp" line="3944"/>
         <source>A file with the same name has already been downloaded. What would you like to do?</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="mainwindow.cpp" line="3929"/>
+        <location filename="mainwindow.cpp" line="3946"/>
         <source>Overwrite</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="mainwindow.cpp" line="3930"/>
+        <location filename="mainwindow.cpp" line="3947"/>
         <source>Rename new file</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="mainwindow.cpp" line="3931"/>
+        <location filename="mainwindow.cpp" line="3948"/>
         <source>Ignore file</source>
         <translation type="unfinished"></translation>
     </message>
@@ -4470,7 +4501,7 @@ p, li { white-space: pre-wrap; }
 <context>
     <name>ModInfoOverwrite</name>
     <message>
-        <location filename="modinfooverwrite.cpp" line="76"/>
+        <location filename="modinfooverwrite.cpp" line="74"/>
         <source>This pseudo mod contains files from the virtual data tree that got modified (i.e. by the construction kit)</source>
         <translation type="unfinished"></translation>
     </message>
@@ -4478,12 +4509,12 @@ p, li { white-space: pre-wrap; }
 <context>
     <name>ModInfoRegular</name>
     <message>
-        <location filename="modinforegular.cpp" line="736"/>
+        <location filename="modinforegular.cpp" line="740"/>
         <source>%1 contains no esp/esm/esl and no asset (textures, meshes, interface, ...) directory</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="modinforegular.cpp" line="742"/>
+        <location filename="modinforegular.cpp" line="750"/>
         <source>Categories: &lt;br&gt;</source>
         <translation type="unfinished"></translation>
     </message>
@@ -4584,178 +4615,198 @@ p, li { white-space: pre-wrap; }
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="modlist.cpp" line="263"/>
+        <location filename="modlist.cpp" line="267"/>
         <source>invalid</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="modlist.cpp" line="409"/>
+        <location filename="modlist.cpp" line="413"/>
         <source>installed version: &quot;%1&quot;, newest version: &quot;%2&quot;</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="modlist.cpp" line="414"/>
+        <location filename="modlist.cpp" line="418"/>
         <source>The newest version on Nexus seems to be older than the one you have installed. This could either mean the version you have has been withdrawn (i.e. due to a bug) or the author uses a non-standard versioning scheme and that newest version is actually newer. Either way you may want to &quot;upgrade&quot;.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="modlist.cpp" line="422"/>
+        <location filename="modlist.cpp" line="426"/>
         <source>This file has been marked as &quot;Old&quot;. There is most likely an updated version of this file available.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="modlist.cpp" line="430"/>
+        <location filename="modlist.cpp" line="434"/>
         <source>This file has been marked as &quot;Deleted&quot;! You may want to check for an update or remove the nexus ID from this mod!</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="modlist.cpp" line="440"/>
+        <location filename="modlist.cpp" line="444"/>
         <source>%1 minute(s) and %2 second(s)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="modlist.cpp" line="442"/>
+        <location filename="modlist.cpp" line="446"/>
         <source>This mod will be available to check in %2.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="modlist.cpp" line="449"/>
+        <location filename="modlist.cpp" line="457"/>
         <source>Categories: &lt;br&gt;</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="modlist.cpp" line="482"/>
+        <location filename="modlist.cpp" line="490"/>
         <source>Invalid name</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="modlist.cpp" line="488"/>
+        <location filename="modlist.cpp" line="496"/>
         <source>Name is already in use by another mod</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="modlist.cpp" line="1225"/>
+        <location filename="modlist.cpp" line="1233"/>
         <source>Confirm</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="modlist.cpp" line="1226"/>
+        <location filename="modlist.cpp" line="1234"/>
         <source>Are you sure you want to remove &quot;%1&quot;?</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="modlist.cpp" line="1307"/>
+        <location filename="modlist.cpp" line="1315"/>
         <source>Conflicts</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="modlist.cpp" line="1309"/>
+        <location filename="modlist.cpp" line="1317"/>
         <source>Flags</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="modlist.cpp" line="1311"/>
+        <location filename="modlist.cpp" line="1319"/>
         <source>Content</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="modlist.cpp" line="1313"/>
+        <location filename="modlist.cpp" line="1321"/>
         <source>Mod Name</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="modlist.cpp" line="1315"/>
+        <location filename="modlist.cpp" line="1323"/>
         <source>Version</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="modlist.cpp" line="1317"/>
+        <location filename="modlist.cpp" line="1325"/>
         <source>Priority</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="modlist.cpp" line="1319"/>
+        <location filename="modlist.cpp" line="1327"/>
         <source>Category</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="modlist.cpp" line="1321"/>
+        <location filename="modlist.cpp" line="1329"/>
+        <source>Author</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="modlist.cpp" line="1331"/>
+        <source>Uploader</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="modlist.cpp" line="1333"/>
         <source>Source Game</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="modlist.cpp" line="1323"/>
+        <location filename="modlist.cpp" line="1335"/>
         <source>Nexus ID</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="modlist.cpp" line="1325"/>
+        <location filename="modlist.cpp" line="1337"/>
         <source>Installation</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="modlist.cpp" line="1327"/>
+        <location filename="modlist.cpp" line="1339"/>
         <source>Notes</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="modlist.cpp" line="1329"/>
-        <location filename="modlist.cpp" line="1373"/>
+        <location filename="modlist.cpp" line="1341"/>
+        <location filename="modlist.cpp" line="1389"/>
         <source>unknown</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="modlist.cpp" line="1337"/>
+        <location filename="modlist.cpp" line="1349"/>
         <source>Name of your mods</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="modlist.cpp" line="1339"/>
+        <location filename="modlist.cpp" line="1351"/>
         <source>Version of the mod (if available)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="modlist.cpp" line="1341"/>
+        <location filename="modlist.cpp" line="1353"/>
         <source>Installation priority of your mod. The higher, the more &quot;important&quot; it is and thus overwrites files from mods with lower priority.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="modlist.cpp" line="1345"/>
+        <location filename="modlist.cpp" line="1357"/>
         <source>Primary category of the mod.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="modlist.cpp" line="1347"/>
+        <location filename="modlist.cpp" line="1359"/>
+        <source>Author(s) of the mod.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="modlist.cpp" line="1361"/>
+        <source>Uploader of the mod. This is not necessarily the same as the author.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="modlist.cpp" line="1363"/>
         <source>The source game which was the origin of this mod.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="modlist.cpp" line="1349"/>
+        <location filename="modlist.cpp" line="1365"/>
         <source>Id of the mod as used on Nexus.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="modlist.cpp" line="1351"/>
+        <location filename="modlist.cpp" line="1367"/>
         <source>Indicators of file conflicts between mods.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="modlist.cpp" line="1353"/>
+        <location filename="modlist.cpp" line="1369"/>
         <source>Emblems to highlight things that might require attention.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="modlist.cpp" line="1360"/>
+        <location filename="modlist.cpp" line="1376"/>
         <source>Depicts the content of the mod:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="modlist.cpp" line="1369"/>
+        <location filename="modlist.cpp" line="1385"/>
         <source>Time this mod was installed</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="modlist.cpp" line="1371"/>
+        <location filename="modlist.cpp" line="1387"/>
         <source>User notes about the mod</source>
         <translation type="unfinished"></translation>
     </message>
@@ -4852,8 +4903,8 @@ p, li { white-space: pre-wrap; }
     </message>
     <message>
         <location filename="modlistcontextmenu.cpp" line="376"/>
-        <location filename="modlistcontextmenu.cpp" line="453"/>
-        <location filename="modlistcontextmenu.cpp" line="622"/>
+        <location filename="modlistcontextmenu.cpp" line="459"/>
+        <location filename="modlistcontextmenu.cpp" line="634"/>
         <source>Open in Explorer</source>
         <translation type="unfinished"></translation>
     </message>
@@ -4869,13 +4920,13 @@ p, li { white-space: pre-wrap; }
     </message>
     <message>
         <location filename="modlistcontextmenu.cpp" line="398"/>
-        <location filename="modlistcontextmenu.cpp" line="525"/>
+        <location filename="modlistcontextmenu.cpp" line="531"/>
         <source>Select Color...</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="modlistcontextmenu.cpp" line="403"/>
-        <location filename="modlistcontextmenu.cpp" line="529"/>
+        <location filename="modlistcontextmenu.cpp" line="535"/>
         <source>Reset Color</source>
         <translation type="unfinished"></translation>
     </message>
@@ -4891,121 +4942,127 @@ p, li { white-space: pre-wrap; }
     </message>
     <message>
         <location filename="modlistcontextmenu.cpp" line="429"/>
-        <location filename="modlistcontextmenu.cpp" line="595"/>
+        <location filename="modlistcontextmenu.cpp" line="601"/>
         <source>Ignore missing data</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="modlistcontextmenu.cpp" line="435"/>
-        <location filename="modlistcontextmenu.cpp" line="602"/>
+        <location filename="modlistcontextmenu.cpp" line="608"/>
         <source>Mark as converted/working</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="modlistcontextmenu.cpp" line="441"/>
-        <location filename="modlistcontextmenu.cpp" line="610"/>
+        <location filename="modlistcontextmenu.cpp" line="616"/>
         <source>Visit on Nexus</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="modlistcontextmenu.cpp" line="448"/>
-        <location filename="modlistcontextmenu.cpp" line="617"/>
+        <location filename="modlistcontextmenu.cpp" line="447"/>
+        <location filename="modlistcontextmenu.cpp" line="622"/>
+        <source>Visit the uploader&apos;s profile</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="modlistcontextmenu.cpp" line="454"/>
+        <location filename="modlistcontextmenu.cpp" line="629"/>
         <source>Visit on %1</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="modlistcontextmenu.cpp" line="466"/>
+        <location filename="modlistcontextmenu.cpp" line="472"/>
         <source>Change versioning scheme</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="modlistcontextmenu.cpp" line="472"/>
+        <location filename="modlistcontextmenu.cpp" line="478"/>
         <source>Force-check updates</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="modlistcontextmenu.cpp" line="476"/>
+        <location filename="modlistcontextmenu.cpp" line="482"/>
         <source>Un-ignore update</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="modlistcontextmenu.cpp" line="481"/>
+        <location filename="modlistcontextmenu.cpp" line="487"/>
         <source>Ignore update</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="modlistcontextmenu.cpp" line="488"/>
+        <location filename="modlistcontextmenu.cpp" line="494"/>
         <source>Enable selected</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="modlistcontextmenu.cpp" line="491"/>
+        <location filename="modlistcontextmenu.cpp" line="497"/>
         <source>Disable selected</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="modlistcontextmenu.cpp" line="502"/>
+        <location filename="modlistcontextmenu.cpp" line="508"/>
         <source>Rename Mod...</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="modlistcontextmenu.cpp" line="505"/>
+        <location filename="modlistcontextmenu.cpp" line="511"/>
         <source>Reinstall Mod</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="modlistcontextmenu.cpp" line="508"/>
+        <location filename="modlistcontextmenu.cpp" line="514"/>
         <source>Remove Mod...</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="modlistcontextmenu.cpp" line="511"/>
+        <location filename="modlistcontextmenu.cpp" line="517"/>
         <source>Create Backup</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="modlistcontextmenu.cpp" line="517"/>
+        <location filename="modlistcontextmenu.cpp" line="523"/>
         <source>Restore hidden files</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="modlistcontextmenu.cpp" line="539"/>
+        <location filename="modlistcontextmenu.cpp" line="545"/>
         <source>Un-Endorse</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="modlistcontextmenu.cpp" line="544"/>
-        <location filename="modlistcontextmenu.cpp" line="552"/>
+        <location filename="modlistcontextmenu.cpp" line="550"/>
+        <location filename="modlistcontextmenu.cpp" line="558"/>
         <source>Endorse</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="modlistcontextmenu.cpp" line="547"/>
+        <location filename="modlistcontextmenu.cpp" line="553"/>
         <source>Won&apos;t endorse</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="modlistcontextmenu.cpp" line="557"/>
+        <location filename="modlistcontextmenu.cpp" line="563"/>
         <source>Endorsement state unknown</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="modlistcontextmenu.cpp" line="567"/>
+        <location filename="modlistcontextmenu.cpp" line="573"/>
         <source>Remap Category (From Nexus)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="modlistcontextmenu.cpp" line="575"/>
+        <location filename="modlistcontextmenu.cpp" line="581"/>
         <source>Start tracking</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="modlistcontextmenu.cpp" line="580"/>
+        <location filename="modlistcontextmenu.cpp" line="586"/>
         <source>Stop tracking</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="modlistcontextmenu.cpp" line="585"/>
+        <location filename="modlistcontextmenu.cpp" line="591"/>
         <source>Tracked state unknown</source>
         <translation type="unfinished"></translation>
     </message>
@@ -5124,7 +5181,7 @@ p, li { white-space: pre-wrap; }
 <context>
     <name>ModListSortProxy</name>
     <message>
-        <location filename="modlistsortproxy.cpp" line="629"/>
+        <location filename="modlistsortproxy.cpp" line="661"/>
         <source>Drag&amp;Drop is only supported when sorting by priority</source>
         <translation type="unfinished"></translation>
     </message>
@@ -5153,17 +5210,17 @@ Please enter the name:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="modlistview.cpp" line="974"/>
+        <location filename="modlistview.cpp" line="976"/>
         <source>Exception: </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="modlistview.cpp" line="976"/>
+        <location filename="modlistview.cpp" line="978"/>
         <source>Unknown exception</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="modlistview.cpp" line="1342"/>
+        <location filename="modlistview.cpp" line="1344"/>
         <source>&lt;Multiple&gt;</source>
         <translation type="unfinished"></translation>
     </message>
@@ -5182,7 +5239,7 @@ Please enter the name:</source>
     </message>
     <message>
         <location filename="modlistviewactions.cpp" line="120"/>
-        <location filename="modlistviewactions.cpp" line="1360"/>
+        <location filename="modlistviewactions.cpp" line="1400"/>
         <source>Create Mod...</source>
         <translation type="unfinished"></translation>
     </message>
@@ -5194,7 +5251,7 @@ Please enter a name:</source>
     </message>
     <message>
         <location filename="modlistviewactions.cpp" line="131"/>
-        <location filename="modlistviewactions.cpp" line="1371"/>
+        <location filename="modlistviewactions.cpp" line="1411"/>
         <source>A mod with this name already exists</source>
         <translation type="unfinished"></translation>
     </message>
@@ -5226,8 +5283,8 @@ Please enter a name:</source>
     </message>
     <message>
         <location filename="modlistviewactions.cpp" line="217"/>
-        <location filename="modlistviewactions.cpp" line="795"/>
-        <location filename="modlistviewactions.cpp" line="1044"/>
+        <location filename="modlistviewactions.cpp" line="816"/>
+        <location filename="modlistviewactions.cpp" line="1084"/>
         <source>Confirm</source>
         <translation type="unfinished"></translation>
     </message>
@@ -5239,8 +5296,8 @@ Please enter a name:</source>
     </message>
     <message>
         <location filename="modlistviewactions.cpp" line="267"/>
-        <location filename="modlistviewactions.cpp" line="1078"/>
-        <location filename="modlistviewactions.cpp" line="1430"/>
+        <location filename="modlistviewactions.cpp" line="1118"/>
+        <location filename="modlistviewactions.cpp" line="1470"/>
         <source>Are you sure?</source>
         <translation type="unfinished"></translation>
     </message>
@@ -5317,178 +5374,197 @@ You can also use online editors and converters instead.</source>
     </message>
     <message>
         <location filename="modlistviewactions.cpp" line="381"/>
-        <source>Nexus_ID</source>
+        <source>Mod_Author</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="modlistviewactions.cpp" line="382"/>
-        <source>Mod_Nexus_URL</source>
+        <source>Mod_Uploader</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="modlistviewactions.cpp" line="383"/>
-        <source>Mod_Version</source>
+        <source>Nexus_ID</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="modlistviewactions.cpp" line="384"/>
-        <source>Install_Date</source>
+        <source>Mod_Nexus_URL</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="modlistviewactions.cpp" line="385"/>
+        <source>Mod_Uploader_URL</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="modlistviewactions.cpp" line="386"/>
+        <source>Mod_Version</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="modlistviewactions.cpp" line="387"/>
+        <source>Install_Date</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="modlistviewactions.cpp" line="388"/>
         <source>Download_File_Name</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="modlistviewactions.cpp" line="512"/>
+        <location filename="modlistviewactions.cpp" line="533"/>
         <source>export failed: %1</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="modlistviewactions.cpp" line="566"/>
+        <location filename="modlistviewactions.cpp" line="587"/>
         <source>Failed to display overwrite dialog: %1</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="modlistviewactions.cpp" line="629"/>
+        <location filename="modlistviewactions.cpp" line="650"/>
         <source>Set Priority</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="modlistviewactions.cpp" line="630"/>
+        <location filename="modlistviewactions.cpp" line="651"/>
         <source>Set the priority of the selected mods</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="modlistviewactions.cpp" line="760"/>
+        <location filename="modlistviewactions.cpp" line="781"/>
         <source>failed to rename mod: %1</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="modlistviewactions.cpp" line="796"/>
+        <location filename="modlistviewactions.cpp" line="817"/>
         <source>Remove the following mods?&lt;br&gt;&lt;ul&gt;%1&lt;/ul&gt;</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="modlistviewactions.cpp" line="813"/>
+        <location filename="modlistviewactions.cpp" line="834"/>
         <source>failed to remove mod: %1</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="modlistviewactions.cpp" line="841"/>
+        <location filename="modlistviewactions.cpp" line="862"/>
         <source>Continue?</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="modlistviewactions.cpp" line="842"/>
+        <location filename="modlistviewactions.cpp" line="863"/>
         <source>The versioning scheme decides which version is considered newer than another.
 This function will guess the versioning scheme under the assumption that the installed version is outdated.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="modlistviewactions.cpp" line="868"/>
+        <location filename="modlistviewactions.cpp" line="889"/>
         <source>Sorry</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="modlistviewactions.cpp" line="869"/>
+        <location filename="modlistviewactions.cpp" line="890"/>
         <source>I don&apos;t know a versioning scheme where %1 is newer than %2.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="modlistviewactions.cpp" line="890"/>
-        <source>Opening Nexus Links</source>
+        <location filename="modlistviewactions.cpp" line="911"/>
+        <source>Nexus Links</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="modlistviewactions.cpp" line="891"/>
-        <source>You are trying to open %1 links to Nexus Mods.  Are you sure you want to do this?</source>
+        <location filename="modlistviewactions.cpp" line="931"/>
+        <location filename="modlistviewactions.cpp" line="949"/>
+        <source>Web Pages</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="modlistviewactions.cpp" line="914"/>
-        <location filename="modlistviewactions.cpp" line="936"/>
-        <source>Opening Web Pages</source>
+        <location filename="modlistviewactions.cpp" line="978"/>
+        <source>Uploader Profiles</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="modlistviewactions.cpp" line="915"/>
-        <location filename="modlistviewactions.cpp" line="937"/>
-        <source>You are trying to open %1 Web Pages.  Are you sure you want to do this?</source>
+        <location filename="modlistviewactions.cpp" line="998"/>
+        <source>Opening %1</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="modlistviewactions.cpp" line="987"/>
-        <location filename="modlistviewactions.cpp" line="992"/>
-        <location filename="modlistviewactions.cpp" line="1003"/>
+        <location filename="modlistviewactions.cpp" line="999"/>
+        <source>You are trying to open %1 %2. Are you sure you want to do this?</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="modlistviewactions.cpp" line="1027"/>
+        <location filename="modlistviewactions.cpp" line="1032"/>
+        <location filename="modlistviewactions.cpp" line="1043"/>
         <source>Failed</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="modlistviewactions.cpp" line="988"/>
+        <location filename="modlistviewactions.cpp" line="1028"/>
         <source>Installation file no longer exists</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="modlistviewactions.cpp" line="993"/>
+        <location filename="modlistviewactions.cpp" line="1033"/>
         <source>Mods installed with old versions of MO can&apos;t be reinstalled in this way.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="modlistviewactions.cpp" line="1003"/>
+        <location filename="modlistviewactions.cpp" line="1043"/>
         <source>Failed to create backup.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="modlistviewactions.cpp" line="1045"/>
+        <location filename="modlistviewactions.cpp" line="1085"/>
         <source>Restore all hidden files in the following mods?&lt;br&gt;&lt;ul&gt;%1&lt;/ul&gt;</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="modlistviewactions.cpp" line="1079"/>
+        <location filename="modlistviewactions.cpp" line="1119"/>
         <source>About to restore all hidden files in:
 </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="modlistviewactions.cpp" line="1112"/>
+        <location filename="modlistviewactions.cpp" line="1152"/>
         <source>Endorsing multiple mods will take a while. Please wait...</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="modlistviewactions.cpp" line="1279"/>
+        <location filename="modlistviewactions.cpp" line="1319"/>
         <source>Overwrite?</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="modlistviewactions.cpp" line="1280"/>
+        <location filename="modlistviewactions.cpp" line="1320"/>
         <source>This will replace the existing mod &quot;%1&quot;. Continue?</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="modlistviewactions.cpp" line="1284"/>
+        <location filename="modlistviewactions.cpp" line="1324"/>
         <source>failed to remove mod &quot;%1&quot;</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="modlistviewactions.cpp" line="1290"/>
+        <location filename="modlistviewactions.cpp" line="1330"/>
         <source>failed to rename &quot;%1&quot; to &quot;%2&quot;</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="modlistviewactions.cpp" line="1342"/>
+        <location filename="modlistviewactions.cpp" line="1382"/>
         <source>Move successful.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="modlistviewactions.cpp" line="1361"/>
+        <location filename="modlistviewactions.cpp" line="1401"/>
         <source>This will move all files from overwrite into a new, regular mod.
 Please enter a name:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="modlistviewactions.cpp" line="1431"/>
+        <location filename="modlistviewactions.cpp" line="1471"/>
         <source>About to recursively delete:
 </source>
         <translation type="unfinished"></translation>
@@ -5553,32 +5629,32 @@ Please enter a name:</source>
 <context>
     <name>NexusInterface</name>
     <message>
-        <location filename="nexusinterface.cpp" line="357"/>
+        <location filename="nexusinterface.cpp" line="360"/>
         <source>Please pick the mod ID for &quot;%1&quot;</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="nexusinterface.cpp" line="848"/>
+        <location filename="nexusinterface.cpp" line="854"/>
         <source>You must authorize MO2 in Settings -&gt; Nexus to use the Nexus API.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="nexusinterface.cpp" line="857"/>
+        <location filename="nexusinterface.cpp" line="863"/>
         <source>You&apos;ve exceeded the Nexus API rate limit and requests are now being throttled. Your next batch of requests will be available in approximately %1 minutes and %2 seconds.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="nexusinterface.cpp" line="938"/>
+        <location filename="nexusinterface.cpp" line="944"/>
         <source>Aborting download: Either you clicked on a premium-only link and your account is not premium, or the download link was generated by a different account than the one stored in Mod Organizer.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="nexusinterface.cpp" line="1079"/>
+        <location filename="nexusinterface.cpp" line="1090"/>
         <source>empty response</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="nexusinterface.cpp" line="1159"/>
+        <location filename="nexusinterface.cpp" line="1170"/>
         <source>invalid response</source>
         <translation type="unfinished"></translation>
     </message>
@@ -5669,208 +5745,208 @@ Please enter a name:</source>
 <context>
     <name>OrganizerCore</name>
     <message>
-        <location filename="organizercore.cpp" line="191"/>
+        <location filename="organizercore.cpp" line="192"/>
         <source>File is write protected</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="organizercore.cpp" line="193"/>
+        <location filename="organizercore.cpp" line="194"/>
         <source>Invalid file format (probably a bug)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="organizercore.cpp" line="195"/>
+        <location filename="organizercore.cpp" line="196"/>
         <source>Unknown error %1</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="organizercore.cpp" line="199"/>
+        <location filename="organizercore.cpp" line="200"/>
         <source>Failed to write settings</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="organizercore.cpp" line="200"/>
+        <location filename="organizercore.cpp" line="201"/>
         <source>An error occurred trying to write back MO settings to %1: %2</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="organizercore.cpp" line="363"/>
+        <location filename="organizercore.cpp" line="364"/>
         <source>Download started</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="organizercore.cpp" line="366"/>
+        <location filename="organizercore.cpp" line="367"/>
         <source>Download failed</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="organizercore.cpp" line="578"/>
+        <location filename="organizercore.cpp" line="579"/>
         <source>The selected profile &apos;%1&apos; does not exist. The profile &apos;%2&apos; will be used instead</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="organizercore.cpp" line="759"/>
+        <location filename="organizercore.cpp" line="778"/>
         <source>Installation cancelled</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="organizercore.cpp" line="760"/>
+        <location filename="organizercore.cpp" line="779"/>
         <source>Another installation is currently in progress.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="organizercore.cpp" line="773"/>
+        <location filename="organizercore.cpp" line="792"/>
         <source>Installation successful</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="organizercore.cpp" line="806"/>
+        <location filename="organizercore.cpp" line="825"/>
         <source>Configure Mod</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="organizercore.cpp" line="807"/>
+        <location filename="organizercore.cpp" line="826"/>
         <source>This mod contains ini tweaks. Do you want to configure them now?</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="organizercore.cpp" line="817"/>
+        <location filename="organizercore.cpp" line="836"/>
         <source>mod not found: %1</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="organizercore.cpp" line="833"/>
+        <location filename="organizercore.cpp" line="852"/>
         <source>Extraction cancelled</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="organizercore.cpp" line="834"/>
+        <location filename="organizercore.cpp" line="853"/>
         <source>The installation was cancelled while extracting files. If this was prior to a FOMOD setup, this warning may be ignored. However, if this was during installation, the mod will likely be missing files.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="organizercore.cpp" line="1061"/>
+        <location filename="organizercore.cpp" line="1080"/>
         <source>file not found: %1</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="organizercore.cpp" line="1077"/>
-        <location filename="organizercore.cpp" line="1093"/>
+        <location filename="organizercore.cpp" line="1096"/>
+        <location filename="organizercore.cpp" line="1112"/>
         <source>failed to generate preview for %1</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="organizercore.cpp" line="1144"/>
+        <location filename="organizercore.cpp" line="1163"/>
         <source>Sorry</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="organizercore.cpp" line="1145"/>
+        <location filename="organizercore.cpp" line="1164"/>
         <source>Sorry, can&apos;t preview anything. This function currently does not support extracting from bsas.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="organizercore.cpp" line="1156"/>
+        <location filename="organizercore.cpp" line="1175"/>
         <source>File &apos;%1&apos; not found.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="organizercore.cpp" line="1164"/>
+        <location filename="organizercore.cpp" line="1183"/>
         <source>Failed to generate preview for %1</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="organizercore.cpp" line="1277"/>
+        <location filename="organizercore.cpp" line="1296"/>
         <source>Failed to refresh list of esps: %1</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="organizercore.cpp" line="1387"/>
+        <location filename="organizercore.cpp" line="1406"/>
         <source>Multiple esps/esls activated, please check that they don&apos;t conflict.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="organizercore.cpp" line="1463"/>
+        <location filename="organizercore.cpp" line="1482"/>
         <source>You need to be logged in with Nexus</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="organizercore.cpp" line="1507"/>
+        <location filename="organizercore.cpp" line="1526"/>
         <source>Download?</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="organizercore.cpp" line="1508"/>
+        <location filename="organizercore.cpp" line="1527"/>
         <source>A download has been started but no installed page plugin recognizes it.
 If you download anyway no information (i.e. version) will be associated with the download.
 Continue?</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="organizercore.cpp" line="1724"/>
-        <location filename="organizercore.cpp" line="1776"/>
+        <location filename="organizercore.cpp" line="1743"/>
+        <location filename="organizercore.cpp" line="1795"/>
         <source>failed to update mod list: %1</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="organizercore.cpp" line="1783"/>
-        <location filename="organizercore.cpp" line="1800"/>
+        <location filename="organizercore.cpp" line="1802"/>
+        <location filename="organizercore.cpp" line="1819"/>
         <source>login successful</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="organizercore.cpp" line="1809"/>
+        <location filename="organizercore.cpp" line="1828"/>
         <source>Login failed</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="organizercore.cpp" line="1810"/>
+        <location filename="organizercore.cpp" line="1829"/>
         <source>Login failed, try again?</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="organizercore.cpp" line="1818"/>
+        <location filename="organizercore.cpp" line="1837"/>
         <source>login failed: %1. Download will not be associated with an account</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="organizercore.cpp" line="1826"/>
+        <location filename="organizercore.cpp" line="1845"/>
         <source>login failed: %1</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="organizercore.cpp" line="1836"/>
+        <location filename="organizercore.cpp" line="1855"/>
         <source>login failed: %1. You need to log-in with Nexus to update MO.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="organizercore.cpp" line="1883"/>
+        <location filename="organizercore.cpp" line="1902"/>
         <source>MO1 &quot;Script Extender&quot; load mechanism has left hook.dll in your game folder</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="organizercore.cpp" line="1887"/>
-        <location filename="organizercore.cpp" line="1908"/>
+        <location filename="organizercore.cpp" line="1906"/>
+        <location filename="organizercore.cpp" line="1927"/>
         <source>Description missing</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="organizercore.cpp" line="1896"/>
+        <location filename="organizercore.cpp" line="1915"/>
         <source>&lt;a href=&quot;%1&quot;&gt;hook.dll&lt;/a&gt; has been found in your game folder (right click to copy the full path). This is most likely a leftover of setting the ModOrganizer 1 load mechanism to &quot;Script Extender&quot;, in which case you must remove this file either by changing the load mechanism in ModOrganizer 1 or manually removing the file, otherwise the game is likely to crash and burn.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="organizercore.cpp" line="1933"/>
+        <location filename="organizercore.cpp" line="1952"/>
         <source>failed to save load order: %1</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="organizercore.cpp" line="2002"/>
+        <location filename="organizercore.cpp" line="2021"/>
         <source>Error</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="organizercore.cpp" line="2084"/>
+        <location filename="organizercore.cpp" line="2103"/>
         <source>The designated write target &quot;%1&quot; is not enabled.</source>
         <translation type="unfinished"></translation>
     </message>
@@ -5996,48 +6072,48 @@ Continue?</source>
 <context>
     <name>PluginContainer</name>
     <message>
-        <location filename="plugincontainer.cpp" line="1106"/>
+        <location filename="plugincontainer.cpp" line="1104"/>
         <source>Plugin error</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="plugincontainer.cpp" line="1107"/>
+        <location filename="plugincontainer.cpp" line="1105"/>
         <source>Mod Organizer failed to load the plugin &apos;%1&apos; last time it was started.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="plugincontainer.cpp" line="1110"/>
+        <location filename="plugincontainer.cpp" line="1108"/>
         <source>The plugin can be skipped for this session, blacklisted, or loaded normally, in which case it might fail again. Blacklisted plugins can be re-enabled later in the settings.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="plugincontainer.cpp" line="1115"/>
+        <location filename="plugincontainer.cpp" line="1113"/>
         <source>Skip this plugin</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="plugincontainer.cpp" line="1116"/>
+        <location filename="plugincontainer.cpp" line="1114"/>
         <source>Blacklist this plugin</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="plugincontainer.cpp" line="1117"/>
+        <location filename="plugincontainer.cpp" line="1115"/>
         <source>Load this plugin</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="plugincontainer.cpp" line="1215"/>
+        <location filename="plugincontainer.cpp" line="1213"/>
         <source>Some plugins could not be loaded</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="plugincontainer.cpp" line="1218"/>
-        <location filename="plugincontainer.cpp" line="1238"/>
+        <location filename="plugincontainer.cpp" line="1216"/>
+        <location filename="plugincontainer.cpp" line="1236"/>
         <source>Description missing</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="plugincontainer.cpp" line="1228"/>
+        <location filename="plugincontainer.cpp" line="1226"/>
         <source>The following plugins could not be loaded. The reason may be missing dependencies (i.e. python) or an outdated version:</source>
         <translation type="unfinished"></translation>
     </message>
@@ -6991,7 +7067,7 @@ p, li { white-space: pre-wrap; }
     </message>
     <message>
         <location filename="createinstancedialogpages.cpp" line="34"/>
-        <location filename="instancemanager.cpp" line="53"/>
+        <location filename="instancemanager.cpp" line="55"/>
         <location filename="moshortcut.cpp" line="38"/>
         <source>Portable</source>
         <translation type="unfinished"></translation>
@@ -7093,7 +7169,7 @@ p, li { white-space: pre-wrap; }
         <location filename="spawn.cpp" line="328"/>
         <location filename="spawn.cpp" line="352"/>
         <location filename="spawn.cpp" line="383"/>
-        <location filename="uilocker.cpp" line="349"/>
+        <location filename="uilocker.cpp" line="351"/>
         <source>Cancel</source>
         <translation type="unfinished"></translation>
     </message>
@@ -7304,22 +7380,22 @@ Destination:<byte value="xd"/>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="instancemanager.cpp" line="818"/>
+        <location filename="instancemanager.cpp" line="863"/>
         <source>Cannot open instance &apos;%1&apos;, failed to read INI file %2.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="instancemanager.cpp" line="833"/>
+        <location filename="instancemanager.cpp" line="878"/>
         <source>Cannot open instance &apos;%1&apos;, the managed game was not found in the INI file %2. Select the game managed by this instance.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="instancemanager.cpp" line="847"/>
+        <location filename="instancemanager.cpp" line="892"/>
         <source>Cannot open instance &apos;%1&apos;, the game plugin &apos;%2&apos; doesn&apos;t exist. It may have been deleted by an antivirus. Select another instance.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="instancemanager.cpp" line="860"/>
+        <location filename="instancemanager.cpp" line="905"/>
         <source>Cannot open instance &apos;%1&apos;, the game directory &apos;%2&apos; doesn&apos;t exist or the game plugin &apos;%3&apos; doesn&apos;t recognize it. Select the game managed by this instance.</source>
         <translation type="unfinished"></translation>
     </message>
@@ -7336,7 +7412,7 @@ Destination:<byte value="xd"/>
     <message>
         <location filename="loglist.cpp" line="384"/>
         <location filename="loot.cpp" line="396"/>
-        <location filename="organizercore.cpp" line="391"/>
+        <location filename="organizercore.cpp" line="392"/>
         <location filename="settingsdialogdiagnostics.cpp" line="40"/>
         <location filename="settingsdialogdiagnostics.cpp" line="66"/>
         <location filename="settingsdialogpaths.cpp" line="100"/>
@@ -7346,7 +7422,7 @@ Destination:<byte value="xd"/>
     </message>
     <message>
         <location filename="loglist.cpp" line="385"/>
-        <location filename="organizercore.cpp" line="392"/>
+        <location filename="organizercore.cpp" line="393"/>
         <source>Failed to create &quot;%1&quot;. Your user account probably lacks permission.</source>
         <translation type="unfinished"></translation>
     </message>
@@ -7438,38 +7514,38 @@ Destination:<byte value="xd"/>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="main.cpp" line="63"/>
+        <location filename="main.cpp" line="62"/>
         <source>Mod Organizer</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="main.cpp" line="64"/>
+        <location filename="main.cpp" line="63"/>
         <source>An instance of Mod Organizer is already running</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="mainwindow.cpp" line="194"/>
+        <location filename="mainwindow.cpp" line="195"/>
         <source>&lt;Unmanaged&gt;</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="mainwindow.cpp" line="1255"/>
+        <location filename="mainwindow.cpp" line="1265"/>
         <source>Please use &quot;Help&quot; from the toolbar to get usage instructions to all elements</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="mainwindow.cpp" line="1597"/>
+        <location filename="mainwindow.cpp" line="1605"/>
         <source>Visit %1 on Nexus</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="mainwindow.cpp" line="1814"/>
-        <location filename="mainwindow.cpp" line="2909"/>
+        <location filename="mainwindow.cpp" line="1819"/>
+        <location filename="mainwindow.cpp" line="2919"/>
         <source>&lt;Manage...&gt;</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="mainwindow.cpp" line="1826"/>
+        <location filename="mainwindow.cpp" line="1831"/>
         <source>failed to parse profile %1: %2</source>
         <translation type="unfinished"></translation>
     </message>
@@ -7567,7 +7643,7 @@ Destination:<byte value="xd"/>
     </message>
     <message>
         <location filename="nxmaccessmanager.cpp" line="423"/>
-        <location filename="nxmaccessmanager.cpp" line="753"/>
+        <location filename="nxmaccessmanager.cpp" line="750"/>
         <source>Cancelled</source>
         <translation type="unfinished"></translation>
     </message>
@@ -7577,37 +7653,37 @@ Destination:<byte value="xd"/>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="nxmaccessmanager.cpp" line="504"/>
+        <location filename="nxmaccessmanager.cpp" line="503"/>
         <source>HTTP code %1</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="nxmaccessmanager.cpp" line="514"/>
+        <location filename="nxmaccessmanager.cpp" line="513"/>
         <source>Invalid JSON</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="nxmaccessmanager.cpp" line="519"/>
+        <location filename="nxmaccessmanager.cpp" line="518"/>
         <source>Bad response</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="nxmaccessmanager.cpp" line="529"/>
+        <location filename="nxmaccessmanager.cpp" line="528"/>
         <source>API key is empty</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="nxmaccessmanager.cpp" line="552"/>
+        <location filename="nxmaccessmanager.cpp" line="553"/>
         <source>SSL error</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="nxmaccessmanager.cpp" line="557"/>
+        <location filename="nxmaccessmanager.cpp" line="558"/>
         <source>Timed out</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="organizercore.cpp" line="410"/>
+        <location filename="organizercore.cpp" line="411"/>
         <source>One of the configured MO2 directories (profiles, mods, or overwrite) is on a path containing a symbolic (or other) link. This is likely to be incompatible with MO2&apos;s virtual filesystem.</source>
         <translation type="unfinished"></translation>
     </message>
@@ -7675,19 +7751,19 @@ This program is known to cause issues with Mod Organizer, such as freezing or bl
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="settings.cpp" line="1435"/>
-        <location filename="settings.cpp" line="1459"/>
-        <location filename="settings.cpp" line="1507"/>
+        <location filename="settings.cpp" line="1436"/>
+        <location filename="settings.cpp" line="1460"/>
+        <location filename="settings.cpp" line="1508"/>
         <source>attempt to store setting for unknown plugin &quot;%1&quot;</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="settings.cpp" line="2005"/>
+        <location filename="settings.cpp" line="2006"/>
         <source>Failed</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="settings.cpp" line="2006"/>
+        <location filename="settings.cpp" line="2007"/>
         <source>Failed to start the helper application: %1</source>
         <translation type="unfinished"></translation>
     </message>
@@ -8143,32 +8219,32 @@ You can restart Mod Organizer as administrator and try launching the program aga
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="uilocker.cpp" line="295"/>
+        <location filename="uilocker.cpp" line="297"/>
         <source>Mod Organizer is locked while the application is running.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="uilocker.cpp" line="297"/>
+        <location filename="uilocker.cpp" line="299"/>
         <source>Mod Organizer is currently running an application.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="uilocker.cpp" line="307"/>
+        <location filename="uilocker.cpp" line="309"/>
         <source>The application must run to completion because its output is required.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="uilocker.cpp" line="314"/>
+        <location filename="uilocker.cpp" line="316"/>
         <source>Mod Organizer is waiting on an application to close before exiting.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="uilocker.cpp" line="330"/>
+        <location filename="uilocker.cpp" line="332"/>
         <source>Unlock</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="uilocker.cpp" line="342"/>
+        <location filename="uilocker.cpp" line="344"/>
         <source>Exit Now</source>
         <translation type="unfinished"></translation>
     </message>
@@ -9322,6 +9398,19 @@ programs you are intentionally running.</source>
     <message>
         <location filename="syncoverwritedialog.cpp" line="160"/>
         <source>failed to move %1 to %2</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>SystemTrayManager</name>
+    <message>
+        <location filename="systemtraymanager.cpp" line="33"/>
+        <source>Mod Organizer</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="systemtraymanager.cpp" line="38"/>
+        <source>Exit</source>
         <translation type="unfinished"></translation>
     </message>
 </context>

--- a/src/organizercore.cpp
+++ b/src/organizercore.cpp
@@ -119,10 +119,10 @@ OrganizerCore::OrganizerCore(Settings& settings)
           &OrganizerCore::onDirectoryRefreshed);
 
   connect(&m_ModList, SIGNAL(removeOrigin(QString)), this, SLOT(removeOrigin(QString)));
-  connect(&m_ModList, &ModList::modStatesChanged, [=] {
+  connect(&m_ModList, &ModList::modStatesChanged, [this] {
     currentProfile()->writeModlist();
   });
-  connect(&m_ModList, &ModList::modPrioritiesChanged, [this](auto&& indexes) {
+  connect(&m_ModList, &ModList::modPrioritiesChanged, [this](const auto& indexes) {
     modPrioritiesChanged(indexes);
   });
 
@@ -466,7 +466,7 @@ void OrganizerCore::createDefaultProfile()
 void OrganizerCore::createOverwriteDirectories()
 {
   QString overwritePath = settings().paths().overwrite();
-  for (auto modDirectory : managedGame()->getModMappings().keys()) {
+  for (const auto& modDirectory : managedGame()->getModMappings().keys()) {
     if (!modDirectory.isEmpty()) {
       QDir(overwritePath).mkdir(modDirectory);
     }
@@ -1084,7 +1084,7 @@ bool OrganizerCore::previewFileWithAlternatives(QWidget* parent, QString fileNam
   // set up preview dialog
   PreviewDialog preview(fileName, parent);
 
-  auto addFunc = [&](int originId, std::wstring archiveName = L"") {
+  auto addFunc = [&](int originId, const std::wstring& archiveName = L"") {
     FilesOrigin& origin = directoryStructure()->getOriginByID(originId);
     QString filePath =
         QDir::fromNativeSeparators(ToQString(origin.getPath())) + "/" + fileName;
@@ -1805,7 +1805,7 @@ void OrganizerCore::loginSuccessful(bool necessary)
     downloadRequestedNXM(url);
   }
   m_PendingDownloads.clear();
-  for (auto task : m_PostLoginTasks) {
+  for (const auto& task : m_PostLoginTasks) {
     task();
   }
 
@@ -2089,9 +2089,9 @@ std::vector<Mapping> OrganizerCore::fileMapping(const QString& profileName,
       for (auto dataMap : dataMaps.asKeyValueRange()) {
         auto mapDir = QDir(modDir.absoluteFilePath(dataMap.first));
         if (mapDir.exists()) {
-          for (auto dir : dataMap.second) {
-            result.insert(result.end(),
-                          {mapDir.absolutePath(), dir, true, createTarget});
+          for (const auto& dir : dataMap.second) {
+            result.emplace(result.end(),
+                          mapDir.absolutePath(), dir, true, createTarget);
           }
         }
       }
@@ -2119,9 +2119,9 @@ std::vector<Mapping> OrganizerCore::fileMapping(const QString& profileName,
   for (auto dataMap : dataMaps.asKeyValueRange()) {
     auto overwriteSubpath = overwriteDir.absoluteFilePath(dataMap.first);
     if (QDir(overwriteSubpath).exists()) {
-      for (auto dir : dataMap.second) {
-        result.insert(result.end(),
-                      {overwriteSubpath, dir, true, customOverwrite.isEmpty()});
+      for (const auto& dir : dataMap.second) {
+        result.emplace(result.end(),
+                      overwriteSubpath, dir, true, customOverwrite.isEmpty());
       }
     }
   }
@@ -2160,7 +2160,7 @@ std::vector<Mapping> OrganizerCore::fileMapping(const QString& dataPath,
     QString source = originPath + relPath + fileName;
     QString target = dataPath + relPath + fileName;
     if (source != target) {
-      result.push_back({source, target, false, false});
+      result.emplace_back(source, target, false, false);
     }
   }
 
@@ -2175,7 +2175,7 @@ std::vector<Mapping> OrganizerCore::fileMapping(const QString& dataPath,
 
     bool writeDestination = (base == directoryEntry) && (origin == createDestination);
 
-    result.push_back({source, target, true, writeDestination});
+    result.emplace_back(source, target, true, writeDestination);
     std::vector<Mapping> subRes =
         fileMapping(dataPath, relPath + dirName + "\\", base, d, createDestination);
     result.insert(result.end(), subRes.begin(), subRes.end());

--- a/src/organizercore.cpp
+++ b/src/organizercore.cpp
@@ -1084,7 +1084,8 @@ bool OrganizerCore::previewFileWithAlternatives(QWidget* parent, QString fileNam
   // set up preview dialog
   PreviewDialog preview(fileName, parent);
 
-  auto addFunc = [this, &fileName, &preview](int originId, const std::wstring& archiveName = L"") {
+  auto addFunc = [this, &fileName, &preview](int originId,
+                                             const std::wstring& archiveName = L"") {
     FilesOrigin& origin = directoryStructure()->getOriginByID(originId);
     QString filePath =
         QDir::fromNativeSeparators(ToQString(origin.getPath())) + "/" + fileName;
@@ -2090,8 +2091,8 @@ std::vector<Mapping> OrganizerCore::fileMapping(const QString& profileName,
         auto mapDir = QDir(modDir.absoluteFilePath(dataMap.first));
         if (mapDir.exists()) {
           for (const auto& dir : dataMap.second) {
-            result.emplace(result.end(),
-                          mapDir.absolutePath(), dir, true, createTarget);
+            result.emplace(result.end(), mapDir.absolutePath(), dir, true,
+                           createTarget);
           }
         }
       }
@@ -2120,8 +2121,8 @@ std::vector<Mapping> OrganizerCore::fileMapping(const QString& profileName,
     auto overwriteSubpath = overwriteDir.absoluteFilePath(dataMap.first);
     if (QDir(overwriteSubpath).exists()) {
       for (const auto& dir : dataMap.second) {
-        result.emplace(result.end(),
-                      overwriteSubpath, dir, true, customOverwrite.isEmpty());
+        result.emplace(result.end(), overwriteSubpath, dir, true,
+                       customOverwrite.isEmpty());
       }
     }
   }

--- a/src/organizercore.cpp
+++ b/src/organizercore.cpp
@@ -261,10 +261,10 @@ void OrganizerCore::connectPlugins(PluginContainer* container)
     emit managedGameChanged(m_GamePlugin);
   }
 
-  connect(m_PluginContainer, &PluginContainer::pluginEnabled, [&](IPlugin* plugin) {
+  connect(m_PluginContainer, &PluginContainer::pluginEnabled, [this](IPlugin* plugin) {
     m_PluginEnabled(plugin);
   });
-  connect(m_PluginContainer, &PluginContainer::pluginDisabled, [&](IPlugin* plugin) {
+  connect(m_PluginContainer, &PluginContainer::pluginDisabled, [this](IPlugin* plugin) {
     m_PluginDisabled(plugin);
   });
 
@@ -316,7 +316,7 @@ bool OrganizerCore::nexusApi(bool retry)
 void OrganizerCore::startMOUpdate()
 {
   if (nexusApi()) {
-    m_PostLoginTasks.append([&]() {
+    m_PostLoginTasks.append([this]() {
       m_Updater.startUpdate();
     });
   } else {
@@ -1084,7 +1084,7 @@ bool OrganizerCore::previewFileWithAlternatives(QWidget* parent, QString fileNam
   // set up preview dialog
   PreviewDialog preview(fileName, parent);
 
-  auto addFunc = [&](int originId, const std::wstring& archiveName = L"") {
+  auto addFunc = [this, &fileName, &preview](int originId, const std::wstring& archiveName = L"") {
     FilesOrigin& origin = directoryStructure()->getOriginByID(originId);
     QString filePath =
         QDir::fromNativeSeparators(ToQString(origin.getPath())) + "/" + fileName;

--- a/src/overwriteinfodialog.cpp
+++ b/src/overwriteinfodialog.cpp
@@ -30,9 +30,9 @@ using namespace MOBase;
 
 OverwriteInfoDialog::OverwriteInfoDialog(ModInfo::Ptr modInfo, OrganizerCore& organizer,
                                          QWidget* parent)
-    : QDialog(parent), m_Organizer(organizer), ui(new Ui::OverwriteInfoDialog),
-      m_FileSystemModel(nullptr), m_DeleteAction(nullptr), m_RenameAction(nullptr),
-      m_OpenAction(nullptr)
+    : QDialog(parent), ui(new Ui::OverwriteInfoDialog), m_FileSystemModel(nullptr),
+      m_DeleteAction(nullptr), m_RenameAction(nullptr), m_OpenAction(nullptr),
+      m_Organizer(organizer)
 {
   ui->setupUi(this);
 
@@ -143,7 +143,7 @@ void OverwriteInfoDialog::delete_activated()
       if (selection->selectedRows().count() == 0) {
         return;
       } else if (selection->selectedRows().count() == 1) {
-        for (auto modDir : m_Organizer.managedGame()->getModMappings().keys()) {
+        for (const auto& modDir : m_Organizer.managedGame()->getModMappings().keys()) {
           if (root.absoluteFilePath(modDir).compare(
                   m_FileSystemModel->filePath(selection->selectedRows().at(0)),
                   Qt::CaseInsensitive) == 0) {
@@ -168,7 +168,7 @@ void OverwriteInfoDialog::delete_activated()
       }
 
       foreach (QModelIndex index, selection->selectedRows()) {
-        for (auto modDir : m_Organizer.managedGame()->getModMappings().keys()) {
+        for (const auto& modDir : m_Organizer.managedGame()->getModMappings().keys()) {
           if (root.absoluteFilePath(modDir).compare(m_FileSystemModel->filePath(index),
                                                     Qt::CaseInsensitive) == 0) {
             return;
@@ -186,7 +186,7 @@ void OverwriteInfoDialog::deleteTriggered()
   if (m_FileSelection.count() == 0) {
     return;
   } else if (m_FileSelection.count() == 1) {
-    for (auto modDir : m_Organizer.managedGame()->getModMappings().keys()) {
+    for (const auto& modDir : m_Organizer.managedGame()->getModMappings().keys()) {
       if (root.absoluteFilePath(modDir).compare(
               m_FileSystemModel->filePath(m_FileSelection.at(0)),
               Qt::CaseInsensitive) == 0) {
@@ -209,7 +209,7 @@ void OverwriteInfoDialog::deleteTriggered()
   }
 
   foreach (QModelIndex index, m_FileSelection) {
-    for (auto modDir : m_Organizer.managedGame()->getModMappings().keys()) {
+    for (const auto& modDir : m_Organizer.managedGame()->getModMappings().keys()) {
       if (root.absoluteFilePath(modDir).compare(m_FileSystemModel->filePath(index),
                                                 Qt::CaseInsensitive) == 0) {
         return;
@@ -227,7 +227,7 @@ void OverwriteInfoDialog::renameTriggered()
   if (!index.isValid() || m_FileSystemModel->isReadOnly()) {
     return;
   }
-  for (auto modDir : m_Organizer.managedGame()->getModMappings().keys()) {
+  for (const auto& modDir : m_Organizer.managedGame()->getModMappings().keys()) {
     if (root.absoluteFilePath(modDir).compare(m_FileSystemModel->filePath(selection),
                                               Qt::CaseInsensitive) == 0) {
       return;

--- a/src/plugincontainer.cpp
+++ b/src/plugincontainer.cpp
@@ -472,7 +472,7 @@ bool PluginContainer::initPlugin(IPlugin* plugin, IPluginProxy* pluginProxy,
 
 void PluginContainer::registerGame(IPluginGame* game)
 {
-  m_SupportedGames.insert({game->gameName(), game});
+  m_SupportedGames.try_emplace(game->gameName(), game);
 }
 
 void PluginContainer::unregisterGame(MOBase::IPluginGame* game)

--- a/src/plugincontainer.cpp
+++ b/src/plugincontainer.cpp
@@ -540,7 +540,7 @@ IPlugin* PluginContainer::registerPlugin(QObject* plugin, const QString& filepat
     if (diagnose != nullptr) {
       bf::at_key<IPluginDiagnose>(m_Plugins).push_back(diagnose);
       bf::at_key<IPluginDiagnose>(m_AccessPlugins)[diagnose] = pluginObj;
-      diagnose->onInvalidated([&]() {
+      diagnose->onInvalidated([this]() {
         emit diagnosisUpdate();
       });
     }

--- a/src/pluginlist.cpp
+++ b/src/pluginlist.cpp
@@ -161,7 +161,7 @@ void PluginList::highlightPlugins(const std::vector<unsigned int>& modIndices,
       const MOShared::FilesOrigin& origin =
           directoryEntry.getOriginByName(selectedMod->internalName().toStdWString());
       if (plugins.size() > 0) {
-        for (auto plugin : plugins) {
+        for (const auto& plugin : plugins) {
           MOShared::FileEntryPtr file = directoryEntry.findFile(plugin.toStdWString());
           if (file && file->getOrigin() != origin.getID()) {
             const auto alternatives = file->getAlternatives();
@@ -241,7 +241,7 @@ void PluginList::refresh(const QString& profileName,
     if (filename.endsWith(".esp", Qt::CaseInsensitive) ||
         filename.endsWith(".esm", Qt::CaseInsensitive) ||
         filename.endsWith(".esl", Qt::CaseInsensitive)) {
-      availablePlugins.insert(std::make_pair(filename, current));
+      availablePlugins.try_emplace(filename, current);
     } else if (filename.endsWith(".bsa", Qt::CaseInsensitive) ||
                filename.endsWith("ba2", Qt::CaseInsensitive)) {
       archiveCandidates.append(filename);
@@ -348,7 +348,7 @@ void PluginList::fixPrimaryPlugins()
   int prio                   = 0;
   int prioBlueprint          = 0;
   bool somethingChanged      = false;
-  for (auto esp : m_ESPs) {
+  for (const auto& esp : m_ESPs) {
     if (!esp.isBlueprintFlagged)
       prioBlueprint++;
   }
@@ -389,7 +389,7 @@ void PluginList::fixPluginRelationships()
   int standardCount        = 0;
   int masterCount          = 0;
   int blueprintMasterCount = 0;
-  for (auto plugin : m_ESPs) {
+  for (const auto& plugin : m_ESPs) {
     if (plugin.hasLightExtension || plugin.hasMasterExtension ||
         plugin.isMasterFlagged) {
       if (plugin.isBlueprintFlagged) {
@@ -1809,7 +1809,7 @@ void PluginList::setPluginPriority(int row, int& newPriority, bool isForced)
     newPriorityTemp = static_cast<int>(m_ESPsByPriority.size()) - 1;
 
   int blueprintStartPos = 0;
-  for (auto esp : m_ESPs) {
+  for (const auto& esp : m_ESPs) {
     if (!esp.isBlueprintFlagged) {
       blueprintStartPos++;
     }
@@ -1858,7 +1858,7 @@ void PluginList::setPluginPriority(int row, int& newPriority, bool isForced)
   int oldPriority = m_ESPs.at(row).priority;
   if (newPriorityTemp < oldPriority) {  // moving up
     // don't allow plugins to be moved above their masters
-    for (auto master : m_ESPs[row].masters) {
+    for (const auto& master : m_ESPs[row].masters) {
       auto iter = m_ESPsByName.find(master);
       if (iter != m_ESPsByName.end()) {
         if (m_ESPs[iter->second].isBlueprintFlagged ==
@@ -1874,7 +1874,7 @@ void PluginList::setPluginPriority(int row, int& newPriority, bool isForced)
     // don't allow masters to be moved below their children
     for (int i = oldPriority + 1; i <= newPriorityTemp; i++) {
       PluginList::ESPInfo* otherInfo = &m_ESPs.at(m_ESPsByPriority[i]);
-      for (auto master : otherInfo->masters) {
+      for (const auto& master : otherInfo->masters) {
         auto iter = m_ESPsByName.find(master);
         if (iter != m_ESPsByName.end()) {
           if (m_ESPs[iter->second].isBlueprintFlagged ==
@@ -2005,9 +2005,9 @@ PluginList::ESPInfo::ESPInfo(const QString& name, bool forceLoaded, bool forceEn
                              bool mediumSupported, bool blueprintSupported)
     : name(name), fullPath(fullPath), enabled(forceLoaded), forceLoaded(forceLoaded),
       forceEnabled(forceEnabled), forceDisabled(forceDisabled), priority(0),
-      loadOrder(-1), originName(originName), hasIni(hasIni),
-      archives(archives.begin(), archives.end()), modSelected(false),
-      isMasterOfSelectedPlugin(false)
+      loadOrder(-1), originName(originName), modSelected(false),
+      isMasterOfSelectedPlugin(false), hasIni(hasIni),
+      archives(archives.begin(), archives.end())
 {
   try {
     ESP::File file(ToWString(fullPath));

--- a/src/pluginlistview.cpp
+++ b/src/pluginlistview.cpp
@@ -231,7 +231,7 @@ void PluginListView::setSelected(const QModelIndex& current,
                                  const QModelIndexList& selected)
 {
   setCurrentIndex(indexModelToView(current));
-  for (auto idx : selected) {
+  for (const auto& idx : selected) {
     selectionModel()->select(indexModelToView(idx),
                              QItemSelectionModel::Select | QItemSelectionModel::Rows);
   }

--- a/src/problemsdialog.cpp
+++ b/src/problemsdialog.cpp
@@ -100,7 +100,7 @@ void ProblemsDialog::selectionChanged()
 void ProblemsDialog::startFix()
 {
   QObject* fixButton = QObject::sender();
-  if (fixButton == NULL) {
+  if (fixButton == nullptr) {
     log::warn("no button");
     return;
   }

--- a/src/processrunner.cpp
+++ b/src/processrunner.cpp
@@ -44,7 +44,7 @@ void adjustForVirtualized(const IPluginGame* game, spawn::SpawnParameters& sp,
         binPath += adjustedBin;
     }
 
-    QString cmdline = QString("launch \"%1\" \"%2\" %3")
+    QString cmdline = QString(R"(launch "%1" "%2" %3)")
                           .arg(QDir::toNativeSeparators(cwdPath),
                                QDir::toNativeSeparators(binPath), sp.arguments);
 
@@ -407,7 +407,7 @@ ProcessRunner::Results waitForProcesses(const std::vector<HANDLE>& initialProces
                             std::ref(interrupt));
 
   QEventLoop events;
-  QObject::connect(t, &QThread::finished, [&] {
+  QObject::connect(t, &QThread::finished, [&events] {
     events.quit();
   });
 
@@ -897,7 +897,7 @@ ProcessRunner::Results ProcessRunner::postRun()
     // how it is
     r = waitForProcess(m_handle.get(), &m_exitCode, nullptr);
   } else {
-    withLock([&](auto& ls) {
+    withLock([this, &r](UILocker::Session& ls) {
       r = waitForProcess(m_handle.get(), &m_exitCode, &ls);
     });
   }
@@ -959,7 +959,7 @@ ProcessRunner::waitForAllUSVFSProcessesWithLock(UILocker::Reasons reason)
   auto r = Error;
 
   for (;;) {
-    withLock([&](auto& ls) {
+    withLock([&r](auto& ls) {
       const auto processes = getRunningUSVFSProcesses();
       if (processes.empty()) {
         r = Completed;

--- a/src/profile.cpp
+++ b/src/profile.cpp
@@ -608,7 +608,7 @@ std::vector<std::tuple<QString, QString, int>> Profile::getActiveMods()
     if (m_ModStatus[index].m_Enabled) {
       ModInfo::Ptr modInfo = ModInfo::getByIndex(index);
       result.emplace_back(modInfo->internalName(), modInfo->absolutePath(),
-                                       m_ModStatus[index].m_Priority);
+                          m_ModStatus[index].m_Priority);
     }
   }
 

--- a/src/profile.cpp
+++ b/src/profile.cpp
@@ -607,8 +607,8 @@ std::vector<std::tuple<QString, QString, int>> Profile::getActiveMods()
   for (const auto& [priority, index] : m_ModIndexByPriority) {
     if (m_ModStatus[index].m_Enabled) {
       ModInfo::Ptr modInfo = ModInfo::getByIndex(index);
-      result.push_back(std::make_tuple(modInfo->internalName(), modInfo->absolutePath(),
-                                       m_ModStatus[index].m_Priority));
+      result.emplace_back(modInfo->internalName(), modInfo->absolutePath(),
+                                       m_ModStatus[index].m_Priority);
     }
   }
 
@@ -747,7 +747,7 @@ std::vector<std::wstring> Profile::splitDZString(const wchar_t* buffer) const
   const wchar_t* pos = buffer;
   size_t length      = wcslen(pos);
   while (length != 0U) {
-    result.push_back(pos);
+    result.emplace_back(pos);
     pos += length + 1;
     length = wcslen(pos);
   }
@@ -983,7 +983,7 @@ QString Profile::absoluteIniFilePath(QString iniFile) const
   QFileInfo targetIniFile(m_GamePlugin->documentsDirectory(), iniFile);
 
   bool isGameIni = false;
-  for (auto gameIni : m_GamePlugin->iniFiles()) {
+  for (const auto& gameIni : m_GamePlugin->iniFiles()) {
     // We compare the target file, not the actual ones:
     if (QFileInfo(m_GamePlugin->documentsDirectory(), gameIni) == targetIniFile) {
       isGameIni = true;
@@ -1060,7 +1060,7 @@ QVariantMap Profile::settingsByGroup(const QString& section) const
 {
   QVariantMap results;
   m_Settings->beginGroup(section);
-  for (auto key : m_Settings->childKeys()) {
+  for (const auto& key : m_Settings->childKeys()) {
     results[key] = m_Settings->value(key);
   }
   m_Settings->endGroup();
@@ -1070,7 +1070,7 @@ QVariantMap Profile::settingsByGroup(const QString& section) const
 void Profile::storeSettingsByGroup(const QString& section, const QVariantMap& values)
 {
   m_Settings->beginGroup(section);
-  for (auto key : values.keys()) {
+  for (const auto& key : values.keys()) {
     m_Settings->setValue(key, values[key]);
   }
   m_Settings->endGroup();
@@ -1083,7 +1083,7 @@ QList<QVariantMap> Profile::settingsByArray(const QString& prefix) const
   for (int i = 0; i < size; i++) {
     m_Settings->setArrayIndex(i);
     QVariantMap item;
-    for (auto key : m_Settings->childKeys()) {
+    for (const auto& key : m_Settings->childKeys()) {
       item[key] = m_Settings->value(key);
     }
     results.append(item);
@@ -1098,7 +1098,7 @@ void Profile::storeSettingsByArray(const QString& prefix,
   m_Settings->beginWriteArray(prefix);
   for (int i = 0; i < values.length(); i++) {
     m_Settings->setArrayIndex(i);
-    for (auto key : values.at(i).keys()) {
+    for (const auto& key : values.at(i).keys()) {
       m_Settings->setValue(key, values.at(i)[key]);
     }
   }
@@ -1126,7 +1126,7 @@ Profile::determineForcedLibraries(const QString& executable) const
   // look for enabled status on forced loads and add those
   for (auto forcedLoad : forcedLoads) {
     bool found = false;
-    for (auto rawSetting : rawSettings) {
+    for (const auto& rawSetting : rawSettings) {
       if ((rawSetting.value("process").toString().compare(forcedLoad.process(),
                                                           Qt::CaseInsensitive) == 0) &&
           (rawSetting.value("library").toString().compare(forcedLoad.library(),
@@ -1144,7 +1144,7 @@ Profile::determineForcedLibraries(const QString& executable) const
   // add everything else
   for (auto rawSetting : rawSettings) {
     bool add = true;
-    for (auto forcedLoad : forcedLoads) {
+    for (const auto& forcedLoad : forcedLoads) {
       if ((rawSetting.value("process").toString().compare(forcedLoad.process(),
                                                           Qt::CaseInsensitive) == 0) &&
           (rawSetting.value("library").toString().compare(forcedLoad.library(),
@@ -1166,7 +1166,7 @@ void Profile::storeForcedLibraries(const QString& executable,
                                    const QList<ExecutableForcedLoadSetting>& values)
 {
   QList<QVariantMap> rawSettings;
-  for (auto setting : values) {
+  for (const auto& setting : values) {
     QVariantMap rawSetting;
     rawSetting["enabled"] = setting.enabled();
     rawSetting["process"] = setting.process();

--- a/src/qdirfiletree.h
+++ b/src/qdirfiletree.h
@@ -17,8 +17,8 @@ You should have received a copy of the GNU General Public License
 along with Mod Organizer.  If not, see <http://www.gnu.org/licenses/>.
 */
 
-#ifndef ARCHIVEFILENETRY_H
-#define ARCHIVEFILENTRY_H
+#ifndef QDIRFILETREE_H
+#define QDIRFILETREE_H
 
 #include <QDir>
 

--- a/src/qtgroupingproxy.cpp
+++ b/src/qtgroupingproxy.cpp
@@ -42,7 +42,7 @@ QtGroupingProxy::QtGroupingProxy(QModelIndex rootNode, int groupedColumn,
   }
 }
 
-QtGroupingProxy::~QtGroupingProxy() {}
+QtGroupingProxy::~QtGroupingProxy() = default;
 
 void QtGroupingProxy::setSourceModel(QAbstractItemModel* model)
 {
@@ -108,7 +108,7 @@ QList<RowData> QtGroupingProxy::belongsTo(const QModelIndex& idx)
     int role         = i.key();
     QVariant variant = i.value();
 
-    if (variant.type() == QVariant::List) {
+    if (variant.typeId() == QMetaType::QVariantList) {
       // a list of variants get's expanded to multiple rows
       QVariantList list = variant.toList();
       for (int i = 0; i < list.length(); i++) {

--- a/src/sanitychecks.cpp
+++ b/src/sanitychecks.cpp
@@ -329,7 +329,7 @@ std::vector<std::pair<QString, QString>> getSystemDirectories()
         path += "\\";
       }
 
-      systemDirs.push_back({path, p.second});
+      systemDirs.emplace_back(path, p.second);
     }
   }
 
@@ -365,7 +365,7 @@ int checkMicrosoftStore(const QDir& gameDir)
       "/ModifiableWindowsApps/",
       "/WindowsApps/",
   };
-  for (auto badPath : pathsToCheck) {
+  for (const auto& badPath : pathsToCheck) {
     if (gameDir.path().contains(badPath)) {
       log::error("This game is not supported by Mod Organizer.");
       log::error("Games installed through the Microsoft Store will not work properly.");

--- a/src/savestab.cpp
+++ b/src/savestab.cpp
@@ -18,19 +18,19 @@ SavesTab::SavesTab(QWidget* window, OrganizerCore& core, Ui::MainWindow* mwui)
   ui.list->installEventFilter(this);
   ui.list->setMouseTracking(true);
 
-  connect(&m_SavesWatcher, &QFileSystemWatcher::directoryChanged, [&] {
+  connect(&m_SavesWatcher, &QFileSystemWatcher::directoryChanged, [this] {
     m_SavesWatcherTimer.start();
   });
 
-  connect(&m_SavesWatcherTimer, &QTimer::timeout, [&] {
+  connect(&m_SavesWatcherTimer, &QTimer::timeout, [this] {
     refreshSavesIfOpen();
   });
 
-  connect(ui.list, &QWidget::customContextMenuRequested, [&](auto pos) {
+  connect(ui.list, &QWidget::customContextMenuRequested, [this](auto pos) {
     onContextMenu(pos);
   });
 
-  connect(ui.list, &QTreeWidget::itemEntered, [&](auto* item) {
+  connect(ui.list, &QTreeWidget::itemEntered, [this](auto* item) {
     saveSelectionChanged(item);
   });
 }
@@ -266,11 +266,11 @@ void SavesTab::onContextMenu(const QPoint& pos)
 
   QString deleteMenuLabel =
       tr("Delete %n save(s)", "", selection->selectedRows().count());
-  menu.addAction(deleteMenuLabel, [&] {
+  menu.addAction(deleteMenuLabel, [this] {
     deleteSavegame();
   });
 
-  menu.addAction(tr("Open in Explorer..."), [&] {
+  menu.addAction(tr("Open in Explorer..."), [this] {
     openInExplorer();
   });
 

--- a/src/savestab.cpp
+++ b/src/savestab.cpp
@@ -9,8 +9,8 @@
 using namespace MOBase;
 
 SavesTab::SavesTab(QWidget* window, OrganizerCore& core, Ui::MainWindow* mwui)
-    : m_window(window), m_core(core), m_CurrentSaveView(nullptr),
-      ui{mwui->tabWidget, mwui->savesTab, mwui->savegameList}
+    : m_window(window), m_core(core), ui{mwui->tabWidget, mwui->savesTab, mwui->savegameList},
+      m_CurrentSaveView(nullptr)
 {
   m_SavesWatcherTimer.setSingleShot(true);
   m_SavesWatcherTimer.setInterval(500);

--- a/src/savestab.cpp
+++ b/src/savestab.cpp
@@ -9,7 +9,8 @@
 using namespace MOBase;
 
 SavesTab::SavesTab(QWidget* window, OrganizerCore& core, Ui::MainWindow* mwui)
-    : m_window(window), m_core(core), ui{mwui->tabWidget, mwui->savesTab, mwui->savegameList},
+    : m_window(window), m_core(core),
+      ui{mwui->tabWidget, mwui->savesTab, mwui->savegameList},
       m_CurrentSaveView(nullptr)
 {
   m_SavesWatcherTimer.setSingleShot(true);

--- a/src/selfupdater.cpp
+++ b/src/selfupdater.cpp
@@ -154,7 +154,7 @@ void SelfUpdater::startUpdate()
   // the button can't be pressed if there isn't an update candidate
   Q_ASSERT(!m_UpdateCandidates.empty());
 
-  auto latestRelease = m_UpdateCandidates.begin()->second;
+  const auto& latestRelease = m_UpdateCandidates.begin()->second;
 
   UpdateDialog dialog(m_Parent);
   dialog.setVersions(MOShared::createVersionInfo().string(),

--- a/src/settings.cpp
+++ b/src/settings.cpp
@@ -121,7 +121,7 @@ void Settings::processUpdates(const QVersionNumber& currentVersion,
     }
   };
 
-  version({2, 2, 0}, [&] {
+  version({2, 2, 0}, [this] {
     remove(m_Settings, "Settings", "steam_password");
     remove(m_Settings, "Settings", "nexus_username");
     remove(m_Settings, "Settings", "nexus_password");
@@ -133,7 +133,7 @@ void Settings::processUpdates(const QVersionNumber& currentVersion,
     removeSection(m_Settings, "Servers");
   });
 
-  version({2, 2, 1}, [&] {
+  version({2, 2, 1}, [this] {
     remove(m_Settings, "General", "mod_info_tabs");
     remove(m_Settings, "General", "mod_info_conflict_expanders");
     remove(m_Settings, "General", "mod_info_conflicts");
@@ -143,7 +143,7 @@ void Settings::processUpdates(const QVersionNumber& currentVersion,
     remove(m_Settings, "General", "mod_info_conflicts_overwritten");
   });
 
-  version({2, 2, 2}, [&] {
+  version({2, 2, 2}, [this] {
     // log splitter is gone, it's a dock now
     remove(m_Settings, "General", "log_split");
 
@@ -177,7 +177,7 @@ void Settings::processUpdates(const QVersionNumber& currentVersion,
     m_Network.updateFromOldMap();
   });
 
-  version({2, 4, 0}, [&] {
+  version({2, 4, 0}, [this] {
     // removed
     remove(m_Settings, "Settings", "hide_unchecked_plugins");
     remove(m_Settings, "Settings", "load_mechanism");
@@ -302,13 +302,14 @@ QString Settings::executablesBlacklist() const
 
 bool Settings::isExecutableBlacklisted(const QString& s) const
 {
-  for (auto exec : executablesBlacklist().split(";")) {
+  /* for (auto exec : executablesBlacklist().split(";")) {
     if (exec.compare(s, Qt::CaseInsensitive) == 0) {
       return true;
     }
   }
 
-  return false;
+  return false;*/
+  return executablesBlacklist().split(";").contains(s, Qt::CaseInsensitive);
 }
 
 void Settings::setExecutablesBlacklist(const QString& s)
@@ -955,7 +956,7 @@ void GeometrySettings::centerOnParent(QWidget* w, QWidget* parent)
   }
 
   if (parent && parent->isVisible()) {
-    const auto pr = parent->geometry();
+    const auto& pr = parent->geometry();
     w->move(pr.center() - w->rect().center());
   }
 }
@@ -981,7 +982,7 @@ Qt::Orientation dockOrientation(const QMainWindow* mw, const QDockWidget* d)
     return Qt::Vertical;
   }
 }
-
+/*
 void GeometrySettings::saveDocks(const QMainWindow* mw)
 {
   // this attempts to fix https://bugreports.qt.io/browse/QTBUG-46620 where dock
@@ -1047,7 +1048,7 @@ void GeometrySettings::restoreDocks(QMainWindow* mw) const
       mw->resizeDocks({info.d}, {info.size}, info.ori);
     }
   });
-}
+}*/
 
 WidgetSettings::WidgetSettings(QSettings& s, bool globalInstance) : m_Settings(s)
 {
@@ -1068,7 +1069,7 @@ WidgetSettings::WidgetSettings(QSettings& s, bool globalInstance) : m_Settings(s
 void WidgetSettings::saveTreeCheckState(const QTreeView* tv, int role)
 {
   QVariantList data;
-  for (auto index : flatIndex(tv->model())) {
+  for (const auto& index : flatIndex(tv->model())) {
     data.append(index.data(role));
   }
   set(m_Settings, "Widgets", indexSettingName(tv), data);
@@ -1093,7 +1094,7 @@ void WidgetSettings::restoreTreeCheckState(QTreeView* tv, int role) const
 void WidgetSettings::saveTreeExpandState(const QTreeView* tv, int role)
 {
   QVariantList expanded;
-  for (auto index : flatIndex(tv->model())) {
+  for (const auto& index : flatIndex(tv->model())) {
     if (tv->isExpanded(index)) {
       expanded.append(index.data(role));
     }
@@ -1106,7 +1107,7 @@ void WidgetSettings::restoreTreeExpandState(QTreeView* tv, int role) const
   if (auto expanded =
           getOptional<QVariantList>(m_Settings, "Widgets", indexSettingName(tv))) {
     tv->collapseAll();
-    for (auto index : flatIndex(tv->model())) {
+    for (const auto& index : flatIndex(tv->model())) {
       if (expanded->contains(index.data(role))) {
         tv->expand(index);
       }
@@ -1367,7 +1368,7 @@ void PluginSettings::registerPlugin(IPlugin* plugin)
 
     if (!temp.isValid()) {
       temp = setting.defaultValue;
-    } else if (!temp.convert(setting.defaultValue.type())) {
+    } else if (!temp.convert(QMetaType(setting.defaultValue.typeId()))) {
       log::warn("failed to interpret \"{}\" as correct type for \"{}\" in plugin "
                 "\"{}\", using default",
                 temp.toString(), setting.key, plugin->name());
@@ -1598,7 +1599,7 @@ std::map<QString, QString> PathSettings::recent() const
     const QVariant dir  = sra.get<QVariant>("directory");
 
     if (name.isValid() && dir.isValid()) {
-      map.emplace(name.toString(), dir.toString());
+      map.try_emplace(name.toString(), dir.toString());
     }
   });
 
@@ -1616,11 +1617,11 @@ void PathSettings::setRecent(const std::map<QString, QString>& map)
 
   ScopedWriteArray swa(m_Settings, "recentDirectories", map.size());
 
-  for (auto&& p : map) {
+  for (auto&& [name, directory] : map) {
     swa.next();
 
-    swa.set("name", p.first);
-    swa.set("directory", p.second);
+    swa.set("name", name);
+    swa.set("directory", directory);
   }
 }
 

--- a/src/settings.cpp
+++ b/src/settings.cpp
@@ -370,7 +370,7 @@ std::vector<std::map<QString, QVariant>> Settings::executables() const
   ScopedReadArray sra(m_Settings, "customExecutables");
   std::vector<std::map<QString, QVariant>> v;
 
-  sra.for_each([&] {
+  sra.for_each([&sra, &v] {
     std::map<QString, QVariant> map;
 
     for (auto&& key : sra.keys()) {
@@ -1577,7 +1577,7 @@ QSet<QString> PluginSettings::readBlacklist() const
   QSet<QString> set;
 
   ScopedReadArray sra(m_Settings, "pluginBlacklist");
-  sra.for_each([&] {
+  sra.for_each([&set, &sra] {
     set.insert(sra.get<QString>("name"));
   });
 
@@ -1594,7 +1594,7 @@ std::map<QString, QString> PathSettings::recent() const
 
   ScopedReadArray sra(m_Settings, "recentDirectories");
 
-  sra.for_each([&] {
+  sra.for_each([&sra, &map] {
     const QVariant name = sra.get<QVariant>("name");
     const QVariant dir  = sra.get<QVariant>("directory");
 
@@ -1791,7 +1791,7 @@ ServerList NetworkSettings::servers() const
   {
     ScopedReadArray sra(m_Settings, "Servers");
 
-    sra.for_each([&] {
+    sra.for_each([&sra, &list] {
       ServerInfo::SpeedList lastDownloads;
 
       const auto lastDownloadsString = sra.get<QString>("lastDownloads", "");
@@ -1902,7 +1902,7 @@ ServerList NetworkSettings::serversFromOldMap() const
   ServerList list;
   const ScopedGroup sg(m_Settings, "Servers");
 
-  sg.for_each([&](auto&& serverKey) {
+  sg.for_each([&sg, &list](auto&& serverKey) {
     QVariantMap data = sg.get<QVariantMap>(serverKey);
 
     ServerInfo server(serverKey, data["premium"].toBool(), data["lastSeen"].toDate(),
@@ -2071,7 +2071,7 @@ void NexusSettings::dump() const
 
   ScopedReadArray sra(s, "handlers");
 
-  sra.for_each([&] {
+  sra.for_each([&sra] {
     const auto games      = sra.get<QVariant>("games");
     const auto executable = sra.get<QVariant>("executable");
     const auto arguments  = sra.get<QVariant>("arguments");

--- a/src/settings.h
+++ b/src/settings.h
@@ -133,8 +133,8 @@ public:
   void saveToolbars(const QMainWindow* w);
   void restoreToolbars(QMainWindow* w) const;
 
-  //void saveDocks(const QMainWindow* w);
-  //void restoreDocks(QMainWindow* w) const;
+  // void saveDocks(const QMainWindow* w);
+  // void restoreDocks(QMainWindow* w) const;
 
   // this should be a generic "tab order" setting, but it only happens for the
   // mod info dialog right now

--- a/src/settings.h
+++ b/src/settings.h
@@ -133,8 +133,8 @@ public:
   void saveToolbars(const QMainWindow* w);
   void restoreToolbars(QMainWindow* w) const;
 
-  void saveDocks(const QMainWindow* w);
-  void restoreDocks(QMainWindow* w) const;
+  //void saveDocks(const QMainWindow* w);
+  //void restoreDocks(QMainWindow* w) const;
 
   // this should be a generic "tab order" setting, but it only happens for the
   // mod info dialog right now

--- a/src/settingsdialogdiagnostics.cpp
+++ b/src/settingsdialogdiagnostics.cpp
@@ -79,7 +79,7 @@ void DiagnosticsSettingsTab::setCrashDumpTypesBox()
 {
   ui->dumpsTypeBox->clear();
 
-  auto add = [&](auto&& text, auto&& type) {
+  auto add = [this](auto&& text, auto&& type) {
     ui->dumpsTypeBox->addItem(text, static_cast<int>(type));
   };
 

--- a/src/settingsdialoggeneral.cpp
+++ b/src/settingsdialoggeneral.cpp
@@ -121,11 +121,11 @@ void GeneralSettingsTab::addLanguages()
       }
     }
 
-    languages.push_back({languageString, match.captured(1)});
+    languages.emplace_back(languageString, match.captured(1));
   }
 
   if (!ui->languageBox->findText("English")) {
-    languages.push_back({QString("English"), QString("en_US")});
+    languages.emplace_back(QString("English"), QString("en_US"));
   }
 
   std::sort(languages.begin(), languages.end());

--- a/src/settingsdialoggeneral.cpp
+++ b/src/settingsdialoggeneral.cpp
@@ -38,11 +38,11 @@ GeneralSettingsTab::GeneralSettingsTab(Settings& s, SettingsDialog& d)
   ui->doubleClickPreviews->setChecked(
       settings().interface().doubleClicksOpenPreviews());
 
-  QObject::connect(ui->categoriesBtn, &QPushButton::clicked, [&] {
+  QObject::connect(ui->categoriesBtn, &QPushButton::clicked, [this] {
     onEditCategories();
   });
 
-  QObject::connect(ui->resetDialogsButton, &QPushButton::clicked, [&] {
+  QObject::connect(ui->resetDialogsButton, &QPushButton::clicked, [this] {
     onResetDialogs();
   });
 }

--- a/src/settingsdialognexus.cpp
+++ b/src/settingsdialognexus.cpp
@@ -256,7 +256,7 @@ bool NexusConnectionUI::clearKey()
 
 void NexusConnectionUI::updateState()
 {
-  auto setButton = [&](QAbstractButton* b, bool enabled, QString caption = {}) {
+  auto setButton = [](QAbstractButton* b, bool enabled, QString caption = {}) {
     if (b) {
       b->setEnabled(enabled);
       if (!caption.isEmpty()) {

--- a/src/settingsdialognexus.cpp
+++ b/src/settingsdialognexus.cpp
@@ -13,7 +13,7 @@ class ServerItem : public QListWidgetItem
 {
 public:
   ServerItem(const QString& text, int sortRole = Qt::DisplayRole,
-             QListWidget* parent = 0, int type = Type)
+             QListWidget* parent = nullptr, int type = Type)
       : QListWidgetItem(text, parent, type), m_SortRole(sortRole)
   {}
 
@@ -35,13 +35,13 @@ public:
     ui->setupUi(this);
     ui->key->setFont(QFontDatabase::systemFont(QFontDatabase::FixedFont));
 
-    connect(ui->openBrowser, &QPushButton::clicked, [&] {
+    connect(ui->openBrowser, &QPushButton::clicked, [this] {
       openBrowser();
     });
-    connect(ui->paste, &QPushButton::clicked, [&] {
+    connect(ui->paste, &QPushButton::clicked, [this] {
       paste();
     });
-    connect(ui->clear, &QPushButton::clicked, [&] {
+    connect(ui->clear, &QPushButton::clicked, [this] {
       clear();
     });
   }
@@ -83,19 +83,19 @@ NexusConnectionUI::NexusConnectionUI(QWidget* parent, Settings* s,
       m_disconnect(disconnectButton), m_manual(manualButton), m_log(logList)
 {
   if (m_connect) {
-    QObject::connect(m_connect, &QPushButton::clicked, [&] {
+    QObject::connect(m_connect, &QPushButton::clicked, [this] {
       connect();
     });
   }
 
   if (m_disconnect) {
-    QObject::connect(m_disconnect, &QPushButton::clicked, [&] {
+    QObject::connect(m_disconnect, &QPushButton::clicked, [this] {
       disconnect();
     });
   }
 
   if (m_manual) {
-    QObject::connect(manualButton, &QPushButton::clicked, [&] {
+    QObject::connect(manualButton, &QPushButton::clicked, [this] {
       manual();
     });
   }
@@ -119,11 +119,11 @@ void NexusConnectionUI::connect()
   if (!m_nexusLogin) {
     m_nexusLogin.reset(new NexusSSOLogin);
 
-    m_nexusLogin->keyChanged = [&](auto&& s) {
+    m_nexusLogin->keyChanged = [this](auto&& s) {
       onSSOKeyChanged(s);
     };
 
-    m_nexusLogin->stateChanged = [&](auto&& s, auto&& e) {
+    m_nexusLogin->stateChanged = [this](auto&& s, auto&& e) {
       onSSOStateChanged(s, e);
     };
   }
@@ -168,7 +168,7 @@ void NexusConnectionUI::validateKey(const QString& key)
     m_nexusValidator.reset(new NexusKeyValidator(
         m_settings, *NexusInterface::instance().getAccessManager()));
 
-    m_nexusValidator->finished = [&](auto&& r, auto&& m, auto&& u) {
+    m_nexusValidator->finished = [this](auto&& r, auto&& m, auto&& u) {
       onValidatorFinished(r, m, u);
     };
   }
@@ -330,25 +330,25 @@ NexusSettingsTab::NexusSettingsTab(Settings& s, SettingsDialog& d) : SettingsTab
 
   QObject::connect(
       m_connectionUI.get(), &NexusConnectionUI::stateChanged, &d,
-      [&] {
+      [this] {
         updateNexusData();
       },
       Qt::QueuedConnection);
 
-  QObject::connect(m_connectionUI.get(), &NexusConnectionUI::keyChanged, &d, [&] {
+  QObject::connect(m_connectionUI.get(), &NexusConnectionUI::keyChanged, &d, [this] {
     dialog().setExitNeeded(Exit::Restart);
   });
 
-  QObject::connect(ui->clearCacheButton, &QPushButton::clicked, [&] {
+  QObject::connect(ui->clearCacheButton, &QPushButton::clicked, [this] {
     clearCache();
   });
-  QObject::connect(ui->associateButton, &QPushButton::clicked, [&] {
+  QObject::connect(ui->associateButton, &QPushButton::clicked, [this] {
     associate();
   });
-  QObject::connect(ui->useCustomBrowser, &QCheckBox::clicked, [&] {
+  QObject::connect(ui->useCustomBrowser, &QCheckBox::clicked, [this] {
     updateCustomBrowser();
   });
-  QObject::connect(ui->browseCustomBrowser, &QPushButton::clicked, [&] {
+  QObject::connect(ui->browseCustomBrowser, &QPushButton::clicked, [this] {
     browseCustomBrowser();
   });
 

--- a/src/settingsdialogpaths.cpp
+++ b/src/settingsdialogpaths.cpp
@@ -26,44 +26,44 @@ PathsSettingsTab::PathsSettingsTab(Settings& s, SettingsDialog& d)
     dir.first->setText(storePath);
   }
 
-  QObject::connect(ui->browseBaseDirBtn, &QPushButton::clicked, [&] {
+  QObject::connect(ui->browseBaseDirBtn, &QPushButton::clicked, [this] {
     on_browseBaseDirBtn_clicked();
   });
-  QObject::connect(ui->browseCacheDirBtn, &QPushButton::clicked, [&] {
+  QObject::connect(ui->browseCacheDirBtn, &QPushButton::clicked, [this] {
     on_browseCacheDirBtn_clicked();
   });
-  QObject::connect(ui->browseDownloadDirBtn, &QPushButton::clicked, [&] {
+  QObject::connect(ui->browseDownloadDirBtn, &QPushButton::clicked, [this] {
     on_browseDownloadDirBtn_clicked();
   });
-  QObject::connect(ui->browseGameDirBtn, &QPushButton::clicked, [&] {
+  QObject::connect(ui->browseGameDirBtn, &QPushButton::clicked, [this] {
     on_browseGameDirBtn_clicked();
   });
-  QObject::connect(ui->browseModDirBtn, &QPushButton::clicked, [&] {
+  QObject::connect(ui->browseModDirBtn, &QPushButton::clicked, [this] {
     on_browseModDirBtn_clicked();
   });
-  QObject::connect(ui->browseOverwriteDirBtn, &QPushButton::clicked, [&] {
+  QObject::connect(ui->browseOverwriteDirBtn, &QPushButton::clicked, [this] {
     on_browseOverwriteDirBtn_clicked();
   });
-  QObject::connect(ui->browseProfilesDirBtn, &QPushButton::clicked, [&] {
+  QObject::connect(ui->browseProfilesDirBtn, &QPushButton::clicked, [this] {
     on_browseProfilesDirBtn_clicked();
   });
 
-  QObject::connect(ui->baseDirEdit, &QLineEdit::editingFinished, [&] {
+  QObject::connect(ui->baseDirEdit, &QLineEdit::editingFinished, [this] {
     on_baseDirEdit_editingFinished();
   });
-  QObject::connect(ui->cacheDirEdit, &QLineEdit::editingFinished, [&] {
+  QObject::connect(ui->cacheDirEdit, &QLineEdit::editingFinished, [this] {
     on_cacheDirEdit_editingFinished();
   });
-  QObject::connect(ui->downloadDirEdit, &QLineEdit::editingFinished, [&] {
+  QObject::connect(ui->downloadDirEdit, &QLineEdit::editingFinished, [this] {
     on_downloadDirEdit_editingFinished();
   });
-  QObject::connect(ui->modDirEdit, &QLineEdit::editingFinished, [&] {
+  QObject::connect(ui->modDirEdit, &QLineEdit::editingFinished, [this] {
     on_modDirEdit_editingFinished();
   });
-  QObject::connect(ui->overwriteDirEdit, &QLineEdit::editingFinished, [&] {
+  QObject::connect(ui->overwriteDirEdit, &QLineEdit::editingFinished, [this] {
     on_overwriteDirEdit_editingFinished();
   });
-  QObject::connect(ui->profilesDirEdit, &QLineEdit::editingFinished, [&] {
+  QObject::connect(ui->profilesDirEdit, &QLineEdit::editingFinished, [this] {
     on_profilesDirEdit_editingFinished();
   });
 }

--- a/src/settingsdialogplugins.cpp
+++ b/src/settingsdialogplugins.cpp
@@ -79,19 +79,19 @@ PluginsSettingsTab::PluginsSettingsTab(Settings& s, PluginContainer* pluginConta
   m_filter.setEdit(ui->pluginFilterEdit);
 
   QObject::connect(ui->pluginsList, &QTreeWidget::currentItemChanged,
-                   [&](auto* current, auto* previous) {
+                   [this](auto* current, auto* previous) {
                      on_pluginsList_currentItemChanged(current, previous);
                    });
-  QObject::connect(ui->enabledCheckbox, &QCheckBox::clicked, [&](bool checked) {
+  QObject::connect(ui->enabledCheckbox, &QCheckBox::clicked, [this](bool checked) {
     on_checkboxEnabled_clicked(checked);
   });
 
   QShortcut* delShortcut =
       new QShortcut(QKeySequence(Qt::Key_Delete), ui->pluginBlacklist);
-  QObject::connect(delShortcut, &QShortcut::activated, &dialog(), [&] {
+  QObject::connect(delShortcut, &QShortcut::activated, &dialog(), [this] {
     deleteBlacklistItem();
   });
-  QObject::connect(&m_filter, &FilterWidget::changed, [&] {
+  QObject::connect(&m_filter, &FilterWidget::changed, [this] {
     filterPluginList();
   });
 

--- a/src/settingsdialogtheme.cpp
+++ b/src/settingsdialogtheme.cpp
@@ -18,11 +18,11 @@ ThemeSettingsTab::ThemeSettingsTab(Settings& s, SettingsDialog& d) : SettingsTab
   // colors
   ui->colorTable->load(s);
 
-  QObject::connect(ui->resetColorsBtn, &QPushButton::clicked, [&] {
+  QObject::connect(ui->resetColorsBtn, &QPushButton::clicked, [this] {
     ui->colorTable->resetColors();
   });
 
-  QObject::connect(ui->exploreStyles, &QPushButton::clicked, [&] {
+  QObject::connect(ui->exploreStyles, &QPushButton::clicked, [this] {
     onExploreStyles();
   });
 }

--- a/src/settingsdialogworkarounds.cpp
+++ b/src/settingsdialogworkarounds.cpp
@@ -115,7 +115,7 @@ WorkaroundsSettingsTab::changeBlacklistLater(QWidget* parent, const QString& cur
   }
 
   QStringList blacklist;
-  for (auto exec : result.split("\n")) {
+  for (const auto& exec : result.split("\n")) {
     if (exec.trimmed().endsWith(".exe", Qt::CaseInsensitive)) {
       blacklist << exec.trimmed();
     }

--- a/src/settingsdialogworkarounds.cpp
+++ b/src/settingsdialogworkarounds.cpp
@@ -37,19 +37,19 @@ WorkaroundsSettingsTab::WorkaroundsSettingsTab(Settings& s, SettingsDialog& d)
   m_SkipFileSuffixes    = settings().skipFileSuffixes();
   m_SkipDirectories     = settings().skipDirectories();
 
-  QObject::connect(ui->bsaDateBtn, &QPushButton::clicked, [&] {
+  QObject::connect(ui->bsaDateBtn, &QPushButton::clicked, [this] {
     on_bsaDateBtn_clicked();
   });
-  QObject::connect(ui->execBlacklistBtn, &QPushButton::clicked, [&] {
+  QObject::connect(ui->execBlacklistBtn, &QPushButton::clicked, [this] {
     on_execBlacklistBtn_clicked();
   });
-  QObject::connect(ui->skipFileSuffixBtn, &QPushButton::clicked, [&] {
+  QObject::connect(ui->skipFileSuffixBtn, &QPushButton::clicked, [this] {
     on_skipFileSuffixBtn_clicked();
   });
-  QObject::connect(ui->skipDirectoriesBtn, &QPushButton::clicked, [&] {
+  QObject::connect(ui->skipDirectoriesBtn, &QPushButton::clicked, [this] {
     on_skipDirectoriesBtn_clicked();
   });
-  QObject::connect(ui->resetGeometryBtn, &QPushButton::clicked, [&] {
+  QObject::connect(ui->resetGeometryBtn, &QPushButton::clicked, [this] {
     on_resetGeometryBtn_clicked();
   });
 }

--- a/src/shared/directoryentry.cpp
+++ b/src/shared/directoryentry.cpp
@@ -180,7 +180,7 @@ void DirectoryEntry::addFromAllBSAs(const std::wstring& originName,
 
     int order = -1;
 
-    for (auto plugin : loadOrder) {
+    for (const auto& plugin : loadOrder) {
       const auto pluginNameLc =
           ToLowerCopy(std::filesystem::path(plugin).stem().native());
 
@@ -367,7 +367,7 @@ bool DirectoryEntry::hasFile(const std::wstring& name) const
   return m_Files.contains(ToLowerCopy(name));
 }
 
-bool DirectoryEntry::containsArchive(std::wstring archiveName)
+bool DirectoryEntry::containsArchive(const std::wstring& archiveName)
 {
   for (auto iter = m_Files.begin(); iter != m_Files.end(); ++iter) {
     FileEntryPtr entry = m_FileRegister->getFile(iter->second);
@@ -790,7 +790,7 @@ DirectoryEntry* DirectoryEntry::getSubDirectoryRecursive(const std::wstring& pat
     return getSubDirectory(path, create, stats);
   } else {
     DirectoryEntry* nextChild =
-        getSubDirectory(path.substr(0, pos), create, stats, originID);
+        getSubDirectory(std::wstring_view(path).substr(0, pos), create, stats, originID);
 
     if (nextChild == nullptr) {
       return nullptr;
@@ -821,7 +821,7 @@ void DirectoryEntry::removeDirRecursive()
 void DirectoryEntry::addDirectoryToList(DirectoryEntry* e, std::wstring nameLc)
 {
   m_SubDirectories.insert(e);
-  m_SubDirectoriesLookup.emplace(std::move(nameLc), e);
+  m_SubDirectoriesLookup.try_emplace(std::move(nameLc), e);
 }
 
 void DirectoryEntry::removeDirectoryFromList(SubDirectories::iterator itor)
@@ -892,8 +892,8 @@ void DirectoryEntry::removeFilesFromList(const std::set<FileIndex>& indices)
 
 void DirectoryEntry::addFileToList(std::wstring fileNameLower, FileIndex index)
 {
-  m_FilesLookup.emplace(fileNameLower, index);
-  m_Files.emplace(std::move(fileNameLower), index);
+  m_FilesLookup.try_emplace(fileNameLower, index);
+  m_Files.try_emplace(std::move(fileNameLower), index);
   // fileNameLower has been moved from this point
 }
 

--- a/src/shared/directoryentry.cpp
+++ b/src/shared/directoryentry.cpp
@@ -789,8 +789,8 @@ DirectoryEntry* DirectoryEntry::getSubDirectoryRecursive(const std::wstring& pat
   if (pos == std::wstring::npos) {
     return getSubDirectory(path, create, stats);
   } else {
-    DirectoryEntry* nextChild =
-        getSubDirectory(std::wstring_view(path).substr(0, pos), create, stats, originID);
+    DirectoryEntry* nextChild = getSubDirectory(std::wstring_view(path).substr(0, pos),
+                                                create, stats, originID);
 
     if (nextChild == nullptr) {
       return nullptr;

--- a/src/shared/directoryentry.h
+++ b/src/shared/directoryentry.h
@@ -170,7 +170,7 @@ public:
   const FileEntryPtr findFile(const DirectoryEntryFileKey& key) const;
 
   bool hasFile(const std::wstring& name) const;
-  bool containsArchive(std::wstring archiveName);
+  bool containsArchive(const std::wstring& archiveName);
 
   // search through this directory and all subdirectories for a file by the
   // specified name (relative path).

--- a/src/shared/fileentry.cpp
+++ b/src/shared/fileentry.cpp
@@ -44,7 +44,7 @@ void FileEntry::addOrigin(OriginID origin, FILETIME fileTime, std::wstring_view 
         });
 
     if (itor == m_Alternatives.end()) {
-      m_Alternatives.push_back({m_Origin, m_Archive});
+      m_Alternatives.emplace_back(m_Origin, m_Archive);
     }
 
     m_Origin   = origin;
@@ -142,7 +142,7 @@ void FileEntry::sortOrigins()
 {
   std::scoped_lock lock(m_OriginsMutex);
 
-  m_Alternatives.push_back({m_Origin, m_Archive});
+  m_Alternatives.emplace_back(m_Origin, m_Archive);
 
   std::sort(m_Alternatives.begin(), m_Alternatives.end(), [&](auto&& LHS, auto&& RHS) {
     if (!LHS.isFromArchive() && !RHS.isFromArchive()) {
@@ -184,7 +184,7 @@ void FileEntry::sortOrigins()
   }
 }
 
-bool FileEntry::isFromArchive(std::wstring archiveName) const
+bool FileEntry::isFromArchive(std::wstring_view archiveName) const
 {
   std::scoped_lock lock(m_OriginsMutex);
 

--- a/src/shared/fileentry.h
+++ b/src/shared/fileentry.h
@@ -47,7 +47,7 @@ public:
 
   const DataArchiveOrigin& getArchive() const { return m_Archive; }
 
-  bool isFromArchive(std::wstring archiveName = L"") const;
+  bool isFromArchive(std::wstring_view archiveName = L"") const;
 
   // if originID is -1, uses the main origin; if this file doesn't exist in the
   // given origin, returns an empty string

--- a/src/shared/filesorigin.cpp
+++ b/src/shared/filesorigin.cpp
@@ -102,7 +102,7 @@ void FilesOrigin::removeFile(FileIndex index)
   }
 }
 
-bool FilesOrigin::containsArchive(std::wstring archiveName)
+bool FilesOrigin::containsArchive(std::wstring_view archiveName)
 {
   std::scoped_lock lock(m_Mutex);
 

--- a/src/shared/filesorigin.h
+++ b/src/shared/filesorigin.h
@@ -49,7 +49,7 @@ public:
 
   void removeFile(FileIndex index);
 
-  bool containsArchive(std::wstring archiveName);
+  bool containsArchive(std::wstring_view archiveName);
 
 private:
   OriginID m_ID;

--- a/src/shared/originconnection.cpp
+++ b/src/shared/originconnection.cpp
@@ -48,7 +48,7 @@ OriginConnection::createOrigin(const std::wstring& originName,
 bool OriginConnection::exists(const std::wstring& name)
 {
   std::scoped_lock lock(m_Mutex);
-  return m_OriginsNameMap.find(name) != m_OriginsNameMap.end();
+  return m_OriginsNameMap.contains(name);
 }
 
 FilesOrigin& OriginConnection::getByID(OriginID ID)
@@ -121,7 +121,7 @@ FilesOrigin& OriginConnection::createOriginNoLock(
                                                  fileRegister, originConnection))
                   .first;
 
-  m_OriginsNameMap.insert({originName, newID});
+  m_OriginsNameMap.try_emplace(originName, newID);
 
   return itor->second;
 }

--- a/src/spawn.cpp
+++ b/src/spawn.cpp
@@ -173,7 +173,7 @@ QMessageBox::StandardButton badSteamReg(QWidget* parent, const QString& keyName,
           QObject::tr("The path to the Steam executable cannot be found. You might try "
                       "reinstalling Steam."))
       .details(details)
-      .icon(QMessageBox::Critical)
+      .icon(QMessageBox::Icon::Critical)
       .button({QObject::tr("Continue without starting Steam"),
                QObject::tr("The program may fail to launch."), QMessageBox::Yes})
       .button({QObject::tr("Cancel"), QMessageBox::Cancel})
@@ -197,7 +197,7 @@ QMessageBox::StandardButton startSteamFailed(QWidget* parent, const QString& key
       .main(QObject::tr("Cannot start Steam"))
       .content(makeContent(sp, e))
       .details(details)
-      .icon(QMessageBox::Critical)
+      .icon(QMessageBox::Icon::Critical)
       .button({QObject::tr("Continue without starting Steam"),
                QObject::tr("The program may fail to launch."), QMessageBox::Yes})
       .button({QObject::tr("Cancel"), QMessageBox::Cancel})
@@ -217,7 +217,7 @@ void spawnFailed(QWidget* parent, const SpawnParameters& sp, DWORD code)
       .main(mainText)
       .content(makeContent(sp, code))
       .details(details)
-      .icon(QMessageBox::Critical)
+      .icon(QMessageBox::Icon::Critical)
       .exec();
 }
 
@@ -241,7 +241,7 @@ void helperFailed(QWidget* parent, DWORD code, const QString& why,
       .main(mainText)
       .content(makeContent(sp, code))
       .details(details)
-      .icon(QMessageBox::Critical)
+      .icon(QMessageBox::Icon::Critical)
       .exec();
 }
 
@@ -270,7 +270,7 @@ bool confirmRestartAsAdmin(QWidget* parent, const SpawnParameters& sp)
           .main(mainText)
           .content(content)
           .details(details)
-          .icon(QMessageBox::Question)
+          .icon(QMessageBox::Icon::Question)
           .button({QObject::tr("Restart Mod Organizer as administrator"),
                    QObject::tr(
                        "You must allow \"helper.exe\" to make changes to the system."),
@@ -294,7 +294,7 @@ confirmStartSteam(QWidget* parent, const SpawnParameters& sp, const QString& det
       .main(mainText)
       .content(content)
       .details(details)
-      .icon(QMessageBox::Question)
+      .icon(QMessageBox::Icon::Question)
       .button({QObject::tr("Start Steam"), QMessageBox::Yes})
       .button({QObject::tr("Continue without starting Steam"),
                QObject::tr("The program might fail to run."), QMessageBox::No})
@@ -318,7 +318,7 @@ QMessageBox::StandardButton confirmRestartAsAdminForSteam(QWidget* parent,
   return MOBase::TaskDialog(parent, title)
       .main(mainText)
       .content(content)
-      .icon(QMessageBox::Question)
+      .icon(QMessageBox::Icon::Question)
       .button(
           {QObject::tr("Restart Mod Organizer as administrator"),
            QObject::tr("You must allow \"helper.exe\" to make changes to the system."),
@@ -345,7 +345,7 @@ bool eventLogNotRunning(QWidget* parent, const env::Service& s,
           .main(mainText)
           .content(content)
           .details(s.toString())
-          .icon(QMessageBox::Question)
+          .icon(QMessageBox::Icon::Question)
           .remember("eventLogService", sp.binary.fileName())
           .button({QObject::tr("Continue"), QObject::tr("Your mods might not work."),
                    QMessageBox::Yes})
@@ -375,7 +375,7 @@ confirmBlacklisted(QWidget* parent, const SpawnParameters& sp, Settings& setting
                .main(mainText)
                .content(content)
                .details(details)
-               .icon(QMessageBox::Question)
+               .icon(QMessageBox::Icon::Question)
                .remember("blacklistedExecutable", sp.binary.fileName())
                .button({QObject::tr("Continue"),
                         QObject::tr("Your mods might not work."), QMessageBox::Yes})

--- a/src/syncoverwritedialog.cpp
+++ b/src/syncoverwritedialog.cpp
@@ -165,7 +165,7 @@ void SyncOverwriteDialog::applyTo(QTreeWidgetItem* item, const QString& path,
   }
 
   QDir dir(m_SourcePath + "/" + path);
-  if ((path.length() > 0) && (dir.count() == 2)) {
+  if (!path.isEmpty() && (dir.count() == 2)) {
     dir.rmpath(".");
   }
 }

--- a/src/texteditor.cpp
+++ b/src/texteditor.cpp
@@ -18,11 +18,11 @@ TextEditor::TextEditor(QWidget* parent)
 
   emit modified(false);
 
-  connect(document(), &QTextDocument::modificationChanged, [&](bool b) {
+  connect(document(), &QTextDocument::modificationChanged, [this](bool b) {
     onModified(b);
   });
 
-  connect(this, &QPlainTextEdit::cursorPositionChanged, [&] {
+  connect(this, &QPlainTextEdit::cursorPositionChanged, [this] {
     highlightCurrentLine();
   });
 }
@@ -380,10 +380,10 @@ TextEditorLineNumbers::TextEditorLineNumbers(TextEditor& editor)
 {
   setFont(editor.font());
 
-  connect(&m_editor, &QPlainTextEdit::blockCountChanged, [&] {
+  connect(&m_editor, &QPlainTextEdit::blockCountChanged, [this] {
     updateAreaWidth();
   });
-  connect(&m_editor, &QPlainTextEdit::updateRequest, [&](auto&& rect, int dy) {
+  connect(&m_editor, &QPlainTextEdit::updateRequest, [this](auto&& rect, int dy) {
     updateArea(rect, dy);
   });
 
@@ -481,13 +481,13 @@ TextEditorToolbar::TextEditorToolbar(TextEditor& editor)
   m_path = new QLineEdit;
   m_path->setReadOnly(true);
 
-  QObject::connect(m_save, &QAction::triggered, [&] {
+  QObject::connect(m_save, &QAction::triggered, [this] {
     m_editor.save();
   });
-  QObject::connect(m_wordWrap, &QAction::triggered, [&] {
+  QObject::connect(m_wordWrap, &QAction::triggered, [this] {
     m_editor.toggleWordWrap();
   });
-  QObject::connect(m_explore, &QAction::triggered, [&] {
+  QObject::connect(m_explore, &QAction::triggered, [this] {
     m_editor.explore();
   });
 
@@ -509,13 +509,13 @@ TextEditorToolbar::TextEditorToolbar(TextEditor& editor)
 
   layout->addWidget(m_path);
 
-  QObject::connect(&m_editor, &TextEditor::modified, [&](bool b) {
+  QObject::connect(&m_editor, &TextEditor::modified, [this](bool b) {
     onTextModified(b);
   });
-  QObject::connect(&m_editor, &TextEditor::wordWrapChanged, [&](bool b) {
+  QObject::connect(&m_editor, &TextEditor::wordWrapChanged, [this](bool b) {
     onWordWrap(b);
   });
-  QObject::connect(&m_editor, &TextEditor::loaded, [&](QString f) {
+  QObject::connect(&m_editor, &TextEditor::loaded, [this](QString f) {
     onLoaded(f);
   });
 }

--- a/src/uilocker.cpp
+++ b/src/uilocker.cpp
@@ -12,7 +12,7 @@ public:
         m_buttons(nullptr), m_reason(UILocker::NoReason)
   {
     m_timer.reset(new QTimer);
-    QObject::connect(m_timer.get(), &QTimer::timeout, [&] {
+    QObject::connect(m_timer.get(), &QTimer::timeout, [this] {
       checkTarget();
     });
     m_timer->start(200);
@@ -331,7 +331,7 @@ private:
     case UILocker::OutputRequired: {
       auto* unlock = new QPushButton(QObject::tr("Unlock"));
 
-      QObject::connect(unlock, &QPushButton::clicked, [&] {
+      QObject::connect(unlock, &QPushButton::clicked, [] {
         UILocker::instance().onForceUnlock();
       });
 
@@ -342,14 +342,14 @@ private:
 
     case UILocker::PreventExit: {
       auto* exit = new QPushButton(QObject::tr("Exit Now"));
-      QObject::connect(exit, &QPushButton::clicked, [&] {
+      QObject::connect(exit, &QPushButton::clicked, [] {
         UILocker::instance().onForceUnlock();
       });
 
       ly->addWidget(exit);
 
       auto* cancel = new QPushButton(QObject::tr("Cancel"));
-      QObject::connect(cancel, &QPushButton::clicked, [&] {
+      QObject::connect(cancel, &QPushButton::clicked, [] {
         UILocker::instance().onCancel();
       });
 

--- a/src/uilocker.cpp
+++ b/src/uilocker.cpp
@@ -137,6 +137,8 @@ private:
   QWidget* findTarget()
   {
     auto isValidTarget = [](QWidget* w) {
+      if (w == nullptr)
+        return false;
       // skip message boxes
       if (dynamic_cast<QMessageBox*>(w)) {
         return false;

--- a/src/updatedialog.cpp
+++ b/src/updatedialog.cpp
@@ -12,10 +12,10 @@ UpdateDialog::UpdateDialog(QWidget* parent)
 {
   // Basic UI stuff
   ui->setupUi(this);
-  connect(ui->installButton, &QPushButton::pressed, this, [&] {
+  connect(ui->installButton, &QPushButton::pressed, this, [this] {
     done(QDialog::Accepted);
   });
-  connect(ui->cancelButton, &QPushButton::pressed, this, [&] {
+  connect(ui->cancelButton, &QPushButton::pressed, this, [this] {
     done(QDialog::Rejected);
   });
 
@@ -49,7 +49,7 @@ UpdateDialog::UpdateDialog(QWidget* parent)
 
   // Setting up the expander
   m_expander.set(ui->detailsButton, ui->detailsWidget);
-  connect(&m_expander, &ExpanderWidget::toggled, this, [&] {
+  connect(&m_expander, &ExpanderWidget::toggled, this, [this] {
     adjustSize();
   });
 

--- a/src/usvfsconnector.cpp
+++ b/src/usvfsconnector.cpp
@@ -62,7 +62,7 @@ LogWorker::LogWorker()
   log::debug("usvfs log messages are written to {}", m_LogFile.fileName());
 }
 
-LogWorker::~LogWorker() {}
+LogWorker::~LogWorker() = default;
 
 void LogWorker::process()
 {
@@ -155,7 +155,7 @@ UsvfsConnector::UsvfsConnector()
   usvfsFreeParameters(params);
 
   usvfsClearExecutableBlacklist();
-  for (auto exec : s.executablesBlacklist().split(";")) {
+  for (auto& exec : s.executablesBlacklist().split(";")) {
     std::wstring buf = exec.toStdWString();
     usvfsBlacklistExecutable(buf.data());
   }
@@ -210,7 +210,7 @@ void UsvfsConnector::updateMapping(const MappingType& mapping)
 
   usvfsClearVirtualMappings();
 
-  for (auto map : mapping) {
+  for (const auto& map : mapping) {
     if (progress.wasCanceled()) {
       usvfsClearVirtualMappings();
       throw UsvfsConnectorException("VFS mapping canceled by user");
@@ -261,7 +261,7 @@ void UsvfsConnector::updateParams(MOBase::log::Levels logLevel,
   usvfsFreeParameters(p);
 
   usvfsClearExecutableBlacklist();
-  for (auto exec : executableBlacklist.split(";")) {
+  for (auto& exec : executableBlacklist.split(";")) {
     std::wstring buf = exec.toStdWString();
     usvfsBlacklistExecutable(buf.data());
   }
@@ -286,7 +286,7 @@ void UsvfsConnector::updateForcedLibraries(
     const QList<MOBase::ExecutableForcedLoadSetting>& forcedLibraries)
 {
   usvfsClearLibraryForceLoads();
-  for (auto setting : forcedLibraries) {
+  for (auto& setting : forcedLibraries) {
     if (setting.enabled()) {
       usvfsForceLoadLibrary(setting.process().toStdWString().data(),
                             setting.library().toStdWString().data());

--- a/src/virtualfiletree.h
+++ b/src/virtualfiletree.h
@@ -17,8 +17,8 @@ You should have received a copy of the GNU General Public License
 along with Mod Organizer.  If not, see <http://www.gnu.org/licenses/>.
 */
 
-#ifndef ARCHIVEFILENETRY_H
-#define ARCHIVEFILENTRY_H
+#ifndef VIRTUALFILETREE_H
+#define VIRTUALFILETREE_H
 
 #include <QDir>
 


### PR DESCRIPTION
Hi there,
I have been wanting to fix the stuck downloads for quite a while now and finally managed to do it.
In the meantime, I've gone through most of the other code and (with the help of static analysis) found a few instances of possible improvements.

MO runs completely fine for me now and have had no issues. I've already reverted changes that were causing issues for me (before pushing the changes that is) and didn't find any more funky behavior.

The commented-out code can be deleted if it won't be used anymore.

### Main Change (DownloadManager)

1. When the download start, we don't immediately create a meta file. Only pausing or finishing a download will do that now
2. Always connect the finished signal from the reply to downloadFinished (although we are checking for duplicate downloads before that)
3. We emit `aboutToUpdate()` only when we will also emit `update()` (otherwise we use `update(downloadInfo)`)
4. `writeData(info)` now does more checks to protect from failed actions
5. For each download, now generate a random downloadID to avoid potential ID overlaps. As downloadID isn't used anywhere else, this won't effect other stuff
6. Also slightly improved redirect handling as this was my first theory as to why we got stuck downloads (it wasn't that).
7. Added a fallback to `getFileNameFromNetworkReply(QNetworkReply* reply)`
8. Commented out m_hasData as it is now obsolete
9. Slight improvements to the logic of `downloadFinished`

### Notable Changes
- Patched Qt deprecation: Using QMetaType with `typeId()` instead of `type()`
- I commented out `GeometrySettings::saveDocks(const QMainWindow* mw)` and `GeometrySettings::restoreDocks(const QMainWindow* mw)` as its comment states that the issue is long fixed in Qt

### Generic Changes
- Replaced a lot of inserts and push_backs with emplace or try_emplace or emplace_back when possible
  - emplace can construct objects in-place but can't be used on all occasions
- Passed objects by (const) reference when possible
  - lots of for-loops and a few other instances were copying objects instead of using a reference
- Passed most references to lambdas explicitely instead of using `&`
  - the compiler can help us better this way and we can clearly see what references are being used in the IDE
- Fixed some typos in header file definitions
- Changed some functions for cleaner code
  - e.g. using `isEmpty()` instead of `size() == 0`
  - moving from erase-remove_if-idioms to erase_if
- Reordered some class inits according to their defined order in the header
- commented out a few unused variables
- removed calls to std::move that weren't able to actually move something in the context used