### PR TITLE
fix crash when CWD is not set to app directory

### DIFF
--- a/src/moapplication.cpp
+++ b/src/moapplication.cpp
@@ -159,7 +159,7 @@ MOApplication::MOApplication(int& argc, char** argv) : QApplication(argc, argv)
   updateStyle(m_defaultStyle);
   addDllsToPath();
 
-  // When MO2 is launched by nxmhandler, CWD is set to `C:\Windows\System32`. 
+  // When MO2 is launched by nxmhandler, CWD is set to `C:\Windows\System32`.
   // QtWebEngineProcess crashes if CWD is not set to the application directory.
   QDir::setCurrent(QCoreApplication::applicationDirPath());
 }

--- a/src/moapplication.cpp
+++ b/src/moapplication.cpp
@@ -158,6 +158,10 @@ MOApplication::MOApplication(int& argc, char** argv) : QApplication(argc, argv)
   m_defaultStyle = "windowsvista";
   updateStyle(m_defaultStyle);
   addDllsToPath();
+
+  // When MO2 is launched by nxmhandler, CWD is set to `C:\Windows\System32`. 
+  // QtWebEngineProcess crashes if CWD is not set to the application directory.
+  QDir::setCurrent(QCoreApplication::applicationDirPath());
 }
 
 OrganizerCore& MOApplication::core()


### PR DESCRIPTION
Should fix the crashes when starting MO2 with a NXM download.

Might also have been the cause to some of the reported crashes when testing CLI commands.