### PR TITLE
Persist QColorDialog custom color selections in ModOrganizer.ini

### DIFF
--- a/src/modlistviewactions.cpp
+++ b/src/modlistviewactions.cpp
@@ -1216,6 +1216,10 @@ void ModListViewActions::setColor(const QModelIndexList& indices,
     return;
 
   settings.colors().setPreviousSeparatorColor(currentColor);
+  for (int i = 0; i < QColorDialog::customCount(); ++i) {
+    const auto customColor = dialog.customColor(i);
+    settings.colors().setCustomColor(i, customColor);
+  }
 
   for (auto& idx : indices) {
     ModInfo::Ptr info = ModInfo::getByIndex(idx.data(ModList::IndexRole).toInt());

--- a/src/settings.cpp
+++ b/src/settings.cpp
@@ -1259,7 +1259,13 @@ void WidgetSettings::resetQuestionButtons()
   removeSection(m_Settings, "DialogChoices");
 }
 
-ColorSettings::ColorSettings(QSettings& s) : m_Settings(s) {}
+ColorSettings::ColorSettings(QSettings& s) : m_Settings(s)
+{
+  for (int i = 0; i < QColorDialog::customCount(); ++i) {
+    const auto color = customColor(i);
+    QColorDialog::setCustomColor(i, color);
+  }
+}
 
 QColor ColorSettings::modlistOverwrittenLoose() const
 {
@@ -1354,6 +1360,17 @@ void ColorSettings::setPreviousSeparatorColor(const QColor& c) const
 void ColorSettings::removePreviousSeparatorColor()
 {
   remove(m_Settings, "General", "previousSeparatorColor");
+}
+
+QColor ColorSettings::customColor(const int index) const
+{
+  return get<QColor>(m_Settings, "Settings", QString("customColor%1").arg(index),
+                     QColor(255, 255, 255));
+}
+
+void ColorSettings::setCustomColor(const int index, const QColor& c)
+{
+  set(m_Settings, "Settings", QString("customColor%1").arg(index), c);
 }
 
 bool ColorSettings::colorSeparatorScrollbar() const

--- a/src/settings.cpp
+++ b/src/settings.cpp
@@ -185,6 +185,10 @@ void Settings::processUpdates(const QVersionNumber& currentVersion,
     remove(m_Settings, "Settings", "load_mechanism");
   });
 
+  version({2, 6, 0}, [&] {
+    m_Colors.copyGlobalCustomColors();
+  });
+
   // save version in all case
   set(m_Settings, "General", "version", currentVersion.toString());
 
@@ -1371,6 +1375,22 @@ QColor ColorSettings::customColor(const int index) const
 void ColorSettings::setCustomColor(const int index, const QColor& c)
 {
   set(m_Settings, "Settings", QString("customColor%1").arg(index), c);
+}
+
+void ColorSettings::copyGlobalCustomColors()
+{
+  // see:
+  // https://codereview.qt-project.org/c/qt/qtbase/+/626629/3/src/gui/kernel/qplatformdialoghelper.cpp#b263
+  QSettings globalSettings(QSettings::UserScope, QStringLiteral("QtProject"));
+  for (int i = 0; i < QColorDialog::customCount(); ++i) {
+    const QVariant v = globalSettings.value(QLatin1StringView("Qt/customColors/") +
+                                            QString::number(i));
+
+    if (v.isValid()) {
+      const QRgb rgba = v.toUInt();
+      setCustomColor(i, QColor::fromRgba(rgba));
+    }
+  }
 }
 
 bool ColorSettings::colorSeparatorScrollbar() const

--- a/src/settings.cpp
+++ b/src/settings.cpp
@@ -1379,6 +1379,9 @@ void ColorSettings::setCustomColor(const int index, const QColor& c)
 
 void ColorSettings::copyGlobalCustomColors()
 {
+  if (m_Settings.contains("Settings/customColor0"))
+    return;  // already set, don't overwrite
+
   // see:
   // https://codereview.qt-project.org/c/qt/qtbase/+/626629/3/src/gui/kernel/qplatformdialoghelper.cpp#b263
   QSettings globalSettings(QSettings::UserScope, QStringLiteral("QtProject"));

--- a/src/settings.h
+++ b/src/settings.h
@@ -265,6 +265,10 @@ public:
   void setPreviousSeparatorColor(const QColor& c) const;
   void removePreviousSeparatorColor();
 
+  // custom colors set in QColorDialog (e.g. for separators)
+  QColor customColor(const int index) const;
+  void setCustomColor(const int index, const QColor& c);
+
   // whether the scrollbar of the mod list should have colors for custom
   // separator colors
   //

--- a/src/settings.h
+++ b/src/settings.h
@@ -269,6 +269,10 @@ public:
   QColor customColor(const int index) const;
   void setCustomColor(const int index, const QColor& c);
 
+  // since MO v2.6.0, custom colors are no longer stored globally in Qt; this ensures
+  // custom colors set in older versions are retained when updating
+  void copyGlobalCustomColors();
+
   // whether the scrollbar of the mod list should have colors for custom
   // separator colors
   //


### PR DESCRIPTION
Custom colors selected in `QColorDialog` used to be saved globally in Mod Organizer v2.5.2, but in Qt 6.11.0, [this is no longer the case](https://codereview.qt-project.org/c/qt/qtbase/+/626629). As a result, they now reset every time after restarting the program.

This PR fixes that by storing them in ModOrganizer.ini.