### PR TITLE
Stable DownloadId refactor

### DIFF
--- a/src/downloadlist.cpp
+++ b/src/downloadlist.cpp
@@ -58,7 +58,9 @@ int DownloadList::columnCount(const QModelIndex&) const
 
 QModelIndex DownloadList::index(int row, int column, const QModelIndex&) const
 {
-  return createIndex(row, column, row);
+  // Embed the stable DownloadID in internalId() so any consumer of the index
+  // can identify the download without having to track row shifts.
+  return createIndex(row, column, m_manager.downloadIDAtRow(row));
 }
 
 QModelIndex DownloadList::parent(const QModelIndex&) const

--- a/src/downloadlist.cpp
+++ b/src/downloadlist.cpp
@@ -35,8 +35,10 @@ DownloadList::DownloadList(OrganizerCore& core, QObject* parent)
     : QAbstractTableModel(parent), m_manager(*core.downloadManager()),
       m_settings(core.settings())
 {
-  connect(&m_manager, SIGNAL(update(int)), this, SLOT(update(int)));
-  connect(&m_manager, SIGNAL(aboutToUpdate()), this, SLOT(aboutToUpdate()));
+  connect(&m_manager, &DownloadManager::aboutToResetModel, this,
+          &DownloadList::onAboutToResetModel);
+  connect(&m_manager, &DownloadManager::modelReset, this, &DownloadList::onModelReset);
+  connect(&m_manager, &DownloadManager::rowChanged, this, &DownloadList::onRowChanged);
 }
 
 int DownloadList::rowCount(const QModelIndex& parent) const
@@ -239,16 +241,19 @@ QVariant DownloadList::data(const QModelIndex& index, int role) const
   return QVariant();
 }
 
-void DownloadList::aboutToUpdate()
+void DownloadList::onAboutToResetModel()
 {
-  emit beginResetModel();
+  beginResetModel();
 }
 
-void DownloadList::update(int row)
+void DownloadList::onModelReset()
 {
-  if (row < 0)
-    emit endResetModel();
-  else if (row < this->rowCount())
+  endResetModel();
+}
+
+void DownloadList::onRowChanged(int row)
+{
+  if (row < this->rowCount())
     emit dataChanged(
         this->index(row, 0, QModelIndex()),
         this->index(row, this->columnCount(QModelIndex()) - 1, QModelIndex()));

--- a/src/downloadlist.cpp
+++ b/src/downloadlist.cpp
@@ -112,14 +112,14 @@ QVariant DownloadList::data(const QModelIndex& index, int role) const
   bool pendingDownload = index.row() >= m_manager.numTotalDownloads();
   if (role == Qt::DisplayRole) {
     if (pendingDownload) {
-      std::tuple<QString, int, int> nexusids =
+      const DownloadManager::PendingDownload pending =
           m_manager.getPendingDownload(index.row() - m_manager.numTotalDownloads());
       switch (index.column()) {
       case COL_NAME:
         return tr("< game %1 mod %2 file %3 >")
-            .arg(std::get<0>(nexusids))
-            .arg(std::get<1>(nexusids))
-            .arg(std::get<2>(nexusids));
+            .arg(pending.gameName)
+            .arg(pending.modID)
+            .arg(pending.fileID);
       case COL_SIZE:
         return tr("Unknown");
       case COL_STATUS:

--- a/src/downloadlist.h
+++ b/src/downloadlist.h
@@ -83,16 +83,20 @@ public:
   //
   bool lessThanPredicate(const QModelIndex& left, const QModelIndex& right);
 
-public slots:
+private slots:
 
   /**
-   * @brief used to inform the model that data has changed
-   *
-   * @param row the row that changed. This can be negative to update the whole view
-   **/
-  void update(int row);
+   * @brief full reset (row count changed). Drops selection and scroll state.
+   */
+  void onAboutToResetModel();
+  void onModelReset();
 
-  void aboutToUpdate();
+  /**
+   * @brief single-row data change (row count unchanged). Preserves view state.
+   *
+   * @param row the row that changed
+   */
+  void onRowChanged(int row);
 
 private:
   DownloadManager& m_manager;

--- a/src/downloadmanager.cpp
+++ b/src/downloadmanager.cpp
@@ -200,7 +200,7 @@ DirWatcherManager::Guard::Guard(DirWatcherManager& manager) : m_manager(manager)
 
 DirWatcherManager::Guard::~Guard()
 {
-  // Queued so file system notifications already posted during the 
+  // Queued so file system notifications already posted during the
   // suspension are dispatched (and filtered) before the suspension lifts.
   QMetaObject::invokeMethod(&m_manager, &DirWatcherManager::releaseSuspension,
                             Qt::QueuedConnection);

--- a/src/downloadmanager.cpp
+++ b/src/downloadmanager.cpp
@@ -741,7 +741,7 @@ DownloadManager::DownloadID DownloadManager::addNXMDownload(const QString& url)
         tr("This is a Nexus collections link. These are not yet supported by MO."));
     QMessageBox::information(m_ParentWidget, tr("Collections Not Supported"),
                              collectionStr, QMessageBox::Ok);
-    return;
+    return 0;
   }
 
   QStringList validGames;

--- a/src/downloadmanager.cpp
+++ b/src/downloadmanager.cpp
@@ -188,6 +188,11 @@ void DirWatcherManager::onDirectoryChanged(const QString&)
   }
 }
 
+void DirWatcherManager::releaseSuspension()
+{
+  --m_suspendDepth;
+}
+
 DirWatcherManager::Guard::Guard(DirWatcherManager& manager) : m_manager(manager)
 {
   ++m_manager.m_suspendDepth;
@@ -195,15 +200,10 @@ DirWatcherManager::Guard::Guard(DirWatcherManager& manager) : m_manager(manager)
 
 DirWatcherManager::Guard::~Guard()
 {
-  // drain queued events while still suspended so they are filtered out,
-  // then release.
-  //
-  // TODO: find alternative, pumping the event loop from a destructor is a reentrancy
-  // hazard; arbitrary slots may run during ~Guard.
-  if (m_manager.m_suspendDepth == 1) {
-    QCoreApplication::processEvents();
-  }
-  --m_manager.m_suspendDepth;
+  // Queued so file system notifications already posted during the 
+  // suspension are dispatched (and filtered) before the suspension lifts.
+  QMetaObject::invokeMethod(&m_manager, &DirWatcherManager::releaseSuspension,
+                            Qt::QueuedConnection);
 }
 
 DirWatcherManager::Guard DirWatcherManager::scopedGuard()

--- a/src/downloadmanager.cpp
+++ b/src/downloadmanager.cpp
@@ -193,8 +193,8 @@ DirWatcherManager::Guard::~Guard()
   // drain queued events while still suspended so they are filtered out,
   // then release.
   //
-  // TODO: find alternative, pumping the event loop from a destructor is a reentrancy hazard;
-  // arbitrary slots may run during ~Guard.
+  // TODO: find alternative, pumping the event loop from a destructor is a reentrancy
+  // hazard; arbitrary slots may run during ~Guard.
   if (m_manager.m_suspendDepth == 1) {
     QCoreApplication::processEvents();
   }
@@ -599,8 +599,7 @@ bool DownloadManager::addDownload(QNetworkReply* reply, const QStringList& URLs,
                "different name.")
                 .arg(baseName),
             QMessageBox::Yes | QMessageBox::No) == QMessageBox::No) {
-      removePending(newDownload->m_FileInfo->gameName,
-                    newDownload->m_FileInfo->modID,
+      removePending(newDownload->m_FileInfo->gameName, newDownload->m_FileInfo->modID,
                     newDownload->m_FileInfo->fileID);
       reply->abort();
       reply->deleteLater();
@@ -682,8 +681,7 @@ void DownloadManager::startDownload(QNetworkReply* reply, DownloadInfo* newDownl
     {
       // coalesce the pending removal and the active append into one reset
       ModelResetGuard guard(*this);
-      removePending(newDownload->m_FileInfo->gameName,
-                    newDownload->m_FileInfo->modID,
+      removePending(newDownload->m_FileInfo->gameName, newDownload->m_FileInfo->modID,
                     newDownload->m_FileInfo->fileID);
       m_ActiveDownloads.append(newDownload);
     }
@@ -753,7 +751,8 @@ void DownloadManager::addNXMDownload(const QString& url)
   }
 
   for (auto tuple : m_PendingDownloads) {
-    if (std::get<0>(tuple).compare(foundGame->gameShortName(), Qt::CaseInsensitive) == 0 &&
+    if (std::get<0>(tuple).compare(foundGame->gameShortName(), Qt::CaseInsensitive) ==
+            0 &&
         std::get<1>(tuple) == nxmInfo.modId() &&
         std::get<2>(tuple) == nxmInfo.fileId()) {
       const auto infoStr =

--- a/src/downloadmanager.cpp
+++ b/src/downloadmanager.cpp
@@ -915,9 +915,9 @@ void DownloadManager::restoreDownload(int index)
 
 void DownloadManager::removeDownload(int index, bool deleteFile)
 {
-  // validate the single-index case before entering the guard so we don't
-  // emit an empty reset on early return
-  if (index >= 0 && index >= m_ActiveDownloads.size()) {
+  // validate before entering the guard so we don't emit an empty reset on
+  // early return
+  if (index >= m_ActiveDownloads.size()) {
     reportError(tr("remove: invalid download index %1").arg(index));
     return;
   }
@@ -950,11 +950,11 @@ void DownloadManager::removeDownload(int index, bool deleteFile)
       delete m_ActiveDownloads.at(index);
       m_ActiveDownloads.erase(m_ActiveDownloads.begin() + index);
     }
-
-    refreshList();
   } catch (const std::exception& e) {
     log::error("failed to remove download: {}", e.what());
   }
+
+  refreshList();
 }
 
 void DownloadManager::cancelDownload(int index)

--- a/src/downloadmanager.cpp
+++ b/src/downloadmanager.cpp
@@ -717,12 +717,9 @@ bool DownloadManager::startDownload(QNetworkReply* reply, DownloadInfo* newDownl
   // Qt will not emit finished() to a slot connected after the reply has already
   // finished, so detect that case and drive the handler manually.
   if (reply->isFinished()) {
-    int index = indexByInfo(newDownload);
-    if (index >= 0) {
-      downloadFinished(index);
-    }
+    finishDownload(newDownload->m_DownloadID);
   } else {
-    connect(newDownload->m_Reply, SIGNAL(finished()), this, SLOT(downloadFinished()));
+    connect(newDownload->m_Reply, SIGNAL(finished()), this, SLOT(onReplyFinished()));
   }
   return true;
 }
@@ -1049,7 +1046,7 @@ void DownloadManager::resumeDownloadInt(int index)
   if (info->m_TotalSize <= info->m_Output.size() && info->m_Reply != nullptr &&
       info->m_Reply->isFinished() && info->m_State != STATE_ERROR) {
     setState(info, STATE_DOWNLOADING);
-    downloadFinished(index);
+    finishDownload(info->m_DownloadID);
     return;
   }
 
@@ -2273,134 +2270,136 @@ void DownloadManager::nxmRequestFailed(QString gameName, int modID, int fileID,
   emit showMessage(tr("Failed to request file info from nexus: %1").arg(errorString));
 }
 
-void DownloadManager::downloadFinished(int index)
+void DownloadManager::onReplyFinished()
+{
+  DownloadInfo* info = findDownload(this->sender());
+  if (info == nullptr) {
+    log::warn("finished signal from unknown reply");
+    return;
+  }
+  finishDownload(info->m_DownloadID);
+}
+
+void DownloadManager::finishDownload(unsigned int id)
 {
   DirWatcherManager::Guard dirWatcherGuard = m_DirWatcher.scopedGuard();
 
-  DownloadInfo* info;
-  if (index > 0)
-    info = m_ActiveDownloads[index];
-  else {
-    info = findDownload(this->sender(), &index);
-    if (info == nullptr && index == 0) {
-      info = m_ActiveDownloads[index];
+  DownloadInfo* info = m_ByID.value(id, nullptr);
+  if (info == nullptr) {
+    log::warn("no download with id {}", id);
+    return;
+  }
+  int index = indexByInfo(info);
+
+  QNetworkReply* reply = info->m_Reply;
+  QByteArray data;
+  if (reply->isOpen() && info->m_HasData) {
+    data = reply->readAll();
+    info->m_Output.write(data);
+  }
+  info->m_Output.close();
+  TaskProgressManager::instance().forgetMe(info->m_TaskProgressId);
+
+  bool error = false;
+  if ((info->m_State != STATE_CANCELING) && (info->m_State != STATE_PAUSING)) {
+    bool textData = reply->header(QNetworkRequest::ContentTypeHeader)
+                        .toString()
+                        .startsWith("text", Qt::CaseInsensitive);
+    if (textData)
+      emit showMessage(
+          tr("Warning: Content type is: %1")
+              .arg(reply->header(QNetworkRequest::ContentTypeHeader).toString()));
+    if ((info->m_Output.size() == 0) ||
+        ((reply->error() != QNetworkReply::NoError) &&
+         (reply->error() != QNetworkReply::OperationCanceledError))) {
+      if (reply->error() == QNetworkReply::UnknownContentError)
+        emit showMessage(
+            tr("Download header content length: %1 downloaded file size: %2")
+                .arg(reply->header(QNetworkRequest::ContentLengthHeader).toLongLong())
+                .arg(info->m_Output.size()));
+      if (info->m_Tries == 0) {
+        emit showMessage(tr("Download failed: %1 (%2)")
+                             .arg(reply->errorString())
+                             .arg(reply->error()));
+      }
+      error = true;
+      setState(info, STATE_ERROR);
     }
   }
 
-  if (info != nullptr) {
-    QNetworkReply* reply = info->m_Reply;
-    QByteArray data;
-    if (reply->isOpen() && info->m_HasData) {
-      data = reply->readAll();
-      info->m_Output.write(data);
+  if (info->m_State == STATE_CANCELING) {
+    setState(info, STATE_CANCELED);
+  } else if (info->m_State == STATE_PAUSING) {
+    if (info->m_Output.isOpen() && info->m_HasData) {
+      info->m_Output.write(info->m_Reply->readAll());
     }
+    setState(info, STATE_PAUSED);
+  }
+
+  if (info->m_State == STATE_CANCELED || (info->m_Tries == 0 && error)) {
+    {
+      ModelResetGuard guard(*this);
+      info->m_Output.remove();
+      m_ByID.remove(info->m_DownloadID);
+      delete info;
+      m_ActiveDownloads.erase(m_ActiveDownloads.begin() + index);
+    }
+    if (error)
+      emit showMessage(
+          tr("We were unable to download the file due to errors after four retries. "
+             "There may be an issue with the Nexus servers."));
+  } else if (info->isPausedState() || info->m_State == STATE_PAUSING) {
     info->m_Output.close();
-    TaskProgressManager::instance().forgetMe(info->m_TaskProgressId);
-
-    bool error = false;
-    if ((info->m_State != STATE_CANCELING) && (info->m_State != STATE_PAUSING)) {
-      bool textData = reply->header(QNetworkRequest::ContentTypeHeader)
-                          .toString()
-                          .startsWith("text", Qt::CaseInsensitive);
-      if (textData)
-        emit showMessage(
-            tr("Warning: Content type is: %1")
-                .arg(reply->header(QNetworkRequest::ContentTypeHeader).toString()));
-      if ((info->m_Output.size() == 0) ||
-          ((reply->error() != QNetworkReply::NoError) &&
-           (reply->error() != QNetworkReply::OperationCanceledError))) {
-        if (reply->error() == QNetworkReply::UnknownContentError)
-          emit showMessage(
-              tr("Download header content length: %1 downloaded file size: %2")
-                  .arg(reply->header(QNetworkRequest::ContentLengthHeader).toLongLong())
-                  .arg(info->m_Output.size()));
-        if (info->m_Tries == 0) {
-          emit showMessage(tr("Download failed: %1 (%2)")
-                               .arg(reply->errorString())
-                               .arg(reply->error()));
-        }
-        error = true;
-        setState(info, STATE_ERROR);
-      }
-    }
-
-    if (info->m_State == STATE_CANCELING) {
-      setState(info, STATE_CANCELED);
-    } else if (info->m_State == STATE_PAUSING) {
-      if (info->m_Output.isOpen() && info->m_HasData) {
-        info->m_Output.write(info->m_Reply->readAll());
-      }
-      setState(info, STATE_PAUSED);
-    }
-
-    if (info->m_State == STATE_CANCELED || (info->m_Tries == 0 && error)) {
-      {
-        ModelResetGuard guard(*this);
-        info->m_Output.remove();
-        m_ByID.remove(info->m_DownloadID);
-        delete info;
-        m_ActiveDownloads.erase(m_ActiveDownloads.begin() + index);
-      }
-      if (error)
-        emit showMessage(
-            tr("We were unable to download the file due to errors after four retries. "
-               "There may be an issue with the Nexus servers."));
-    } else if (info->isPausedState() || info->m_State == STATE_PAUSING) {
-      info->m_Output.close();
-      createMetaFile(info);
-    } else {
-      QString url = info->m_Urls[info->m_CurrentUrl];
-      if (info->m_FileInfo->userData.contains("downloadMap")) {
-        foreach (const QVariant& server,
-                 info->m_FileInfo->userData["downloadMap"].toList()) {
-          QVariantMap serverMap = server.toMap();
-          if (serverMap["URI"].toString() == url) {
-            int deltaTime = info->m_StartTime.elapsed() / 1000;
-            if (deltaTime > 5) {
-              emit downloadSpeed(serverMap["short_name"].toString(),
-                                 (info->m_TotalSize - info->m_PreResumeSize) /
-                                     deltaTime);
-            }  // no division by zero please! Also, if the download is shorter than a
-               // few seconds, the result is way to inprecise
-            break;
-          }
-        }
-      }
-
-      bool isNexus = info->m_FileInfo->repository == "Nexus";
-      // need to change state before changing the file name, otherwise .unfinished is
-      // appended
-      if (isNexus) {
-        setState(info, STATE_FETCHINGMODINFO);
-      } else {
-        setState(info, STATE_NOFETCH);
-      }
-
-      QString newName = getFileNameFromNetworkReply(reply);
-      QString oldName = QFileInfo(info->m_Output).fileName();
-
-      if (!newName.isEmpty() && (oldName.isEmpty())) {
-        info->setName(getDownloadFileName(newName), true);
-      } else {
-        info->setName(m_OutputDirectory + "/" + info->m_FileName,
-                      true);  // don't rename but remove the ".unfinished" extension
-      }
-
-      if (!isNexus) {
-        setState(info, STATE_READY);
-      }
-
-      notifyRowChanged(index);
-    }
-    reply->close();
-    reply->deleteLater();
-
-    if ((info->m_Tries > 0) && error) {
-      --info->m_Tries;
-      resumeDownloadInt(index);
-    }
+    createMetaFile(info);
   } else {
-    log::warn("no download index {}", index);
+    QString url = info->m_Urls[info->m_CurrentUrl];
+    if (info->m_FileInfo->userData.contains("downloadMap")) {
+      foreach (const QVariant& server,
+               info->m_FileInfo->userData["downloadMap"].toList()) {
+        QVariantMap serverMap = server.toMap();
+        if (serverMap["URI"].toString() == url) {
+          int deltaTime = info->m_StartTime.elapsed() / 1000;
+          if (deltaTime > 5) {
+            emit downloadSpeed(serverMap["short_name"].toString(),
+                               (info->m_TotalSize - info->m_PreResumeSize) / deltaTime);
+          }  // no division by zero please! Also, if the download is shorter than a
+             // few seconds, the result is way to inprecise
+          break;
+        }
+      }
+    }
+
+    bool isNexus = info->m_FileInfo->repository == "Nexus";
+    // need to change state before changing the file name, otherwise .unfinished is
+    // appended
+    if (isNexus) {
+      setState(info, STATE_FETCHINGMODINFO);
+    } else {
+      setState(info, STATE_NOFETCH);
+    }
+
+    QString newName = getFileNameFromNetworkReply(reply);
+    QString oldName = QFileInfo(info->m_Output).fileName();
+
+    if (!newName.isEmpty() && (oldName.isEmpty())) {
+      info->setName(getDownloadFileName(newName), true);
+    } else {
+      info->setName(m_OutputDirectory + "/" + info->m_FileName,
+                    true);  // don't rename but remove the ".unfinished" extension
+    }
+
+    if (!isNexus) {
+      setState(info, STATE_READY);
+    }
+
+    notifyRowChanged(index);
+  }
+  reply->close();
+  reply->deleteLater();
+
+  if ((info->m_Tries > 0) && error) {
+    --info->m_Tries;
+    resumeDownloadInt(index);
   }
 }
 
@@ -2453,7 +2452,7 @@ void DownloadManager::checkDownloadTimeout()
         m_ActiveDownloads[i]->m_Reply != nullptr &&
         m_ActiveDownloads[i]->m_Reply->isOpen()) {
       pauseDownload(i);
-      downloadFinished(i);
+      finishDownload(m_ActiveDownloads[i]->m_DownloadID);
       resumeDownload(i);
     }
   }

--- a/src/downloadmanager.cpp
+++ b/src/downloadmanager.cpp
@@ -83,20 +83,21 @@ DownloadManager::DownloadInfo::createFromMeta(const QString& filePath, bool show
                                               const QString outputDirectory,
                                               std::optional<uint64_t> fileSize)
 {
-  DownloadInfo* info = new DownloadInfo;
-
   QString metaFileName = filePath + ".meta";
   QFileInfo metaFileInfo(metaFileName);
   if (QDir::fromNativeSeparators(metaFileInfo.path())
           .compare(QDir::fromNativeSeparators(outputDirectory), Qt::CaseInsensitive) !=
       0)
     return nullptr;
+
   QSettings metaFile(metaFileName, QSettings::IniFormat);
-  if (!showHidden && metaFile.value("removed", false).toBool()) {
+  const bool hidden = metaFile.value("removed", false).toBool();
+  if (!showHidden && hidden) {
     return nullptr;
-  } else {
-    info->m_Hidden = metaFile.value("removed", false).toBool();
   }
+
+  DownloadInfo* info = new DownloadInfo;
+  info->m_Hidden     = hidden;
 
   QString fileName = QFileInfo(filePath).fileName();
 

--- a/src/downloadmanager.cpp
+++ b/src/downloadmanager.cpp
@@ -205,6 +205,30 @@ DirWatcherManager::Guard DirWatcherManager::scopedGuard()
   return Guard(*this);
 }
 
+DownloadManager::ModelResetGuard::ModelResetGuard(DownloadManager& manager)
+    : m_manager(manager)
+{
+  if (m_manager.m_modelResetDepth++ == 0) {
+    emit m_manager.aboutToResetModel();
+  }
+}
+
+DownloadManager::ModelResetGuard::~ModelResetGuard()
+{
+  if (--m_manager.m_modelResetDepth == 0) {
+    emit m_manager.modelReset();
+  }
+}
+
+void DownloadManager::notifyRowChanged(int row)
+{
+  // suppressed while a reset is in progress; the outer reset will refresh
+  // all rows on release
+  if (m_modelResetDepth == 0) {
+    emit rowChanged(row);
+  }
+}
+
 void DownloadManager::DownloadInfo::setName(QString newName, bool renameFile)
 {
   QString oldMetaFileName = QString("%1.meta").arg(m_FileName);
@@ -349,11 +373,10 @@ void DownloadManager::refreshList()
 {
   TimeThis tt("DownloadManager::refreshList()");
 
-  try {
-    emit aboutToUpdate();
-    // avoid triggering other refreshes
-    DirWatcherManager::Guard dirWatcherGuard = m_DirWatcher.scopedGuard();
+  DirWatcherManager::Guard dirWatcherGuard = m_DirWatcher.scopedGuard();
+  ModelResetGuard guard(*this);
 
+  try {
     int downloadsBefore = m_ActiveDownloads.size();
 
     // remove finished downloads
@@ -451,9 +474,6 @@ void DownloadManager::refreshList()
         });
 
     log::debug("saw {} downloads", m_ActiveDownloads.size());
-
-    emit update(-1);
-
   } catch (const std::bad_alloc&) {
     reportError(tr("Memory allocation error (in refreshing directory)."));
   }
@@ -575,7 +595,6 @@ bool DownloadManager::addDownload(QNetworkReply* reply, const QStringList& URLs,
   }
 
   startDownload(reply, newDownload, false);
-  //  emit update(-1);
   return true;
 }
 
@@ -592,15 +611,15 @@ void DownloadManager::removePending(QString gameName, int modID, int fileID)
       break;
     }
   }
-  emit aboutToUpdate();
   for (auto iter : m_PendingDownloads) {
     if (gameShortName.compare(std::get<0>(iter), Qt::CaseInsensitive) == 0 &&
         (std::get<1>(iter) == modID) && (std::get<2>(iter) == fileID)) {
+      // only emit a reset if we actually have a row to remove
+      ModelResetGuard guard(*this);
       m_PendingDownloads.removeAt(m_PendingDownloads.indexOf(iter));
       break;
     }
   }
-  emit update(-1);
 }
 
 void DownloadManager::startDownload(QNetworkReply* reply, DownloadInfo* newDownload,
@@ -639,13 +658,14 @@ void DownloadManager::startDownload(QNetworkReply* reply, DownloadInfo* newDownl
 
   if (!resume) {
     newDownload->m_PreResumeSize = newDownload->m_Output.size();
-    removePending(newDownload->m_FileInfo->gameName, newDownload->m_FileInfo->modID,
-                  newDownload->m_FileInfo->fileID);
-
-    emit aboutToUpdate();
-    m_ActiveDownloads.append(newDownload);
-
-    emit update(-1);
+    {
+      // coalesce the pending removal and the active append into one reset
+      ModelResetGuard guard(*this);
+      removePending(newDownload->m_FileInfo->gameName,
+                    newDownload->m_FileInfo->modID,
+                    newDownload->m_FileInfo->fileID);
+      m_ActiveDownloads.append(newDownload);
+    }
     emit downloadAdded();
 
     if (QFile::exists(m_OutputDirectory + "/" + newDownload->m_FileName)) {
@@ -808,12 +828,11 @@ void DownloadManager::addNXMDownload(const QString& url)
     }
   }
 
-  emit aboutToUpdate();
-
-  m_PendingDownloads.append(
-      std::make_tuple(foundGame->gameShortName(), nxmInfo.modId(), nxmInfo.fileId()));
-
-  emit update(-1);
+  {
+    ModelResetGuard guard(*this);
+    m_PendingDownloads.append(
+        std::make_tuple(foundGame->gameShortName(), nxmInfo.modId(), nxmInfo.fileId()));
+  }
   emit downloadAdded();
   ModRepositoryFileInfo* info = new ModRepositoryFileInfo();
 
@@ -935,11 +954,17 @@ void DownloadManager::restoreDownload(int index)
 
 void DownloadManager::removeDownload(int index, bool deleteFile)
 {
-  try {
-    // avoid dirWatcher triggering refreshes
-    DirWatcherManager::Guard dirWatcherGuard = m_DirWatcher.scopedGuard();
+  // validate the single-index case before entering the guard so we don't
+  // emit an empty reset on early return
+  if (index >= 0 && index >= m_ActiveDownloads.size()) {
+    reportError(tr("remove: invalid download index %1").arg(index));
+    return;
+  }
 
-    emit aboutToUpdate();
+  try {
+    DirWatcherManager::Guard dirWatcherGuard = m_DirWatcher.scopedGuard();
+    // coalesce the removal and the subsequent refresh into one reset
+    ModelResetGuard guard(*this);
 
     if (index < 0) {
       bool removeAll            = (index == -1);
@@ -960,21 +985,15 @@ void DownloadManager::removeDownload(int index, bool deleteFile)
         }
       }
     } else {
-      if (index >= m_ActiveDownloads.size()) {
-        reportError(tr("remove: invalid download index %1").arg(index));
-        // emit update(-1);
-        return;
-      }
-
       removeFile(index, deleteFile);
       delete m_ActiveDownloads.at(index);
       m_ActiveDownloads.erase(m_ActiveDownloads.begin() + index);
     }
-    emit update(-1);
+
+    refreshList();
   } catch (const std::exception& e) {
     log::error("failed to remove download: {}", e.what());
   }
-  refreshList();
 }
 
 void DownloadManager::cancelDownload(int index)
@@ -1074,7 +1093,7 @@ void DownloadManager::resumeDownloadInt(int index)
     log::debug("resume at {} bytes", info->m_ResumePos);
     startDownload(m_NexusInterface->getAccessManager()->get(request), info, true);
   }
-  emit update(index);
+  notifyRowChanged(index);
 }
 
 DownloadManager::DownloadInfo* DownloadManager::downloadInfoByID(unsigned int id)
@@ -1735,7 +1754,7 @@ void DownloadManager::downloadProgress(qint64 bytesReceived, qint64 bytesTotal)
 
         TaskProgressManager::instance().updateProgress(info->m_TaskProgressId,
                                                        bytesReceived, bytesTotal);
-        emit update(index);
+        notifyRowChanged(index);
       }
     }
   } catch (const std::bad_alloc&) {
@@ -1785,7 +1804,7 @@ void DownloadManager::createMetaFile(DownloadInfo* info)
   // slightly hackish...
   for (int i = 0; i < m_ActiveDownloads.size(); ++i) {
     if (m_ActiveDownloads[i] == info) {
-      emit update(i);
+      notifyRowChanged(i);
     }
   }
 }
@@ -2255,19 +2274,20 @@ void DownloadManager::nxmRequestFailed(QString gameName, int modID, int fileID,
       } else {
         info->m_State = STATE_READY;
         queryInfo(index);
-        emit update(index);
+        notifyRowChanged(index);
         return;
       }
     }
 
     if (info->m_FileInfo->modID == modID) {
       if (info->m_State < STATE_FETCHINGMODINFO) {
+        ModelResetGuard guard(*this);
         m_ActiveDownloads.erase(iter);
         delete info;
       } else {
         setState(info, STATE_READY);
+        notifyRowChanged(index);
       }
-      emit update(index);
       break;
     }
   }
