### PR TITLE
fix: checkForProblems synchronous

### DIFF
--- a/src/mainwindow.cpp
+++ b/src/mainwindow.cpp
@@ -243,8 +243,7 @@ MainWindow::MainWindow(Settings& settings, OrganizerCore& organizerCore,
       m_PluginContainer(pluginContainer),
       m_ArchiveListWriter(std::bind(&MainWindow::saveArchiveList, this)),
       m_LinkToolbar(nullptr), m_LinkDesktop(nullptr), m_LinkStartMenu(nullptr),
-      m_SystemTrayManager(nullptr), m_NumberOfProblems(0),
-      m_ProblemsCheckRequired(false)
+      m_SystemTrayManager(nullptr), m_NumberOfProblems(0)
 {
   // disables incredibly slow menu fade in effect that looks and feels like crap.
   // this was only happening to users with the windows
@@ -467,7 +466,7 @@ MainWindow::MainWindow(Settings& settings, OrganizerCore& organizerCore,
 
   m_UpdateProblemsTimer.setSingleShot(true);
   connect(&m_UpdateProblemsTimer, &QTimer::timeout, this,
-          &MainWindow::checkForProblemsAsync);
+          &MainWindow::checkForProblems);
   connect(this, &MainWindow::checkForProblemsDone, this,
           &MainWindow::updateProblemsButton, Qt::ConnectionType::QueuedConnection);
 
@@ -1021,35 +1020,24 @@ bool MainWindow::errorReported(QString& logFile)
   return false;
 }
 
-QFuture<void> MainWindow::checkForProblemsAsync()
+void MainWindow::checkForProblems()
 {
-  return QtConcurrent::run([this]() {
-    checkForProblemsImpl();
-  });
-}
-
-void MainWindow::checkForProblemsImpl()
-{
-  m_ProblemsCheckRequired = true;
-
-  std::scoped_lock lk(m_CheckForProblemsMutex);
-
-  // another thread might already have checked while this one was waiting on the lock
-  if (m_ProblemsCheckRequired) {
-    m_ProblemsCheckRequired = false;
-    TimeThis tt("MainWindow::checkForProblemsImpl()");
-    size_t numProblems = 0;
-    for (QObject* pluginObj : m_PluginContainer.plugins<QObject>()) {
-      IPlugin* plugin = qobject_cast<IPlugin*>(pluginObj);
-      if (plugin == nullptr || m_PluginContainer.isEnabled(plugin)) {
-        IPluginDiagnose* diagnose = qobject_cast<IPluginDiagnose*>(pluginObj);
-        if (diagnose != nullptr)
-          numProblems += diagnose->activeProblems().size();
-      }
+  // This must run on the GUI thread. The diagnose plugins query live model
+  // state (plugin list masters/states, mod list, ...) which is mutated on the
+  // GUI thread; running this concurrently races those containers and corrupts
+  // the heap (e.g. while rapidly toggling a mod on and off).
+  TimeThis tt("MainWindow::checkForProblems()");
+  size_t numProblems = 0;
+  for (QObject* pluginObj : m_PluginContainer.plugins<QObject>()) {
+    IPlugin* plugin = qobject_cast<IPlugin*>(pluginObj);
+    if (plugin == nullptr || m_PluginContainer.isEnabled(plugin)) {
+      IPluginDiagnose* diagnose = qobject_cast<IPluginDiagnose*>(pluginObj);
+      if (diagnose != nullptr)
+        numProblems += diagnose->activeProblems().size();
     }
-    m_NumberOfProblems = numProblems;
-    emit checkForProblemsDone();
   }
+  m_NumberOfProblems = numProblems;
+  emit checkForProblemsDone();
 }
 
 void MainWindow::about()
@@ -3735,9 +3723,7 @@ void MainWindow::on_bsaList_itemChanged(QTreeWidgetItem*, int)
 
 void MainWindow::on_actionNotifications_triggered()
 {
-  auto future = checkForProblemsAsync();
-
-  future.waitForFinished();
+  checkForProblems();
 
   ProblemsDialog problems(m_PluginContainer, this);
   problems.exec();

--- a/src/mainwindow.h
+++ b/src/mainwindow.h
@@ -231,7 +231,11 @@ private:
                        std::string fileName);
 
   // Performs checks, sets the m_NumberOfProblems and signals checkForProblemsDone().
-  void checkForProblemsImpl();
+  //
+  // Must run on the GUI thread: the diagnose plugins read live model state
+  // (plugin list, mod list, ...) which is mutated on the GUI thread. Running
+  // this on a worker thread races those containers and corrupts the heap.
+  void checkForProblems();
 
   void setCategoryListVisible(bool visible);
 
@@ -322,9 +326,7 @@ private:
   // when painting the count
   QIcon m_originalNotificationIcon;
 
-  std::atomic<std::size_t> m_NumberOfProblems;
-  std::atomic<bool> m_ProblemsCheckRequired;
-  std::mutex m_CheckForProblemsMutex;
+  std::size_t m_NumberOfProblems;
 
   QVersionNumber m_LastVersion;
 
@@ -418,9 +420,6 @@ private slots:
   // Queue a problem check to allow collapsing of multiple requests in short amount of
   // time.
   void scheduleCheckForProblems();
-
-  // Perform the actual problem check in another thread.
-  QFuture<void> checkForProblemsAsync();
 
   void saveModMetas();
 


### PR DESCRIPTION
checkForProblems is no longer race-condition-prone; previously it could interact with unguarded vars (i.e m_ESPs, m_ESPsByName, etc) while main thread was updating them.
it doesn't take long (personal testing shows ~30ms) so just moved that to main thread instead of playing whack-a-mole with all the vars it (and other detection plugins) could access