### PR TITLE
Handle Nexus collections links

### DIFF
--- a/src/downloadmanager.cpp
+++ b/src/downloadmanager.cpp
@@ -676,6 +676,14 @@ void DownloadManager::addNXMDownload(const QString& url)
 {
   NXMUrl nxmInfo(url);
 
+  if (nxmInfo.isCollection()) {
+    QString collectionStr(
+        tr("This is a Nexus collections link. These are not yet supported by MO."));
+    QMessageBox::information(m_ParentWidget, tr("Collections Not Supported"),
+                             collectionStr, QMessageBox::Ok);
+    return;
+  }
+
   QStringList validGames;
   MOBase::IPluginGame* foundGame = nullptr;
   validGames.append(m_ManagedGame->gameShortName());


### PR DESCRIPTION
- Pops up dialog when the NXM link is a collection
- Collection link data available, though still unsupported

Requires https://github.com/ModOrganizer2/modorganizer-uibase/pull/184