### PR TITLE
Change IconDelegate::paintIcons to only execute when iconWidth > 0

### DIFF
--- a/src/icondelegate.cpp
+++ b/src/icondelegate.cpp
@@ -51,7 +51,7 @@ void IconDelegate::paintIcons(QPainter* painter, const QStyleOptionViewItem& opt
     iconWidth        = std::min(16, iconWidth);
     const int margin = (option.rect.height() - iconWidth) / 2;
     painter->translate(option.rect.topLeft());
-    int x            = 4;
+    int x = 4;
     for (const QString& iconId : icons) {
       if (iconId.isEmpty()) {
         x += iconWidth + 4;

--- a/src/icondelegate.cpp
+++ b/src/icondelegate.cpp
@@ -44,34 +44,34 @@ IconDelegate::IconDelegate(QTreeView* view, int column, int compactSize)
 void IconDelegate::paintIcons(QPainter* painter, const QStyleOptionViewItem& option,
                               const QModelIndex& index, const QList<QString>& icons)
 {
-  int x = 4;
-  painter->save();
+  int iconWidth = !icons.isEmpty() ? ((option.rect.width() / icons.size()) - 4) : 16;
 
-  int iconWidth = icons.size() > 0 ? ((option.rect.width() / icons.size()) - 4) : 16;
-  iconWidth     = std::min(16, iconWidth);
-
-  const int margin = (option.rect.height() - iconWidth) / 2;
-
-  painter->translate(option.rect.topLeft());
-  for (const QString& iconId : icons) {
-    if (iconId.isEmpty()) {
-      x += iconWidth + 4;
-      continue;
-    }
-    QPixmap icon;
-    QString fullIconId = QString("%1_%2").arg(iconId).arg(iconWidth);
-    if (!QPixmapCache::find(fullIconId, &icon)) {
-      icon = QIcon(iconId).pixmap(iconWidth, iconWidth);
-      if (icon.isNull()) {
-        log::warn("failed to load icon {}", iconId);
+  if (iconWidth > 0) {
+    painter->save();
+    iconWidth        = std::min(16, iconWidth);
+    const int margin = (option.rect.height() - iconWidth) / 2;
+    painter->translate(option.rect.topLeft());
+    int x            = 4;
+    for (const QString& iconId : icons) {
+      if (iconId.isEmpty()) {
+        x += iconWidth + 4;
+        continue;
       }
-      QPixmapCache::insert(fullIconId, icon);
+      QPixmap icon;
+      QString fullIconId = QString("%1_%2").arg(iconId).arg(iconWidth);
+      if (!QPixmapCache::find(fullIconId, &icon)) {
+        icon = QIcon(iconId).pixmap(iconWidth, iconWidth);
+        if (icon.isNull()) {
+          log::warn("failed to load icon {}", iconId);
+        }
+        QPixmapCache::insert(fullIconId, icon);
+      }
+      painter->drawPixmap(x, margin, iconWidth, iconWidth, icon);
+      x += iconWidth + 4;
     }
-    painter->drawPixmap(x, margin, iconWidth, iconWidth, icon);
-    x += iconWidth + 4;
-  }
 
-  painter->restore();
+    painter->restore();
+  }
 }
 
 void IconDelegate::paint(QPainter* painter, const QStyleOptionViewItem& option,


### PR DESCRIPTION
### Bug
When too many Content Icons are supposed to render in too little space in the mod table, the code tries to create a pixmap with dimensions 0x0 resulting in a null icon and generating warning messages in the log.
#### How to reproduce
- create a mod (or separator with many mods below it) which include many different file content categories
- 11 different content categories triggered the warning messages for me on default MO2 resolution with 1440p monitor
- alternatively resize the Content row to make it very small
- You might need to scroll to a "new" entry to trigger this code
### Fix 
Calculate the iconWidth first and then decide if we want to draw icons.
### Side effects?
I didn't encounter any unusual behavior and have been using this for a week now.
Content categories still get shown as usual when hovering over the content row of a modlist entry where this code skipped the icon painting.
It also looks the same whether or not null icons get "drawn".
Anything else that needs to be tested?

Edit: I said "category" but I meant "content"

Example:
<img width="788" height="833" alt="grafik" src="https://github.com/user-attachments/assets/29ec6764-f050-4895-9b4c-bec000fb9eaf" />
