### PR TITLE
Fix IModRepositoryBridge request methods using the wrong game

### DIFF
--- a/src/modinfo.cpp
+++ b/src/modinfo.cpp
@@ -314,8 +314,8 @@ bool ModInfo::checkAllForUpdate(PluginContainer* pluginContainer, QObject* recei
   }
 
   // Detect invalid source games
+  const auto& gamePlugins = pluginContainer->plugins<IPluginGame>();
   for (auto itr = games.begin(); itr != games.end();) {
-    auto gamePlugins        = pluginContainer->plugins<IPluginGame>();
     IPluginGame* gamePlugin = qApp->property("managed_game").value<IPluginGame*>();
     for (auto plugin : gamePlugins) {
       if (plugin != nullptr &&

--- a/src/nexusinterface.cpp
+++ b/src/nexusinterface.cpp
@@ -415,7 +415,7 @@ QString NexusInterface::getGameURL(QString gameName) const
   }
 }
 
-QString NexusInterface::getOldModsURL(QString gameName) const
+QString NexusInterface::getOldModsURL(const QString& gameName) const
 {
   IPluginGame* game = getGame(gameName);
   if (game != nullptr) {
@@ -465,11 +465,10 @@ void NexusInterface::setPluginContainer(PluginContainer* pluginContainer)
 }
 
 int NexusInterface::requestDescription(QString gameName, int modID, QObject* receiver,
-                                       QVariant userData, const QString& subModule,
-                                       MOBase::IPluginGame const* game)
+                                       QVariant userData, const QString& subModule)
 {
   NXMRequestInfo requestInfo(modID, NXMRequestInfo::TYPE_DESCRIPTION, userData,
-                             subModule, game);
+                             subModule, getGameNexusName(gameName));
   m_RequestQueue.enqueue(requestInfo);
 
   connect(this, SIGNAL(nxmDescriptionAvailable(QString, int, QVariant, QVariant, int)),
@@ -487,8 +486,7 @@ int NexusInterface::requestDescription(QString gameName, int modID, QObject* rec
 }
 
 int NexusInterface::requestModInfo(QString gameName, int modID, QObject* receiver,
-                                   QVariant userData, const QString& subModule,
-                                   MOBase::IPluginGame const* game)
+                                   QVariant userData, const QString& subModule)
 {
   if (m_User.shouldThrottle()) {
     throttledWarning(m_User);
@@ -496,7 +494,7 @@ int NexusInterface::requestModInfo(QString gameName, int modID, QObject* receive
   }
 
   NXMRequestInfo requestInfo(modID, NXMRequestInfo::TYPE_MODINFO, userData, subModule,
-                             game);
+                             getGameNexusName(gameName));
   m_RequestQueue.enqueue(requestInfo);
 
   connect(this, SIGNAL(nxmModInfoAvailable(QString, int, QVariant, QVariant, int)),
@@ -515,8 +513,7 @@ int NexusInterface::requestModInfo(QString gameName, int modID, QObject* receive
 int NexusInterface::requestUpdateInfo(QString gameName,
                                       NexusInterface::UpdatePeriod period,
                                       QObject* receiver, QVariant userData,
-                                      const QString& subModule,
-                                      const MOBase::IPluginGame* game)
+                                      const QString& subModule)
 {
   if (m_User.shouldThrottle()) {
     throttledWarning(m_User);
@@ -524,7 +521,7 @@ int NexusInterface::requestUpdateInfo(QString gameName,
   }
 
   NXMRequestInfo requestInfo(period, NXMRequestInfo::TYPE_CHECKUPDATES, userData,
-                             subModule, game);
+                             subModule, getGameNexusName(gameName));
   m_RequestQueue.enqueue(requestInfo);
 
   connect(this, SIGNAL(nxmUpdateInfoAvailable(QString, QVariant, QVariant, int)),
@@ -556,7 +553,7 @@ int NexusInterface::requestUpdates(const int& modID, QObject* receiver,
   }
 
   NXMRequestInfo requestInfo(modID, NXMRequestInfo::TYPE_GETUPDATES, userData,
-                             subModule, game);
+                             subModule, game->gameNexusName());
   m_RequestQueue.enqueue(requestInfo);
 
   connect(this, SIGNAL(nxmUpdatesAvailable(QString, int, QVariant, QVariant, int)),
@@ -594,11 +591,10 @@ void NexusInterface::fakeFiles()
 }
 
 int NexusInterface::requestFiles(QString gameName, int modID, QObject* receiver,
-                                 QVariant userData, const QString& subModule,
-                                 MOBase::IPluginGame const* game)
+                                 QVariant userData, const QString& subModule)
 {
   NXMRequestInfo requestInfo(modID, NXMRequestInfo::TYPE_FILES, userData, subModule,
-                             game);
+                             getGameNexusName(gameName));
   m_RequestQueue.enqueue(requestInfo);
   connect(this, SIGNAL(nxmFilesAvailable(QString, int, QVariant, QVariant, int)),
           receiver, SLOT(nxmFilesAvailable(QString, int, QVariant, QVariant, int)),
@@ -617,14 +613,9 @@ int NexusInterface::requestFileInfo(QString gameName, int modID, int fileID,
                                     QObject* receiver, QVariant userData,
                                     const QString& subModule)
 {
-  IPluginGame* gamePlugin = getGame(gameName);
-  if (gamePlugin == nullptr) {
-    log::error("requestFileInfo can't find plugin for {}", gameName);
-    return -1;
-  }
 
   NXMRequestInfo requestInfo(modID, fileID, NXMRequestInfo::TYPE_FILEINFO, userData,
-                             subModule, gamePlugin);
+                             subModule, getGameNexusName(gameName));
   m_RequestQueue.enqueue(requestInfo);
 
   connect(
@@ -643,11 +634,10 @@ int NexusInterface::requestFileInfo(QString gameName, int modID, int fileID,
 
 int NexusInterface::requestDownloadURL(QString gameName, int modID, int fileID,
                                        QObject* receiver, QVariant userData,
-                                       const QString& subModule,
-                                       MOBase::IPluginGame const* game)
+                                       const QString& subModule)
 {
   NXMRequestInfo requestInfo(modID, fileID, NXMRequestInfo::TYPE_DOWNLOADURL, userData,
-                             subModule, game);
+                             subModule, getGameNexusName(gameName));
   m_RequestQueue.enqueue(requestInfo);
 
   connect(this,
@@ -687,8 +677,7 @@ int NexusInterface::requestEndorsementInfo(QObject* receiver, QVariant userData,
 int NexusInterface::requestToggleEndorsement(QString gameName, int modID,
                                              QString modVersion, bool endorse,
                                              QObject* receiver, QVariant userData,
-                                             const QString& subModule,
-                                             MOBase::IPluginGame const* game)
+                                             const QString& subModule)
 {
   if (m_User.shouldThrottle()) {
     throttledWarning(m_User);
@@ -696,7 +685,7 @@ int NexusInterface::requestToggleEndorsement(QString gameName, int modID,
   }
 
   NXMRequestInfo requestInfo(modID, modVersion, NXMRequestInfo::TYPE_TOGGLEENDORSEMENT,
-                             userData, subModule, game);
+                             userData, subModule, getGameNexusName(gameName));
   requestInfo.m_Endorse = endorse;
   m_RequestQueue.enqueue(requestInfo);
 
@@ -733,8 +722,7 @@ int NexusInterface::requestTrackingInfo(QObject* receiver, QVariant userData,
 
 int NexusInterface::requestToggleTracking(QString gameName, int modID, bool track,
                                           QObject* receiver, QVariant userData,
-                                          const QString& subModule,
-                                          MOBase::IPluginGame const* game)
+                                          const QString& subModule)
 {
   if (m_User.shouldThrottle()) {
     throttledWarning(m_User);
@@ -742,7 +730,7 @@ int NexusInterface::requestToggleTracking(QString gameName, int modID, bool trac
   }
 
   NXMRequestInfo requestInfo(modID, NXMRequestInfo::TYPE_TOGGLETRACKING, userData,
-                             subModule, game);
+                             subModule, getGameNexusName(gameName));
   requestInfo.m_Track = track;
   m_RequestQueue.enqueue(requestInfo);
 
@@ -760,15 +748,15 @@ int NexusInterface::requestToggleTracking(QString gameName, int modID, bool trac
 }
 
 int NexusInterface::requestGameInfo(QString gameName, QObject* receiver,
-                                    QVariant userData, const QString& subModule,
-                                    MOBase::IPluginGame const* game)
+                                    QVariant userData, const QString& subModule)
 {
   if (m_User.shouldThrottle()) {
     throttledWarning(m_User);
     return -1;
   }
 
-  NXMRequestInfo requestInfo(NXMRequestInfo::TYPE_GAMEINFO, userData, subModule, game);
+  NXMRequestInfo requestInfo(NXMRequestInfo::TYPE_GAMEINFO, userData, subModule,
+                             getGameNexusName(gameName));
   m_RequestQueue.enqueue(requestInfo);
 
   connect(this, SIGNAL(nxmGameInfoAvailable(QString, QVariant, QVariant, int)),
@@ -786,11 +774,10 @@ int NexusInterface::requestGameInfo(QString gameName, QObject* receiver,
 
 int NexusInterface::requestInfoFromMd5(QString gameName, QByteArray& hash,
                                        QObject* receiver, QVariant userData,
-                                       const QString& subModule,
-                                       MOBase::IPluginGame const* game)
+                                       const QString& subModule)
 {
   NXMRequestInfo requestInfo(hash, NXMRequestInfo::TYPE_FILEINFO_MD5, userData,
-                             subModule, game);
+                             subModule, getGameNexusName(gameName));
   requestInfo.m_Hash = hash;
   requestInfo.m_AllowedErrors[QNetworkReply::NetworkError::ContentNotFoundError].append(
       404);
@@ -810,10 +797,10 @@ int NexusInterface::requestInfoFromMd5(QString gameName, QByteArray& hash,
   return requestInfo.m_ID;
 }
 
-IPluginGame* NexusInterface::getGame(QString gameName) const
+IPluginGame* NexusInterface::getGame(const QString& gameName) const
 {
-  auto gamePlugins        = m_PluginContainer->plugins<IPluginGame>();
-  IPluginGame* gamePlugin = qApp->property("managed_game").value<IPluginGame*>();
+  const auto& gamePlugins = m_PluginContainer->plugins<IPluginGame>();
+  IPluginGame* gamePlugin = nullptr;
   for (auto plugin : gamePlugins) {
     if (plugin != nullptr &&
         plugin->gameShortName().compare(gameName, Qt::CaseInsensitive) == 0) {
@@ -822,6 +809,16 @@ IPluginGame* NexusInterface::getGame(QString gameName) const
     }
   }
   return gamePlugin;
+}
+
+QString NexusInterface::getGameNexusName(const QString& gameName) const
+{
+  IPluginGame* game = getGame(gameName);
+  if (game != nullptr) {
+    return game->gameNexusName();
+  }
+
+  return gameName;
 }
 
 void NexusInterface::cleanup()
@@ -1254,45 +1251,41 @@ QString get_management_url()
 
 NexusInterface::NXMRequestInfo::NXMRequestInfo(
     int modID, NexusInterface::NXMRequestInfo::Type type, QVariant userData,
-    const QString& subModule, MOBase::IPluginGame const* game)
+    const QString& subModule, const QString& gameNexusName)
     : m_ModID(modID), m_ModVersion("0"), m_FileID(0), m_Reply(nullptr), m_Type(type),
       m_UpdatePeriod(UpdatePeriod::NONE), m_UserData(userData), m_Timeout(nullptr),
       m_Reroute(false), m_ID(s_NextID.fetchAndAddAcquire(1)),
-      m_URL(get_management_url()), m_SubModule(subModule),
-      m_NexusGameID(game->nexusGameID()), m_GameName(game->gameNexusName()),
+      m_URL(get_management_url()), m_SubModule(subModule), m_GameName(gameNexusName),
       m_Endorse(false), m_Track(false), m_Hash(QByteArray())
 {}
 
 NexusInterface::NXMRequestInfo::NXMRequestInfo(
     int modID, QString modVersion, NexusInterface::NXMRequestInfo::Type type,
-    QVariant userData, const QString& subModule, MOBase::IPluginGame const* game)
+    QVariant userData, const QString& subModule, const QString& gameNexusName)
     : m_ModID(modID), m_ModVersion(modVersion), m_FileID(0), m_Reply(nullptr),
       m_Type(type), m_UpdatePeriod(UpdatePeriod::NONE), m_UserData(userData),
       m_Timeout(nullptr), m_Reroute(false), m_ID(s_NextID.fetchAndAddAcquire(1)),
-      m_URL(get_management_url()), m_SubModule(subModule),
-      m_NexusGameID(game->nexusGameID()), m_GameName(game->gameNexusName()),
+      m_URL(get_management_url()), m_SubModule(subModule), m_GameName(gameNexusName),
       m_Endorse(false), m_Track(false), m_Hash(QByteArray())
 {}
 
 NexusInterface::NXMRequestInfo::NXMRequestInfo(Type type, QVariant userData,
                                                const QString& subModule,
-                                               MOBase::IPluginGame const* game)
+                                               const QString& gameNexusName)
     : m_ModID(0), m_ModVersion("0"), m_FileID(0), m_Reply(nullptr), m_Type(type),
       m_UpdatePeriod(UpdatePeriod::NONE), m_UserData(userData), m_Timeout(nullptr),
       m_Reroute(false), m_ID(s_NextID.fetchAndAddAcquire(1)),
-      m_URL(get_management_url()), m_SubModule(subModule),
-      m_NexusGameID(game->nexusGameID()), m_GameName(game->gameNexusName()),
+      m_URL(get_management_url()), m_SubModule(subModule), m_GameName(gameNexusName),
       m_Endorse(false), m_Track(false), m_Hash(QByteArray())
 {}
 
 NexusInterface::NXMRequestInfo::NXMRequestInfo(
     int modID, int fileID, NexusInterface::NXMRequestInfo::Type type, QVariant userData,
-    const QString& subModule, MOBase::IPluginGame const* game)
+    const QString& subModule, const QString& gameNexusName)
     : m_ModID(modID), m_ModVersion("0"), m_FileID(fileID), m_Reply(nullptr),
       m_Type(type), m_UpdatePeriod(UpdatePeriod::NONE), m_UserData(userData),
       m_Timeout(nullptr), m_Reroute(false), m_ID(s_NextID.fetchAndAddAcquire(1)),
-      m_URL(get_management_url()), m_SubModule(subModule),
-      m_NexusGameID(game->nexusGameID()), m_GameName(game->gameNexusName()),
+      m_URL(get_management_url()), m_SubModule(subModule), m_GameName(gameNexusName),
       m_Endorse(false), m_Track(false), m_Hash(QByteArray())
 {}
 
@@ -1301,28 +1294,26 @@ NexusInterface::NXMRequestInfo::NXMRequestInfo(Type type, QVariant userData,
     : m_ModID(0), m_ModVersion("0"), m_FileID(0), m_Reply(nullptr), m_Type(type),
       m_UpdatePeriod(UpdatePeriod::NONE), m_UserData(userData), m_Timeout(nullptr),
       m_Reroute(false), m_ID(s_NextID.fetchAndAddAcquire(1)),
-      m_URL(get_management_url()), m_SubModule(subModule), m_NexusGameID(0),
-      m_GameName(""), m_Endorse(false), m_Track(false), m_Hash(QByteArray())
+      m_URL(get_management_url()), m_SubModule(subModule), m_GameName(""),
+      m_Endorse(false), m_Track(false), m_Hash(QByteArray())
 {}
 
 NexusInterface::NXMRequestInfo::NXMRequestInfo(
     UpdatePeriod period, NexusInterface::NXMRequestInfo::Type type, QVariant userData,
-    const QString& subModule, MOBase::IPluginGame const* game)
+    const QString& subModule, const QString& gameNexusName)
     : m_ModID(0), m_ModVersion("0"), m_FileID(0), m_Reply(nullptr), m_Type(type),
       m_UpdatePeriod(period), m_UserData(userData), m_Timeout(nullptr),
       m_Reroute(false), m_ID(s_NextID.fetchAndAddAcquire(1)),
-      m_URL(get_management_url()), m_SubModule(subModule),
-      m_NexusGameID(game->nexusGameID()), m_GameName(game->gameNexusName()),
+      m_URL(get_management_url()), m_SubModule(subModule), m_GameName(gameNexusName),
       m_Endorse(false), m_Track(false), m_Hash(QByteArray())
 {}
 
 NexusInterface::NXMRequestInfo::NXMRequestInfo(
     QByteArray& hash, NexusInterface::NXMRequestInfo::Type type, QVariant userData,
-    const QString& subModule, MOBase::IPluginGame const* game)
+    const QString& subModule, const QString& gameNexusName)
     : m_ModID(0), m_ModVersion("0"), m_FileID(0), m_Reply(nullptr), m_Type(type),
       m_UpdatePeriod(UpdatePeriod::NONE), m_UserData(userData), m_Timeout(nullptr),
       m_Reroute(false), m_ID(s_NextID.fetchAndAddAcquire(1)),
-      m_URL(get_management_url()), m_SubModule(subModule),
-      m_NexusGameID(game->nexusGameID()), m_GameName(game->gameNexusName()),
+      m_URL(get_management_url()), m_SubModule(subModule), m_GameName(gameNexusName),
       m_Endorse(false), m_Track(false), m_Hash(hash)
 {}

--- a/src/nexusinterface.h
+++ b/src/nexusinterface.h
@@ -63,6 +63,7 @@ public:
   /**
    * @brief request description for a mod
    *
+   * @param gameName the game short name to support multiple game sources
    * @param modID id of the mod caller is interested in
    * @param userData user data to be returned with the result
    * @param url the url to request from
@@ -80,6 +81,7 @@ public:
   /**
    * @brief request info about a single file of a mod
    *
+   * @param gameName the game short name to support multiple game sources
    * @param modID id of the mod caller is interested in
    * @param fileID id of the file the caller is interested in
    * @param userData user data to be returned with the result
@@ -90,6 +92,7 @@ public:
   /**
    * @brief request the download url of a file
    *
+   * @param gameName the game short name to support multiple game sources
    * @param modID id of the mod caller is interested in
    * @param fileID id of the file the caller is interested in
    * @param userData user data to be returned with the result
@@ -99,6 +102,8 @@ public:
 
   /**
    * @brief requestToggleEndorsement
+   *
+   * @param gameName the game short name to support multiple game sources
    * @param modID id of the mod caller is interested in
    * @param userData user data to be returned with the result
    */
@@ -107,6 +112,8 @@ public:
 
   /**
    * @brief requestToggleTracking
+   *
+   * @param gameName the game short name to support multiple game sources
    * @param modID id of the mod caller is interested in
    * @param userData user data to be returned with the result
    */
@@ -115,6 +122,8 @@ public:
 
   /**
    * @brief requestGameInfo
+   *
+   * @param gameName the game short name to support multiple game sources
    * @param userData user data to be returned with the result
    */
   virtual void requestGameInfo(QString gameName, QVariant userData);
@@ -221,26 +230,7 @@ public:
    * @return int an id to identify the request
    **/
   int requestDescription(QString gameName, int modID, QObject* receiver,
-                         QVariant userData, const QString& subModule)
-  {
-    return requestDescription(gameName, modID, receiver, userData, subModule,
-                              getGame(gameName));
-  }
-
-  /**
-   * @brief request description for a mod
-   *
-   * @param gameName the game short name to support multiple game sources
-   * @param modID id of the mod caller is interested in
-   * @param receiver the object to receive the result asynchronously via a signal
-   *(nxmDescriptionAvailable)
-   * @param userData user data to be returned with the result
-   * @param game Game with which the mod is associated
-   * @return int an id to identify the request
-   **/
-  int requestDescription(QString gameName, int modID, QObject* receiver,
-                         QVariant userData, const QString& subModule,
-                         MOBase::IPluginGame const* game);
+                         QVariant userData, const QString& subModule);
 
   /**
    * @brief request description for a mod
@@ -254,36 +244,10 @@ public:
    * @return int an id to identify the request
    **/
   int requestModInfo(QString gameName, int modID, QObject* receiver, QVariant userData,
-                     const QString& subModule)
-  {
-    return requestModInfo(gameName, modID, receiver, userData, subModule,
-                          getGame(gameName));
-  }
+                     const QString& subModule);
 
-  /**
-   * @brief request mod info
-   *
-   * @param gameName the game short name to support multiple game sources
-   * @param modID id of the mod caller is interested in
-   * @param receiver the object to receive the result asynchronously via a signal
-   *(nxmModInfoAvailable)
-   * @param userData user data to be returned with the result
-   * @param game Game with which the mod is associated
-   * @return int an id to identify the request
-   **/
-  int requestModInfo(QString gameName, int modID, QObject* receiver, QVariant userData,
-                     const QString& subModule, MOBase::IPluginGame const* game);
-
-  int requestUpdateInfo(QString gameName, NexusInterface::UpdatePeriod period,
-                        QObject* receiver, QVariant userData, const QString& subModule)
-  {
-    return requestUpdateInfo(gameName, period, receiver, userData, subModule,
-                             getGame(gameName));
-  }
-
-  int requestUpdateInfo(QString gameName, NexusInterface::UpdatePeriod period,
-                        QObject* receiver, QVariant userData, const QString& subModule,
-                        const MOBase::IPluginGame* game);
+  int requestUpdateInfo(QString gameNexusName, NexusInterface::UpdatePeriod period,
+                        QObject* receiver, QVariant userData, const QString& subModule);
 
   /**
    * @brief request nexus descriptions for multiple mods at once
@@ -309,30 +273,12 @@ public:
    * @return int an id to identify the request
    **/
   int requestFiles(QString gameName, int modID, QObject* receiver, QVariant userData,
-                   const QString& subModule)
-  {
-    return requestFiles(gameName, modID, receiver, userData, subModule,
-                        getGame(gameName));
-  }
-
-  /**
-   * @brief request a list of the files belonging to a mod
-   *
-   * @param gameName the game short name to support multiple game sources
-   * @param modID id of the mod caller is interested in
-   * @param receiver the object to receive the result asynchronously via a signal
-   *(nxmFilesAvailable)
-   * @param userData user data to be returned with the result
-   * @param game the game with which the mods are associated
-   * @return int an id to identify the request
-   **/
-  int requestFiles(QString gameName, int modID, QObject* receiver, QVariant userData,
-                   const QString& subModule, MOBase::IPluginGame const* game);
+                   const QString& subModule);
 
   /**
    * @brief request info about a single file of a mod
    *
-   * @param gameName name of the game short name to request the download from
+   * @param gameName game short name to request the download from
    * @param modID id of the mod caller is interested in (assumed to be for the current
    *game)
    * @param fileID id of the file the caller is interested in
@@ -357,27 +303,7 @@ public:
    * @return int an id to identify the request
    **/
   int requestDownloadURL(QString gameName, int modID, int fileID, QObject* receiver,
-                         QVariant userData, const QString& subModule)
-  {
-    return requestDownloadURL(gameName, modID, fileID, receiver, userData, subModule,
-                              getGame(gameName));
-  }
-
-  /**
-   * @brief request the download url of a file
-   *
-   * @param gameName the game short name to support multiple game sources
-   * @param modID id of the mod caller is interested in
-   * @param fileID id of the file the caller is interested in
-   * @param receiver the object to receive the result asynchronously via a signal
-   *(nxmFilesAvailable)
-   * @param userData user data to be returned with the result
-   * @param game the game with which the mods are associated
-   * @return int an id to identify the request
-   **/
-  int requestDownloadURL(QString gameName, int modID, int fileID, QObject* receiver,
-                         QVariant userData, const QString& subModule,
-                         MOBase::IPluginGame const* game);
+                         QVariant userData, const QString& subModule);
 
   int requestEndorsementInfo(QObject* receiver, QVariant userData,
                              const QString& subModule);