@@ -2335,22 +2355,21 @@ void DownloadManager::downloadFinished(int index)
     }
 
     if (info->m_State == STATE_CANCELED || (info->m_Tries == 0 && error)) {
-      emit aboutToUpdate();
-      info->m_Output.remove();
-      delete info;
-      m_ActiveDownloads.erase(m_ActiveDownloads.begin() + index);
+      {
+        ModelResetGuard guard(*this);
+        info->m_Output.remove();
+        delete info;
+        m_ActiveDownloads.erase(m_ActiveDownloads.begin() + index);
+      }
       if (error)
         emit showMessage(
             tr("We were unable to download the file due to errors after four retries. "
                "There may be an issue with the Nexus servers."));
-      emit update(-1);
     } else if (info->isPausedState() || info->m_State == STATE_PAUSING) {
-      emit aboutToUpdate();
       info->m_Output.close();
       createMetaFile(info);
-      emit update(index);
+      notifyRowChanged(index);
     } else {
-      emit aboutToUpdate();
       QString url = info->m_Urls[info->m_CurrentUrl];
       if (info->m_FileInfo->userData.contains("downloadMap")) {
         foreach (const QVariant& server,
@@ -2395,7 +2414,7 @@ void DownloadManager::downloadFinished(int index)
         setState(info, STATE_READY);
       }
 
-      emit update(index);
+      notifyRowChanged(index);
     }
     reply->close();
     reply->deleteLater();

--- a/src/downloadmanager.cpp
+++ b/src/downloadmanager.cpp
@@ -385,8 +385,6 @@ void DownloadManager::refreshList()
   ModelResetGuard guard(*this);
 
   try {
-    int downloadsBefore = m_ActiveDownloads.size();
-
     // remove finished downloads
     for (QVector<DownloadInfo*>::iterator iter = m_ActiveDownloads.begin();
          iter != m_ActiveDownloads.end();) {
@@ -492,7 +490,7 @@ void DownloadManager::refreshList()
 void DownloadManager::queryDownloadListInfo()
 {
   int incompleteCount = 0;
-  for (size_t i = 0; i < m_ActiveDownloads.size(); i++) {
+  for (int i = 0; i < m_ActiveDownloads.size(); i++) {
     if (isInfoIncomplete(i)) {
       incompleteCount++;
     }
@@ -510,7 +508,7 @@ void DownloadManager::queryDownloadListInfo()
     log::info("Querying metadata for every download with incomplete info...");
     {
       DirWatcherManager::Guard dirWatcherGuard = m_DirWatcher.scopedGuard();
-      for (size_t i = 0; i < m_ActiveDownloads.size(); i++) {
+      for (int i = 0; i < m_ActiveDownloads.size(); i++) {
         if (isInfoIncomplete(i)) {
           queryInfoMd5(i, false);
         }
@@ -1715,7 +1713,6 @@ void DownloadManager::downloadProgress(qint64 bytesReceived, qint64 bytesTotal)
         if (bytesTotal > info->m_TotalSize) {
           info->m_TotalSize = bytesTotal;
         }
-        int oldProgress        = info->m_Progress.first;
         info->m_Progress.first = ((info->m_ResumePos + bytesReceived) * 100) /
                                  (info->m_ResumePos + bytesTotal);
 

--- a/src/downloadmanager.cpp
+++ b/src/downloadmanager.cpp
@@ -56,7 +56,6 @@ using namespace MOBase;
 static const char UNFINISHED[] = ".unfinished";
 
 unsigned int DownloadManager::DownloadInfo::s_NextDownloadID = 1U;
-int DownloadManager::m_DirWatcherDisabler                    = 0;
 
 DownloadManager::DownloadInfo*
 DownloadManager::DownloadInfo::createNew(const ModRepositoryFileInfo* fileInfo,
@@ -156,34 +155,54 @@ DownloadManager::DownloadInfo::createFromMeta(const QString& filePath, bool show
   return info;
 }
 
-ScopedDisableDirWatcher::ScopedDisableDirWatcher(DownloadManager* downloadManager)
+DirWatcherManager::DirWatcherManager(QObject* parent) : QObject(parent)
 {
-  m_downloadManager = downloadManager;
-  m_downloadManager->startDisableDirWatcher();
-  log::debug("Scoped Disable DirWatcher: Started");
+  connect(&m_watcher, &QFileSystemWatcher::directoryChanged, this,
+          &DirWatcherManager::onDirectoryChanged);
 }
 
-ScopedDisableDirWatcher::~ScopedDisableDirWatcher()
+void DirWatcherManager::setPath(const QString& path)
 {
-  m_downloadManager->endDisableDirWatcher();
-  m_downloadManager = nullptr;
-  log::debug("Scoped Disable DirWatcher: Stopped");
-}
-
-void DownloadManager::startDisableDirWatcher()
-{
-  DownloadManager::m_DirWatcherDisabler++;
-}
-
-void DownloadManager::endDisableDirWatcher()
-{
-  if (DownloadManager::m_DirWatcherDisabler > 0) {
-    if (DownloadManager::m_DirWatcherDisabler == 1)
-      QCoreApplication::processEvents();
-    DownloadManager::m_DirWatcherDisabler--;
-  } else {
-    DownloadManager::m_DirWatcherDisabler = 0;
+  const QStringList existing = m_watcher.directories();
+  if (!existing.isEmpty()) {
+    m_watcher.removePaths(existing);
   }
+  m_watcher.addPath(path);
+}
+
+bool DirWatcherManager::isSuspended() const
+{
+  return m_suspendDepth > 0;
+}
+
+void DirWatcherManager::onDirectoryChanged(const QString&)
+{
+  if (!isSuspended()) {
+    emit directoryChanged();
+  }
+}
+
+DirWatcherManager::Guard::Guard(DirWatcherManager& manager) : m_manager(manager)
+{
+  ++m_manager.m_suspendDepth;
+}
+
+DirWatcherManager::Guard::~Guard()
+{
+  // drain queued events while still suspended so they are filtered out,
+  // then release.
+  //
+  // TODO: find alternative, pumping the event loop from a destructor is a reentrancy hazard;
+  // arbitrary slots may run during ~Guard.
+  if (m_manager.m_suspendDepth == 1) {
+    QCoreApplication::processEvents();
+  }
+  --m_manager.m_suspendDepth;
+}
+
+DirWatcherManager::Guard DirWatcherManager::scopedGuard()
+{
+  return Guard(*this);
 }
 
 void DownloadManager::DownloadInfo::setName(QString newName, bool renameFile)
@@ -225,12 +244,12 @@ QString DownloadManager::DownloadInfo::currentURL()
 }
 
 DownloadManager::DownloadManager(NexusInterface* nexusInterface, QObject* parent)
-    : m_NexusInterface(nexusInterface), m_DirWatcher(), m_ShowHidden(false),
+    : m_NexusInterface(nexusInterface), m_DirWatcher(this), m_ShowHidden(false),
       m_ParentWidget(nullptr)
 {
   m_OrganizerCore = dynamic_cast<OrganizerCore*>(parent);
-  connect(&m_DirWatcher, SIGNAL(directoryChanged(QString)), this,
-          SLOT(directoryChanged(QString)));
+  connect(&m_DirWatcher, &DirWatcherManager::directoryChanged, this,
+          &DownloadManager::refreshList);
   m_TimeoutTimer.setSingleShot(false);
   // connect(&m_TimeoutTimer, SIGNAL(timeout()), this, SLOT(checkDownloadTimeout()));
   m_TimeoutTimer.start(5 * 1000);
@@ -308,15 +327,11 @@ void DownloadManager::pauseAll()
 void DownloadManager::setOutputDirectory(const QString& outputDirectory,
                                          const bool refresh)
 {
-  QStringList directories = m_DirWatcher.directories();
-  if (directories.length() != 0) {
-    m_DirWatcher.removePaths(directories);
-  }
   m_OutputDirectory = QDir::fromNativeSeparators(outputDirectory);
   if (refresh) {
     refreshList();
   }
-  m_DirWatcher.addPath(m_OutputDirectory);
+  m_DirWatcher.setPath(m_OutputDirectory);
 }
 
 void DownloadManager::setShowHidden(bool showHidden)
@@ -337,7 +352,7 @@ void DownloadManager::refreshList()
   try {
     emit aboutToUpdate();
     // avoid triggering other refreshes
-    ScopedDisableDirWatcher scopedDirWatcher(this);
+    DirWatcherManager::Guard dirWatcherGuard = m_DirWatcher.scopedGuard();
 
     int downloadsBefore = m_ActiveDownloads.size();
 
@@ -463,13 +478,14 @@ void DownloadManager::queryDownloadListInfo()
           QMessageBox::Yes | QMessageBox::No) == QMessageBox::Yes) {
     TimeThis tt("DownloadManager::queryDownloadListInfo()");
     log::info("Querying metadata for every download with incomplete info...");
-    startDisableDirWatcher();
-    for (size_t i = 0; i < m_ActiveDownloads.size(); i++) {
-      if (isInfoIncomplete(i)) {
-        queryInfoMd5(i, false);
+    {
+      DirWatcherManager::Guard dirWatcherGuard = m_DirWatcher.scopedGuard();
+      for (size_t i = 0; i < m_ActiveDownloads.size(); i++) {
+        if (isInfoIncomplete(i)) {
+          queryInfoMd5(i, false);
+        }
       }
     }
-    endDisableDirWatcher();
     log::info("Metadata has been retrieved successfully!");
   }
 }
@@ -553,9 +569,10 @@ bool DownloadManager::addDownload(QNetworkReply* reply, const QStringList& URLs,
     baseName.truncate(queryIndex);
   }
 
-  startDisableDirWatcher();
-  newDownload->setName(getDownloadFileName(baseName), false);
-  endDisableDirWatcher();
+  {
+    DirWatcherManager::Guard dirWatcherGuard = m_DirWatcher.scopedGuard();
+    newDownload->setName(getDownloadFileName(baseName), false);
+  }
 
   startDownload(reply, newDownload, false);
   //  emit update(-1);
@@ -646,9 +663,11 @@ void DownloadManager::startDownload(QNetworkReply* reply, DownloadInfo* newDownl
         else
           setState(newDownload, STATE_CANCELING);
       } else {
-        startDisableDirWatcher();
-        newDownload->setName(getDownloadFileName(newDownload->m_FileName, true), true);
-        endDisableDirWatcher();
+        {
+          DirWatcherManager::Guard dirWatcherGuard = m_DirWatcher.scopedGuard();
+          newDownload->setName(getDownloadFileName(newDownload->m_FileName, true),
+                               true);
+        }
         if (newDownload->m_State == STATE_PAUSED)
           resumeDownload(indexByInfo(newDownload));
         else
@@ -811,7 +830,7 @@ void DownloadManager::addNXMDownload(const QString& url)
 void DownloadManager::removeFile(int index, bool deleteFile)
 {
   // Avoid triggering refreshes from DirWatcher
-  ScopedDisableDirWatcher scopedDirWatcher(this);
+  DirWatcherManager::Guard dirWatcherGuard = m_DirWatcher.scopedGuard();
 
   if (index >= m_ActiveDownloads.size()) {
     throw MyException(tr("remove: invalid download index %1").arg(index));
@@ -907,11 +926,9 @@ void DownloadManager::restoreDownload(int index)
       QString filePath = m_OutputDirectory + "/" + download->m_FileName;
 
       // avoid dirWatcher triggering refreshes
-      startDisableDirWatcher();
+      DirWatcherManager::Guard dirWatcherGuard = m_DirWatcher.scopedGuard();
       QSettings metaSettings(filePath.append(".meta"), QSettings::IniFormat);
       metaSettings.setValue("removed", false);
-
-      endDisableDirWatcher();
     }
   }
 }
@@ -920,7 +937,7 @@ void DownloadManager::removeDownload(int index, bool deleteFile)
 {
   try {
     // avoid dirWatcher triggering refreshes
-    ScopedDisableDirWatcher scopedDirWatcher(this);
+    DirWatcherManager::Guard dirWatcherGuard = m_DirWatcher.scopedGuard();
 
     emit aboutToUpdate();
 
@@ -1509,7 +1526,7 @@ void DownloadManager::markInstalled(int index)
   }
 
   // Avoid triggering refreshes from DirWatcher
-  ScopedDisableDirWatcher scopedDirWatcher(this);
+  DirWatcherManager::Guard dirWatcherGuard = m_DirWatcher.scopedGuard();
 
   DownloadInfo* info = m_ActiveDownloads.at(index);
   QSettings metaFile(info->m_Output.fileName() + ".meta", QSettings::IniFormat);
@@ -1528,7 +1545,7 @@ void DownloadManager::markInstalled(QString fileName)
     DownloadInfo* info = getDownloadInfo(fileName);
     if (info != nullptr) {
       // Avoid triggering refreshes from DirWatcher
-      ScopedDisableDirWatcher scopedDirWatcher(this);
+      DirWatcherManager::Guard dirWatcherGuard = m_DirWatcher.scopedGuard();
 
       QSettings metaFile(info->m_Output.fileName() + ".meta", QSettings::IniFormat);
       metaFile.setValue("installed", true);
@@ -1550,7 +1567,7 @@ void DownloadManager::markUninstalled(int index)
   }
 
   // Avoid triggering refreshes from DirWatcher
-  ScopedDisableDirWatcher scopedDirWatcher(this);
+  DirWatcherManager::Guard dirWatcherGuard = m_DirWatcher.scopedGuard();
 
   DownloadInfo* info = m_ActiveDownloads.at(index);
   QSettings metaFile(info->m_Output.fileName() + ".meta", QSettings::IniFormat);
@@ -1570,7 +1587,7 @@ void DownloadManager::markUninstalled(QString fileName)
     if (info != nullptr) {
 
       // Avoid triggering refreshes from DirWatcher
-      ScopedDisableDirWatcher scopedDirWatcher(this);
+      DirWatcherManager::Guard dirWatcherGuard = m_DirWatcher.scopedGuard();
 
       QSettings metaFile(info->m_Output.fileName() + ".meta", QSettings::IniFormat);
       metaFile.setValue("uninstalled", true);
@@ -1738,7 +1755,7 @@ void DownloadManager::downloadReadyRead()
 void DownloadManager::createMetaFile(DownloadInfo* info)
 {
   // Avoid triggering refreshes from DirWatcher
-  ScopedDisableDirWatcher scopedDirWatcher(this);
+  DirWatcherManager::Guard dirWatcherGuard = m_DirWatcher.scopedGuard();
 
   QSettings metaFile(QString("%1.meta").arg(info->m_Output.fileName()),
                      QSettings::IniFormat);
@@ -2364,14 +2381,15 @@ void DownloadManager::downloadFinished(int index)
       QString newName = getFileNameFromNetworkReply(reply);
       QString oldName = QFileInfo(info->m_Output).fileName();
 
-      startDisableDirWatcher();
-      if (!newName.isEmpty() && (oldName.isEmpty())) {
-        info->setName(getDownloadFileName(newName), true);
-      } else {
-        info->setName(m_OutputDirectory + "/" + info->m_FileName,
-                      true);  // don't rename but remove the ".unfinished" extension
+      {
+        DirWatcherManager::Guard dirWatcherGuard = m_DirWatcher.scopedGuard();
+        if (!newName.isEmpty() && (oldName.isEmpty())) {
+          info->setName(getDownloadFileName(newName), true);
+        } else {
+          info->setName(m_OutputDirectory + "/" + info->m_FileName,
+                        true);  // don't rename but remove the ".unfinished" extension
+        }
       }
-      endDisableDirWatcher();
 
       if (!isNexus) {
         setState(info, STATE_READY);
@@ -2409,9 +2427,10 @@ void DownloadManager::metaDataChanged()
   if (info != nullptr) {
     QString newName = getFileNameFromNetworkReply(info->m_Reply);
     if (!newName.isEmpty() && (info->m_FileName.isEmpty())) {
-      startDisableDirWatcher();
-      info->setName(getDownloadFileName(newName), true);
-      endDisableDirWatcher();
+      {
+        DirWatcherManager::Guard dirWatcherGuard = m_DirWatcher.scopedGuard();
+        info->setName(getDownloadFileName(newName), true);
+      }
       refreshAlphabeticalTranslation();
       if (!info->m_Output.isOpen() &&
           !info->m_Output.open(QIODevice::WriteOnly | QIODevice::Append)) {
@@ -2422,12 +2441,6 @@ void DownloadManager::metaDataChanged()
   } else {
     log::warn("meta data event for unknown download");
   }
-}
-
-void DownloadManager::directoryChanged(const QString&)
-{
-  if (DownloadManager::m_DirWatcherDisabler == 0)
-    refreshList();
 }
 
 void DownloadManager::managedGameChanged(MOBase::IPluginGame const* managedGame)

--- a/src/downloadmanager.cpp
+++ b/src/downloadmanager.cpp
@@ -760,10 +760,9 @@ void DownloadManager::addNXMDownload(const QString& url)
   }
 
   for (auto tuple : m_PendingDownloads) {
-    if (std::get<0>(tuple).compare(foundGame->gameShortName(), Qt::CaseInsensitive) ==
-            0,
+    if (std::get<0>(tuple).compare(foundGame->gameShortName(), Qt::CaseInsensitive) == 0 &&
         std::get<1>(tuple) == nxmInfo.modId() &&
-            std::get<2>(tuple) == nxmInfo.fileId()) {
+        std::get<2>(tuple) == nxmInfo.fileId()) {
       const auto infoStr =
           tr("There is already a download queued for this file.\n\nMod %1\nFile %2")
               .arg(nxmInfo.modId())

--- a/src/downloadmanager.cpp
+++ b/src/downloadmanager.cpp
@@ -604,19 +604,19 @@ bool DownloadManager::addDownload(QNetworkReply* reply, const QStringList& URLs,
                "different name.")
                 .arg(baseName),
             QMessageBox::Yes | QMessageBox::No) == QMessageBox::No) {
-      notifyPendingDownloadFailed(gameName, modID, fileID);
-      removePending(gameName, modID, fileID);
-      reply->abort();
-      reply->deleteLater();
-      delete newDownload;
+      cancelPendingDownload(newDownload, reply);
       return false;
     }
     renameToUnique = true;
   }
 
-  {
+  try {
     DirWatcherManager::Guard dirWatcherGuard = m_DirWatcher.scopedGuard();
     newDownload->setName(getDownloadFileName(baseName, renameToUnique), false);
+  } catch (const std::exception& e) {
+    log::error("exception preparing download: {}", e.what());
+    cancelPendingDownload(newDownload, reply);
+    return false;
   }
 
   return startDownload(reply, newDownload, false);
@@ -631,6 +631,21 @@ void DownloadManager::notifyPendingDownloadFailed(const QString& gameName, int m
       m_DownloadFailed(pending.reservedID);
       return;
     }
+  }
+}
+
+void DownloadManager::cancelPendingDownload(DownloadInfo* newDownload,
+                                            QNetworkReply* reply)
+{
+  notifyPendingDownloadFailed(newDownload->m_FileInfo->gameName,
+                              newDownload->m_FileInfo->modID,
+                              newDownload->m_FileInfo->fileID);
+  removePending(newDownload->m_FileInfo->gameName, newDownload->m_FileInfo->modID,
+                newDownload->m_FileInfo->fileID);
+  delete newDownload;
+  if (reply != nullptr) {
+    reply->abort();
+    reply->deleteLater();
   }
 }
 
@@ -673,16 +688,7 @@ bool DownloadManager::startDownload(QNetworkReply* reply, DownloadInfo* newDownl
                     .arg(reply->url().toString())
                     .arg(newDownload->m_Output.fileName()));
     if (!resume) {
-      // newDownload has not been appended to m_ActiveDownloads yet: drop it
-      // here, otherwise it leaks. The resume path is owned elsewhere.
-      notifyPendingDownloadFailed(newDownload->m_FileInfo->gameName,
-                                  newDownload->m_FileInfo->modID,
-                                  newDownload->m_FileInfo->fileID);
-      removePending(newDownload->m_FileInfo->gameName, newDownload->m_FileInfo->modID,
-                    newDownload->m_FileInfo->fileID);
-      reply->abort();
-      reply->deleteLater();
-      delete newDownload;
+      cancelPendingDownload(newDownload, reply);
     }
     return false;
   }

--- a/src/downloadmanager.cpp
+++ b/src/downloadmanager.cpp
@@ -922,10 +922,11 @@ void DownloadManager::removeDownload(int index, bool deleteFile)
     return;
   }
 
+  // coalesce the removal and the subsequent refresh into one reset
+  ModelResetGuard guard(*this);
+
   try {
     DirWatcherManager::Guard dirWatcherGuard = m_DirWatcher.scopedGuard();
-    // coalesce the removal and the subsequent refresh into one reset
-    ModelResetGuard guard(*this);
 
     if (index < 0) {
       bool removeAll            = (index == -1);

--- a/src/downloadmanager.cpp
+++ b/src/downloadmanager.cpp
@@ -1278,6 +1278,7 @@ void DownloadManager::openMetaFile(int index)
     shell::Open(metaPath);
     return;
   } else {
+    DirWatcherManager::Guard dirWatcherGuard = m_DirWatcher.scopedGuard();
     QSettings metaFile(metaPath, QSettings::IniFormat);
     metaFile.setValue("removed", false);
   }

--- a/src/downloadmanager.cpp
+++ b/src/downloadmanager.cpp
@@ -2070,6 +2070,32 @@ int DownloadManager::indexByInfo(const DownloadInfo* info) const
   return -1;
 }
 
+DownloadManager::DownloadID DownloadManager::downloadIDAtRow(int row) const
+{
+  if (row >= 0 && row < m_ActiveDownloads.size()) {
+    return m_ActiveDownloads[row]->m_DownloadID;
+  }
+  const int pendingRow = row - m_ActiveDownloads.size();
+  if (pendingRow >= 0 && pendingRow < m_PendingDownloads.size()) {
+    return m_PendingDownloads[pendingRow].reservedID;
+  }
+  return 0;
+}
+
+int DownloadManager::rowForDownloadID(DownloadID id) const
+{
+  if (DownloadInfo* info = m_ByID.value(id, nullptr)) {
+    return indexByInfo(info);
+  }
+  const int base = m_ActiveDownloads.size();
+  for (int i = 0; i < m_PendingDownloads.size(); ++i) {
+    if (m_PendingDownloads[i].reservedID == id) {
+      return base + i;
+    }
+  }
+  return -1;
+}
+
 void DownloadManager::nxmDownloadURLsAvailable(QString gameName, int modID, int fileID,
                                                QVariant userData, QVariant resultData,
                                                int requestID)

--- a/src/downloadmanager.cpp
+++ b/src/downloadmanager.cpp
@@ -1606,15 +1606,16 @@ void DownloadManager::markUninstalled(QString fileName)
 
 QString DownloadManager::getDownloadFileName(const QString& baseName, bool rename) const
 {
-  QString fullPath = m_OutputDirectory + "/" + MOBase::sanitizeFileName(baseName);
+  const QString sanitized = MOBase::sanitizeFileName(baseName);
+  QString fullPath        = m_OutputDirectory + "/" + sanitized;
   if (QFile::exists(fullPath) && rename) {
     int i = 1;
     while (QFile::exists(
-        QString("%1/%2_%3").arg(m_OutputDirectory).arg(i).arg(baseName))) {
+        QString("%1/%2_%3").arg(m_OutputDirectory).arg(i).arg(sanitized))) {
       ++i;
     }
 
-    fullPath = QString("%1/%2_%3").arg(m_OutputDirectory).arg(i).arg(baseName);
+    fullPath = QString("%1/%2_%3").arg(m_OutputDirectory).arg(i).arg(sanitized);
   }
   return fullPath;
 }

--- a/src/downloadmanager.cpp
+++ b/src/downloadmanager.cpp
@@ -848,7 +848,6 @@ void DownloadManager::addNXMDownload(const QString& url)
 
 void DownloadManager::removeFile(int index, bool deleteFile)
 {
-  // Avoid triggering refreshes from DirWatcher
   DirWatcherManager::Guard dirWatcherGuard = m_DirWatcher.scopedGuard();
 
   if (index >= m_ActiveDownloads.size()) {
@@ -944,10 +943,13 @@ void DownloadManager::restoreDownload(int index)
 
       QString filePath = m_OutputDirectory + "/" + download->m_FileName;
 
-      // avoid dirWatcher triggering refreshes
-      DirWatcherManager::Guard dirWatcherGuard = m_DirWatcher.scopedGuard();
-      QSettings metaSettings(filePath.append(".meta"), QSettings::IniFormat);
-      metaSettings.setValue("removed", false);
+      {
+        DirWatcherManager::Guard dirWatcherGuard = m_DirWatcher.scopedGuard();
+        QSettings metaSettings(filePath.append(".meta"), QSettings::IniFormat);
+        metaSettings.setValue("removed", false);
+      }
+
+      notifyRowChanged(index);
     }
   }
 }
@@ -1093,7 +1095,6 @@ void DownloadManager::resumeDownloadInt(int index)
     log::debug("resume at {} bytes", info->m_ResumePos);
     startDownload(m_NexusInterface->getAccessManager()->get(request), info, true);
   }
-  notifyRowChanged(index);
 }
 
 DownloadManager::DownloadInfo* DownloadManager::downloadInfoByID(unsigned int id)
@@ -1544,7 +1545,6 @@ void DownloadManager::markInstalled(int index)
     throw MyException(tr("mark installed: invalid download index %1").arg(index));
   }
 
-  // Avoid triggering refreshes from DirWatcher
   DirWatcherManager::Guard dirWatcherGuard = m_DirWatcher.scopedGuard();
 
   DownloadInfo* info = m_ActiveDownloads.at(index);
@@ -1563,7 +1563,6 @@ void DownloadManager::markInstalled(QString fileName)
   } else {
     DownloadInfo* info = getDownloadInfo(fileName);
     if (info != nullptr) {
-      // Avoid triggering refreshes from DirWatcher
       DirWatcherManager::Guard dirWatcherGuard = m_DirWatcher.scopedGuard();
 
       QSettings metaFile(info->m_Output.fileName() + ".meta", QSettings::IniFormat);
@@ -1585,7 +1584,6 @@ void DownloadManager::markUninstalled(int index)
     throw MyException(tr("mark uninstalled: invalid download index %1").arg(index));
   }
 
-  // Avoid triggering refreshes from DirWatcher
   DirWatcherManager::Guard dirWatcherGuard = m_DirWatcher.scopedGuard();
 
   DownloadInfo* info = m_ActiveDownloads.at(index);
@@ -1605,7 +1603,6 @@ void DownloadManager::markUninstalled(QString fileName)
     DownloadInfo* info = getDownloadInfo(filePath);
     if (info != nullptr) {
 
-      // Avoid triggering refreshes from DirWatcher
       DirWatcherManager::Guard dirWatcherGuard = m_DirWatcher.scopedGuard();
 
       QSettings metaFile(info->m_Output.fileName() + ".meta", QSettings::IniFormat);
@@ -1648,28 +1645,26 @@ QString DownloadManager::getFileNameFromNetworkReply(QNetworkReply* reply)
 void DownloadManager::setState(DownloadManager::DownloadInfo* info,
                                DownloadManager::DownloadState state)
 {
-  int row = 0;
-  for (int i = 0; i < m_ActiveDownloads.size(); ++i) {
-    if (m_ActiveDownloads[i] == info) {
-      row = i;
-      break;
-    }
-  }
   info->m_State = state;
+  // Row is re-looked up at each use: reply->abort() and plugin callbacks can
+  // re-enter and erase info (and info may not be tracked yet on first state).
   switch (state) {
   case STATE_PAUSED: {
     info->m_Reply->abort();
     info->m_Output.close();
-    m_DownloadPaused(row);
+    if (const int r = indexByInfo(info); r >= 0)
+      m_DownloadPaused(r);
   } break;
   case STATE_ERROR: {
     info->m_Reply->abort();
     info->m_Output.close();
-    m_DownloadFailed(row);
+    if (const int r = indexByInfo(info); r >= 0)
+      m_DownloadFailed(r);
   } break;
   case STATE_CANCELED: {
     info->m_Reply->abort();
-    m_DownloadFailed(row);
+    if (const int r = indexByInfo(info); r >= 0)
+      m_DownloadFailed(r);
   } break;
   case STATE_FETCHINGMODINFO: {
     m_RequestIDs.insert(m_NexusInterface->requestDescription(
@@ -1689,12 +1684,16 @@ void DownloadManager::setState(DownloadManager::DownloadInfo* info,
   } break;
   case STATE_READY: {
     createMetaFile(info);
-    m_DownloadComplete(row);
+    if (const int r = indexByInfo(info); r >= 0)
+      m_DownloadComplete(r);
   } break;
   default: /* NOP */
     break;
   }
-  emit stateChanged(row, state);
+  if (const int row = indexByInfo(info); row >= 0) {
+    emit stateChanged(row, state);
+    notifyRowChanged(row);
+  }
 }
 
 DownloadManager::DownloadInfo* DownloadManager::findDownload(QObject* reply,
@@ -1773,7 +1772,6 @@ void DownloadManager::downloadReadyRead()
 
 void DownloadManager::createMetaFile(DownloadInfo* info)
 {
-  // Avoid triggering refreshes from DirWatcher
   DirWatcherManager::Guard dirWatcherGuard = m_DirWatcher.scopedGuard();
 
   QSettings metaFile(QString("%1.meta").arg(info->m_Output.fileName()),
@@ -1800,13 +1798,6 @@ void DownloadManager::createMetaFile(DownloadInfo* info)
   metaFile.setValue("paused", (info->m_State == DownloadManager::STATE_PAUSED) ||
                                   (info->m_State == DownloadManager::STATE_ERROR));
   metaFile.setValue("removed", info->m_Hidden);
-
-  // slightly hackish...
-  for (int i = 0; i < m_ActiveDownloads.size(); ++i) {
-    if (m_ActiveDownloads[i] == info) {
-      notifyRowChanged(i);
-    }
-  }
 }
 
 void DownloadManager::nxmDescriptionAvailable(QString, int, QVariant userData,
@@ -2274,7 +2265,6 @@ void DownloadManager::nxmRequestFailed(QString gameName, int modID, int fileID,
       } else {
         info->m_State = STATE_READY;
         queryInfo(index);
-        notifyRowChanged(index);
         return;
       }
     }
@@ -2286,7 +2276,6 @@ void DownloadManager::nxmRequestFailed(QString gameName, int modID, int fileID,
         delete info;
       } else {
         setState(info, STATE_READY);
-        notifyRowChanged(index);
       }
       break;
     }
@@ -2298,6 +2287,8 @@ void DownloadManager::nxmRequestFailed(QString gameName, int modID, int fileID,
 
 void DownloadManager::downloadFinished(int index)
 {
+  DirWatcherManager::Guard dirWatcherGuard = m_DirWatcher.scopedGuard();
+
   DownloadInfo* info;
   if (index > 0)
     info = m_ActiveDownloads[index];
@@ -2368,7 +2359,6 @@ void DownloadManager::downloadFinished(int index)
     } else if (info->isPausedState() || info->m_State == STATE_PAUSING) {
       info->m_Output.close();
       createMetaFile(info);
-      notifyRowChanged(index);
     } else {
       QString url = info->m_Urls[info->m_CurrentUrl];
       if (info->m_FileInfo->userData.contains("downloadMap")) {
@@ -2400,14 +2390,11 @@ void DownloadManager::downloadFinished(int index)
       QString newName = getFileNameFromNetworkReply(reply);
       QString oldName = QFileInfo(info->m_Output).fileName();
 
-      {
-        DirWatcherManager::Guard dirWatcherGuard = m_DirWatcher.scopedGuard();
-        if (!newName.isEmpty() && (oldName.isEmpty())) {
-          info->setName(getDownloadFileName(newName), true);
-        } else {
-          info->setName(m_OutputDirectory + "/" + info->m_FileName,
-                        true);  // don't rename but remove the ".unfinished" extension
-        }
+      if (!newName.isEmpty() && (oldName.isEmpty())) {
+        info->setName(getDownloadFileName(newName), true);
+      } else {
+        info->setName(m_OutputDirectory + "/" + info->m_FileName,
+                      true);  // don't rename but remove the ".unfinished" extension
       }
 
       if (!isNexus) {
@@ -2451,6 +2438,7 @@ void DownloadManager::metaDataChanged()
         info->setName(getDownloadFileName(newName), true);
       }
       refreshAlphabeticalTranslation();
+      notifyRowChanged(index);
       if (!info->m_Output.isOpen() &&
           !info->m_Output.open(QIODevice::WriteOnly | QIODevice::Append)) {
         reportError(tr("failed to re-open %1").arg(info->m_FileName));

--- a/src/downloadmanager.cpp
+++ b/src/downloadmanager.cpp
@@ -876,38 +876,6 @@ void DownloadManager::removeFile(int index, bool deleteFile)
   m_DownloadRemoved(index);
 }
 
-class LessThanWrapper
-{
-public:
-  LessThanWrapper(DownloadManager* manager) : m_Manager(manager) {}
-  bool operator()(int LHS, int RHS)
-  {
-    return m_Manager->getFileName(LHS).compare(m_Manager->getFileName(RHS),
-                                               Qt::CaseInsensitive) < 0;
-  }
-
-private:
-  DownloadManager* m_Manager;
-};
-
-bool DownloadManager::ByName(int LHS, int RHS)
-{
-  return m_ActiveDownloads[LHS]->m_FileName < m_ActiveDownloads[RHS]->m_FileName;
-}
-
-void DownloadManager::refreshAlphabeticalTranslation()
-{
-  m_AlphabeticalTranslation.clear();
-  int pos = 0;
-  for (QVector<DownloadInfo*>::iterator iter = m_ActiveDownloads.begin();
-       iter != m_ActiveDownloads.end(); ++iter, ++pos) {
-    m_AlphabeticalTranslation.push_back(pos);
-  }
-
-  std::sort(m_AlphabeticalTranslation.begin(), m_AlphabeticalTranslation.end(),
-            LessThanWrapper(this));
-}
-
 void DownloadManager::restoreDownload(int index)
 {
 
@@ -2429,7 +2397,6 @@ void DownloadManager::metaDataChanged()
         DirWatcherManager::Guard dirWatcherGuard = m_DirWatcher.scopedGuard();
         info->setName(getDownloadFileName(newName), true);
       }
-      refreshAlphabeticalTranslation();
       notifyRowChanged(index);
       if (!info->m_Output.isOpen() &&
           !info->m_Output.open(QIODevice::WriteOnly | QIODevice::Append)) {

--- a/src/downloadmanager.cpp
+++ b/src/downloadmanager.cpp
@@ -330,8 +330,7 @@ void DownloadManager::pauseAll()
 
   auto stillTransitioning = [this] {
     for (const DownloadInfo* info : m_ActiveDownloads) {
-      if (info->m_State < STATE_CANCELED ||
-          info->m_State == STATE_FETCHINGFILEINFO ||
+      if (info->m_State < STATE_CANCELED || info->m_State == STATE_FETCHINGFILEINFO ||
           info->m_State == STATE_FETCHINGMODINFO ||
           info->m_State == STATE_FETCHINGMODINFO_MD5) {
         return true;
@@ -679,8 +678,7 @@ bool DownloadManager::startDownload(QNetworkReply* reply, DownloadInfo* newDownl
       notifyPendingDownloadFailed(newDownload->m_FileInfo->gameName,
                                   newDownload->m_FileInfo->modID,
                                   newDownload->m_FileInfo->fileID);
-      removePending(newDownload->m_FileInfo->gameName,
-                    newDownload->m_FileInfo->modID,
+      removePending(newDownload->m_FileInfo->gameName, newDownload->m_FileInfo->modID,
                     newDownload->m_FileInfo->fileID);
       reply->abort();
       reply->deleteLater();
@@ -719,7 +717,10 @@ bool DownloadManager::startDownload(QNetworkReply* reply, DownloadInfo* newDownl
   // queued call rather than reentering startDownload synchronously.
   if (reply->isFinished()) {
     QMetaObject::invokeMethod(
-        this, [this, id = newDownload->m_DownloadID] { finishDownload(id); },
+        this,
+        [this, id = newDownload->m_DownloadID] {
+          finishDownload(id);
+        },
         Qt::QueuedConnection);
   }
   return true;

--- a/src/downloadmanager.cpp
+++ b/src/downloadmanager.cpp
@@ -589,9 +589,29 @@ bool DownloadManager::addDownload(QNetworkReply* reply, const QStringList& URLs,
     baseName.truncate(queryIndex);
   }
 
+  bool renameToUnique = false;
+  if (QFile::exists(m_OutputDirectory + "/" + MOBase::sanitizeFileName(baseName))) {
+    if (QMessageBox::question(
+            m_ParentWidget, tr("Download again?"),
+            tr("A file with the same name \"%1\" has already been downloaded. "
+               "Do you want to download it again? The new file will receive a "
+               "different name.")
+                .arg(baseName),
+            QMessageBox::Yes | QMessageBox::No) == QMessageBox::No) {
+      removePending(newDownload->m_FileInfo->gameName,
+                    newDownload->m_FileInfo->modID,
+                    newDownload->m_FileInfo->fileID);
+      reply->abort();
+      reply->deleteLater();
+      delete newDownload;
+      return false;
+    }
+    renameToUnique = true;
+  }
+
   {
     DirWatcherManager::Guard dirWatcherGuard = m_DirWatcher.scopedGuard();
-    newDownload->setName(getDownloadFileName(baseName), false);
+    newDownload->setName(getDownloadFileName(baseName, renameToUnique), false);
   }
 
   startDownload(reply, newDownload, false);
@@ -668,47 +688,19 @@ void DownloadManager::startDownload(QNetworkReply* reply, DownloadInfo* newDownl
     }
     emit downloadAdded();
 
-    if (QFile::exists(m_OutputDirectory + "/" + newDownload->m_FileName)) {
-      setState(newDownload, STATE_PAUSING);
-      QCoreApplication::processEvents();
-      if (QMessageBox::question(
-              m_ParentWidget, tr("Download again?"),
-              tr("A file with the same name \"%1\" has already been downloaded. "
-                 "Do you want to download it again? The new file will receive a "
-                 "different name.")
-                  .arg(newDownload->m_FileName),
-              QMessageBox::Yes | QMessageBox::No) == QMessageBox::No) {
-        if (reply->isFinished())
-          setState(newDownload, STATE_CANCELED);
-        else
-          setState(newDownload, STATE_CANCELING);
-      } else {
-        {
-          DirWatcherManager::Guard dirWatcherGuard = m_DirWatcher.scopedGuard();
-          newDownload->setName(getDownloadFileName(newDownload->m_FileName, true),
-                               true);
-        }
-        if (newDownload->m_State == STATE_PAUSED)
-          resumeDownload(indexByInfo(newDownload));
-        else
-          setState(newDownload, STATE_DOWNLOADING);
-      }
-    } else
-      connect(newDownload->m_Reply, SIGNAL(finished()), this, SLOT(downloadFinished()));
-
     QCoreApplication::processEvents();
+  }
 
-    if (newDownload->m_State != STATE_DOWNLOADING &&
-        newDownload->m_State != STATE_READY &&
-        newDownload->m_State != STATE_FETCHINGMODINFO && reply->isFinished()) {
-      int index = indexByInfo(newDownload);
-      if (index >= 0) {
-        downloadFinished(index);
-      }
-      return;
+  // Qt will not emit finished() to a slot connected after the reply has already
+  // finished, so detect that case and drive the handler manually.
+  if (reply->isFinished()) {
+    int index = indexByInfo(newDownload);
+    if (index >= 0) {
+      downloadFinished(index);
     }
-  } else
+  } else {
     connect(newDownload->m_Reply, SIGNAL(finished()), this, SLOT(downloadFinished()));
+  }
 }
 
 void DownloadManager::addNXMDownload(const QString& url)

--- a/src/downloadmanager.cpp
+++ b/src/downloadmanager.cpp
@@ -620,17 +620,7 @@ bool DownloadManager::addDownload(QNetworkReply* reply, const QStringList& URLs,
 
 void DownloadManager::removePending(QString gameName, int modID, int fileID)
 {
-  QString gameShortName = gameName;
-  QStringList games(m_ManagedGame->validShortNames());
-  games += m_ManagedGame->gameShortName();
-  for (auto game : games) {
-    MOBase::IPluginGame* gamePlugin = m_OrganizerCore->getGame(game);
-    if (gamePlugin != nullptr &&
-        gamePlugin->gameNexusName().compare(gameName, Qt::CaseInsensitive) == 0) {
-      gameShortName = gamePlugin->gameShortName();
-      break;
-    }
-  }
+  QString gameShortName = getValidGameShortName(gameName);
   for (auto iter : m_PendingDownloads) {
     if (gameShortName.compare(std::get<0>(iter), Qt::CaseInsensitive) == 0 &&
         (std::get<1>(iter) == modID) && (std::get<2>(iter) == fileID)) {
@@ -1917,15 +1907,7 @@ void DownloadManager::nxmFileInfoAvailable(QString gameName, int modID, int file
 
   info->repository = "Nexus";
 
-  QStringList games(m_ManagedGame->validShortNames());
-  games += m_ManagedGame->gameShortName();
-  for (auto game : games) {
-    MOBase::IPluginGame* gamePlugin = m_OrganizerCore->getGame(game);
-    if (gamePlugin != nullptr &&
-        gamePlugin->gameNexusName().compare(gameName, Qt::CaseInsensitive) == 0) {
-      info->gameName = gamePlugin->gameShortName();
-    }
-  }
+  info->gameName = getValidGameShortName(gameName);
 
   info->modID  = modID;
   info->fileID = fileID;
@@ -2169,19 +2151,7 @@ void DownloadManager::nxmFileInfoFromMd5Available(QString gameName, QVariant use
   info->m_FileInfo->uploader    = modDetails["uploaded_by"].toString();
   info->m_FileInfo->uploaderUrl = modDetails["uploaded_users_profile_url"].toString();
 
-  QString gameShortName = gameName;
-  QStringList games(m_ManagedGame->validShortNames());
-  games += m_ManagedGame->gameShortName();
-  for (auto game : games) {
-    MOBase::IPluginGame* gamePlugin = m_OrganizerCore->getGame(game);
-    if (gamePlugin != nullptr &&
-        gamePlugin->gameNexusName().compare(gameName, Qt::CaseInsensitive) == 0) {
-      gameShortName = gamePlugin->gameShortName();
-      break;
-    }
-  }
-
-  info->m_FileInfo->gameName = gameShortName;
+  info->m_FileInfo->gameName = getValidGameShortName(gameName);
 
   // If the file description is not present, send another query to get it
   if (!fileDetails["description"].isValid()) {
@@ -2451,4 +2421,19 @@ void DownloadManager::writeData(DownloadInfo* info)
                       .arg(fileName));
     }
   }
+}
+
+QString DownloadManager::getValidGameShortName(const QString& gameNexusName) const
+{
+  QStringList games(m_ManagedGame->validShortNames());
+  games.prepend(m_ManagedGame->gameShortName());
+  for (auto& game : games) {
+    MOBase::IPluginGame* gamePlugin = m_OrganizerCore->getGame(game);
+    if (gamePlugin != nullptr &&
+        gamePlugin->gameNexusName().compare(gameNexusName, Qt::CaseInsensitive) == 0) {
+      return gamePlugin->gameShortName();
+    }
+  }
+
+  return gameNexusName;
 }

--- a/src/downloadmanager.cpp
+++ b/src/downloadmanager.cpp
@@ -605,6 +605,7 @@ bool DownloadManager::addDownload(QNetworkReply* reply, const QStringList& URLs,
                "different name.")
                 .arg(baseName),
             QMessageBox::Yes | QMessageBox::No) == QMessageBox::No) {
+      notifyPendingDownloadFailed(gameName, modID, fileID);
       removePending(gameName, modID, fileID);
       reply->abort();
       reply->deleteLater();

--- a/src/downloadmanager.cpp
+++ b/src/downloadmanager.cpp
@@ -43,7 +43,6 @@ along with Mod Organizer.  If not, see <http://www.gnu.org/licenses/>.
 #include <QInputDialog>
 #include <QMessageBox>
 #include <QTextDocument>
-#include <QTimer>
 
 #include <boost/bind/bind.hpp>
 #include <regex>
@@ -281,9 +280,6 @@ DownloadManager::DownloadManager(NexusInterface* nexusInterface, QObject* parent
   m_OrganizerCore = dynamic_cast<OrganizerCore*>(parent);
   connect(&m_DirWatcher, &DirWatcherManager::directoryChanged, this,
           &DownloadManager::refreshList);
-  m_TimeoutTimer.setSingleShot(false);
-  // connect(&m_TimeoutTimer, SIGNAL(timeout()), this, SLOT(checkDownloadTimeout()));
-  m_TimeoutTimer.start(5 * 1000);
 }
 
 DownloadManager::~DownloadManager()
@@ -2466,20 +2462,6 @@ void DownloadManager::metaDataChanged()
 void DownloadManager::managedGameChanged(MOBase::IPluginGame const* managedGame)
 {
   m_ManagedGame = managedGame;
-}
-
-void DownloadManager::checkDownloadTimeout()
-{
-  for (DownloadInfo* info : m_ActiveDownloads) {
-    if (info->m_StartTime.elapsed() - info->m_DownloadTimeLast > 5 * 1000 &&
-        info->m_State == STATE_DOWNLOADING && info->m_Reply != nullptr &&
-        info->m_Reply->isOpen()) {
-      const DownloadID id = info->m_DownloadID;
-      pauseDownload(id);
-      finishDownload(id);
-      resumeDownload(id);
-    }
-  }
 }
 
 void DownloadManager::writeData(DownloadInfo* info)

--- a/src/downloadmanager.cpp
+++ b/src/downloadmanager.cpp
@@ -35,7 +35,6 @@ along with Mod Organizer.  If not, see <http://www.gnu.org/licenses/>.
 #include <taskprogressmanager.h>
 #include <utility.h>
 
-#include <QCoreApplication>
 #include <QDesktopServices>
 #include <QDirIterator>
 #include <QEventLoop>
@@ -694,6 +693,7 @@ bool DownloadManager::startDownload(QNetworkReply* reply, DownloadInfo* newDownl
   connect(newDownload->m_Reply, SIGNAL(readyRead()), this, SLOT(downloadReadyRead()));
   connect(newDownload->m_Reply, SIGNAL(metaDataChanged()), this,
           SLOT(metaDataChanged()));
+  connect(newDownload->m_Reply, SIGNAL(finished()), this, SLOT(onReplyFinished()));
 
   if (!resume) {
     newDownload->m_PreResumeSize = newDownload->m_Output.size();
@@ -706,16 +706,14 @@ bool DownloadManager::startDownload(QNetworkReply* reply, DownloadInfo* newDownl
       m_ByID.insert(newDownload->m_DownloadID, newDownload);
     }
     emit downloadAdded();
-
-    QCoreApplication::processEvents();
   }
 
-  // Qt will not emit finished() to a slot connected after the reply has already
-  // finished, so detect that case and drive the handler manually.
+  // Reply may have finished before we connected; defer a manual finish via a
+  // queued call rather than reentering startDownload synchronously.
   if (reply->isFinished()) {
-    finishDownload(newDownload->m_DownloadID);
-  } else {
-    connect(newDownload->m_Reply, SIGNAL(finished()), this, SLOT(onReplyFinished()));
+    QMetaObject::invokeMethod(
+        this, [this, id = newDownload->m_DownloadID] { finishDownload(id); },
+        Qt::QueuedConnection);
   }
   return true;
 }

--- a/src/downloadmanager.cpp
+++ b/src/downloadmanager.cpp
@@ -64,10 +64,11 @@ unsigned int DownloadManager::DownloadInfo::newDownloadID()
 
 DownloadManager::DownloadInfo*
 DownloadManager::DownloadInfo::createNew(const ModRepositoryFileInfo* fileInfo,
-                                         const QStringList& URLs)
+                                         const QStringList& URLs,
+                                         std::optional<unsigned int> reservedID)
 {
   DownloadInfo* info = new DownloadInfo;
-  info->m_DownloadID = newDownloadID();
+  info->m_DownloadID = reservedID.has_value() ? *reservedID : newDownloadID();
   info->m_StartTime.start();
   info->m_PreResumeSize  = 0LL;
   info->m_Progress       = std::make_pair<int, QString>(0, "0.0 B/s ");
@@ -520,7 +521,8 @@ void DownloadManager::queryDownloadListInfo()
 }
 
 bool DownloadManager::addDownload(const QStringList& URLs, QString gameName, int modID,
-                                  int fileID, const ModRepositoryFileInfo* fileInfo)
+                                  int fileID, const ModRepositoryFileInfo* fileInfo,
+                                  std::optional<unsigned int> reservedID)
 {
   QString fileName = QFileInfo(URLs.first()).fileName();
   if (fileName.isEmpty()) {
@@ -558,7 +560,7 @@ bool DownloadManager::addDownload(const QStringList& URLs, QString gameName, int
                        QNetworkRequest::AlwaysNetwork);
   request.setHttp2Configuration(h2Conf);
   return addDownload(m_NexusInterface->getAccessManager()->get(request), URLs, fileName,
-                     gameName, modID, fileID, fileInfo);
+                     gameName, modID, fileID, fileInfo, reservedID);
 }
 
 bool DownloadManager::addDownload(QNetworkReply* reply,
@@ -575,11 +577,12 @@ bool DownloadManager::addDownload(QNetworkReply* reply,
 
 bool DownloadManager::addDownload(QNetworkReply* reply, const QStringList& URLs,
                                   const QString& fileName, QString gameName, int modID,
-                                  int fileID, const ModRepositoryFileInfo* fileInfo)
+                                  int fileID, const ModRepositoryFileInfo* fileInfo,
+                                  std::optional<unsigned int> reservedID)
 {
   // download invoked from an already open network reply (i.e. download link in the
   // browser)
-  DownloadInfo* newDownload = DownloadInfo::createNew(fileInfo, URLs);
+  DownloadInfo* newDownload = DownloadInfo::createNew(fileInfo, URLs, reservedID);
 
   QString baseName = fileName;
   if (!fileInfo->fileName.isEmpty()) {
@@ -607,8 +610,7 @@ bool DownloadManager::addDownload(QNetworkReply* reply, const QStringList& URLs,
                "different name.")
                 .arg(baseName),
             QMessageBox::Yes | QMessageBox::No) == QMessageBox::No) {
-      removePending(newDownload->m_FileInfo->gameName, newDownload->m_FileInfo->modID,
-                    newDownload->m_FileInfo->fileID);
+      removePending(gameName, modID, fileID);
       reply->abort();
       reply->deleteLater();
       delete newDownload;
@@ -622,8 +624,19 @@ bool DownloadManager::addDownload(QNetworkReply* reply, const QStringList& URLs,
     newDownload->setName(getDownloadFileName(baseName, renameToUnique), false);
   }
 
-  startDownload(reply, newDownload, false);
-  return true;
+  return startDownload(reply, newDownload, false);
+}
+
+void DownloadManager::notifyPendingDownloadFailed(const QString& gameName, int modID,
+                                                  int fileID)
+{
+  for (const PendingDownload& pending : m_PendingDownloads) {
+    if (pending.gameName.compare(gameName, Qt::CaseInsensitive) == 0 &&
+        pending.modID == modID && pending.fileID == fileID) {
+      m_DownloadFailed(pending.reservedID);
+      return;
+    }
+  }
 }
 
 void DownloadManager::removePending(QString gameName, int modID, int fileID)
@@ -642,7 +655,7 @@ void DownloadManager::removePending(QString gameName, int modID, int fileID)
   }
 }
 
-void DownloadManager::startDownload(QNetworkReply* reply, DownloadInfo* newDownload,
+bool DownloadManager::startDownload(QNetworkReply* reply, DownloadInfo* newDownload,
                                     bool resume)
 {
   reply->setReadBufferSize(
@@ -659,14 +672,24 @@ void DownloadManager::startDownload(QNetworkReply* reply, DownloadInfo* newDownl
   }
 
   newDownload->m_StartTime.start();
-  createMetaFile(newDownload);
 
   if (!newDownload->m_Output.open(mode)) {
     reportError(tr("failed to download %1: could not open output file: %2")
                     .arg(reply->url().toString())
                     .arg(newDownload->m_Output.fileName()));
-    return;
+    if (!resume) {
+      // newDownload has not been appended to m_ActiveDownloads yet: drop it
+      // here, otherwise it leaks. The resume path is owned elsewhere.
+      reply->abort();
+      reply->deleteLater();
+      delete newDownload;
+    }
+    return false;
   }
+
+  // Write the .meta only once we know the download is actually going to start.
+  // Otherwise a failed start leaves an orphan .meta on disk.
+  createMetaFile(newDownload);
 
   connect(newDownload->m_Reply, SIGNAL(downloadProgress(qint64, qint64)), this,
           SLOT(downloadProgress(qint64, qint64)));
@@ -701,9 +724,10 @@ void DownloadManager::startDownload(QNetworkReply* reply, DownloadInfo* newDownl
   } else {
     connect(newDownload->m_Reply, SIGNAL(finished()), this, SLOT(downloadFinished()));
   }
+  return true;
 }
 
-void DownloadManager::addNXMDownload(const QString& url)
+unsigned int DownloadManager::addNXMDownload(const QString& url)
 {
   NXMUrl nxmInfo(url);
 
@@ -748,9 +772,11 @@ void DownloadManager::addNXMDownload(const QString& url)
             .arg(nxmInfo.game())
             .arg(m_ManagedGame->gameShortName()),
         QMessageBox::Ok);
-    return;
+    return 0;
   }
 
+  // If a pending entry already covers this file, return its id so callers that
+  // poll by id see the same download regardless of how many times they queue.
   for (const PendingDownload& pending : m_PendingDownloads) {
     if (pending.gameName.compare(foundGame->gameShortName(), Qt::CaseInsensitive) == 0 &&
         pending.modID == nxmInfo.modId() && pending.fileID == nxmInfo.fileId()) {
@@ -764,7 +790,7 @@ void DownloadManager::addNXMDownload(const QString& url)
 
       QMessageBox::information(m_ParentWidget, tr("Already Queued"), infoStr,
                                QMessageBox::Ok);
-      return;
+      return pending.reservedID;
     }
   }
 
@@ -813,15 +839,19 @@ void DownloadManager::addNXMDownload(const QString& url)
         log::debug("{}", debugStr);
         QMessageBox::information(m_ParentWidget, tr("Already Started"), infoStr,
                                  QMessageBox::Ok);
-        return;
+        return download->m_DownloadID;
       }
     }
   }
 
+  // Reserve the id now (before any async work) so the caller can refer to the
+  // eventual download before the Nexus API responds and a DownloadInfo exists.
+  const unsigned int reservedID = DownloadInfo::newDownloadID();
+
   {
     ModelResetGuard guard(*this);
     PendingDownload pending{foundGame->gameShortName(), nxmInfo.modId(),
-                            nxmInfo.fileId()};
+                            nxmInfo.fileId(), reservedID};
     m_PendingDownloads.append(pending);
   }
   emit downloadAdded();
@@ -835,6 +865,7 @@ void DownloadManager::addNXMDownload(const QString& url)
   m_RequestIDs.insert(m_NexusInterface->requestFileInfo(
       foundGame->gameShortName(), nxmInfo.modId(), nxmInfo.fileId(), this,
       QVariant::fromValue(test), ""));
+  return reservedID;
 }
 
 void DownloadManager::removeFile(int index, bool deleteFile)
@@ -873,7 +904,7 @@ void DownloadManager::removeFile(int index, bool deleteFile)
     if (!download->m_Hidden)
       metaSettings.setValue("removed", true);
   }
-  m_DownloadRemoved(index);
+  m_DownloadRemoved(download->m_DownloadID);
 }
 
 void DownloadManager::restoreDownload(int index)
@@ -1602,47 +1633,48 @@ QString DownloadManager::getFileNameFromNetworkReply(QNetworkReply* reply)
 void DownloadManager::setState(DownloadManager::DownloadInfo* info,
                                DownloadManager::DownloadState state)
 {
-  info->m_State = state;
-  // Row is re-looked up at each use: reply->abort() and plugin callbacks can
-  // re-enter and erase info (and info may not be tracked yet on first state).
+  // Cache the id before reply->abort(): aborting fires signals synchronously
+  // and a slot may erase info, leaving this pointer dangling. The id is stable
+  // and m_ByID.contains() lets us check whether info is still present afterward.
+  const unsigned int id = info->m_DownloadID;
+  info->m_State         = state;
   switch (state) {
   case STATE_PAUSED: {
     info->m_Reply->abort();
     info->m_Output.close();
-    if (const int r = indexByInfo(info); r >= 0)
-      m_DownloadPaused(r);
+    if (m_ByID.contains(id))
+      m_DownloadPaused(id);
   } break;
   case STATE_ERROR: {
     info->m_Reply->abort();
     info->m_Output.close();
-    if (const int r = indexByInfo(info); r >= 0)
-      m_DownloadFailed(r);
+    if (m_ByID.contains(id))
+      m_DownloadFailed(id);
   } break;
   case STATE_CANCELED: {
     info->m_Reply->abort();
-    if (const int r = indexByInfo(info); r >= 0)
-      m_DownloadFailed(r);
+    if (m_ByID.contains(id))
+      m_DownloadFailed(id);
   } break;
   case STATE_FETCHINGMODINFO: {
     m_RequestIDs.insert(m_NexusInterface->requestDescription(
-        info->m_FileInfo->gameName, info->m_FileInfo->modID, this, info->m_DownloadID,
-        QString()));
+        info->m_FileInfo->gameName, info->m_FileInfo->modID, this, id, QString()));
   } break;
   case STATE_FETCHINGFILEINFO: {
     m_RequestIDs.insert(m_NexusInterface->requestFiles(info->m_FileInfo->gameName,
                                                        info->m_FileInfo->modID, this,
-                                                       info->m_DownloadID, QString()));
+                                                       id, QString()));
   } break;
   case STATE_FETCHINGMODINFO_MD5: {
     log::debug("Searching {} for MD5 of {}", info->m_GamesToQuery[0],
                QString(info->m_Hash.toHex()));
     m_RequestIDs.insert(m_NexusInterface->requestInfoFromMd5(
-        info->m_GamesToQuery[0], info->m_Hash, this, info->m_DownloadID, QString()));
+        info->m_GamesToQuery[0], info->m_Hash, this, id, QString()));
   } break;
   case STATE_READY: {
     createMetaFile(info);
-    if (const int r = indexByInfo(info); r >= 0)
-      m_DownloadComplete(r);
+    if (m_ByID.contains(id))
+      m_DownloadComplete(id);
   } break;
   default: /* NOP */
     break;
@@ -1957,9 +1989,12 @@ bool ServerByPreference(const ServerList::container& preferredServers,
 
 int DownloadManager::startDownloadURLs(const QStringList& urls)
 {
+  const unsigned int reservedID = DownloadInfo::newDownloadID();
   ModRepositoryFileInfo info;
-  addDownload(urls, "", -1, -1, &info);
-  return m_ActiveDownloads.size() - 1;
+  if (!addDownload(urls, "", -1, -1, &info, reservedID)) {
+    return 0;
+  }
+  return static_cast<int>(reservedID);
 }
 
 int DownloadManager::startDownloadURLWithMeta(const QString& url, const QString& name,
@@ -1981,15 +2016,17 @@ int DownloadManager::startDownloadURLWithMeta(const QString& url, const QString&
 int DownloadManager::startDownloadNexusFile(const QString& gameName, int modID,
                                             int fileID)
 {
-  int newID = m_ActiveDownloads.size();
-  addNXMDownload(
-      QString("nxm://%1/mods/%2/files/%3").arg(gameName).arg(modID).arg(fileID));
-  return newID;
+  return static_cast<int>(addNXMDownload(
+      QString("nxm://%1/mods/%2/files/%3").arg(gameName).arg(modID).arg(fileID)));
 }
 
 QString DownloadManager::downloadPath(int id)
 {
-  return getFilePath(id);
+  DownloadInfo* info = downloadInfoByID(static_cast<unsigned int>(id));
+  if (info == nullptr) {
+    return QString();
+  }
+  return m_OutputDirectory + "/" + info->m_FileName;
 }
 
 boost::signals2::connection
@@ -2053,6 +2090,7 @@ void DownloadManager::nxmDownloadURLsAvailable(QString gameName, int modID, int 
       qobject_cast<ModRepositoryFileInfo*>(qvariant_cast<QObject*>(userData));
   QVariantList resultList = resultData.toList();
   if (resultList.length() == 0) {
+    notifyPendingDownloadFailed(gameName, modID, fileID);
     removePending(gameName, modID, fileID);
     emit showMessage(tr("No download server available. Please try again later."));
     return;
@@ -2070,7 +2108,18 @@ void DownloadManager::nxmDownloadURLsAvailable(QString gameName, int modID, int 
   foreach (const QVariant& server, resultList) {
     URLs.append(server.toMap()["URI"].toString());
   }
-  addDownload(URLs, gameName, modID, fileID, info);
+
+  // Carry the pending entry's reserved id into the DownloadInfo so callers who
+  // received it from addNXMDownload can continue to identify the download.
+  std::optional<unsigned int> reservedID;
+  for (const PendingDownload& pending : m_PendingDownloads) {
+    if (pending.gameName.compare(gameName, Qt::CaseInsensitive) == 0 &&
+        pending.modID == modID && pending.fileID == fileID) {
+      reservedID = pending.reservedID;
+      break;
+    }
+  }
+  addDownload(URLs, gameName, modID, fileID, info, reservedID);
 }
 
 void DownloadManager::nxmFileInfoFromMd5Available(QString gameName, QVariant userData,
@@ -2219,6 +2268,7 @@ void DownloadManager::nxmRequestFailed(QString gameName, int modID, int fileID,
     }
   }
 
+  notifyPendingDownloadFailed(gameName, modID, fileID);
   removePending(gameName, modID, fileID);
   emit showMessage(tr("Failed to request file info from nexus: %1").arg(errorString));
 }

--- a/src/downloadmanager.cpp
+++ b/src/downloadmanager.cpp
@@ -38,11 +38,13 @@ along with Mod Organizer.  If not, see <http://www.gnu.org/licenses/>.
 #include <QCoreApplication>
 #include <QDesktopServices>
 #include <QDirIterator>
+#include <QEventLoop>
 #include <QFileInfo>
 #include <QHttp2Configuration>
 #include <QInputDialog>
 #include <QMessageBox>
 #include <QTextDocument>
+#include <QTimer>
 
 #include <boost/bind/bind.hpp>
 #include <regex>
@@ -321,35 +323,35 @@ bool DownloadManager::downloadsInProgressNoPause()
 
 void DownloadManager::pauseAll()
 {
-
-  // first loop: pause all downloads
   for (DownloadInfo* info : m_ActiveDownloads) {
     if (info->m_State < STATE_READY) {
       pauseDownload(info->m_DownloadID);
     }
   }
 
-  ::Sleep(100);
-
-  bool done       = false;
-  QTime startTime = QTime::currentTime();
-  // further loops: busy waiting for all downloads to complete. This could be neater...
-  while (!done && (startTime.secsTo(QTime::currentTime()) < 5)) {
-    QCoreApplication::processEvents();
-    done = true;
-    foreach (DownloadInfo* info, m_ActiveDownloads) {
-      if ((info->m_State < STATE_CANCELED) ||
-          (info->m_State == STATE_FETCHINGFILEINFO) ||
-          (info->m_State == STATE_FETCHINGMODINFO) ||
-          (info->m_State == STATE_FETCHINGMODINFO_MD5)) {
-        done = false;
-        break;
+  auto stillTransitioning = [this] {
+    for (const DownloadInfo* info : m_ActiveDownloads) {
+      if (info->m_State < STATE_CANCELED ||
+          info->m_State == STATE_FETCHINGFILEINFO ||
+          info->m_State == STATE_FETCHINGMODINFO ||
+          info->m_State == STATE_FETCHINGMODINFO_MD5) {
+        return true;
       }
     }
-    if (!done) {
-      ::Sleep(100);
+    return false;
+  };
+
+  QEventLoop loop;
+  QTimer::singleShot(5000, &loop, &QEventLoop::quit);
+  const auto conn = connect(this, &DownloadManager::stateChanged, &loop, [&] {
+    if (!stillTransitioning()) {
+      loop.quit();
     }
+  });
+  if (stillTransitioning()) {
+    loop.exec();
   }
+  disconnect(conn);
 }
 
 void DownloadManager::setOutputDirectory(const QString& outputDirectory,

--- a/src/downloadmanager.cpp
+++ b/src/downloadmanager.cpp
@@ -675,6 +675,12 @@ bool DownloadManager::startDownload(QNetworkReply* reply, DownloadInfo* newDownl
     if (!resume) {
       // newDownload has not been appended to m_ActiveDownloads yet: drop it
       // here, otherwise it leaks. The resume path is owned elsewhere.
+      notifyPendingDownloadFailed(newDownload->m_FileInfo->gameName,
+                                  newDownload->m_FileInfo->modID,
+                                  newDownload->m_FileInfo->fileID);
+      removePending(newDownload->m_FileInfo->gameName,
+                    newDownload->m_FileInfo->modID,
+                    newDownload->m_FileInfo->fileID);
       reply->abort();
       reply->deleteLater();
       delete newDownload;

--- a/src/downloadmanager.cpp
+++ b/src/downloadmanager.cpp
@@ -775,7 +775,8 @@ DownloadManager::DownloadID DownloadManager::addNXMDownload(const QString& url)
   // If a pending entry already covers this file, return its id so callers that
   // poll by id see the same download regardless of how many times they queue.
   for (const PendingDownload& pending : m_PendingDownloads) {
-    if (pending.gameName.compare(foundGame->gameShortName(), Qt::CaseInsensitive) == 0 &&
+    if (pending.gameName.compare(foundGame->gameShortName(), Qt::CaseInsensitive) ==
+            0 &&
         pending.modID == nxmInfo.modId() && pending.fileID == nxmInfo.fileId()) {
       const auto infoStr =
           tr("There is already a download queued for this file.\n\nMod %1\nFile %2")
@@ -1658,9 +1659,8 @@ void DownloadManager::setState(DownloadManager::DownloadInfo* info,
         info->m_FileInfo->gameName, info->m_FileInfo->modID, this, id, QString()));
   } break;
   case STATE_FETCHINGFILEINFO: {
-    m_RequestIDs.insert(m_NexusInterface->requestFiles(info->m_FileInfo->gameName,
-                                                       info->m_FileInfo->modID, this,
-                                                       id, QString()));
+    m_RequestIDs.insert(m_NexusInterface->requestFiles(
+        info->m_FileInfo->gameName, info->m_FileInfo->modID, this, id, QString()));
   } break;
   case STATE_FETCHINGMODINFO_MD5: {
     log::debug("Searching {} for MD5 of {}", info->m_GamesToQuery[0],

--- a/src/downloadmanager.cpp
+++ b/src/downloadmanager.cpp
@@ -55,9 +55,9 @@ using namespace MOBase;
 
 static const char UNFINISHED[] = ".unfinished";
 
-unsigned int DownloadManager::DownloadInfo::s_NextDownloadID = 1U;
+DownloadManager::DownloadID DownloadManager::DownloadInfo::s_NextDownloadID = 1U;
 
-unsigned int DownloadManager::DownloadInfo::newDownloadID()
+DownloadManager::DownloadID DownloadManager::DownloadInfo::newDownloadID()
 {
   return s_NextDownloadID++;
 }
@@ -65,7 +65,7 @@ unsigned int DownloadManager::DownloadInfo::newDownloadID()
 DownloadManager::DownloadInfo*
 DownloadManager::DownloadInfo::createNew(const ModRepositoryFileInfo* fileInfo,
                                          const QStringList& URLs,
-                                         std::optional<unsigned int> reservedID)
+                                         std::optional<DownloadID> reservedID)
 {
   DownloadInfo* info = new DownloadInfo;
   info->m_DownloadID = reservedID.has_value() ? *reservedID : newDownloadID();
@@ -327,9 +327,9 @@ void DownloadManager::pauseAll()
 {
 
   // first loop: pause all downloads
-  for (int i = 0; i < m_ActiveDownloads.count(); ++i) {
-    if (m_ActiveDownloads[i]->m_State < STATE_READY) {
-      pauseDownload(i);
+  for (DownloadInfo* info : m_ActiveDownloads) {
+    if (info->m_State < STATE_READY) {
+      pauseDownload(info->m_DownloadID);
     }
   }
 
@@ -522,7 +522,7 @@ void DownloadManager::queryDownloadListInfo()
 
 bool DownloadManager::addDownload(const QStringList& URLs, QString gameName, int modID,
                                   int fileID, const ModRepositoryFileInfo* fileInfo,
-                                  std::optional<unsigned int> reservedID)
+                                  std::optional<DownloadID> reservedID)
 {
   QString fileName = QFileInfo(URLs.first()).fileName();
   if (fileName.isEmpty()) {
@@ -578,7 +578,7 @@ bool DownloadManager::addDownload(QNetworkReply* reply,
 bool DownloadManager::addDownload(QNetworkReply* reply, const QStringList& URLs,
                                   const QString& fileName, QString gameName, int modID,
                                   int fileID, const ModRepositoryFileInfo* fileInfo,
-                                  std::optional<unsigned int> reservedID)
+                                  std::optional<DownloadID> reservedID)
 {
   // download invoked from an already open network reply (i.e. download link in the
   // browser)
@@ -724,7 +724,7 @@ bool DownloadManager::startDownload(QNetworkReply* reply, DownloadInfo* newDownl
   return true;
 }
 
-unsigned int DownloadManager::addNXMDownload(const QString& url)
+DownloadManager::DownloadID DownloadManager::addNXMDownload(const QString& url)
 {
   NXMUrl nxmInfo(url);
 
@@ -843,7 +843,7 @@ unsigned int DownloadManager::addNXMDownload(const QString& url)
 
   // Reserve the id now (before any async work) so the caller can refer to the
   // eventual download before the Nexus API responds and a DownloadInfo exists.
-  const unsigned int reservedID = DownloadInfo::newDownloadID();
+  const DownloadID reservedID = DownloadInfo::newDownloadID();
 
   {
     ModelResetGuard guard(*this);
@@ -989,26 +989,26 @@ void DownloadManager::removeDownload(int index, bool deleteFile)
   refreshList();
 }
 
-void DownloadManager::cancelDownload(int index)
+void DownloadManager::cancelDownload(DownloadID id)
 {
-  if ((index < 0) || (index >= m_ActiveDownloads.size())) {
-    reportError(tr("cancel: invalid download index %1").arg(index));
+  DownloadInfo* info = m_ByID.value(id, nullptr);
+  if (info == nullptr) {
+    reportError(tr("cancel: invalid download id %1").arg(id));
     return;
   }
 
-  if (m_ActiveDownloads.at(index)->m_State == STATE_DOWNLOADING) {
-    setState(m_ActiveDownloads.at(index), STATE_CANCELING);
+  if (info->m_State == STATE_DOWNLOADING) {
+    setState(info, STATE_CANCELING);
   }
 }
 
-void DownloadManager::pauseDownload(int index)
+void DownloadManager::pauseDownload(DownloadID id)
 {
-  if ((index < 0) || (index >= m_ActiveDownloads.size())) {
-    reportError(tr("pause: invalid download index %1").arg(index));
+  DownloadInfo* info = m_ByID.value(id, nullptr);
+  if (info == nullptr) {
+    reportError(tr("pause: invalid download id %1").arg(id));
     return;
   }
-
-  DownloadInfo* info = m_ActiveDownloads.at(index);
 
   if (info->m_State == STATE_DOWNLOADING) {
     if ((info->m_Reply != nullptr) && (info->m_Reply->isRunning())) {
@@ -1023,24 +1023,24 @@ void DownloadManager::pauseDownload(int index)
   }
 }
 
-void DownloadManager::resumeDownload(int index)
+void DownloadManager::resumeDownload(DownloadID id)
 {
-  if ((index < 0) || (index >= m_ActiveDownloads.size())) {
-    reportError(tr("resume: invalid download index %1").arg(index));
+  DownloadInfo* info = m_ByID.value(id, nullptr);
+  if (info == nullptr) {
+    reportError(tr("resume: invalid download id %1").arg(id));
     return;
   }
-  DownloadInfo* info = m_ActiveDownloads[index];
-  info->m_Tries      = AUTOMATIC_RETRIES;
-  resumeDownloadInt(index);
+  info->m_Tries = AUTOMATIC_RETRIES;
+  resumeDownloadInt(id);
 }
 
-void DownloadManager::resumeDownloadInt(int index)
+void DownloadManager::resumeDownloadInt(DownloadID id)
 {
-  if ((index < 0) || (index >= m_ActiveDownloads.size())) {
-    reportError(tr("resume (int): invalid download index %1").arg(index));
+  DownloadInfo* info = m_ByID.value(id, nullptr);
+  if (info == nullptr) {
+    reportError(tr("resume (int): invalid download id %1").arg(id));
     return;
   }
-  DownloadInfo* info = m_ActiveDownloads[index];
 
   // Check for finished download;
   if (info->m_TotalSize <= info->m_Output.size() && info->m_Reply != nullptr &&
@@ -1088,7 +1088,7 @@ void DownloadManager::resumeDownloadInt(int index)
   }
 }
 
-DownloadManager::DownloadInfo* DownloadManager::downloadInfoByID(unsigned int id)
+DownloadManager::DownloadInfo* DownloadManager::downloadInfoByID(DownloadID id)
 {
   return m_ByID.value(id, nullptr);
 }
@@ -1633,8 +1633,8 @@ void DownloadManager::setState(DownloadManager::DownloadInfo* info,
   // Cache the id before reply->abort(): aborting fires signals synchronously
   // and a slot may erase info, leaving this pointer dangling. The id is stable
   // and m_ByID.contains() lets us check whether info is still present afterward.
-  const unsigned int id = info->m_DownloadID;
-  info->m_State         = state;
+  const DownloadID id = info->m_DownloadID;
+  info->m_State       = state;
   switch (state) {
   case STATE_PAUSED: {
     info->m_Reply->abort();
@@ -1986,7 +1986,7 @@ bool ServerByPreference(const ServerList::container& preferredServers,
 
 int DownloadManager::startDownloadURLs(const QStringList& urls)
 {
-  const unsigned int reservedID = DownloadInfo::newDownloadID();
+  const DownloadID reservedID = DownloadInfo::newDownloadID();
   ModRepositoryFileInfo info;
   if (!addDownload(urls, "", -1, -1, &info, reservedID)) {
     return 0;
@@ -2019,7 +2019,7 @@ int DownloadManager::startDownloadNexusFile(const QString& gameName, int modID,
 
 QString DownloadManager::downloadPath(int id)
 {
-  DownloadInfo* info = downloadInfoByID(static_cast<unsigned int>(id));
+  DownloadInfo* info = downloadInfoByID(static_cast<DownloadID>(id));
   if (info == nullptr) {
     return QString();
   }
@@ -2134,7 +2134,7 @@ void DownloadManager::nxmDownloadURLsAvailable(QString gameName, int modID, int 
 
   // Carry the pending entry's reserved id into the DownloadInfo so callers who
   // received it from addNXMDownload can continue to identify the download.
-  std::optional<unsigned int> reservedID;
+  std::optional<DownloadID> reservedID;
   for (const PendingDownload& pending : m_PendingDownloads) {
     if (pending.gameName.compare(gameName, Qt::CaseInsensitive) == 0 &&
         pending.modID == modID && pending.fileID == fileID) {
@@ -2306,7 +2306,7 @@ void DownloadManager::onReplyFinished()
   finishDownload(info->m_DownloadID);
 }
 
-void DownloadManager::finishDownload(unsigned int id)
+void DownloadManager::finishDownload(DownloadID id)
 {
   DirWatcherManager::Guard dirWatcherGuard = m_DirWatcher.scopedGuard();
 
@@ -2423,9 +2423,12 @@ void DownloadManager::finishDownload(unsigned int id)
   reply->close();
   reply->deleteLater();
 
-  if ((info->m_Tries > 0) && error) {
-    --info->m_Tries;
-    resumeDownloadInt(index);
+  // The CANCELED / retries-exhausted branch above may have deleted info; use
+  // m_ByID to check liveness before reading any more fields or retrying.
+  if (DownloadInfo* aliveInfo = m_ByID.value(id, nullptr);
+      aliveInfo != nullptr && error && aliveInfo->m_Tries > 0) {
+    --aliveInfo->m_Tries;
+    resumeDownloadInt(id);
   }
 }
 
@@ -2470,16 +2473,14 @@ void DownloadManager::managedGameChanged(MOBase::IPluginGame const* managedGame)
 
 void DownloadManager::checkDownloadTimeout()
 {
-  for (int i = 0; i < m_ActiveDownloads.size(); ++i) {
-    if (m_ActiveDownloads[i]->m_StartTime.elapsed() -
-                m_ActiveDownloads[i]->m_DownloadTimeLast >
-            5 * 1000 &&
-        m_ActiveDownloads[i]->m_State == STATE_DOWNLOADING &&
-        m_ActiveDownloads[i]->m_Reply != nullptr &&
-        m_ActiveDownloads[i]->m_Reply->isOpen()) {
-      pauseDownload(i);
-      finishDownload(m_ActiveDownloads[i]->m_DownloadID);
-      resumeDownload(i);
+  for (DownloadInfo* info : m_ActiveDownloads) {
+    if (info->m_StartTime.elapsed() - info->m_DownloadTimeLast > 5 * 1000 &&
+        info->m_State == STATE_DOWNLOADING && info->m_Reply != nullptr &&
+        info->m_Reply->isOpen()) {
+      const DownloadID id = info->m_DownloadID;
+      pauseDownload(id);
+      finishDownload(id);
+      resumeDownload(id);
     }
   }
 }

--- a/src/downloadmanager.cpp
+++ b/src/downloadmanager.cpp
@@ -57,12 +57,17 @@ static const char UNFINISHED[] = ".unfinished";
 
 unsigned int DownloadManager::DownloadInfo::s_NextDownloadID = 1U;
 
+unsigned int DownloadManager::DownloadInfo::newDownloadID()
+{
+  return s_NextDownloadID++;
+}
+
 DownloadManager::DownloadInfo*
 DownloadManager::DownloadInfo::createNew(const ModRepositoryFileInfo* fileInfo,
                                          const QStringList& URLs)
 {
   DownloadInfo* info = new DownloadInfo;
-  info->m_DownloadID = s_NextDownloadID++;
+  info->m_DownloadID = newDownloadID();
   info->m_StartTime.start();
   info->m_PreResumeSize  = 0LL;
   info->m_Progress       = std::make_pair<int, QString>(0, "0.0 B/s ");
@@ -119,7 +124,7 @@ DownloadManager::DownloadInfo::createFromMeta(const QString& filePath, bool show
     }
   }
 
-  info->m_DownloadID = s_NextDownloadID++;
+  info->m_DownloadID = newDownloadID();
   info->m_Output.setFileName(filePath);
   info->m_TotalSize      = fileSize ? *fileSize : QFileInfo(filePath).size();
   info->m_PreResumeSize  = info->m_TotalSize;
@@ -287,6 +292,7 @@ DownloadManager::~DownloadManager()
     delete *iter;
   }
   m_ActiveDownloads.clear();
+  m_ByID.clear();
 }
 
 void DownloadManager::setParentWidget(QWidget* w)
@@ -385,6 +391,7 @@ void DownloadManager::refreshList()
          iter != m_ActiveDownloads.end();) {
       if (((*iter)->m_State == STATE_READY) || ((*iter)->m_State == STATE_INSTALLED) ||
           ((*iter)->m_State == STATE_UNINSTALLED)) {
+        m_ByID.remove((*iter)->m_DownloadID);
         delete *iter;
         iter = m_ActiveDownloads.erase(iter);
       } else {
@@ -469,6 +476,7 @@ void DownloadManager::refreshList()
           }
 
           cx.self.m_ActiveDownloads.push_front(info);
+          cx.self.m_ByID.insert(info->m_DownloadID, info);
           cx.seen.insert(std::move(lc));
           cx.seen.insert(
               QFileInfo(info->m_Output.fileName()).fileName().toLower().toStdWString());
@@ -621,12 +629,14 @@ bool DownloadManager::addDownload(QNetworkReply* reply, const QStringList& URLs,
 void DownloadManager::removePending(QString gameName, int modID, int fileID)
 {
   QString gameShortName = getValidGameShortName(gameName);
-  for (auto iter : m_PendingDownloads) {
-    if (gameShortName.compare(std::get<0>(iter), Qt::CaseInsensitive) == 0 &&
-        (std::get<1>(iter) == modID) && (std::get<2>(iter) == fileID)) {
+
+  for (int i = 0; i < m_PendingDownloads.size(); ++i) {
+    const PendingDownload& pending = m_PendingDownloads.at(i);
+    if (gameShortName.compare(pending.gameName, Qt::CaseInsensitive) == 0 &&
+        pending.modID == modID && pending.fileID == fileID) {
       // only emit a reset if we actually have a row to remove
       ModelResetGuard guard(*this);
-      m_PendingDownloads.removeAt(m_PendingDownloads.indexOf(iter));
+      m_PendingDownloads.removeAt(i);
       break;
     }
   }
@@ -674,6 +684,7 @@ void DownloadManager::startDownload(QNetworkReply* reply, DownloadInfo* newDownl
       removePending(newDownload->m_FileInfo->gameName, newDownload->m_FileInfo->modID,
                     newDownload->m_FileInfo->fileID);
       m_ActiveDownloads.append(newDownload);
+      m_ByID.insert(newDownload->m_DownloadID, newDownload);
     }
     emit downloadAdded();
 
@@ -740,11 +751,9 @@ void DownloadManager::addNXMDownload(const QString& url)
     return;
   }
 
-  for (auto tuple : m_PendingDownloads) {
-    if (std::get<0>(tuple).compare(foundGame->gameShortName(), Qt::CaseInsensitive) ==
-            0 &&
-        std::get<1>(tuple) == nxmInfo.modId() &&
-        std::get<2>(tuple) == nxmInfo.fileId()) {
+  for (const PendingDownload& pending : m_PendingDownloads) {
+    if (pending.gameName.compare(foundGame->gameShortName(), Qt::CaseInsensitive) == 0 &&
+        pending.modID == nxmInfo.modId() && pending.fileID == nxmInfo.fileId()) {
       const auto infoStr =
           tr("There is already a download queued for this file.\n\nMod %1\nFile %2")
               .arg(nxmInfo.modId())
@@ -811,8 +820,9 @@ void DownloadManager::addNXMDownload(const QString& url)
 
   {
     ModelResetGuard guard(*this);
-    m_PendingDownloads.append(
-        std::make_tuple(foundGame->gameShortName(), nxmInfo.modId(), nxmInfo.fileId()));
+    PendingDownload pending{foundGame->gameShortName(), nxmInfo.modId(),
+                            nxmInfo.fileId()};
+    m_PendingDownloads.append(pending);
   }
   emit downloadAdded();
   ModRepositoryFileInfo* info = new ModRepositoryFileInfo();
@@ -929,6 +939,7 @@ void DownloadManager::removeDownload(int index, bool deleteFile)
         if ((removeAll && (downloadState >= STATE_READY)) ||
             (removeState == downloadState)) {
           removeFile(index, deleteFile);
+          m_ByID.remove((*iter)->m_DownloadID);
           delete *iter;
           iter = m_ActiveDownloads.erase(iter);
         } else {
@@ -937,8 +948,10 @@ void DownloadManager::removeDownload(int index, bool deleteFile)
         }
       }
     } else {
+      DownloadInfo* info = m_ActiveDownloads.at(index);
       removeFile(index, deleteFile);
-      delete m_ActiveDownloads.at(index);
+      m_ByID.remove(info->m_DownloadID);
+      delete info;
       m_ActiveDownloads.erase(m_ActiveDownloads.begin() + index);
     }
   } catch (const std::exception& e) {
@@ -1049,15 +1062,7 @@ void DownloadManager::resumeDownloadInt(int index)
 
 DownloadManager::DownloadInfo* DownloadManager::downloadInfoByID(unsigned int id)
 {
-  auto iter = std::find_if(m_ActiveDownloads.begin(), m_ActiveDownloads.end(),
-                           [id](DownloadInfo* info) {
-                             return info->m_DownloadID == id;
-                           });
-  if (iter != m_ActiveDownloads.end()) {
-    return *iter;
-  } else {
-    return nullptr;
-  }
+  return m_ByID.value(id, nullptr);
 }
 
 void DownloadManager::queryInfo(int index)
@@ -1314,7 +1319,7 @@ int DownloadManager::numPendingDownloads() const
   return m_PendingDownloads.size();
 }
 
-std::tuple<QString, int, int> DownloadManager::getPendingDownload(int index)
+DownloadManager::PendingDownload DownloadManager::getPendingDownload(int index)
 {
   if ((index < 0) || (index >= m_PendingDownloads.size())) {
     throw MyException(tr("get pending: invalid download index %1").arg(index));
@@ -2204,6 +2209,7 @@ void DownloadManager::nxmRequestFailed(QString gameName, int modID, int fileID,
     if (info->m_FileInfo->modID == modID) {
       if (info->m_State < STATE_FETCHINGMODINFO) {
         ModelResetGuard guard(*this);
+        m_ByID.remove(info->m_DownloadID);
         m_ActiveDownloads.erase(iter);
         delete info;
       } else {
@@ -2281,6 +2287,7 @@ void DownloadManager::downloadFinished(int index)
       {
         ModelResetGuard guard(*this);
         info->m_Output.remove();
+        m_ByID.remove(info->m_DownloadID);
         delete info;
         m_ActiveDownloads.erase(m_ActiveDownloads.begin() + index);
       }

--- a/src/downloadmanager.h
+++ b/src/downloadmanager.h
@@ -175,7 +175,7 @@ public:
     QString gameName;
     int modID;
     int fileID;
-    unsigned int reservedID;
+    DownloadID reservedID;
   };
 
 private:
@@ -186,7 +186,7 @@ private:
     accumulator_set<qint64, stats<tag::rolling_mean>> m_DownloadTimeAcc;
     qint64 m_DownloadLast;
     qint64 m_DownloadTimeLast;
-    unsigned int m_DownloadID;
+    DownloadID m_DownloadID;
     QString m_FileName;
     QFile m_Output;
     QNetworkReply* m_Reply;
@@ -221,7 +221,7 @@ private:
      * The only supported way to obtain one; ids are monotonically increasing
      * within a session and never reused.
      */
-    static unsigned int newDownloadID();
+    static DownloadID newDownloadID();
 
     /**
      * @brief Create a new DownloadInfo for a fresh download.
@@ -234,7 +234,7 @@ private:
      */
     static DownloadInfo* createNew(const MOBase::ModRepositoryFileInfo* fileInfo,
                                    const QStringList& URLs,
-                                   std::optional<unsigned int> reservedID = {});
+                                   std::optional<DownloadID> reservedID = {});
     static DownloadInfo* createFromMeta(const QString& filePath, bool showHidden,
                                         const QString outputDirectory,
                                         std::optional<uint64_t> fileSize = {});
@@ -249,14 +249,14 @@ private:
      **/
     void setName(QString newName, bool renameFile);
 
-    unsigned int downloadID() { return m_DownloadID; }
+    DownloadID downloadID() { return m_DownloadID; }
 
     bool isPausedState();
 
     QString currentURL();
 
   private:
-    static unsigned int s_NextDownloadID;
+    static DownloadID s_NextDownloadID;
 
   private:
     DownloadInfo()
@@ -344,7 +344,7 @@ public:
                    const QString& fileName, QString gameName, int modID, int fileID = 0,
                    const MOBase::ModRepositoryFileInfo* fileInfo =
                        new MOBase::ModRepositoryFileInfo(),
-                   std::optional<unsigned int> reservedID = {});
+                   std::optional<DownloadID> reservedID = {});
 
   /**
    * @brief start a download using a nxm-link
@@ -358,7 +358,7 @@ public:
    * @todo the game name encoded into the link is currently ignored, all downloads are
    *incorrectly assumed to be for the identified game
    **/
-  unsigned int addNXMDownload(const QString& url);
+  DownloadID addNXMDownload(const QString& url);
 
   /**
    * @brief retrieve the total number of downloads, both finished and unfinished
@@ -643,13 +643,13 @@ public slots:
    * @brief cancel the specified download. This will lead to the corresponding file to
    *be deleted
    *
-   * @param index index of the download to cancel
+   * @param id id of the download to cancel
    **/
-  void cancelDownload(int index);
+  void cancelDownload(DownloadID id);
 
-  void pauseDownload(int index);
+  void pauseDownload(DownloadID id);
 
-  void resumeDownload(int index);
+  void resumeDownload(DownloadID id);
 
   void queryInfo(int index);
 
@@ -703,7 +703,7 @@ private slots:
    * Writes any remaining data, transitions the download's state, and emits
    * the appropriate plugin signals.
    */
-  void finishDownload(unsigned int id);
+  void finishDownload(DownloadID id);
   void downloadError(QNetworkReply::NetworkError error);
   void metaDataChanged();
   void checkDownloadTimeout();
@@ -733,7 +733,7 @@ private:
    * before returning. Returns whether the download actually started.
    */
   bool startDownload(QNetworkReply* reply, DownloadInfo* newDownload, bool resume);
-  void resumeDownloadInt(int index);
+  void resumeDownloadInt(DownloadID id);
 
   /**
    * @brief start a download from a url
@@ -745,7 +745,7 @@ private:
    **/
   bool addDownload(const QStringList& URLs, QString gameName, int modID, int fileID,
                    const MOBase::ModRepositoryFileInfo* fileInfo,
-                   std::optional<unsigned int> reservedID = {});
+                   std::optional<DownloadID> reservedID = {});
 
   // important: the caller has to lock the list-mutex, otherwise the
   // DownloadInfo-pointer might get invalidated at any time
@@ -757,7 +757,7 @@ private:
 
   void setState(DownloadInfo* info, DownloadManager::DownloadState state);
 
-  DownloadInfo* downloadInfoByID(unsigned int id);
+  DownloadInfo* downloadInfoByID(DownloadID id);
 
   void removePending(QString gameName, int modID, int fileID);
 
@@ -791,7 +791,7 @@ private:
 
   // Secondary index into m_ActiveDownloads keyed by m_DownloadID; kept in sync
   // with every m_ActiveDownloads mutation.
-  QHash<unsigned int, DownloadInfo*> m_ByID;
+  QHash<DownloadID, DownloadInfo*> m_ByID;
 
   QString m_OutputDirectory;
   std::set<int> m_RequestIDs;

--- a/src/downloadmanager.h
+++ b/src/downloadmanager.h
@@ -770,6 +770,15 @@ private:
    */
   void notifyPendingDownloadFailed(const QString& gameName, int modID, int fileID);
 
+  /**
+   * @brief Roll back a download that has not yet been activated.
+   *
+   * Ensures a caller awaiting the reservedID receives an onDownloadFailed
+   * callback. Must not be called once the download has been registered as
+   * active.
+   */
+  void cancelPendingDownload(DownloadInfo* newDownload, QNetworkReply* reply);
+
   static QString getFileTypeString(int fileType);
 
   void writeData(DownloadInfo* info);

--- a/src/downloadmanager.h
+++ b/src/downloadmanager.h
@@ -113,6 +113,25 @@ class DownloadManager : public QObject
   Q_OBJECT
 
 public:
+  /**
+   * @brief RAII full-reset guard. Use when the row count changes; drops
+   * view selection/scroll state. Nests safely: inner guards coalesce into
+   * the outermost scope so only one reset is emitted.
+   */
+  class [[nodiscard]] ModelResetGuard
+  {
+  public:
+    explicit ModelResetGuard(DownloadManager& manager);
+    ~ModelResetGuard();
+    ModelResetGuard(const ModelResetGuard&)            = delete;
+    ModelResetGuard& operator=(const ModelResetGuard&) = delete;
+    ModelResetGuard(ModelResetGuard&&)                 = delete;
+    ModelResetGuard& operator=(ModelResetGuard&&)      = delete;
+
+  private:
+    DownloadManager& m_manager;
+  };
+
   enum DownloadState
   {
     STATE_STARTED = 0,
@@ -480,16 +499,38 @@ public:  // IDownloadManager interface:
 
   void pauseAll();
 
-Q_SIGNALS:
-
-  void aboutToUpdate();
-
   /**
-   * @brief signals that the specified download has changed
+   * @brief notify the UI that a single row's data changed. Preserves view
+   * state; prefer over ModelResetGuard when the row count is unchanged.
    *
    * @param row the row that changed. This corresponds to the download index
-   **/
-  void update(int row);
+   */
+  void notifyRowChanged(int row);
+
+Q_SIGNALS:
+
+  /**
+   * @brief emitted before the download list model is about to be reset
+   *
+   * Emitted by ModelResetGuard on construction. Views should call
+   * beginResetModel() in response.
+   */
+  void aboutToResetModel();
+
+  /**
+   * @brief emitted after the download list model has been reset
+   *
+   * Emitted by ModelResetGuard on destruction. Views should call
+   * endResetModel() in response.
+   */
+  void modelReset();
+
+  /**
+   * @brief signals that the specified download row's data has changed
+   *
+   * @param row the row that changed. This corresponds to the download index
+   */
+  void rowChanged(int row);
 
   /**
    * @brief signals the ui that a message should be displayed
@@ -659,6 +700,9 @@ private:
   QVector<int> m_AlphabeticalTranslation;
 
   DirWatcherManager m_DirWatcher;
+
+  // nesting depth of active ModelResetGuard scopes; see its docs
+  int m_modelResetDepth = 0;
 
   SignalDownloadCallback m_DownloadComplete;
   SignalDownloadCallback m_DownloadPaused;

--- a/src/downloadmanager.h
+++ b/src/downloadmanager.h
@@ -666,7 +666,21 @@ private slots:
 
   void downloadProgress(qint64 bytesReceived, qint64 bytesTotal);
   void downloadReadyRead();
-  void downloadFinished(int index = 0);
+  /**
+   * @brief Slot wired to QNetworkReply::finished().
+   *
+   * Resolves the originating reply through sender() and then dispatches to
+   * finishDownload. Use the public finishDownload directly for non-slot calls.
+   */
+  void onReplyFinished();
+
+  /**
+   * @brief Run the post-download bookkeeping for the given download.
+   *
+   * Writes any remaining data, transitions the download's state, and emits
+   * the appropriate plugin signals.
+   */
+  void finishDownload(unsigned int id);
   void downloadError(QNetworkReply::NetworkError error);
   void metaDataChanged();
   void checkDownloadTimeout();

--- a/src/downloadmanager.h
+++ b/src/downloadmanager.h
@@ -101,6 +101,8 @@ private slots:
   void onDirectoryChanged(const QString&);
 
 private:
+  void releaseSuspension();
+
   QFileSystemWatcher m_watcher;
   int m_suspendDepth = 0;
 };

--- a/src/downloadmanager.h
+++ b/src/downloadmanager.h
@@ -666,10 +666,6 @@ private:
 
   void removeFile(int index, bool deleteFile);
 
-  void refreshAlphabeticalTranslation();
-
-  bool ByName(int LHS, int RHS);
-
   QString getFileNameFromNetworkReply(QNetworkReply* reply);
 
   void setState(DownloadInfo* info, DownloadManager::DownloadState state);
@@ -697,7 +693,6 @@ private:
 
   QString m_OutputDirectory;
   std::set<int> m_RequestIDs;
-  QVector<int> m_AlphabeticalTranslation;
 
   DirWatcherManager m_DirWatcher;
 

--- a/src/downloadmanager.h
+++ b/src/downloadmanager.h
@@ -32,7 +32,6 @@ along with Mod Organizer.  If not, see <http://www.gnu.org/licenses/>.
 #include <QSettings>
 #include <QStringList>
 #include <QTime>
-#include <QTimer>
 #include <QUrl>
 #include <QVector>
 #include <boost/accumulators/accumulators.hpp>
@@ -706,7 +705,6 @@ private slots:
   void finishDownload(DownloadID id);
   void downloadError(QNetworkReply::NetworkError error);
   void metaDataChanged();
-  void checkDownloadTimeout();
 
 private:
   void createMetaFile(DownloadInfo* info);
@@ -806,13 +804,9 @@ private:
   SignalDownloadCallback m_DownloadFailed;
   SignalDownloadCallback m_DownloadRemoved;
 
-  std::map<QString, int> m_DownloadFails;
-
   bool m_ShowHidden;
 
   MOBase::IPluginGame const* m_ManagedGame;
-
-  QTimer m_TimeoutTimer;
 };
 
 #endif  // DOWNLOADMANAGER_H

--- a/src/downloadmanager.h
+++ b/src/downloadmanager.h
@@ -158,13 +158,16 @@ public:
    *
    * Created when the user initiates an NXM download; drained either when the
    * Nexus API returns the actual download URL (at which point a DownloadInfo
-   * is created) or when the request is cancelled or fails.
+   * is created using reservedID as its download id so that external references
+   * handed out before the download existed remain valid) or when the request
+   * is cancelled or fails.
    */
   struct PendingDownload
   {
     QString gameName;
     int modID;
     int fileID;
+    unsigned int reservedID;
   };
 
 private:
@@ -212,8 +215,18 @@ private:
      */
     static unsigned int newDownloadID();
 
+    /**
+     * @brief Create a new DownloadInfo for a fresh download.
+     *
+     * When reservedID is provided it is used as the download id. Callers that
+     * need to hand out an id before the DownloadInfo exists (e.g. the NXM flow
+     * reserves an id when the request is queued, long before the Nexus API
+     * returns the actual URL) should reserve via newDownloadID() and pass it
+     * here. Otherwise a fresh id is drawn internally.
+     */
     static DownloadInfo* createNew(const MOBase::ModRepositoryFileInfo* fileInfo,
-                                   const QStringList& URLs);
+                                   const QStringList& URLs,
+                                   std::optional<unsigned int> reservedID = {});
     static DownloadInfo* createFromMeta(const QString& filePath, bool showHidden,
                                         const QString outputDirectory,
                                         std::optional<uint64_t> fileSize = {});
@@ -322,18 +335,22 @@ public:
   bool addDownload(QNetworkReply* reply, const QStringList& URLs,
                    const QString& fileName, QString gameName, int modID, int fileID = 0,
                    const MOBase::ModRepositoryFileInfo* fileInfo =
-                       new MOBase::ModRepositoryFileInfo());
+                       new MOBase::ModRepositoryFileInfo(),
+                   std::optional<unsigned int> reservedID = {});
 
   /**
    * @brief start a download using a nxm-link
    *
-   * starts a download using a nxm-link. The download manager will first query the nexus
-   * page for file information.
+   * Starts a download using a nxm-link. The download manager will first query the
+   * nexus page for file information. The returned id identifies the eventual
+   * download; it is reserved immediately so external references remain valid even
+   * before the Nexus API responds.
    * @param url a nxm link looking like this: nxm://skyrim/mods/1234/files/4711
+   * @return the reserved download id
    * @todo the game name encoded into the link is currently ignored, all downloads are
    *incorrectly assumed to be for the identified game
    **/
-  void addNXMDownload(const QString& url);
+  unsigned int addNXMDownload(const QString& url);
 
   /**
    * @brief retrieve the total number of downloads, both finished and unfinished
@@ -671,7 +688,14 @@ public:
   QString getDownloadFileName(const QString& baseName, bool rename = false) const;
 
 private:
-  void startDownload(QNetworkReply* reply, DownloadInfo* newDownload, bool resume);
+  /**
+   * @brief Begin downloading into newDownload from reply.
+   *
+   * On the !resume path newDownload becomes owned by m_ActiveDownloads on
+   * success; on failure (e.g. the output file cannot be opened) it is deleted
+   * before returning. Returns whether the download actually started.
+   */
+  bool startDownload(QNetworkReply* reply, DownloadInfo* newDownload, bool resume);
   void resumeDownloadInt(int index);
 
   /**
@@ -683,7 +707,8 @@ private:
    *only happens if there is a duplicate and the user decides not to download again
    **/
   bool addDownload(const QStringList& URLs, QString gameName, int modID, int fileID,
-                   const MOBase::ModRepositoryFileInfo* fileInfo);
+                   const MOBase::ModRepositoryFileInfo* fileInfo,
+                   std::optional<unsigned int> reservedID = {});
 
   // important: the caller has to lock the list-mutex, otherwise the
   // DownloadInfo-pointer might get invalidated at any time
@@ -698,6 +723,15 @@ private:
   DownloadInfo* downloadInfoByID(unsigned int id);
 
   void removePending(QString gameName, int modID, int fileID);
+
+  /**
+   * @brief Fire onDownloadFailed for a pending entry, if any matches.
+   *
+   * Used on Nexus API failures so callers holding a reserved id from
+   * addNXMDownload do not wait indefinitely for a result. No-op if no pending
+   * entry matches the (gameName, modID, fileID) triple.
+   */
+  void notifyPendingDownloadFailed(const QString& gameName, int modID, int fileID);
 
   static QString getFileTypeString(int fileType);
 

--- a/src/downloadmanager.h
+++ b/src/downloadmanager.h
@@ -52,6 +52,58 @@ class NexusInterface;
 class PluginContainer;
 class OrganizerCore;
 
+/**
+ * @brief QFileSystemWatcher with a nestable RAII suspension scope.
+ *
+ * Forwards directoryChanged() only while no Guard is alive. Use a Guard to
+ * bracket filesystem writes that would otherwise trigger a spurious refresh.
+ */
+class DirWatcherManager : public QObject
+{
+  Q_OBJECT
+
+public:
+  explicit DirWatcherManager(QObject* parent = nullptr);
+
+  /// Set the directory being watched (replaces any previous path).
+  void setPath(const QString& path);
+
+  /// True while one or more Guards are alive.
+  bool isSuspended() const;
+
+  /**
+   * @brief RAII suspension guard. Nests safely; the only way to suspend
+   * forwarding.
+   */
+  class [[nodiscard]] Guard
+  {
+  public:
+    explicit Guard(DirWatcherManager& manager);
+    ~Guard();
+    Guard(const Guard&)            = delete;
+    Guard& operator=(const Guard&) = delete;
+    Guard(Guard&&)                 = delete;
+    Guard& operator=(Guard&&)      = delete;
+
+  private:
+    DirWatcherManager& m_manager;
+  };
+
+  /// Returns a suspension Guard bound to the caller's scope.
+  [[nodiscard]] Guard scopedGuard();
+
+signals:
+  /// Emitted when the watched directory changes and no Guard is active.
+  void directoryChanged();
+
+private slots:
+  void onDirectoryChanged(const QString&);
+
+private:
+  QFileSystemWatcher m_watcher;
+  int m_suspendDepth = 0;
+};
+
 /*!
  * \brief manages downloading of files and provides progress information for gui
  *elements
@@ -190,19 +242,6 @@ public:
    * @param outputDirectory the new output directory
    **/
   void setOutputDirectory(const QString& outputDirectory, const bool refresh = true);
-
-  /**
-   * @brief disables feedback from the downlods fileSystemWhatcher untill
-   *disableDownloadsWatcherEnd() is called
-   *
-   **/
-  static void startDisableDirWatcher();
-
-  /**
-   * @brief re-enables feedback from the downlods fileSystemWhatcher after
-   *disableDownloadsWatcherStart() was called
-   **/
-  static void endDisableDirWatcher();
 
   /**
    * @return current download directory
@@ -408,6 +447,12 @@ public:
    */
   void queryDownloadListInfo();
 
+  /**
+   * @return the directory watcher for the downloads folder; call
+   * scopedGuard() on it to suspend across filesystem writes.
+   */
+  DirWatcherManager& dirWatcher() { return m_DirWatcher; }
+
 public:  // IDownloadManager interface:
   int startDownloadURLs(const QStringList& urls);
   int startDownloadURLWithMeta(const QString& url, const QString& name,
@@ -541,7 +586,6 @@ private slots:
   void downloadFinished(int index = 0);
   void downloadError(QNetworkReply::NetworkError error);
   void metaDataChanged();
-  void directoryChanged(const QString& dirctory);
   void checkDownloadTimeout();
 
 private:
@@ -614,19 +658,12 @@ private:
   std::set<int> m_RequestIDs;
   QVector<int> m_AlphabeticalTranslation;
 
-  QFileSystemWatcher m_DirWatcher;
+  DirWatcherManager m_DirWatcher;
 
   SignalDownloadCallback m_DownloadComplete;
   SignalDownloadCallback m_DownloadPaused;
   SignalDownloadCallback m_DownloadFailed;
   SignalDownloadCallback m_DownloadRemoved;
-
-  // The dirWatcher is actually triggering off normal Mo operations such as deleting
-  // downloads or editing .meta files so it needs to be disabled during operations that
-  // are known to cause the creation or deletion of files in the Downloads folder.
-  // Notably using QSettings to edit a file creates a temporarily .lock file that causes
-  // the Watcher to trigger multiple listRefreshes freezing the ui.
-  static int m_DirWatcherDisabler;
 
   std::map<QString, int> m_DownloadFails;
 
@@ -635,16 +672,6 @@ private:
   MOBase::IPluginGame const* m_ManagedGame;
 
   QTimer m_TimeoutTimer;
-};
-
-class ScopedDisableDirWatcher
-{
-public:
-  ScopedDisableDirWatcher(DownloadManager* downloadManager);
-  ~ScopedDisableDirWatcher();
-
-private:
-  DownloadManager* m_downloadManager;
 };
 
 #endif  // DOWNLOADMANAGER_H

--- a/src/downloadmanager.h
+++ b/src/downloadmanager.h
@@ -153,6 +153,14 @@ public:
   };
 
   /**
+   * @brief Stable identifier for a download.
+   *
+   * Monotonically increasing within a session and never reused. Distinct from
+   * row indices, which are positional and shift as the list is mutated.
+   */
+  using DownloadID = unsigned int;
+
+  /**
    * @brief A download that has been requested but has not yet produced a
    * DownloadInfo.
    *
@@ -374,6 +382,21 @@ public:
    * @return the PendingDownload entry at the given index
    */
   PendingDownload getPendingDownload(int index);
+
+  /**
+   * @brief Resolve a view row to a stable DownloadID.
+   *
+   * Rows cover active downloads followed by pending ones. Returns 0 if the row
+   * is out of range.
+   */
+  DownloadID downloadIDAtRow(int row) const;
+
+  /**
+   * @brief Resolve a stable DownloadID to its current view row.
+   *
+   * @return the current row, or -1 if no download with that id is tracked.
+   */
+  int rowForDownloadID(DownloadID id) const;
 
   /**
    * @brief retrieve the full path to the download specified by index

--- a/src/downloadmanager.h
+++ b/src/downloadmanager.h
@@ -24,6 +24,7 @@ along with Mod Organizer.  If not, see <http://www.gnu.org/licenses/>.
 #include <QElapsedTimer>
 #include <QFile>
 #include <QFileSystemWatcher>
+#include <QHash>
 #include <QMap>
 #include <QNetworkReply>
 #include <QObject>
@@ -40,6 +41,7 @@ along with Mod Organizer.  If not, see <http://www.gnu.org/licenses/>.
 #include <boost/signals2.hpp>
 #include <idownloadmanager.h>
 #include <modrepositoryfileinfo.h>
+#include <optional>
 #include <set>
 using namespace boost::accumulators;
 
@@ -150,6 +152,21 @@ public:
     STATE_UNINSTALLED
   };
 
+  /**
+   * @brief A download that has been requested but has not yet produced a
+   * DownloadInfo.
+   *
+   * Created when the user initiates an NXM download; drained either when the
+   * Nexus API returns the actual download URL (at which point a DownloadInfo
+   * is created) or when the request is cancelled or fails.
+   */
+  struct PendingDownload
+  {
+    QString gameName;
+    int modID;
+    int fileID;
+  };
+
 private:
   struct DownloadInfo
   {
@@ -186,6 +203,14 @@ private:
     MOBase::ModRepositoryFileInfo* m_FileInfo{nullptr};
 
     bool m_Hidden;
+
+    /**
+     * @brief Issue a new download id.
+     *
+     * The only supported way to obtain one; ids are monotonically increasing
+     * within a session and never reused.
+     */
+    static unsigned int newDownloadID();
 
     static DownloadInfo* createNew(const MOBase::ModRepositoryFileInfo* fileInfo,
                                    const QStringList& URLs);
@@ -329,9 +354,9 @@ public:
    * @brief retrieve the info of a pending download
    * @param index index of the pending download (index in the range [0,
    * numPendingDownloads()[)
-   * @return pair of modid, fileid
+   * @return the PendingDownload entry at the given index
    */
-  std::tuple<QString, int, int> getPendingDownload(int index);
+  PendingDownload getPendingDownload(int index);
 
   /**
    * @brief retrieve the full path to the download specified by index
@@ -689,9 +714,13 @@ private:
   OrganizerCore* m_OrganizerCore;
   QWidget* m_ParentWidget;
 
-  QVector<std::tuple<QString, int, int>> m_PendingDownloads;
+  QVector<PendingDownload> m_PendingDownloads;
 
   QVector<DownloadInfo*> m_ActiveDownloads;
+
+  // Secondary index into m_ActiveDownloads keyed by m_DownloadID; kept in sync
+  // with every m_ActiveDownloads mutation.
+  QHash<unsigned int, DownloadInfo*> m_ByID;
 
   QString m_OutputDirectory;
   std::set<int> m_RequestIDs;

--- a/src/downloadmanager.h
+++ b/src/downloadmanager.h
@@ -678,6 +678,8 @@ private:
 
   void writeData(DownloadInfo* info);
 
+  QString getValidGameShortName(const QString& gameNexusName) const;
+
 private:
   static const int AUTOMATIC_RETRIES = 3;
 

--- a/src/downloadstab.cpp
+++ b/src/downloadstab.cpp
@@ -49,12 +49,17 @@ DownloadsTab::DownloadsTab(OrganizerCore& core, Ui::MainWindow* mwui)
           SLOT(removeDownload(int, bool)));
   connect(ui.list, SIGNAL(restoreDownload(int)), m_core.downloadManager(),
           SLOT(restoreDownload(int)));
-  connect(ui.list, SIGNAL(cancelDownload(int)), m_core.downloadManager(),
-          SLOT(cancelDownload(int)));
-  connect(ui.list, SIGNAL(pauseDownload(int)), m_core.downloadManager(),
-          SLOT(pauseDownload(int)));
-  connect(ui.list, &DownloadListView::resumeDownload, [&](int i) {
-    resumeDownload(i);
+  // The view reports actions by row; translate to DownloadID at the boundary.
+  connect(ui.list, &DownloadListView::cancelDownload, this, [this](int row) {
+    auto* dm = m_core.downloadManager();
+    dm->cancelDownload(dm->downloadIDAtRow(row));
+  });
+  connect(ui.list, &DownloadListView::pauseDownload, this, [this](int row) {
+    auto* dm = m_core.downloadManager();
+    dm->pauseDownload(dm->downloadIDAtRow(row));
+  });
+  connect(ui.list, &DownloadListView::resumeDownload, this, [this](int row) {
+    resumeDownload(row);
   });
 }
 
@@ -105,6 +110,7 @@ void DownloadsTab::queryInfos()
 void DownloadsTab::resumeDownload(int downloadIndex)
 {
   m_core.loggedInAction(ui.list, [this, downloadIndex] {
-    m_core.downloadManager()->resumeDownload(downloadIndex);
+    auto* dm = m_core.downloadManager();
+    dm->resumeDownload(dm->downloadIDAtRow(downloadIndex));
   });
 }

--- a/src/modlistviewactions.cpp
+++ b/src/modlistviewactions.cpp
@@ -818,11 +818,13 @@ void ModListViewActions::removeMods(const QModelIndexList& indices) const
               QMessageBox::Yes | QMessageBox::No) == QMessageBox::Yes) {
         // use mod names instead of indexes because those become invalid during the
         // removal
-        DownloadManager::startDisableDirWatcher();
-        for (QString name : modNames) {
-          m_core.modList()->removeRowForce(ModInfo::getIndex(name), QModelIndex());
+        {
+          DirWatcherManager::Guard dirWatcherGuard =
+              m_core.downloadManager()->dirWatcher().scopedGuard();
+          for (QString name : modNames) {
+            m_core.modList()->removeRowForce(ModInfo::getIndex(name), QModelIndex());
+          }
         }
-        DownloadManager::endDisableDirWatcher();
       }
     } else if (!indices.isEmpty()) {
       m_core.modList()->removeRow(indices[0].data(ModList::IndexRole).toInt(),

--- a/src/organizercore.cpp
+++ b/src/organizercore.cpp
@@ -866,7 +866,8 @@ OrganizerCore::doInstall(const QString& archivePath, GuessedValue<QString> modNa
 
 ModInfo::Ptr OrganizerCore::installDownload(int index, int priority)
 {
-  DirWatcherManager::Guard dirWatcherGuard = m_DownloadManager.dirWatcher().scopedGuard();
+  DirWatcherManager::Guard dirWatcherGuard =
+      m_DownloadManager.dirWatcher().scopedGuard();
 
   try {
     QString fileName        = m_DownloadManager.getFilePath(index);

--- a/src/organizercore.cpp
+++ b/src/organizercore.cpp
@@ -866,7 +866,7 @@ OrganizerCore::doInstall(const QString& archivePath, GuessedValue<QString> modNa
 
 ModInfo::Ptr OrganizerCore::installDownload(int index, int priority)
 {
-  ScopedDisableDirWatcher scopedDirwatcher(&m_DownloadManager);
+  DirWatcherManager::Guard dirWatcherGuard = m_DownloadManager.dirWatcher().scopedGuard();
 
   try {
     QString fileName        = m_DownloadManager.getFilePath(index);


### PR DESCRIPTION
- Includes the changes from #2372 

## Summary

Three threads of work in the download manager:

- **Stable `DownloadID`s** replace row indices in the plugin-facing API and in `cancelDownload`/`pauseDownload`/`resumeDownload`. A new `PendingDownload` struct lets an id be reserved and handed out before the Nexus API resolves.
- **Async correctness.** `QCoreApplication::processEvents()` removed from `pauseAll`, `~DirWatcherManager::Guard`, and `startDownload`'s "reply already finished" path. Replaced with a `QEventLoop` (driven by `stateChanged`) for `pauseAll`, a queued meta-call for the guard release, and "connect-then-check-isFinished" + queued invoke for `startDownload`. No more busy-polling, wall-clock arithmetic, or arbitrary slot reentry mid-construction.
- **Pending-download cleanup.** Every pre-active failure path (output-file open, filesystem rename, duplicate-name dialog "No") now routes through a single `cancelPendingDownload` helper that fires `onDownloadFailed` for the reserved id and clears the pending row. Plugins awaiting a reserved id no longer leak.

Plus dead-code removal (`m_DownloadFails`, the disabled `m_TimeoutTimer`/`checkDownloadTimeout`), splitting `downloadFinished` into `onReplyFinished` + `finishDownload`, and a handful of unused-variable / `size_t` warning fixes.