@@ -394,27 +320,7 @@ public:
    */
   int requestToggleEndorsement(QString gameName, int modID, QString modVersion,
                                bool endorse, QObject* receiver, QVariant userData,
-                               const QString& subModule)
-  {
-    return requestToggleEndorsement(gameName, modID, modVersion, endorse, receiver,
-                                    userData, subModule, getGame(gameName));
-  }
-
-  /**
-   * @param gameName the game short name to support multiple game sources
-   * @brief toggle endorsement state of the mod
-   * @param modID id of the mod
-   * @param endorse true if the mod should be endorsed, false for un-endorse
-   * @param receiver the object to receive the result asynchronously via a signal
-   * (nxmFilesAvailable)
-   * @param userData user data to be returned with the result
-   * @param game the game with which the mods are associated
-   * @return int an id to identify the request
-   */
-  int requestToggleEndorsement(QString gameName, int modID, QString modVersion,
-                               bool endorse, QObject* receiver, QVariant userData,
-                               const QString& subModule,
-                               MOBase::IPluginGame const* game);
+                               const QString& subModule);
 
   int requestTrackingInfo(QObject* receiver, QVariant userData,
                           const QString& subModule);
@@ -431,26 +337,7 @@ public:
    * @return int an id to identify the request
    */
   int requestToggleTracking(QString gameName, int modID, bool track, QObject* receiver,
-                            QVariant userData, const QString& subModule)
-  {
-    return requestToggleTracking(gameName, modID, track, receiver, userData, subModule,
-                                 getGame(gameName));
-  }
-
-  /**
-   * @param gameName the game short name to support multiple game sources
-   * @brief toggle tracking state of the mod
-   * @param modID id of the mod
-   * @param track true if the mod should be tracked, false for not tracked
-   * @param receiver the object to receive the result asynchronously via a signal
-   * (nxmFilesAvailable)
-   * @param userData user data to be returned with the result
-   * @param game the game with which the mods are associated
-   * @return int an id to identify the request
-   */
-  int requestToggleTracking(QString gameName, int modID, bool track, QObject* receiver,
-                            QVariant userData, const QString& subModule,
-                            MOBase::IPluginGame const* game);
+                            QVariant userData, const QString& subModule);
 
   /**
    * @param gameName the game short name to support multiple game sources
@@ -464,41 +351,13 @@ public:
    * @return int an id to identify the request
    */
   int requestGameInfo(QString gameName, QObject* receiver, QVariant userData,
-                      const QString& subModule)
-  {
-    return requestGameInfo(gameName, receiver, userData, subModule, getGame(gameName));
-  }
-
-  /**
-   * @param gameName the game short name to support multiple game sources
-   * @brief toggle tracking state of the mod
-   * @param modID id of the mod
-   * @param track true if the mod should be tracked, false for not tracked
-   * @param receiver the object to receive the result asynchronously via a signal
-   * (nxmFilesAvailable)
-   * @param userData user data to be returned with the result
-   * @param game the game with which the mods are associated
-   * @return int an id to identify the request
-   */
-  int requestGameInfo(QString gameName, QObject* receiver, QVariant userData,
-                      const QString& subModule, MOBase::IPluginGame const* game);
+                      const QString& subModule);
 
   /**
    *
    */
   int requestInfoFromMd5(QString gameName, QByteArray& hash, QObject* receiver,
-                         QVariant userData, const QString& subModule)
-  {
-    return requestInfoFromMd5(gameName, hash, receiver, userData, subModule,
-                              getGame(gameName));
-  }
-
-  /**
-   *
-   */
-  int requestInfoFromMd5(QString gameName, QByteArray& hash, QObject* receiver,
-                         QVariant userData, const QString& subModule,
-                         MOBase::IPluginGame const* game);
+                         QVariant userData, const QString& subModule);
 
   /**
    * @param directory the directory to store cache files
@@ -641,7 +500,6 @@ private:
     QString m_URL;
     QString m_SubModule;
     QString m_GameName;
-    int m_NexusGameID;
     bool m_Reroute;
     int m_ID;
     int m_Endorse;
@@ -651,18 +509,18 @@ private:
     bool m_IgnoreGenericErrorHandler;
 
     NXMRequestInfo(int modID, Type type, QVariant userData, const QString& subModule,
-                   MOBase::IPluginGame const* game);
+                   const QString& gameNexusName);
     NXMRequestInfo(int modID, QString modVersion, Type type, QVariant userData,
-                   const QString& subModule, MOBase::IPluginGame const* game);
+                   const QString& subModule, const QString& gameNexusName);
     NXMRequestInfo(int modID, int fileID, Type type, QVariant userData,
-                   const QString& subModule, MOBase::IPluginGame const* game);
+                   const QString& subModule, const QString& gameNexusName);
     NXMRequestInfo(Type type, QVariant userData, const QString& subModule,
-                   MOBase::IPluginGame const* game);
+                   const QString& gameNexusName);
     NXMRequestInfo(Type type, QVariant userData, const QString& subModule);
     NXMRequestInfo(UpdatePeriod period, Type type, QVariant userData,
-                   const QString& subModule, MOBase::IPluginGame const* game);
+                   const QString& subModule, const QString& gameNexusName);
     NXMRequestInfo(QByteArray& hash, Type type, QVariant userData,
-                   const QString& subModule, MOBase::IPluginGame const* game);
+                   const QString& subModule, const QString& gameNexusName);
 
   private:
     static QAtomicInt s_NextID;
@@ -673,8 +531,9 @@ private:
 private:
   void nextRequest();
   void requestFinished(std::list<NXMRequestInfo>::iterator iter);
-  MOBase::IPluginGame* getGame(QString gameName) const;
-  QString getOldModsURL(QString gameName) const;
+  MOBase::IPluginGame* getGame(const QString& gameName) const;
+  QString getGameNexusName(const QString& gameName) const;
+  QString getOldModsURL(const QString& gameName) const;
 
 private:
   QNetworkDiskCache* m_DiskCache;


### PR DESCRIPTION
All `request`-methods of the `IModRepositoryBridge` accept a `gameName` argument, but this argument only works correctly if there is a game plugin with a `gameShortName` that matches the `gameName`. Otherwise, it just falls back to the currently managed game, which would probably confuse plugin developers using this API for games on Nexus that don't have a MO2 plugin (e.g., the [Modding Tools](https://www.nexusmods.com/games/site) section).

To fix this, I made some changes to the Nexus interface classes:
* I removed `m_NexusGameID` from the `NXMRequestInfo` struct, which seems to be unused.
  * Now that this is no longer needed, the constructors only need the Nexus game name instead of the whole game plugin.
  * As a result, any `request` method overloads with a `IPluginGame` parameter can be (and have been) removed.
* I changed `getGame` to return a `nullptr` instead of the currently managed game if no matching game plugin is found.
  * All call sites already check for `nullptr` anyway (in case the managed game is also null).
* I added a `getGameNexusName` method that falls back to the supplied `gameName` if `getGame` returns `nullptr`. I changed all implementations of the `request`-methods of `IModRepositoryBridge` to use this method instead of `getGame(gameName)->gameNexusName()`. 

In other words, if there is no game plugin matching the specified `gameName`, it's assumed that `gameName` is already a Nexus game name, allowing plugin developers to use this API even without a matching game plugin. If it turns out that it wasn't a Nexus game name, the request will just fail, which I'd still prefer to silently falling back to the currently managed game.

Based on #2374 to avoid merge conflicts.